### PR TITLE
Fix integ tests caused by change in SDK 10->11 behavior

### DIFF
--- a/core/src/software/aws/toolkits/core/s3/BucketUtils.kt
+++ b/core/src/software/aws/toolkits/core/s3/BucketUtils.kt
@@ -6,11 +6,14 @@ import software.amazon.awssdk.services.s3.model.ObjectIdentifier
 
 fun S3Client.deleteBucketAndContents(bucket: String) {
     this.listObjectVersionsPaginator(ListObjectVersionsRequest.builder().bucket(bucket).build()).forEach { resp ->
-        val versions = resp.versions()?.map {
+        val versions = resp.versions().map {
             ObjectIdentifier.builder()
-                    .key(it.key())
-                    .versionId(it.versionId()).build()
-        } ?: return@forEach
+                .key(it.key())
+                .versionId(it.versionId()).build()
+        }
+        if (versions.isEmpty()) {
+            return@forEach
+        }
         this.deleteObjects { it.bucket(bucket).delete { it.objects(versions) } }
     }
 


### PR DESCRIPTION
SDK will now no longer return null for empty collections


```
git:(master) ✗ ./gradlew integrationTest

BUILD SUCCESSFUL in 42s
40 actionable tasks: 21 executed, 19 up-to-date
```