### PR TITLE
Install the SpeedSearch feature to the explorer tree

### DIFF
--- a/src/main/kotlin/com/amazonaws/intellij/ui/explorer/ExplorerToolWindow.kt
+++ b/src/main/kotlin/com/amazonaws/intellij/ui/explorer/ExplorerToolWindow.kt
@@ -6,6 +6,7 @@ import com.intellij.ide.util.treeView.NodeRenderer
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.util.Disposer
+import com.intellij.ui.TreeUIHelper
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.panels.Wrapper
 import com.intellij.ui.treeStructure.Tree
@@ -48,6 +49,7 @@ class ExplorerToolWindow(val project: Project):
 
     private fun createTree(): JTree {
         val awsTree = Tree()
+        TreeUIHelper.getInstance().installTreeSpeedSearch(awsTree)
         UIUtil.setLineStyleAngled(awsTree)
         awsTree.isRootVisible = false
         awsTree.autoscrolls = true


### PR DESCRIPTION
This adds the SpeedSearch feature (searches the exposed tree nodes when you type) into the explorer window tree

![screen shot 2017-08-21 at 3 33 30 pm](https://user-images.githubusercontent.com/8992246/29540987-500d6100-8686-11e7-83e7-59a34a9cf46d.png)