### PR TITLE
Decouple the settings status panel from the explorer

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -33,6 +33,7 @@
         <projectService serviceInterface="software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager"
                         serviceImplementation="software.aws.toolkits.jetbrains.core.credentials.DefaultProjectAccountSettingsManager"
                         testServiceImplementation="software.aws.toolkits.jetbrains.core.credentials.MockProjectAccountSettingsManager"/>
+        <postStartupActivity implementation="software.aws.toolkits.jetbrains.core.AwsSettingsPanelInstaller"/>
 
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.core.AwsClientManager"/>
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.core.DefaultAwsResourceCache"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerFactory.kt
@@ -4,13 +4,10 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
-import com.intellij.openapi.wm.WindowManager
-import software.aws.toolkits.jetbrains.core.AwsSettingsPanel
 
 @Suppress("unused")
 class AwsExplorerFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         toolWindow.component.parent.add(ExplorerToolWindow(project))
-        WindowManager.getInstance().getStatusBar(project).addWidget(AwsSettingsPanel(project), project)
     }
 }


### PR DESCRIPTION
* The status panel would not be installed until the explorer window was added, this did not happen if the user had show tool buttons unchecked