### PR TITLE
Cred management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,5 +48,6 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-lambda:$awsSdkVersion"
     compile "com.amazonaws:aws-java-sdk-iam:$awsSdkVersion"
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.8.0'
 }
 

--- a/src/main/java/com/amazonaws/intellij/ui/credentials/CredentialFileBasedProfileEditor.form
+++ b/src/main/java/com/amazonaws/intellij/ui/credentials/CredentialFileBasedProfileEditor.form
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.amazonaws.intellij.ui.credentials.CredentialFileBasedProfileEditor">
+  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="222" height="78"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="5995a" class="com.intellij.ui.components.JBLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="8c180"/>
+          <text value="Access Key"/>
+        </properties>
+      </component>
+      <component id="884ed" class="com.intellij.ui.components.JBLabel">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="a6ce9"/>
+          <text value="Secret Key"/>
+        </properties>
+      </component>
+      <component id="8c180" class="com.intellij.ui.components.JBTextField" binding="accessKeyInput">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="a6ce9" class="com.intellij.ui.components.JBPasswordField" binding="secretKeyInput">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <vspacer id="46410">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+    </children>
+  </grid>
+</form>

--- a/src/main/java/com/amazonaws/intellij/ui/credentials/CredentialFileBasedProfileEditor.java
+++ b/src/main/java/com/amazonaws/intellij/ui/credentials/CredentialFileBasedProfileEditor.java
@@ -1,0 +1,52 @@
+package com.amazonaws.intellij.ui.credentials;
+
+import com.amazonaws.auth.profile.internal.BasicProfile;
+import com.amazonaws.auth.profile.internal.ProfileKeyConstants;
+import com.amazonaws.intellij.credentials.CredentialFileBasedProfile;
+import com.amazonaws.intellij.credentials.ProfileEditor;
+import com.intellij.ui.components.JBPasswordField;
+import com.intellij.ui.components.JBTextField;
+import java.util.HashMap;
+import java.util.Map;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import org.jetbrains.annotations.NotNull;
+
+public class CredentialFileBasedProfileEditor extends ProfileEditor<CredentialFileBasedProfile> {
+    private JPanel component;
+    private JBTextField accessKeyInput;
+    private JBPasswordField secretKeyInput;
+
+    public CredentialFileBasedProfileEditor() {
+        this("", "", "");
+    }
+
+    public CredentialFileBasedProfileEditor(CredentialFileBasedProfile source) {
+        this(source.getName(), source.getProfile().getAwsAccessIdKey(), source.getProfile().getAwsSecretAccessKey());
+    }
+
+    private CredentialFileBasedProfileEditor(String name, String accessKey, String secretKey) {
+        super(name);
+        this.accessKeyInput.setText(accessKey);
+        this.secretKeyInput.setText(secretKey);
+        this.secretKeyInput.setPasswordIsStored(secretKey.length() > 0);
+    }
+
+    @NotNull
+    @Override
+    public JComponent getEditorComponent() {
+        return component;
+    }
+
+    @NotNull
+    @Override
+    public CredentialFileBasedProfile commit() {
+        // TODO: Stop using internal APIs, https://github.com/aws/aws-sdk-java-v2/issues/70
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ProfileKeyConstants.AWS_ACCESS_KEY_ID, accessKeyInput.getText());
+        properties.put(ProfileKeyConstants.AWS_SECRET_ACCESS_KEY, new String(secretKeyInput.getPassword()));
+
+        BasicProfile profile = new BasicProfile(getProfileNameEditor().getValue(), properties);
+        return new CredentialFileBasedProfile(profile);
+    }
+}

--- a/src/main/java/com/amazonaws/intellij/ui/credentials/ProfileNameEditor.form
+++ b/src/main/java/com/amazonaws/intellij/ui/credentials/ProfileNameEditor.form
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.amazonaws.intellij.ui.credentials.ProfileNameEditor">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="420" height="28"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="79cc4" class="com.intellij.ui.components.JBLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="3f8a"/>
+          <text value="Profile Name"/>
+        </properties>
+      </component>
+      <component id="3f8a" class="com.intellij.ui.components.JBTextField" binding="profileNameInput">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/src/main/java/com/amazonaws/intellij/ui/credentials/ProfileNameEditor.java
+++ b/src/main/java/com/amazonaws/intellij/ui/credentials/ProfileNameEditor.java
@@ -1,0 +1,26 @@
+package com.amazonaws.intellij.ui.credentials;
+
+import com.intellij.ui.components.JBTextField;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+public class ProfileNameEditor {
+    private JPanel panel;
+    private JBTextField profileNameInput;
+
+    public ProfileNameEditor(String value) {
+        profileNameInput.setText(value);
+    }
+
+    public String getValue() {
+        return profileNameInput.getText();
+    }
+
+    public JComponent getPanel() {
+        return panel;
+    }
+
+    public JComponent getInput() {
+        return profileNameInput;
+    }
+}

--- a/src/main/java/com/amazonaws/intellij/ui/options/AWSCredentialsConfigurable.form
+++ b/src/main/java/com/amazonaws/intellij/ui/options/AWSCredentialsConfigurable.form
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.amazonaws.intellij.ui.options.AWSCredentialsConfigurable">
+  <grid id="27dc6" binding="credentialsPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="588" height="574"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <grid id="34b9e" binding="credentialFilePanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="4a3b4" class="com.intellij.ui.components.JBLabel">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Credential file"/>
+            </properties>
+          </component>
+          <component id="bf56d" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="credentialFileChooser">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <grid id="4f258" binding="tablePanel" layout-manager="BorderLayout" hgap="0" vgap="0">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children/>
+          </grid>
+          <component id="c6d01" class="com.intellij.ui.components.JBLabel" binding="errorLabel">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Error goes here"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/src/main/java/com/amazonaws/intellij/ui/options/AWSCredentialsConfigurable.java
+++ b/src/main/java/com/amazonaws/intellij/ui/options/AWSCredentialsConfigurable.java
@@ -1,0 +1,246 @@
+package com.amazonaws.intellij.ui.options;
+
+import com.amazonaws.intellij.credentials.AWSCredentialsProfileProvider;
+import com.amazonaws.intellij.credentials.CredentialFileBasedProfile;
+import com.amazonaws.intellij.credentials.CredentialProfile;
+import com.amazonaws.intellij.credentials.CredentialProfileFactory;
+import com.amazonaws.intellij.credentials.ProfileEditor;
+import com.amazonaws.intellij.ui.credentials.CredentialsDialog;
+import com.amazonaws.intellij.ui.credentials.CredentialsTable;
+import com.amazonaws.intellij.ui.credentials.ProfileNameEditor;
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.util.BrowseFilesListener;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextBrowseFolderListener;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.ui.ValidationInfo;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.ui.popup.PopupStep;
+import com.intellij.openapi.ui.popup.util.BaseListPopupStep;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.ui.AnActionButton;
+import com.intellij.ui.DocumentAdapter;
+import com.intellij.ui.IdeBorderFactory;
+import com.intellij.ui.ToolbarDecorator;
+import com.intellij.ui.components.JBLabel;
+import java.awt.BorderLayout;
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.event.DocumentEvent;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AWSCredentialsConfigurable implements Configurable, Configurable.NoScroll {
+    private final AWSCredentialsProfileProvider optionsProvider;
+    private JPanel credentialsPanel;
+    private JPanel tablePanel;
+    private TextFieldWithBrowseButton credentialFileChooser;
+    private JPanel credentialFilePanel;
+    private JBLabel errorLabel;
+    private CredentialsTable credentialsTable;
+
+    private String currentCredentialFileLocation;
+
+    public AWSCredentialsConfigurable(Project project) {
+        optionsProvider = AWSCredentialsProfileProvider.getInstance(project);
+
+        credentialFilePanel.setBorder(IdeBorderFactory.createTitledBorder("Credentials", false));
+
+        credentialFileChooser.addBrowseFolderListener(new TextBrowseFolderListener(BrowseFilesListener.SINGLE_FILE_DESCRIPTOR));
+        credentialFileChooser.getTextField().getDocument().addDocumentListener(new CredentialFileChangeListener());
+
+        credentialsTable = new CredentialsTable();
+
+        ToolbarDecorator decorator = ToolbarDecorator.createDecorator(credentialsTable);
+        decorator.disableUpDownActions();
+        decorator.setAddAction(this::createNewProfile);
+        decorator.setEditAction(button -> editProfile());
+
+        tablePanel.add(decorator.createPanel(), BorderLayout.CENTER);
+    }
+
+    private void createNewProfile(AnActionButton button) {
+        CredentialProfileFactory<? extends CredentialProfile>[] providerFactories = CredentialProfileFactory.credentialProviderTypes();
+        // No extensions are registered, go directly to the profile creation, else we will make a pop up menu to give a choice
+        if (providerFactories.length == 1) {
+            createNewProfile(providerFactories[0]);
+        } else {
+            createProfileTypePopup(button, providerFactories);
+        }
+    }
+
+    private void createProfileTypePopup(AnActionButton button, CredentialProfileFactory<? extends CredentialProfile>[] providerFactories) {
+        BaseListPopupStep<CredentialProfileFactory<? extends CredentialProfile>> step =
+            new BaseListPopupStep<CredentialProfileFactory<? extends CredentialProfile>>(null, providerFactories) {
+                @NotNull
+                @Override
+                public String getTextFor(CredentialProfileFactory<? extends CredentialProfile> value) {
+                    return value.getDescription();
+                }
+
+                @Override
+                public PopupStep onChosen(CredentialProfileFactory<? extends CredentialProfile> selectedValue, boolean finalChoice) {
+                    return doFinalStep(() -> createNewProfile(selectedValue));
+                }
+            };
+
+        JBPopupFactory.getInstance().createListPopup(step).show(button.getPreferredPopupPoint());
+    }
+
+    private <T extends CredentialProfile> void createNewProfile(CredentialProfileFactory<T> providerFactory) {
+        String title = "Create New " + providerFactory.getDescription().toLowerCase();
+        CredentialProfile newProfile = createEditor(title, providerFactory.configurationComponent(), null);
+        if (newProfile != null) {
+            credentialsTable.getModel().addRow(newProfile);
+        }
+    }
+
+    private void editProfile() {
+        CredentialProfile profileToEdit = credentialsTable.getSelectedObject();
+        if(profileToEdit == null) {
+            return;
+        }
+
+        CredentialProfileFactory factory = CredentialProfileFactory.factoryFor(profileToEdit.getId());
+
+        if(factory == null) {
+            throw new IllegalStateException("The factory for " + profileToEdit.getId() + " is missing");
+        }
+
+        String title = "Edit " + factory.getDescription();
+        CredentialProfile editedProfile = createEditor(title, factory.configurationComponent(profileToEdit), profileToEdit);
+        if (editedProfile != null) {
+            List<CredentialProfile> items = credentialsTable.getModel().getItems();
+            List<CredentialProfile> updatedList = items.stream().filter(p -> p != profileToEdit).collect(Collectors.toList());
+            updatedList.add(editedProfile);
+
+            credentialsTable.getModel().setItems(updatedList);
+        }
+    }
+
+    private CredentialProfile createEditor(String title, ProfileEditor<?> profileEditor, CredentialProfile sourceProfile) {
+        CredentialsDialog dialogBuilder = new CredentialsDialog(profileEditor, credentialsPanel);
+        dialogBuilder.setTitle(title);
+        dialogBuilder.setValidator(credentialsDialog -> {
+            // Validate the profile name
+            ProfileNameEditor nameEditor = profileEditor.getProfileNameEditor();
+            String newName = nameEditor.getValue();
+            if (StringUtil.isEmpty(newName)) {
+                return new ValidationInfo("Profile name is required", nameEditor.getInput());
+            }
+
+            List<CredentialProfile> profiles = credentialsTable.getModel().getItems();
+            Optional<CredentialProfile> nameMatch = profiles.stream()
+                                                            .filter(p -> newName.equals(p.getName()))
+                                                            .findFirst();
+
+            // If this is an edit, see if we are editing the match'ed profile
+            if (nameMatch.isPresent()) {
+                if (nameMatch.get() != sourceProfile) {
+                    return new ValidationInfo("A profile with that name already exists", nameEditor.getInput());
+                }
+            }
+
+            return null;
+        });
+
+        boolean isOkay = dialogBuilder.showAndGet();
+        if (isOkay) {
+            return profileEditor.commit();
+        }
+
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        return credentialsPanel;
+    }
+
+    @Override
+    public boolean isModified() {
+        return !Objects.equals(optionsProvider.getCredentialFileLocation(), currentCredentialFileLocation)
+            || !optionsProvider.getProfiles().equals(credentialsTable.getModel().getItems());
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        optionsProvider.setCredentialFileLocation(currentCredentialFileLocation);
+        optionsProvider.setProfiles(credentialsTable.getModel().getItems());
+    }
+
+    @Override
+    public void reset() {
+        currentCredentialFileLocation = optionsProvider.getCredentialFileLocation();
+        credentialFileChooser.setText(currentCredentialFileLocation);
+        credentialsTable.getModel().setItems(optionsProvider.getProfiles());
+    }
+
+    @Nls
+    @Override
+    public String getDisplayName() {
+        return "AWS";
+    }
+
+    private class CredentialFileChangeListener extends DocumentAdapter {
+        @Override
+        protected void textChanged(DocumentEvent event) {
+            String newCredentialFileLocation = credentialFileChooser.getText();
+            if (Objects.equals(currentCredentialFileLocation, newCredentialFileLocation)) {
+                return;
+            }
+
+            // Keep all the non-credential file profiles
+            List<CredentialProfile> currentProfiles = credentialsTable.getItems();
+            List<CredentialProfile> newProfiles = currentProfiles.stream()
+                                                                 .filter(this::isCredentialFileBased)
+                                                                 .collect(Collectors.toList());
+
+            if (StringUtil.isNotEmpty(newCredentialFileLocation)) {
+                File credentialFile = new File(newCredentialFileLocation);
+                newProfiles.addAll(loadNewProfiles(credentialFile));
+            }
+            currentProfiles = newProfiles;
+            credentialsTable.getModel().setItems(currentProfiles);
+            currentCredentialFileLocation = newCredentialFileLocation;
+        }
+
+        private Collection<CredentialProfile> loadNewProfiles(File credentialFile) {
+            if (!credentialFile.exists()) {
+                errorLabel.setIcon(AllIcons.General.Warning);
+                errorLabel.setText("Specified credential file does not exist, will be created");
+                errorLabel.setVisible(true);
+                return Collections.emptyList();
+            }
+
+            try {
+                Map<String, CredentialProfile> loadedProfiles = AWSCredentialsProfileProvider
+                    .loadFromCredentialProfile(credentialFile);
+
+                errorLabel.setVisible(false);
+                return loadedProfiles.values();
+            } catch (RuntimeException e) {
+                errorLabel.setIcon(AllIcons.General.Error);
+                errorLabel.setText("Specified credential file invalid");
+                errorLabel.setVisible(true);
+                return Collections.emptyList();
+            }
+        }
+
+        private boolean isCredentialFileBased(CredentialProfile profile) {
+            return !(profile instanceof CredentialFileBasedProfile);
+        }
+    }
+}

--- a/src/main/kotlin/com/amazonaws/intellij/credentials/AWSCredentialsProfileProvider.kt
+++ b/src/main/kotlin/com/amazonaws/intellij/credentials/AWSCredentialsProfileProvider.kt
@@ -1,0 +1,154 @@
+package com.amazonaws.intellij.credentials
+
+import com.amazonaws.auth.profile.ProfilesConfigFile
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.util.get
+import com.intellij.util.xmlb.Accessor
+import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters
+import com.intellij.util.xmlb.XmlSerializer
+import org.jdom.Element
+import org.jetbrains.annotations.TestOnly
+import org.jetbrains.jps.model.serialization.PathMacroUtil
+import java.io.File
+import java.nio.file.Paths
+
+@State(name = "credentialProfiles", storages = arrayOf(Storage("aws.xml")))
+class AWSCredentialsProfileProvider(private val project: Project) : PersistentStateComponent<Element> {
+    private data class State(
+            var credentialFileLocation: String? = defaultCredentialLocation(),
+            var selectedProfileName: String? = null
+    )
+
+    private val state = State()
+    private val credentialProfiles = mutableMapOf<String, CredentialProfile>()
+
+    var credentialFileLocation: String?
+        get() = state.credentialFileLocation
+        set(value) { state.credentialFileLocation = value }
+
+    var selectedProfile: CredentialProfile?
+        get() = credentialProfiles[state.selectedProfileName]
+        set(value) { state.selectedProfileName = value?.name }
+
+    init {
+        reloadCredentialFile()
+    }
+
+    fun addProfile(profile: CredentialProfile) {
+        credentialProfiles.put(profile.name, profile)
+    }
+
+    fun setProfiles(profiles: List<CredentialProfile>) {
+        credentialProfiles.clear()
+        profiles.forEach { credentialProfiles.put(it.name, it) }
+
+        if(credentialProfiles[state.selectedProfileName] == null) {
+            state.selectedProfileName = null
+        }
+    }
+
+    fun getProfiles(): List<CredentialProfile> {
+        return credentialProfiles.values.toList()
+    }
+
+    fun reloadCredentialFile() {
+        credentialProfiles.values.removeIf { it is CredentialFileBasedProfile }
+
+        credentialProfiles.putAll(loadFromCredentialProfile(File(state.credentialFileLocation)))
+    }
+
+    override fun getState(): Element {
+        val serializedState = Element("state")
+        XmlSerializer.serializeInto(state, serializedState, object : SkipDefaultValuesSerializationFilters() {
+            override fun accepts(accessor: Accessor, bean: Any): Boolean {
+                return super.accepts(accessor, bean)
+            }
+        })
+
+        val serializedProfiles = Element("profiles")
+
+        credentialProfiles.values
+                .filterNot { it is CredentialFileBasedProfile }
+                .forEach {
+                    val profileState = Element("profile")
+                    it.save(project, profileState)
+                    // Set after so they can't blow it away
+                    profileState.setAttribute("id", it.id)
+                    profileState.setAttribute("name", it.name)
+                    serializedProfiles.addContent(profileState)
+                }
+
+        val credentialFileProfiles = credentialProfiles
+                .values
+                .filterIsInstance<CredentialFileBasedProfile>()
+                .map { it.profile }
+                .toTypedArray()
+
+        CredentialFileWriter.dumpToFile(File(credentialFileLocation), true, *credentialFileProfiles)
+
+        if (serializedProfiles.contentSize != 0) {
+            serializedState.addContent(serializedProfiles)
+        }
+        return serializedState
+    }
+
+    override fun loadState(serializedState: Element) {
+        XmlSerializer.deserializeInto(state, serializedState)
+
+        serializedState.get("profiles")?.getChildren("profile")?.forEach {
+            val id = it.getAttributeValue("id")
+            val name = it.getAttributeValue("name")
+
+            if (id != null && name != null) {
+                val factory = CredentialProfileFactory.factoryFor(id)
+                if (factory != null) {
+                    val credentialProfile = factory.createProvider()
+                    credentialProfile.load(project, it)
+                    credentialProfile.name = name
+                    addProfile(credentialProfile)
+                } else {
+                    LOG.warn("Failed to find CredentialProfileFactory for type $id")
+                }
+            }
+        }
+
+        reloadCredentialFile()
+    }
+
+    @TestOnly
+    fun reset() {
+        credentialProfiles.clear()
+    }
+
+    companion object {
+        val LOG = Logger.getInstance(AWSCredentialsProfileProvider::class.java)
+
+        //TODO: The SDK has its credential locators as internal and returns null instead of the File so if it is a brand new
+        // install we won't know where to put them.
+        private fun defaultCredentialLocation(): String {
+            return Paths.get(PathMacroUtil.getUserHomePath(), ".aws", "credentials").toString()
+        }
+
+        @JvmStatic
+        fun getInstance(project: Project): AWSCredentialsProfileProvider {
+            return ServiceManager.getService(project, AWSCredentialsProfileProvider::class.java)
+        }
+
+        @JvmStatic
+        fun loadFromCredentialProfile(fileLocation: File): MutableMap<String, CredentialProfile> {
+            if (!fileLocation.exists()) {
+                return mutableMapOf()
+            }
+
+            val profilesConfigFile = ProfilesConfigFile(fileLocation)
+            profilesConfigFile.refresh()
+
+            return profilesConfigFile.allBasicProfiles.mapValues { CredentialFileBasedProfile(it.value) }.toMutableMap()
+        }
+    }
+}

--- a/src/main/kotlin/com/amazonaws/intellij/credentials/CredentialFileBasedProfile.kt
+++ b/src/main/kotlin/com/amazonaws/intellij/credentials/CredentialFileBasedProfile.kt
@@ -1,0 +1,41 @@
+package com.amazonaws.intellij.credentials
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.profile.internal.BasicProfile
+import com.amazonaws.intellij.ui.credentials.CredentialFileBasedProfileEditor
+
+data class CredentialFileBasedProfile(val profile: BasicProfile) : CredentialProfile() {
+    init {
+        name = profile.profileName
+    }
+
+    override val id = CredentialFileBasedProfileFactory.ID
+
+    // TODO: This requires re-parsing of the profile file...., https://github.com/aws/aws-sdk-java-v2/issues/70
+    override val awsCredentials: AWSCredentialsProvider
+        get() = ProfileCredentialsProvider(profile.profileName)
+}
+
+class CredentialFileBasedProfileFactory : CredentialProfileFactory<CredentialFileBasedProfile>() {
+    override fun getKey() = ID
+
+    override fun configurationComponent(): CredentialFileBasedProfileEditor {
+        return CredentialFileBasedProfileEditor()
+    }
+
+    override fun configurationComponent(source: CredentialProfile): CredentialFileBasedProfileEditor {
+        return CredentialFileBasedProfileEditor(source as CredentialFileBasedProfile)
+    }
+
+    override val description = DESCRIPTION
+
+    override fun createProvider(): CredentialFileBasedProfile {
+        throw UnsupportedOperationException("Should never happen")
+    }
+
+    companion object {
+        const val ID = "credentialFileProfile"
+        const val DESCRIPTION = "Credentials file based profile";
+    }
+}

--- a/src/main/kotlin/com/amazonaws/intellij/credentials/CredentialFileWriter.kt
+++ b/src/main/kotlin/com/amazonaws/intellij/credentials/CredentialFileWriter.kt
@@ -1,0 +1,371 @@
+package com.amazonaws.intellij.credentials
+
+import com.amazonaws.auth.profile.ProfilesConfigFile
+import com.amazonaws.auth.profile.internal.AbstractProfilesConfigFileScanner
+import com.amazonaws.auth.profile.internal.BasicProfile
+import com.amazonaws.auth.profile.internal.ProfileKeyConstants
+import com.amazonaws.util.StringUtils
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.debug
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.io.Writer
+import java.nio.charset.StandardCharsets
+import java.util.Collections
+import java.util.HashMap
+import java.util.HashSet
+import java.util.LinkedHashMap
+import java.util.Scanner
+import java.util.UUID
+
+/**
+ * The class for creating and modifying the credential profiles file.
+ *
+ * TODO: This should be handled by the SDK, https://github.com/aws/aws-sdk-java-v2/issues/31
+ */
+object CredentialFileWriter {
+    private val LOG = Logger.getInstance(CredentialFileWriter.javaClass)
+
+    /**
+     * Write all the credential profiles to a file. Note that this method will
+     * clobber the existing content in the destination file if it's in the
+     * overwrite mode. Use [modifyOrInsertProfiles]
+     * instead, if you want to perform in-place modification on your existing
+     * credentials file.
+     *
+     * @param destination The destination file where the credentials will be written to.
+     * @param overwrite If true, this method If false, this method will throw exception if the file already exists.
+     * @param profiles All the credential profiles to be written.
+     */
+    fun dumpToFile(destination: File, overwrite: Boolean, vararg profiles: BasicProfile) {
+        if (destination.exists() && !overwrite) {
+            throw IllegalStateException(
+                    "The destination file already exists. Set overwrite=true if you want to clobber the existing " +
+                            "content and completely re-write the file.")
+        }
+
+        OutputStreamWriter(FileOutputStream(destination, false), StandardCharsets.UTF_8).use { writer ->
+            val modifications = LinkedHashMap<String, BasicProfile>()
+            for (profile in profiles) {
+                modifications.put(profile.profileName, profile)
+            }
+            ProfilesConfigFileWriterHelper(writer, modifications).writeWithoutExistingContent()
+        }
+    }
+
+    /**
+     * Modify or insert new profiles into an existing credentials file by
+     * in-place modification. Only the properties of the affected profiles will
+     * be modified; all the unaffected profiles and comment lines will remain
+     * the same. This method does not support renaming a profile.
+
+     * @param destination The destination file to modify
+     * @param profiles All the credential profiles to be written.
+     */
+    fun modifyOrInsertProfiles(destination: File, vararg profiles: BasicProfile) {
+        val modifications = LinkedHashMap<String, BasicProfile>()
+        for (profile in profiles) {
+            modifications.put(profile.profileName, profile)
+        }
+
+        modifyProfiles(destination, modifications)
+    }
+
+    /**
+     * Modify one profile in the existing credentials file by in-place
+     * modification. This method will rename the existing profile if the
+     * specified Profile has a different name.
+
+     * @param destination The destination file to modify
+     * @param profileName The name of the existing profile to be modified
+     * @param newProfile The new Profile object.
+     */
+    fun modifyOneProfile(destination: File, profileName: String, newProfile: BasicProfile) {
+        val modifications = Collections.singletonMap(profileName, newProfile)
+
+        modifyProfiles(destination, modifications)
+    }
+
+    /**
+     * Remove one or more profiles from the existing credentials file by
+     * in-place modification.
+
+     * @param destination The destination file to modify
+     * @param profileNames The names of all the profiles to be deleted.
+     */
+    fun deleteProfiles(destination: File, vararg profileNames: String) {
+        modifyProfiles(destination, profileNames.associateBy({ it }, { null }))
+    }
+
+    /**
+     * A method that supports all kinds of profile modification,
+     * including renaming or deleting one or more profiles.
+     *
+     * @param modifications Use null value to indicate a profile that is to be deleted.
+     */
+    fun modifyProfiles(destination: File, modifications: Map<String, BasicProfile?>) {
+        val inPlaceModify = destination.exists()
+
+        // We can't use File.createTempFile, since it will always create that file no matter what, and File.renameTo
+        // does not allow the destination to be an existing file
+        val stashLocation = File(destination.parentFile, destination.name + ".bak." + UUID.randomUUID().toString())
+
+        // Stash the original file, before we apply the changes
+        if (inPlaceModify) {
+            val stashed = destination.renameTo(stashLocation)
+            if (!stashed) {
+                throw IllegalStateException("Failed to stash the existing credentials file before applying the changes.")
+            } else {
+                if (LOG.isDebugEnabled) {
+                    LOG.debug(String.format("The original credentials file is stashed to location (%s).", stashLocation.absolutePath))
+                }
+            }
+        }
+
+        try {
+            OutputStreamWriter(FileOutputStream(destination), StringUtils.UTF8).use { writer ->
+                val writerHelper = ProfilesConfigFileWriterHelper(writer, modifications)
+
+                if (inPlaceModify) {
+                    val existingContent = Scanner(stashLocation, StandardCharsets.UTF_8.name())
+                    writerHelper.writeWithExistingContent(existingContent)
+                } else {
+                    writerHelper.writeWithoutExistingContent()
+                }
+
+                // Make sure the output is valid and can be loaded by the loader
+                ProfilesConfigFile(destination)
+
+                if (inPlaceModify && !stashLocation.delete()) {
+                    LOG.debug {
+                        "Successfully modified the credentials file. But failed to delete the stashed copy of the " +
+                                "original file (${stashLocation.absolutePath})."
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            // Restore the stashed file
+            if (inPlaceModify) {
+                // We don't really care about what destination.delete() returns, since the file might not have been
+                // created when the error occurred.
+                if (!destination.delete()) {
+                    LOG.debug { "Unable to remove the credentials file before restoring the original one." }
+                }
+
+                if (!stashLocation.renameTo(destination)) {
+                    throw IllegalStateException("Unable to restore the original credentials file. File content " +
+                            "stashed in ${stashLocation.absolutePath}")
+                }
+            }
+
+            throw IllegalStateException("Unable to modify the credentials file. (The original file has been restored.)",
+                    e)
+        }
+    }
+
+    /**
+     * Implementation of AbstractProfilesConfigFileScanner, which reads the
+     * content from an existing credentials file (if any) and then modifies some
+     * of the profile properties in place.
+     *
+     * @constructor Creates ProfilesConfigFileWriterHelper with the specified new profiles.
+     * @param writer The writer where the modified content is output to.
+     * @param modifications A map of all the new profiles, keyed by the profile name.
+     * If a profile name is associated with a null value, it's profile content will be removed.
+     */
+    private class ProfilesConfigFileWriterHelper(private val writer: Writer, modifications: Map<String, BasicProfile?>)
+        : AbstractProfilesConfigFileScanner() {
+
+        /** Map of all the profiles to be modified, keyed by profile names  */
+        private val newProfiles = LinkedHashMap<String, BasicProfile>()
+
+        /** Map of the names of all the profiles to be deleted  */
+        private val deletedProfiles = HashSet<String>()
+
+        private val buffer = StringBuilder()
+        private val existingProfileProperties = HashMap<String, MutableSet<String>>()
+
+        init {
+            for ((profileName, profile) in modifications) {
+                if (profile == null) {
+                    deletedProfiles.add(profileName)
+                } else {
+                    newProfiles.put(profileName, profile)
+                }
+            }
+        }
+
+        /**
+         * Append the new profiles to the writer, by reading from empty content.
+         */
+        fun writeWithoutExistingContent() {
+            buffer.setLength(0)
+            existingProfileProperties.clear()
+
+            // Use empty String as input, since we are bootstrapping a new file.
+            run(Scanner(""))
+        }
+
+        /**
+         * Read the existing content of a credentials file, and then make
+         * in-place modification according to the new profiles specified in this
+         * class.
+         */
+        fun writeWithExistingContent(existingContent: Scanner) {
+            buffer.setLength(0)
+            existingProfileProperties.clear()
+
+            run(existingContent)
+        }
+
+        override fun onEmptyOrCommentLine(profileName: String?, line: String) {
+            /*
+             * Buffer the line until we reach the next property line or the end
+             * of the profile. We do this so that new properties could be
+             * inserted at more appropriate location. For example:
+             *
+             * [default]
+             * # access key
+             * aws_access_key_id=aaa
+             * # secret key
+             * aws_secret_access_key=sss
+             * # We want new properties to be inserted before this line
+             * # instead of after the following empty line
+             *
+             * [next profile]
+             * ...
+             */
+            if (profileName == null || !deletedProfiles.contains(profileName)) {
+                buffer(line)
+            }
+        }
+
+        override fun onProfileStartingLine(profileName: String, line: String) {
+            var profileNameLine = line
+            existingProfileProperties.put(profileName, HashSet<String>())
+
+            // Copy the line after flush the buffer
+            flush()
+
+            if (deletedProfiles.contains(profileName)) {
+                return
+            }
+
+            // If the profile name is changed
+            newProfiles[profileName]?.let {
+                val newProfileName = it.profileName
+                if (newProfileName != profileName) {
+                    profileNameLine = "[$newProfileName]"
+                }
+            }
+
+            writeLine(profileNameLine)
+        }
+
+        override fun onProfileEndingLine(prevProfileName: String) {
+            // Check whether we need to insert new properties into this profile
+            val modifiedProfile = newProfiles[prevProfileName]
+            if (modifiedProfile != null) {
+                for ((propertyKey, propertyValue) in modifiedProfile.properties) {
+                    if (!existingProfileProperties[prevProfileName]!!.contains(propertyKey)) {
+                        writeProperty(propertyKey, propertyValue)
+                    }
+                }
+            }
+
+            // flush all the buffered comments and empty lines
+            flush()
+        }
+
+        override fun onProfileProperty(profileName: String,
+                                       propertyKey: String, propertyValue: String,
+                                       isSupportedProperty: Boolean, line: String) {
+            // Record that this property key has been declared for this profile
+            existingProfileProperties.putIfAbsent(profileName, HashSet<String>())
+            existingProfileProperties[profileName]!!.add(propertyKey)
+
+            if (deletedProfiles.contains(profileName)) {
+                return
+            }
+
+            // Keep the unsupported properties
+            if (!isSupportedProperty) {
+                writeLine(line)
+                return
+            }
+
+            // flush all the buffered comments and empty lines before this property line
+            flush()
+
+            // Modify the property value
+            if (newProfiles.containsKey(profileName)) {
+                val newValue = newProfiles[profileName]!!.getPropertyValue(propertyKey)
+                if (newValue != null) {
+                    writeProperty(propertyKey, newValue)
+                }
+                // else remove that line
+            } else {
+                writeLine(line)
+            }
+        }
+
+        override fun onEndOfFile() {
+            // Append profiles that don't exist in the original file
+            for ((profileName, profile) in newProfiles) {
+                if (!existingProfileProperties.containsKey(profileName)) {
+                    // The profile name is not found in the file
+                    // Append the profile properties
+                    writeProfile(profile)
+                    writeLine("")
+                }
+            }
+
+            // Flush the "real" writer
+            writer.flush()
+        }
+
+        override fun isSupportedProperty(propertyName: String): Boolean {
+            return ProfileKeyConstants.AWS_ACCESS_KEY_ID == propertyName ||
+                    ProfileKeyConstants.AWS_SECRET_ACCESS_KEY == propertyName ||
+                    ProfileKeyConstants.AWS_SESSION_TOKEN == propertyName ||
+                    ProfileKeyConstants.EXTERNAL_ID == propertyName ||
+                    ProfileKeyConstants.ROLE_ARN == propertyName ||
+                    ProfileKeyConstants.ROLE_SESSION_NAME == propertyName ||
+                    ProfileKeyConstants.SOURCE_PROFILE == propertyName ||
+                    ProfileKeyConstants.REGION == propertyName
+        }
+
+        private fun writeProfile(profile: BasicProfile) {
+            writeProfileName(profile.profileName)
+            profile.properties.forEach(this::writeProperty)
+        }
+
+        private fun writeProfileName(profileName: String) {
+            writeLine(String.format("[%s]", profileName))
+        }
+
+        private fun writeProperty(propertyKey: String, propertyValue: String) {
+            writeLine(String.format("%s=%s", propertyKey, propertyValue))
+        }
+
+        private fun writeLine(line: String) {
+            append(String.format("%s%n", line))
+        }
+
+        private fun append(str: String) {
+            writer.append(str)
+        }
+
+        private fun flush() {
+            if (buffer.isNotEmpty()) {
+                append(buffer.toString())
+                buffer.setLength(0)
+            }
+        }
+
+        private fun buffer(line: String) {
+            buffer.append(String.format("%s%n", line))
+        }
+    }
+}

--- a/src/main/kotlin/com/amazonaws/intellij/credentials/CredentialProfile.kt
+++ b/src/main/kotlin/com/amazonaws/intellij/credentials/CredentialProfile.kt
@@ -1,0 +1,94 @@
+package com.amazonaws.intellij.credentials
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.intellij.ui.credentials.ProfileNameEditor
+import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.openapi.util.KeyedExtensionCollector
+import com.intellij.util.KeyedLazyInstance
+import org.jdom.Element
+import javax.swing.JComponent
+
+/**
+ * Component responsible for holding the current settings, constructing the UI for modifying the settings,
+ * and creating the actual AWSCredentialsProvider for the SDK.
+ */
+abstract class CredentialProfile {
+    /**
+     * Construct the AWS Credential Provider from the stored settings
+     */
+    abstract val awsCredentials: AWSCredentialsProvider
+
+    /**
+     * Name of the profile assigned by the user
+     */
+    lateinit var name: String
+
+    /**
+     * Internal ID used to identify the of credential profile factory, must match [CredentialProfileFactory.getKey]
+     */
+    abstract val id: String
+
+    /**
+     * Called by the [AWSCredentialsProfileProvider] to save the credential metadata, secret data should NOT be
+     * written to any part of the passed in Element.
+     */
+    open fun save(project: Project, element: Element){}
+
+    /**
+     * Called by the AWSCredentialsProfileProvider when it is loading its settings from disk
+     */
+    open fun load(project: Project, element: Element): Unit {}
+
+    override fun toString(): String {
+        return "${javaClass.simpleName}($name)"
+    }
+}
+
+abstract class ProfileEditor<out T : CredentialProfile>(name: String = "") {
+    val profileNameEditor = ProfileNameEditor(name)
+
+    abstract val editorComponent: JComponent
+
+    fun validateEditor(): ValidationInfo? {
+        return null;
+    }
+
+    abstract fun commit(): T
+}
+
+/**
+ * Factory to create a new CredentialProfile whenever we need to construct a blank one. This is the factory that
+ * should be implemented and registered when a plugin wishes to add a new credential provider option.
+ */
+abstract class CredentialProfileFactory<T : CredentialProfile> :  KeyedLazyInstance<CredentialProfileFactory<T>>{
+    abstract override fun getKey(): String
+
+    override fun getInstance(): CredentialProfileFactory<T> {
+        return this
+    }
+
+    abstract fun createProvider(): T
+
+    abstract val description: String
+
+    abstract fun configurationComponent(): ProfileEditor<T>
+
+    abstract fun configurationComponent(source: CredentialProfile): ProfileEditor<T>
+
+    companion object {
+        val EP_NAME = ExtensionPointName.create<CredentialProfileFactory<out CredentialProfile>>("com.amazonaws.intellij.credentialProviderFactory")
+        private val COLLECTOR = KeyedExtensionCollector<CredentialProfileFactory<out CredentialProfile>, String>(EP_NAME.name)
+
+        @JvmStatic
+        fun credentialProviderTypes(): Array<CredentialProfileFactory<out CredentialProfile>> {
+            return EP_NAME.extensions
+        }
+
+        @JvmStatic
+        fun factoryFor(id: String): CredentialProfileFactory<out CredentialProfile>? {
+            return COLLECTOR.findSingle(id);
+        }
+    }
+}

--- a/src/main/kotlin/com/amazonaws/intellij/ui/credentials/CredentialsDialog.kt
+++ b/src/main/kotlin/com/amazonaws/intellij/ui/credentials/CredentialsDialog.kt
@@ -1,0 +1,42 @@
+package com.amazonaws.intellij.ui.credentials
+
+import com.amazonaws.intellij.credentials.ProfileEditor
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.IdeBorderFactory
+import java.awt.Component
+import java.util.function.Function
+import javax.swing.Action
+import javax.swing.JComponent
+
+class CredentialsDialog(private val profileEditor: ProfileEditor<*>, parentComponent: Component)
+    : DialogWrapper(parentComponent, false) {
+    lateinit var validator: Function<CredentialsDialog, ValidationInfo?>
+
+    init {
+        setResizable(false);
+    }
+
+    override fun createNorthPanel(): JComponent? {
+        return profileEditor.profileNameEditor.panel
+    }
+
+    override fun createCenterPanel(): JComponent? {
+        val component = profileEditor.editorComponent
+        component.border = IdeBorderFactory.createTitledBorder("Profile Options", true)
+        return component
+    }
+
+    override fun doValidate(): ValidationInfo? {
+        return validator.apply(this) ?: profileEditor.validateEditor()
+    }
+
+    override fun createActions(): Array<Action> {
+        return arrayOf(okAction, cancelAction)
+    }
+
+    override fun show() {
+        init();
+        super.show()
+    }
+}

--- a/src/main/kotlin/com/amazonaws/intellij/ui/credentials/CredentialsTable.kt
+++ b/src/main/kotlin/com/amazonaws/intellij/ui/credentials/CredentialsTable.kt
@@ -1,0 +1,64 @@
+package com.amazonaws.intellij.ui.credentials
+
+import com.amazonaws.intellij.credentials.CredentialProfile
+import com.amazonaws.intellij.credentials.CredentialProfileFactory
+import com.intellij.ui.table.TableView
+import com.intellij.util.ui.ColumnInfo
+import com.intellij.util.ui.ListTableModel
+import java.util.function.Function
+import javax.swing.JTable
+import javax.swing.RowSorter
+import javax.swing.SortOrder
+import javax.swing.table.TableRowSorter
+
+class CredentialsTable : TableView<CredentialProfile>(createModel()) {
+    init {
+        autoResizeMode = (JTable.AUTO_RESIZE_LAST_COLUMN)
+        isStriped = true
+        emptyText.text = "No credentials configured"
+        model.isSortable = true
+        tableHeader.reorderingAllowed = false
+
+
+        val sorter = TableRowSorter<ListTableModel<CredentialProfile>>(model)
+        sorter.setSortable(0, true)
+        sorter.setSortable(1, true)
+        sorter.sortsOnUpdates = true
+        sorter.sortKeys = listOf(RowSorter.SortKey(0, SortOrder.ASCENDING))
+
+        rowSorter = sorter
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getModel(): ListTableModel<CredentialProfile> {
+        return super.getModel() as ListTableModel<CredentialProfile>
+    }
+
+    private companion object {
+        private fun createModel(): ListTableModel<CredentialProfile> {
+            val listTableModel = ListTableModel<CredentialProfile>(*createColumnInfo())
+            listTableModel.isSortable = true
+
+            return listTableModel;
+        }
+
+        private fun createColumnInfo(): Array<ColumnInfo<CredentialProfile, String>> {
+            val columnInfo = arrayOf<ColumnInfo<CredentialProfile, String>>(
+                    CredentialProfileColumn("Profile Name", Function { it.name }),
+                    CredentialProfileColumn("Type", Function {
+                        CredentialProfileFactory.factoryFor(it.id)!!.description
+                    })
+            )
+
+            return columnInfo
+        }
+    }
+
+    private class CredentialProfileColumn constructor(columnName: String,
+                                                      private val valueExtractor: Function<CredentialProfile, String>)
+        : ColumnInfo<CredentialProfile, String>(columnName) {
+        override fun valueOf(credentialProfile: CredentialProfile): String? {
+            return valueExtractor.apply(credentialProfile)
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,13 +22,29 @@
   <depends>com.intellij.modules.lang</depends>
   -->
 
+  <extensionPoints>
+    <extensionPoint qualifiedName="com.amazonaws.intellij.credentialProviderFactory"
+                    interface="com.amazonaws.intellij.credentials.CredentialProfileFactory"/>
+  </extensionPoints>
+
   <extensions defaultExtensionNs="com.intellij">
-    <toolWindow id="AWS Explorer" anchor="bottom" factoryClass="com.amazonaws.intellij.ui.explorer.AwsExplorerToolWindow" icon="/icons/aws-box.gif"/>
+    <!-- Credential Management -->
+    <projectConfigurable displayName="AWS" id="aws"
+                         instance="com.amazonaws.intellij.ui.options.AWSCredentialsConfigurable"/>
+    <projectService serviceImplementation="com.amazonaws.intellij.credentials.AWSCredentialsProfileProvider"/>
+
+    <toolWindow id="AWS Explorer" anchor="bottom"
+                factoryClass="com.amazonaws.intellij.ui.explorer.AwsExplorerToolWindow" icon="/icons/aws-box.gif"/>
+  </extensions>
+
+  <extensions defaultExtensionNs="com.amazonaws.intellij">
+    <credentialProviderFactory implementation="com.amazonaws.intellij.credentials.CredentialFileBasedProfileFactory"/>
   </extensions>
 
   <actions>
     <group id="AWS.Toolkit.ActionGroup" icon="/icons/aws-box.gif" text="AWS" popup="true">
-      <action id="AWS.Toolkit.UploadLambdaFunction" class="com.amazonaws.intellij.actions.UploadLambdaFunction" text="Upload to AWS _Lambda..." icon="/icons/lambda-service.png"/>
+      <action id="AWS.Toolkit.UploadLambdaFunction" class="com.amazonaws.intellij.actions.UploadLambdaFunction"
+              text="Upload to AWS _Lambda..." icon="/icons/lambda-service.png"/>
       <add-to-group group-id="EditorPopupMenu" anchor="last"/>
     </group>
   </actions>

--- a/src/test/kotlin/com/amazonaws/intellij/credentials/AWSCredentialsProfileProviderTest.kt
+++ b/src/test/kotlin/com/amazonaws/intellij/credentials/AWSCredentialsProfileProviderTest.kt
@@ -1,0 +1,279 @@
+package com.amazonaws.intellij.credentials
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.profile.ProfilesConfigFile
+import com.amazonaws.auth.profile.internal.BasicProfile
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.ProjectRule
+import com.intellij.util.attribute
+import com.intellij.util.get
+import org.assertj.core.api.Assertions.assertThat
+import org.jdom.Element
+import org.jdom.input.SAXBuilder
+import org.jdom.output.XMLOutputter
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.StringReader
+
+internal class AWSCredentialsProfileProviderTest {
+    @Rule
+    @JvmField
+    val projectRule = ProjectRule()
+
+    @Rule
+    @JvmField
+    val temporaryDirectory = TemporaryFolder()
+
+    val testProfile = BasicProfile("TestProfile", emptyMap())
+
+    private lateinit var credentialProvider: AWSCredentialsProfileProvider
+    private lateinit var project: Project
+    private lateinit var credentialFile: File
+
+    @Before
+    fun setUp() {
+        credentialFile = createCredentialsFile()
+
+        project = projectRule.project
+
+        credentialProvider = AWSCredentialsProfileProvider.getInstance(project)
+        credentialProvider.reset()
+        credentialProvider.credentialFileLocation = credentialFile.absolutePath
+    }
+
+    @Test
+    fun testCredentialFileLoading() {
+        CredentialFileWriter.dumpToFile(credentialFile, true, testProfile)
+        credentialProvider.reloadCredentialFile()
+
+        assertThat(credentialProvider.getProfiles())
+                .hasSize(1)
+                .element(0)
+                .hasFieldOrPropertyWithValue("name", testProfile.profileName)
+    }
+
+    @Test
+    fun testSaving() {
+        val expectedState = """
+                            <state>
+                                <option name="credentialFileLocation" value="${credentialFile.absolutePath}" />
+                                <option name="selectedProfileName" value="${testProfile.profileName}" />
+                            </state>
+                            """.trimMargin()
+
+        CredentialFileWriter.dumpToFile(credentialFile, true, testProfile)
+        credentialProvider.selectedProfile = CredentialFileBasedProfile(testProfile)
+
+        assertThat(toXml(credentialProvider.state)).isEqualToIgnoringWhitespace(expectedState)
+    }
+
+    @Test
+    fun testAddingCredentialProfile() {
+        assertThat(ProfilesConfigFile(credentialFile).allBasicProfiles).isEmpty()
+
+        credentialProvider.setProfiles(listOf(CredentialFileBasedProfile(testProfile)))
+        assertThat(credentialProvider.getProfiles()).hasSize(1)
+
+        // Triggers the save
+        credentialProvider.state
+
+        assertThat(ProfilesConfigFile(credentialFile).allBasicProfiles).hasSize(1)
+    }
+
+    @Test
+    fun testDeletingCredentialProfile() {
+        CredentialFileWriter.dumpToFile(credentialFile, true, testProfile)
+        credentialProvider.reloadCredentialFile()
+
+        credentialProvider.selectedProfile = CredentialFileBasedProfile(testProfile)
+
+        assertThat(credentialProvider.getProfiles()).hasSize(1)
+
+        credentialProvider.setProfiles(emptyList())
+
+        val expectedState = """
+                            <state>
+                                <option name="credentialFileLocation" value="${credentialFile.absolutePath}" />
+                            </state>
+                            """.trimMargin()
+        // deleting the selected profile should also reset the selected profile
+        assertThat(credentialProvider.selectedProfile).isNull()
+        assertThat(toXml(credentialProvider.state)).isEqualToIgnoringWhitespace(expectedState)
+
+        assertThat(ProfilesConfigFile(credentialFile).allBasicProfiles).isEmpty()
+    }
+
+    @Test
+    fun testLoading() {
+        CredentialFileWriter.dumpToFile(credentialFile, true, testProfile)
+        val serializedState = """
+                              <state>
+                                  <option name="credentialFileLocation" value="${credentialFile.absolutePath}" />
+                                  <option name="selectedProfileName" value="${testProfile.profileName}" />
+                              </state>
+                              """.trimMargin()
+
+        credentialProvider.loadState(fromXml(serializedState))
+
+        assertThat(credentialProvider).satisfies {
+            assertThat(it.credentialFileLocation).isEqualTo(credentialFile.absolutePath)
+            assertThat(it.getProfiles()).hasSize(1)
+            assertThat(it.selectedProfile).isNotNull()
+        }
+    }
+
+    @Test
+    fun testLoadingAProfileThatIsMissing() {
+        val serializedState = """
+                              <state>
+                                  <option name="credentialFileLocation" value="${credentialFile.absolutePath}" />
+                                  <option name="selectedProfileName" value="DoesNotExist" />
+                              </state>
+                              """.trimMargin()
+
+        credentialProvider.loadState(fromXml(serializedState))
+
+        assertThat(credentialProvider).satisfies {
+            assertThat(it.credentialFileLocation).isEqualTo(credentialFile.absolutePath)
+            assertThat(it.getProfiles()).isEmpty()
+            assertThat(it.selectedProfile).isNull()
+        }
+    }
+
+    @Test
+    fun testSaveCustomProfile() {
+        val testExtensionFactory = TestExtensionFactory()
+        PlatformTestUtil.registerExtension(CredentialProfileFactory.EP_NAME, testExtensionFactory, project)
+
+        val testExtensionProfile = testExtensionFactory.createProvider()
+        testExtensionProfile.someField = "Hello"
+        testExtensionProfile.name = "TestExtensionProfile"
+
+        credentialProvider.addProfile(testExtensionProfile)
+        credentialProvider.selectedProfile = testExtensionProfile
+
+        val expectedState = """
+                              <state>
+                                  <option name="credentialFileLocation" value="${credentialFile.absolutePath}" />
+                                  <option name="selectedProfileName" value="TestExtensionProfile" />
+                                  <profiles>
+                                      <profile id="TestExtension" name="TestExtensionProfile">
+                                          <property someField="Hello" />
+                                      </profile>
+                                  </profiles>
+                              </state>
+                              """.trimMargin()
+        assertThat(toXml(credentialProvider.state)).isEqualToIgnoringWhitespace(expectedState)
+    }
+
+    @Test
+    fun testLoadCustomProfile() {
+        val testExtensionFactory = TestExtensionFactory()
+        PlatformTestUtil.registerExtension(CredentialProfileFactory.EP_NAME, testExtensionFactory, project)
+
+        val serializedState = """
+                              <state>
+                                  <option name="credentialFileLocation" value="${credentialFile.absolutePath}" />
+                                  <option name="selectedProfileName" value="TestExtensionProfile" />
+                                  <profiles>
+                                      <profile id="TestExtension" name="TestExtensionProfile">
+                                          <property someField="Hello" />
+                                      </profile>
+                                  </profiles>
+                              </state>
+                              """.trimMargin()
+
+        credentialProvider.loadState(fromXml(serializedState))
+
+        assertThat(credentialProvider).satisfies {
+            assertThat(it.credentialFileLocation).isEqualTo(credentialFile.absolutePath)
+            assertThat(it.getProfiles())
+                    .hasSize(1)
+                    .element(0)
+                    .hasFieldOrPropertyWithValue("name", "TestExtensionProfile")
+                    .hasFieldOrPropertyWithValue("someField", "Hello")
+            assertThat(it.selectedProfile).isNotNull()
+        }
+    }
+
+    @Test
+    fun testLoadCustomProfileNoLongerExists() {
+        val serializedState = """
+                              <state>
+                                  <option name="credentialFileLocation" value="${credentialFile.absolutePath}" />
+                                  <option name="selectedProfileName" value="BadProfile" />
+                                  <profiles>
+                                      <profile id="DoesNotExist" name="BadProfile">
+                                          <property someField="Hello" />
+                                      </profile>
+                                  </profiles>
+                              </state>
+                              """.trimMargin()
+
+        credentialProvider.loadState(fromXml(serializedState))
+
+        assertThat(credentialProvider).satisfies {
+            assertThat(it.credentialFileLocation).isEqualTo(credentialFile.absolutePath)
+            assertThat(it.getProfiles()).isEmpty()
+            assertThat(it.selectedProfile).isNull()
+        }
+    }
+
+    private class TestExtensionProfile : CredentialProfile() {
+        var someField: String? = null
+
+        override val awsCredentials: AWSCredentialsProvider
+            get() = throw UnsupportedOperationException("Not implemented")
+
+        override val id = TestExtensionFactory.ID
+
+        override fun save(project: Project, element: Element) {
+            element.addContent(Element("property").attribute("someField", someField))
+        }
+
+        override fun load(project: Project, element: Element) {
+            someField = element.get("property")?.getAttributeValue("someField")
+        }
+    }
+
+    private class TestExtensionFactory : CredentialProfileFactory<TestExtensionProfile>() {
+        override fun getKey(): String {
+            return ID;
+        }
+
+        override fun createProvider(): TestExtensionProfile {
+            return TestExtensionProfile()
+        }
+
+        override val description: String
+            get() = ""
+
+        override fun configurationComponent(): ProfileEditor<TestExtensionProfile> {
+            throw UnsupportedOperationException("Not implemented")
+        }
+
+        override fun configurationComponent(source: CredentialProfile): ProfileEditor<TestExtensionProfile> {
+            throw UnsupportedOperationException("Not implemented")
+        }
+
+        companion object {
+            val ID = "TestExtension"
+        }
+    }
+
+    private fun toXml(element: Element): String {
+        return XMLOutputter().outputString(element)
+    }
+
+    private fun fromXml(xml: String): Element {
+        return SAXBuilder().build(StringReader(xml)).rootElement
+    }
+
+    private fun createCredentialsFile(): File {
+        return temporaryDirectory.newFile("credentials")
+    }
+}

--- a/src/test/kotlin/com/amazonaws/intellij/credentials/CredentialFileWriterTest.kt
+++ b/src/test/kotlin/com/amazonaws/intellij/credentials/CredentialFileWriterTest.kt
@@ -1,0 +1,309 @@
+package com.amazonaws.intellij.credentials
+
+import com.amazonaws.auth.profile.ProfilesConfigFile
+import com.amazonaws.auth.profile.internal.BasicProfile
+import com.amazonaws.auth.profile.internal.ProfileKeyConstants
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+internal class CredentialFileWriterTest {
+    @Rule
+    @JvmField
+    val temporaryDirectory = TemporaryFolder()
+
+    @Test
+    fun testDumpToFile() {
+        val credentialsFile = createCredentialsFile()
+
+        val profiles = arrayOf(
+                BasicProfile("a", basicCred1),
+                BasicProfile("b", basicCred2),
+                BasicProfile("c", sessionCred1),
+                BasicProfile("d", sessionCred2)
+        )
+        CredentialFileWriter.dumpToFile(credentialsFile, true, *profiles)
+        checkCredentialsFile(credentialsFile, *profiles)
+
+        // Rewrite the file with overwrite=true
+        val profile = arrayOf(BasicProfile("a", basicCred1))
+        CredentialFileWriter.dumpToFile(credentialsFile, true, *profile)
+        checkCredentialsFile(credentialsFile, *profile)
+
+        // Rewrite the file with overwrite=false is not allowed
+        assertThatThrownBy { CredentialFileWriter.dumpToFile(credentialsFile, false, BasicProfile("a", basicCred1)) }
+                .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun testModifyProfile() {
+        val credentialsFile = temporaryDirectory.newFile("credentials")
+
+        val profiles = arrayOf(
+                BasicProfile("a", basicCred1),
+                BasicProfile("b", basicCred2),
+                BasicProfile("c", sessionCred1),
+                BasicProfile("d", sessionCred2)
+        )
+        CredentialFileWriter.dumpToFile(credentialsFile, true, *profiles)
+
+        // a <==> c, b <==> d
+        val modified = arrayOf(
+                BasicProfile("a", sessionCred1),
+                BasicProfile("b", sessionCred2),
+                BasicProfile("c", basicCred1),
+                BasicProfile("d", basicCred2)
+        )
+        CredentialFileWriter.modifyOrInsertProfiles(credentialsFile, *modified)
+        checkCredentialsFile(credentialsFile, *modified)
+    }
+
+    @Test
+    fun testInsertProfile() {
+        val credentialsFile = temporaryDirectory.newFile("credentials")
+
+        val profiles = arrayOf(
+                BasicProfile("a", basicCred1),
+                BasicProfile("b", basicCred2),
+                BasicProfile("c", sessionCred1),
+                BasicProfile("d", sessionCred2)
+        )
+        CredentialFileWriter.dumpToFile(credentialsFile, true, *profiles)
+
+        // Insert [e] profile
+        val e = BasicProfile("e", basicCred1)
+        CredentialFileWriter.modifyOrInsertProfiles(credentialsFile, e)
+        checkCredentialsFile(credentialsFile, *profiles, e)
+    }
+
+    @Test
+    fun testModifyAndInsertProfile() {
+        val credentialsFile = temporaryDirectory.newFile("credentials")
+
+        val profiles = arrayOf(
+                BasicProfile("a", basicCred1),
+                BasicProfile("b", basicCred2),
+                BasicProfile("c", sessionCred1),
+                BasicProfile("d", sessionCred2)
+        )
+        CredentialFileWriter.dumpToFile(credentialsFile, true, *profiles)
+
+        // a <==> c, b <==> d, +e
+        val modified = arrayOf(
+                BasicProfile("a", sessionCred1),
+                BasicProfile("b", sessionCred2),
+                BasicProfile("c", basicCred1),
+                BasicProfile("d", basicCred2),
+                BasicProfile("e", basicCred1)
+        )
+        CredentialFileWriter.modifyOrInsertProfiles(credentialsFile, *modified)
+        checkCredentialsFile(credentialsFile, *modified)
+    }
+
+    /**
+     * Tests that comments and unsupported properties are preserved after
+     * profile modification.
+     */
+    @Test
+    fun testModifyAndInsertProfile_WithComments() {
+        val originalProfile = """
+                              # I love comments...
+
+                              # [a]
+                              [a]
+                              #aws_access_key_id=wrong-key
+                              aws_access_key_id=basicCred1access
+                              # More comments...
+                              aws_secret_access_key=basicCred1secret
+                              unsupported_property=foo
+
+                              # More comments...
+
+                              [b]
+                              # More comments...
+                              aws_access_key_id=basicCred2access
+                              aws_secret_access_key=basicCred2secret
+
+                              [c]
+                              aws_access_key_id=sessionCred1access
+                              # More comments...
+                              aws_secret_access_key=sessionCred1secret
+                              aws_session_token=sessionCred1session
+
+                              [d]
+                              aws_access_key_id=sessionCred2access
+                              aws_secret_access_key=sessionCred2secret
+                              # More comments...
+                              aws_session_token=sessionCred2session
+
+                              # More comments...
+                              """.trimIndent()
+
+        val credentialsFile = createCredentialsFile()
+        credentialsFile.writeText(originalProfile, StandardCharsets.UTF_8)
+
+        val expected = arrayOf(
+                BasicProfile("a", basicCred1.plus(Pair("unsupported_property", "foo"))),
+                BasicProfile("b", basicCred2),
+                BasicProfile("c", sessionCred1),
+                BasicProfile("d", sessionCred2)
+        )
+        checkCredentialsFile(credentialsFile, *expected)
+
+        // a <==> b, c <==> d, also renaming them to uppercase letters
+        val modified = arrayOf(
+                BasicProfile("A", basicCred2.plus(Pair("unsupported_property", "foo"))),
+                BasicProfile("B", basicCred1),
+                BasicProfile("C", sessionCred2),
+                BasicProfile("D", sessionCred1)
+        )
+
+        val updatedProfiles = mapOf(
+                Pair("a", modified[0]),
+                Pair("b", modified[1]),
+                Pair("c", modified[2]),
+                Pair("d", modified[3])
+        )
+
+        CredentialFileWriter.modifyProfiles(credentialsFile, updatedProfiles)
+        checkCredentialsFile(credentialsFile, *modified)
+
+        // Sanity check that the content is altered
+        val modifiedContent = credentialsFile.readText(StandardCharsets.UTF_8)
+        assertThat(modifiedContent).isNotEqualTo(originalProfile)
+
+        // Restore the properties
+        val restoredProfiles = mapOf(
+                Pair("A", expected[0]),
+                Pair("B", expected[1]),
+                Pair("C", expected[2]),
+                Pair("D", expected[3])
+        )
+        CredentialFileWriter.modifyProfiles(credentialsFile, restoredProfiles)
+        checkCredentialsFile(credentialsFile, *expected)
+
+        // Check that the content is now the same as the original
+        assertThat(credentialsFile).hasContent(originalProfile)
+    }
+
+    @Test
+    fun testRenameProfile() {
+        val credentialsFile = temporaryDirectory.newFile("credentials")
+
+        val profiles = arrayOf(
+                BasicProfile("a", basicCred1),
+                BasicProfile("b", basicCred2),
+                BasicProfile("c", sessionCred1),
+                BasicProfile("d", sessionCred2)
+        )
+        CredentialFileWriter.dumpToFile(credentialsFile, true, *profiles)
+
+        // Rename a to A
+        val modified = arrayOf(
+                BasicProfile("A", basicCred1),
+                BasicProfile("b", basicCred2),
+                BasicProfile("c", sessionCred1),
+                BasicProfile("d", sessionCred2)
+        )
+        CredentialFileWriter.modifyOneProfile(credentialsFile, "a", BasicProfile("A", basicCred1))
+        checkCredentialsFile(credentialsFile, *modified)
+    }
+
+    @Test
+    fun testDeleteProfile() {
+        val credentialsFile = temporaryDirectory.newFile("credentials")
+
+        val profiles = arrayOf(
+                BasicProfile("a", basicCred1),
+                BasicProfile("b", basicCred2),
+                BasicProfile("c", sessionCred1),
+                BasicProfile("d", sessionCred2)
+        )
+        CredentialFileWriter.dumpToFile(credentialsFile, true, *profiles)
+
+        // Delete a and c
+        val modified = arrayOf(
+                BasicProfile("b", basicCred2),
+                BasicProfile("d", sessionCred2)
+        )
+        CredentialFileWriter.deleteProfiles(credentialsFile, "a", "c")
+        checkCredentialsFile(credentialsFile, *modified)
+    }
+
+    /**
+     * Tests that the original credentials file is properly restored if the
+     * in-place modification fails with error.
+     */
+    @Test
+    fun testInPlaceModificationErrorHandling() {
+        val credentialsFile = temporaryDirectory.newFile("credentials")
+
+        val profiles = arrayOf(
+                BasicProfile("a", basicCred1),
+                BasicProfile("b", basicCred2),
+                BasicProfile("c", sessionCred1),
+                BasicProfile("d", sessionCred2)
+        )
+        CredentialFileWriter.dumpToFile(credentialsFile, true, *profiles)
+        val originalContent = credentialsFile.readText(StandardCharsets.UTF_8)
+
+        // Insert [e] profile, which throws RuntimeException when the getProperties method is called.
+        val e = object : BasicProfile("e", emptyMap()) {
+            override fun getProperties(): Map<String, String> {
+                throw RuntimeException("Some exception...")
+            }
+        }
+        assertThatThrownBy { CredentialFileWriter.modifyOrInsertProfiles(credentialsFile, e) }
+
+        // Check that the original file is restored
+        assertThat(credentialsFile).exists().hasContent(originalContent)
+    }
+
+    private fun createCredentialsFile(): File {
+        return temporaryDirectory.newFile("credentials")
+    }
+
+    companion object {
+        private val basicCred1 = mapOf(
+                Pair(ProfileKeyConstants.AWS_ACCESS_KEY_ID, "basicCred1access"),
+                Pair(ProfileKeyConstants.AWS_SECRET_ACCESS_KEY, "basicCred1secret")
+        )
+
+        private val basicCred2 = mapOf(
+                Pair(ProfileKeyConstants.AWS_ACCESS_KEY_ID, "basicCred2access"),
+                Pair(ProfileKeyConstants.AWS_SECRET_ACCESS_KEY, "basicCred2secret")
+        )
+
+        private val sessionCred1 = mapOf(
+                Pair(ProfileKeyConstants.AWS_ACCESS_KEY_ID, "sessionCred1access"),
+                Pair(ProfileKeyConstants.AWS_SECRET_ACCESS_KEY, "sessionCred1secret"),
+                Pair(ProfileKeyConstants.AWS_SESSION_TOKEN, "sessionCred1session")
+        )
+
+        private val sessionCred2 = mapOf(
+                Pair(ProfileKeyConstants.AWS_ACCESS_KEY_ID, "sessionCred2access"),
+                Pair(ProfileKeyConstants.AWS_SECRET_ACCESS_KEY, "sessionCred2secret"),
+                Pair(ProfileKeyConstants.AWS_SESSION_TOKEN, "sessionCred2session")
+        )
+
+        /**
+         * Loads the given credentials file and checks that it contains the same
+         * set of profiles as expected.
+         */
+        private fun checkCredentialsFile(file: File, vararg expectedProfiles: BasicProfile) {
+            val parsedFile = ProfilesConfigFile(file)
+            val loadedProfiles = parsedFile.allBasicProfiles
+
+            assertThat(loadedProfiles).hasSameSizeAs(expectedProfiles)
+
+            for (expectedProfile in expectedProfiles) {
+                val loadedProfile = loadedProfiles[expectedProfile.profileName]
+                assertThat(loadedProfile).isEqualToComparingFieldByField(expectedProfile)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Creates a proof of concept of credential management allowing:

* Additional credential providers to be registered as extensions
* Credentials can save metadata to the underlying aws settings file
* Can provide a specific UI editor for the credential type

UIs are coded in Java and .form files, everything else is Kotlin

![credsexample](https://user-images.githubusercontent.com/8992246/28028979-40a80584-6553-11e7-8053-85486a4e14e7.PNG)
