### PR TITLE
Clean up the lambda invoker UI

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaEditorPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaEditorPanel.form
@@ -88,107 +88,74 @@
           <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.function_name"/>
         </properties>
       </component>
-      <splitpane id="beee5">
+      <grid id="7464f" binding="invokePanel" layout-manager="BorderLayout" hgap="0" vgap="0">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <preferred-size width="200" height="200"/>
-          </grid>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
-        <properties>
-          <dividerSize value="4"/>
-          <orientation value="0"/>
-          <resizeWeight value="0.75"/>
-        </properties>
-        <border type="empty"/>
+        <properties/>
+        <border type="none"/>
         <children>
-          <splitpane id="c4a17">
-            <constraints>
-              <splitpane position="left"/>
-            </constraints>
-            <properties>
-              <continuousLayout value="true"/>
-              <dividerLocation value="616"/>
-              <dividerSize value="4"/>
-              <enabled value="true"/>
-              <resizeWeight value="0.75"/>
-            </properties>
-            <border type="none"/>
-            <children>
-              <grid id="2ca14" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
-                <constraints>
-                  <splitpane position="left"/>
-                </constraints>
-                <properties/>
-                <border type="none" title-resource-bundle="software/aws/toolkits/resources/localized_messages" title-key="lambda.input"/>
-                <children>
-                  <component id="a7139" class="com.intellij.ui.EditorTextField" binding="input" custom-create="true">
-                    <constraints>
-                      <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
-                        <minimum-size width="150" height="150"/>
-                      </grid>
-                    </constraints>
-                    <properties/>
-                  </component>
-                  <component id="aaba5" class="javax.swing.JButton" binding="invoke">
-                    <constraints>
-                      <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <icon value="general/run.png"/>
-                      <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.invoke"/>
-                    </properties>
-                  </component>
-                  <component id="659a2" class="javax.swing.JComboBox" binding="exampleRequests">
-                    <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties/>
-                  </component>
-                </children>
-              </grid>
-              <grid id="43fb9" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
-                <constraints>
-                  <splitpane position="right"/>
-                </constraints>
-                <properties/>
-                <border type="none" title-resource-bundle="software/aws/toolkits/resources/localized_messages" title-key="lambda.response"/>
-                <children>
-                  <component id="186c2" class="com.intellij.ui.EditorTextField" binding="response" custom-create="true">
-                    <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties/>
-                  </component>
-                </children>
-              </grid>
-            </children>
-          </splitpane>
-          <grid id="f8747" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-            <margin top="0" left="0" bottom="0" right="0"/>
-            <constraints>
-              <splitpane position="right"/>
-            </constraints>
+          <grid id="f8747" binding="logOutputPanel" layout-manager="BorderLayout" hgap="0" vgap="0">
+            <constraints border-constraint="South"/>
             <properties/>
-            <border type="none" title-resource-bundle="software/aws/toolkits/resources/localized_messages" title-key="lambda.log_output">
+            <border type="empty" title-resource-bundle="software/aws/toolkits/resources/localized_messages" title-key="lambda.log_output">
               <title-color color="-16777216"/>
+              <size top="5" left="5" bottom="5" right="5"/>
             </border>
             <children>
-              <component id="8e911" class="javax.swing.JTextArea" binding="logOutput">
+              <component id="9c138" class="com.intellij.ui.EditorTextField" binding="logOutput" custom-create="true">
+                <constraints border-constraint="Center"/>
+                <properties/>
+              </component>
+            </children>
+          </grid>
+          <grid id="2ca14" binding="inputPanel" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints border-constraint="West"/>
+            <properties/>
+            <border type="none" title-resource-bundle="software/aws/toolkits/resources/localized_messages" title-key="lambda.input"/>
+            <children>
+              <component id="a7139" class="com.intellij.ui.EditorTextField" binding="input" custom-create="true">
                 <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
-                    <preferred-size width="150" height="100"/>
+                  <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                    <minimum-size width="150" height="150"/>
                   </grid>
                 </constraints>
+                <properties/>
+              </component>
+              <component id="aaba5" class="javax.swing.JButton" binding="invoke">
+                <constraints>
+                  <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
                 <properties>
-                  <editable value="false"/>
+                  <icon value="general/run.png"/>
+                  <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.invoke"/>
                 </properties>
+              </component>
+              <component id="659a2" class="javax.swing.JComboBox" binding="exampleRequests">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+              </component>
+            </children>
+          </grid>
+          <grid id="43fb9" binding="responsePanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints border-constraint="Center"/>
+            <properties/>
+            <border type="none" title-resource-bundle="software/aws/toolkits/resources/localized_messages" title-key="lambda.response"/>
+            <children>
+              <component id="186c2" class="com.intellij.ui.EditorTextField" binding="response" custom-create="true">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
               </component>
             </children>
           </grid>
         </children>
-      </splitpane>
+      </grid>
     </children>
   </grid>
 </form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaEditorPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaEditorPanel.java
@@ -3,20 +3,25 @@ package software.aws.toolkits.jetbrains.services.lambda;
 import com.intellij.json.JsonLanguage;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.fileTypes.PlainTextLanguage;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Splitter;
 import com.intellij.ui.EditorCustomization;
 import com.intellij.ui.EditorTextField;
 import com.intellij.ui.EditorTextFieldProvider;
+import com.intellij.ui.IdeBorderFactory;
+import com.intellij.ui.JBSplitter;
+import com.intellij.util.ui.JBUI;
+import java.awt.BorderLayout;
+import java.awt.Insets;
 import java.util.Collections;
-import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JTextArea;
 import javax.swing.JTextField;
-import javax.swing.border.BevelBorder;
 import org.jetbrains.annotations.NotNull;
+import software.aws.toolkits.resources.Localization;
 
 public final class LambdaEditorPanel {
     private final Project project;
@@ -30,19 +35,42 @@ public final class LambdaEditorPanel {
     JTextField arn;
     JButton invoke;
     EditorTextField response;
-    JTextArea logOutput;
+    EditorTextField logOutput;
     JComboBox exampleRequests;
+    private JPanel logOutputPanel;
+    private JPanel invokePanel;
+    private JPanel inputPanel;
+    private JPanel responsePanel;
 
     public LambdaEditorPanel(Project project) {
         this.project = project;
+
+        // Patch up the UI with things we can't do in the designer easily
+        Insets insets = JBUI.emptyInsets();
+        inputPanel.setBorder(IdeBorderFactory.createTitledBorder(Localization.message("lambda.input"), false, insets));
+        responsePanel.setBorder(IdeBorderFactory.createTitledBorder(Localization.message("lambda.response"), false, insets));
+        logOutputPanel.setBorder(IdeBorderFactory.createTitledBorder(Localization.message("lambda.log_output"), false, insets));
+
+        input.setBorder(IdeBorderFactory.createBorder());
+        response.setBorder(IdeBorderFactory.createBorder());
+        logOutput.setBorder(IdeBorderFactory.createBorder());
+
+        Splitter horizontalSplitter = new JBSplitter();
+        horizontalSplitter.setFirstComponent(inputPanel);
+        horizontalSplitter.setSecondComponent(responsePanel);
+
+        Splitter verticalSplitter = new JBSplitter(true, 0.75f);
+        verticalSplitter.setFirstComponent(horizontalSplitter);
+        verticalSplitter.setSecondComponent(logOutputPanel);
+
+        invokePanel.add(verticalSplitter, BorderLayout.CENTER);
     }
 
     private void createUIComponents() {
         EditorTextFieldProvider textFieldProvider = ServiceManager.getService(project, EditorTextFieldProvider.class);
         input = textFieldProvider.getEditorField(JsonLanguage.INSTANCE, project, Collections.emptyList());
         response = textFieldProvider.getEditorField(JsonLanguage.INSTANCE, project, Collections.singletonList(new IsViewerCustomization()));
-        input.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
-        response.setBorder(BorderFactory.createBevelBorder(BevelBorder.LOWERED));
+        logOutput = textFieldProvider.getEditorField(PlainTextLanguage.INSTANCE, project, Collections.singletonList(new IsViewerCustomization()));
     }
 
     public void setBusy(Boolean busy) {


### PR DESCRIPTION
* Add borders around editors
* Switch to JBSplitters for consistent look
* Log output is a plain text editor so scrolling works
* Fix spacing with title borders

Before:
![screen shot 2018-07-26 at 3 53 35 pm](https://user-images.githubusercontent.com/8992246/43292948-a4d855c0-90ec-11e8-89dd-f539638c9ac4.png)

After:
![screen shot 2018-07-26 at 3 49 09 pm](https://user-images.githubusercontent.com/8992246/43292952-a93afa00-90ec-11e8-84a2-ce5882a2f36c.png)