### PR TITLE
Add ktlint, doesn't fail build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,14 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
+        classpath "gradle.plugin.org.jmailen.gradle:kotlinter-gradle:$kotlinterPluginVersion"
     }
 }
 
@@ -27,9 +31,15 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'kotlin'
     apply plugin: 'org.jetbrains.dokka'
+    apply plugin: 'org.jmailen.kotlinter'
 
     dependencies {
         compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    }
+
+    kotlinter {
+        ignoreFailures = true // TODO: Fix errors
+        reporters = ['checkstyle', 'plain']
     }
 
     compileKotlin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ kotlinVersion = 1.2.21
 awsSdkVersion = 1.11.176
 dokkaVersion = 0.9.11
 ideaPluginVersion = 0.2.18
+kotlinterPluginVersion = 1.7.0


### PR DESCRIPTION
```
➜  aws-intellij-toolkit git:(ktlint) ./gradlew lintKotlin

> Task :intellij:lintKotlinMain
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/actions/UploadLambdaFunction.kt:3:1: Needless blank line(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/AwsModels.kt:5:20: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/AwsResourceManager.kt:9:1: Unused import
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/AwsResourceManager.kt:38:77: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/Extensions.kt:9:12: Missing spacing after "catch"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/lambda/LambdaCreator.kt:25:54: Missing spacing after ":"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/s3/S3BucketViewerPanel.kt:58:23: Missing spacing after "if"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/s3/S3BucketViewerPanel.kt:72:17: Missing spacing after "when"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/s3/S3FileTypes.kt:16:68: Unnecessary space(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/s3/S3FileTypes.kt:34:68: Unnecessary space(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/s3/S3VirtualFileSystem.kt:4:1: Wildcard import
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/aws/s3/S3VirtualFileSystem.kt:120:1: Needless blank line(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/core/AwsClientManager.kt:47:26: Missing spacing before ":"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/core/AwsSettingsProvider.kt:15:56: Missing spacing before ":"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/core/AwsSettingsProvider.kt:28:97: Line must not end with "?:"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/core/AwsSettingsProvider.kt:29:115: Line must not end with "?:"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/core/region/AwsRegion.kt:8:1: Unexpected indentation (5) (it should be 4)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/core/region/AwsRegion.kt:9:1: Unexpected indentation (5) (it should be 4)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/core/region/AwsRegion.kt:20:1: Unexpected indentation (-1) (it should be 8)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/core/region/AwsRegionProvider.kt:26:111: Missing spacing before "}"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/core/region/AwsRegionProvider.kt:35:33: Missing spacing before "?:"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/credentials/AwsCredentialsProfileProvider.kt:51:11: Missing spacing after "if"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/credentials/CredentialFileBasedProfile.kt:39:65: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/credentials/CredentialProfile.kt:37:54: Missing spacing before "{"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/credentials/CredentialProfile.kt:42:56: Unnecessary "Unit" return type
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/credentials/CredentialProfile.kt:55:20: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/credentials/CredentialProfile.kt:65:66: Unnecessary space(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/credentials/CredentialProfile.kt:65:113: Missing spacing before "{"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/credentials/CredentialProfile.kt:91:44: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/s3/explorer/AwsExplorerS3Node.kt:3:1: Needless blank line(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/credentials/CredentialsDialog.kt:17:28: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/credentials/CredentialsDialog.kt:39:15: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/credentials/CredentialsTable.kt:22:1: Needless blank line(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/credentials/CredentialsTable.kt:42:34: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerNode.kt:18:1: Needless blank line(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/AwsExplorerTreeBuilder.kt:9:89: Missing spacing before ":"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/ExplorerToolWindow.kt:174:37: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/explorer/ExplorerToolWindow.kt:199:17: Unnecessary semicolon
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/Icons.kt:5:1: Needless blank line(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/modals/UploadToLambdaModal.kt:11:1: Wildcard import
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/modals/UploadToLambdaModal.kt:15:1: Wildcard import
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/modals/UploadToLambdaModal.kt:46:1: Unexpected blank line(s) before "}"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/modals/UploadToLambdaModal.kt:184:1: Unexpected blank line(s) before "}"
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/s3/S3BucketViewer.kt:3:1: Needless blank line(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/s3/S3TestAction.kt:9:1: Needless blank line(s)
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/ui/widgets/AwsSettingsPanel.kt:4:1: Wildcard import
Lint error > src/main/kotlin/software/aws/toolkits/jetbrains/utils/LazyExtensionProperty.kt:17:5: Unexpected newline before "{"

> Task :intellij:lintKotlinTest
Lint error > src/test/kotlin/software/aws/toolkits/jetbrains/credentials/AwsCredentialsProfileProviderTest.kt:245:22: Unnecessary semicolon
Lint error > src/test/kotlin/software/aws/toolkits/jetbrains/toolWindow/AwsExplorerToolWindowTest.kt:4:1: Wildcard import
Lint error > src/test/kotlin/software/aws/toolkits/jetbrains/toolWindow/AwsExplorerToolWindowTest.kt:7:1: Needless blank line(s)
Lint error > src/test/kotlin/software/aws/toolkits/jetbrains/toolWindow/AwsExplorerToolWindowTest.kt:23:1: Unexpected blank line(s) before "}"
Lint error > src/test/kotlin/software/aws/toolkits/jetbrains/toolWindow/AwsExplorerToolWindowTest.kt:31:5: Unexpected newline before "{"


BUILD SUCCESSFUL in 1s
```