### PR TITLE
Add the ability to handle pagination in the explorer

### DIFF
--- a/src/main/kotlin/software/aws/toolkits/jetbrains/lambda/explorer/AwsExplorerLambdaNode.kt
+++ b/src/main/kotlin/software/aws/toolkits/jetbrains/lambda/explorer/AwsExplorerLambdaNode.kt
@@ -2,29 +2,39 @@ package software.aws.toolkits.jetbrains.lambda.explorer
 
 import com.amazonaws.services.lambda.AWSLambda
 import com.amazonaws.services.lambda.model.FunctionConfiguration
+import com.amazonaws.services.lambda.model.ListFunctionsRequest
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.project.Project
 import software.aws.toolkits.jetbrains.core.AwsClientFactory
-import software.aws.toolkits.jetbrains.ui.LAMBDA_FUNCTION_ICON
 import software.aws.toolkits.jetbrains.ui.LAMBDA_SERVICE_ICON
+import software.aws.toolkits.jetbrains.ui.SQS_QUEUE_ICON
 import software.aws.toolkits.jetbrains.ui.explorer.AwsExplorerNode
 import software.aws.toolkits.jetbrains.ui.explorer.AwsExplorerServiceRootNode
+import software.aws.toolkits.jetbrains.ui.explorer.AwsTruncatedResultNode
 
-class AwsExplorerLambdaRootNode(project: Project, profile: String, region: String):
-        AwsExplorerServiceRootNode<FunctionConfiguration>(project, "AWS Lambda", profile, region, LAMBDA_SERVICE_ICON) {
+class AwsExplorerLambdaRootNode(project: Project, profile: String, region: String) :
+        AwsExplorerServiceRootNode(project, "AWS Lambda", LAMBDA_SERVICE_ICON) {
 
     private val client: AWSLambda = AwsClientFactory.getInstance(project).getLambdaClient(profile, region)
 
-    override fun loadResources(): Collection<FunctionConfiguration> {
-        //TODO We need to list all the functions, not just one page
-        return client.listFunctions().functions
+    override fun loadResources(paginationToken: String?): Collection<AwsExplorerNode<*>> {
+        val request = ListFunctionsRequest()
+        paginationToken?.let { request.withMarker(paginationToken) }
+
+        val response = client.listFunctions(request)
+        val resources: MutableList<AwsExplorerNode<*>> = response.functions.map { mapResourceToNode(it) }.toMutableList()
+        response.nextMarker?.let {
+            resources.add(AwsTruncatedResultNode(this, it))
+        }
+
+        return resources
     }
 
-    override fun mapResourceToNode(resource: FunctionConfiguration) = AwsExplorerFunctionNode(project!!, resource, profile, region)
+    private fun mapResourceToNode(resource: FunctionConfiguration) = AwsExplorerFunctionNode(project!!, resource)
 }
 
-class AwsExplorerFunctionNode(project: Project, private val function: FunctionConfiguration, profile: String, region: String):
-        AwsExplorerNode<FunctionConfiguration>(project, function, profile, region, LAMBDA_FUNCTION_ICON) {
+class AwsExplorerFunctionNode(project: Project, private val function: FunctionConfiguration) :
+        AwsExplorerNode<FunctionConfiguration>(project, function, SQS_QUEUE_ICON) { //TODO replace to Function icon
 
     override fun getChildren(): Collection<AbstractTreeNode<Any>> {
         return emptyList()

--- a/src/main/kotlin/software/aws/toolkits/jetbrains/s3/explorer/AwsExplorerS3Node.kt
+++ b/src/main/kotlin/software/aws/toolkits/jetbrains/s3/explorer/AwsExplorerS3Node.kt
@@ -1,30 +1,32 @@
 package software.aws.toolkits.jetbrains.s3.explorer
 
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.Bucket
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.project.Project
-import software.aws.toolkits.jetbrains.core.AwsClientFactory
 import software.aws.toolkits.jetbrains.ui.S3_BUCKET_ICON
 import software.aws.toolkits.jetbrains.ui.S3_SERVICE_ICON
 import software.aws.toolkits.jetbrains.ui.explorer.AwsExplorerNode
 import software.aws.toolkits.jetbrains.ui.explorer.AwsExplorerServiceRootNode
 
-class AwsExplorerS3RootNode(project: Project, profile: String, region: String):
-        AwsExplorerServiceRootNode<Bucket>(project, "Amazon S3", profile, region, S3_SERVICE_ICON) {
+class AwsExplorerS3RootNode(project: Project, region: String) :
+        AwsExplorerServiceRootNode(project, "Amazon S3", S3_SERVICE_ICON) {
 
-    private var client: AmazonS3 = AwsClientFactory.getInstance(project).getS3Client(profile, region)
+    //TODO use a ClientFactory instead
+    private val client: AmazonS3 = AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .build()
 
-    //TODO we need to load all the buckets
-    override fun loadResources(): Collection<Bucket> {
-        return client.listBuckets()
+    override fun loadResources(paginationToken: String?): Collection<AwsExplorerNode<*>> {
+        return  client.listBuckets().map { mapResourceToNode(it) }
     }
 
-    override fun mapResourceToNode(resource: Bucket) = AwsExplorerBucketNode(project!!, resource, profile, region)
+    private fun mapResourceToNode(resource: Bucket) = AwsExplorerBucketNode(project!!, resource)
 }
 
-class AwsExplorerBucketNode(project: Project, private val bucket: Bucket, profile: String, region: String):
-        AwsExplorerNode<Bucket>(project, bucket, profile, region, S3_BUCKET_ICON) {
+class AwsExplorerBucketNode(project: Project, private val bucket: Bucket):
+        AwsExplorerNode<Bucket>(project, bucket, S3_BUCKET_ICON) {
 
     override fun getChildren(): Collection<AbstractTreeNode<Any>> {
         return emptyList()

--- a/src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerFactory.kt
+++ b/src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerFactory.kt
@@ -2,13 +2,11 @@ package software.aws.toolkits.jetbrains.ui.explorer
 
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
-import com.intellij.ui.components.panels.Wrapper
 
+@Suppress("unused")
 class AwsExplorerFactory : ToolWindowFactory, DumbAware {
-
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         toolWindow.component.parent.add(ExplorerToolWindow(project))
     }

--- a/src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerNode.kt
+++ b/src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerNode.kt
@@ -1,26 +1,33 @@
 package software.aws.toolkits.jetbrains.ui.explorer
 
+import com.intellij.ide.IdeBundle
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.ClearableLazyValue
+import com.intellij.ui.LoadingNode
 import com.intellij.ui.SimpleTextAttributes
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.ui.AWS_ICON
 import javax.swing.Icon
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeModel
+import javax.swing.tree.MutableTreeNode
 
-abstract class AwsExplorerNode<T>(project: Project, value: T, val profile: String, val region: String, val awsIcon: Icon?):
-        AbstractTreeNode<T>(project, value) {
+
+abstract class AwsExplorerNode<T>(project: Project, value: T, private val awsIcon: Icon?) : AbstractTreeNode<T>(project, value) {
 
     override fun update(presentation: PresentationData?) {
         presentation?.setIcon(awsIcon)
     }
 
     override fun toString() = value.toString()
+
+    open fun onDoubleClick(model: DefaultTreeModel, selectedElement: DefaultMutableTreeNode) {}
 }
 
-class AwsExplorerRootNode(project: Project, profile: String, region: String):
-        AwsExplorerNode<String>(project, "ROOT", profile, region, AWS_ICON) {
+class AwsExplorerRootNode(project: Project, private val profile: String, private val region: String) :
+        AwsExplorerNode<String>(project, "ROOT", AWS_ICON) {
 
     override fun getChildren(): Collection<AbstractTreeNode<String>> {
         val childrenList = mutableListOf<AbstractTreeNode<String>>()
@@ -32,59 +39,132 @@ class AwsExplorerRootNode(project: Project, profile: String, region: String):
     }
 }
 
-abstract class AwsExplorerServiceRootNode<Resource>(project: Project, value: String, profile: String, region: String, awsIcon: Icon):
-        AwsExplorerNode<String>(project, value, profile, region, awsIcon) {
-    val cache: ClearableLazyValue<Collection<AwsExplorerNode<*>>>
+abstract class AwsExplorerServiceRootNode(project: Project, value: String, awsIcon: Icon) :
+        AwsExplorerNode<String>(project, value, awsIcon) {
+    private val childNodes: MutableList<AwsExplorerNode<*>> by lazy {
+        val initialList = mutableListOf<AwsExplorerNode<*>>()
 
-    init {
-        cache = object : ClearableLazyValue<Collection<AwsExplorerNode<*>>>() {
-            override fun compute(): Collection<AwsExplorerNode<*>> {
-                return try {
-                    val resources = loadResources()
-                    if (resources.isEmpty()) {
-                        // Return EmptyNode as the single node of the list
-                        listOf(AwsExplorerEmptyNode(project, profile, region))
-                    } else {
-                        resources.map { mapResourceToNode(it) }
-                    }
-                } catch (e: Exception) {
-                    // Return the ErrorNode as the single Node of the list
-                    listOf(AwsExplorerErrorNode(project, e, profile, region))
-                }
-            }
+        val data = loadData()
+        if (data.isEmpty()) {
+            initialList.add(AwsExplorerEmptyNode(project))
+        } else {
+            initialList.addAll(data)
         }
+        initialList
     }
 
-    override fun getChildren(): Collection<AwsExplorerNode<*>> {
-        return cache.value
+    override fun getChildren(): MutableList<AwsExplorerNode<*>> = childNodes
+
+    fun loadData(paginationToken: String? = null): Collection<AwsExplorerNode<*>> = try {
+        loadResources(paginationToken)
+    } catch (e: Exception) {
+        // Return the ErrorNode as the single Node of the list
+        listOf(AwsExplorerErrorNode(project!!, e))
     }
 
-    // This method may throw RuntimeException, must handle it
-    abstract fun loadResources(): Collection<Resource>
-
-    abstract fun mapResourceToNode(resource: Resource): AwsExplorerNode<Resource>
+    protected abstract fun loadResources(paginationToken: String? = null): Collection<AwsExplorerNode<*>>
 }
 
-class AwsExplorerErrorNode(project: Project, exception: Exception, profile: String, region: String):
-        AwsExplorerNode<Exception>(project, exception, profile, region, null) {
+class AwsTruncatedResultNode(private val parentNode: AwsExplorerServiceRootNode, val paginationToken: String) :
+        AwsExplorerNode<String>(parentNode.project!!, MESSAGE, null) {
 
     override fun getChildren(): Collection<AbstractTreeNode<Any>> {
         return emptyList()
     }
 
-    override fun toString(): String {
-        return "Error Loading Resources..."
+    override fun update(presentation: PresentationData?) {
+        presentation?.addText(value, SimpleTextAttributes.GRAYED_ATTRIBUTES)
+    }
+
+    override fun onDoubleClick(model: DefaultTreeModel, selectedElement: DefaultMutableTreeNode) {
+        // The Tree is represented by two systems. The entire tree (AbstractTreeNode) and the subsection
+        // of the tree that is visible (MutableTreeNode). We have to update both systems if we wish to show the
+        // data correctly, else we will lose data either when nodes are collapsed/expanded again, or the tree UI does
+        // not show the new data. Tree Node will refer to nodes of type AbstractTreeNode, UI node will refer to
+        // MutableTreeNode
+
+        // Remove the truncated node from the Tree Node and add our fake loading node so that if they collapse and
+        // expand quick enough it'll stay in loading mode
+        val children = parentNode.children
+        children.asReversed().removeIf { it is AwsTruncatedResultNode }
+        children.add(AwsExplorerLoadingNode(project!!))
+
+        // Update the UI version to remove the truncation node and add loading
+        val parent = selectedElement.parent as DefaultMutableTreeNode
+        model.removeNodeFromParent(selectedElement)
+        val loadingNode = LoadingNode()
+        model.insertNodeInto(loadingNode, parent, parent.childCount)
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val nextSetOfResources = parentNode.loadData(paginationToken)
+
+            // Run next steps on the EDT thread
+            ApplicationManager.getApplication().invokeLater {
+                // If the parent UI node is gone, we re-collapsed so no reason to remove it
+                val parentTreeNode = loadingNode.parent as? MutableTreeNode
+                if (parentTreeNode != null) {
+                    model.removeNodeFromParent(loadingNode)
+                }
+
+                // Remove our fake loading node from Tree Node
+                children.removeIf {
+                    it is AwsExplorerLoadingNode
+                }
+
+                nextSetOfResources.forEach {
+                    // This call is usually handled by the Tree infrastructure, but we are doing pagination manually
+                    // so we also need to update the presentation data manually else it will render without the
+                    // proper text
+                    it.update()
+                    children.add(it)
+
+                    if (parentTreeNode != null) {
+                        model.insertNodeInto(DefaultMutableTreeNode(it), parentTreeNode, parentTreeNode.childCount)
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        val MESSAGE = "Results truncated, double click to load more"
+    }
+}
+
+class AwsExplorerLoadingNode(project: Project) :
+        AwsExplorerNode<String>(project, IdeBundle.message("treenode.loading"), null) {
+
+    override fun getChildren(): Collection<AbstractTreeNode<Any>> {
+        return emptyList()
+    }
+
+    override fun update(presentation: PresentationData?) {
+        presentation?.addText(value, SimpleTextAttributes.GRAYED_ATTRIBUTES)
+    }
+}
+
+class AwsExplorerErrorNode(project: Project, exception: Exception) :
+        AwsExplorerNode<Exception>(project, exception, null) {
+
+    override fun getChildren(): Collection<AbstractTreeNode<Any>> {
+        return emptyList()
     }
 
     override fun update(presentation: PresentationData?) {
         super.update(presentation)
-        presentation?.tooltip = value.message
-        presentation?.addText(toString(), SimpleTextAttributes.ERROR_ATTRIBUTES)
+        presentation?.apply {
+            // If we don't have a message, at least give them the error type
+            tooltip = value.message ?: value.javaClass.simpleName
+            addText(MSG, SimpleTextAttributes.ERROR_ATTRIBUTES)
+        }
+    }
+
+    companion object {
+        val MSG = "Error Loading Resources..."
     }
 }
 
-class AwsExplorerEmptyNode(project: Project, profile: String, region: String): AwsExplorerNode<String>(project, "empty", profile, region, null) {
-
+class AwsExplorerEmptyNode(project: Project) : AwsExplorerNode<String>(project, "empty", awsIcon = null) {
     override fun getChildren(): Collection<AbstractTreeNode<Any>> {
         return emptyList()
     }

--- a/src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerService.kt
+++ b/src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerService.kt
@@ -10,7 +10,7 @@ import software.aws.toolkits.jetbrains.s3.explorer.AwsExplorerS3RootNode
 enum class AwsExplorerService(val serviceId: String) {
     S3(AmazonS3.ENDPOINT_PREFIX) {
         override fun buildServiceRootNode(project: Project, profile: String, region: String): AwsExplorerS3RootNode {
-            return AwsExplorerS3RootNode(project, profile, region)
+            return AwsExplorerS3RootNode(project, region)
         }
     },
     LAMBDA(AWSLambda.ENDPOINT_PREFIX) {

--- a/src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerTreeBuilder.kt
+++ b/src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerTreeBuilder.kt
@@ -7,11 +7,12 @@ import javax.swing.JTree
 import javax.swing.tree.DefaultTreeModel
 
 class AwsExplorerTreeBuilder(tree: JTree, treeModel: DefaultTreeModel, project: Project, profile: String, region: String):
-        AbstractTreeBuilder(tree, treeModel, AwsExplorerTreeStructure(project, profile, region), null, false) {
-
+        AbstractTreeBuilder(tree, treeModel, AwsExplorerTreeStructure(project, profile = profile, region = region), null, false) {
     init {
         initRootNode()
     }
 
-    override fun isAlwaysShowPlus(descriptor: NodeDescriptor<*>?) = descriptor is AwsExplorerServiceRootNode<*>
+    override fun isAlwaysShowPlus(descriptor: NodeDescriptor<*>?): Boolean {
+        return descriptor is AwsExplorerServiceRootNode
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -35,7 +35,6 @@
     <projectService serviceImplementation="software.aws.toolkits.jetbrains.core.AwsSettingsProvider"/>
     <projectService serviceImplementation="software.aws.toolkits.jetbrains.core.region.AwsRegionProvider"/>
     <projectService serviceImplementation="software.aws.toolkits.jetbrains.core.AwsClientFactory"/>
-
     <toolWindow id="AWS Explorer" anchor="right"
                 factoryClass="software.aws.toolkits.jetbrains.ui.explorer.AwsExplorerFactory" icon="/icons/aws-box.gif"/>
   </extensions>


### PR DESCRIPTION
If the results are paginated an additional node that can be added and clicked on to load more results. The next set of results are loaded asynchronously

Cleaned up the API of the explorer nodes

![paginationexample](https://user-images.githubusercontent.com/8992246/29481533-1afc7ede-8437-11e7-9e8f-34b5b2e8ec87.png)

