### PR TITLE
Re-baseline on 2018.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-ideaVersion=2018.1
+ideaVersion=2018.2
 javaVersion=1.8
 kotlinVersion=1.2.60
 awsSdkVersion=2.0.0-preview-11

--- a/jetbrains-core/build.gradle
+++ b/jetbrains-core/build.gradle
@@ -5,7 +5,7 @@ intellij {
     pluginName 'aws-intellij-toolkit'
     updateSinceUntilBuild false
     downloadSources = System.getenv("CI") == null
-    plugins = ["PythonCore:2018.1.181.4203.550"]
+    plugins = ["PythonCore:2018.2.182.3684.101"]
 }
 
 jar.baseName = 'aws-intellij-toolkit-core'

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/JavaLambdaPackagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/JavaLambdaPackagerTest.kt
@@ -2,9 +2,8 @@ package software.aws.toolkits.jetbrains.services.lambda
 
 import com.fasterxml.jackson.annotation.JacksonAnnotation
 import com.intellij.compiler.CompilerTestUtil
-import com.intellij.openapi.application.Result
 import com.intellij.openapi.application.runInEdt
-import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.command.WriteCommandAction.writeCommandAction
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl
@@ -230,17 +229,15 @@ class JavaLambdaPackagerTest {
         val project = projectRule.project
         val modules = ModuleManager.getInstance(project).modules
 
-        object : WriteCommandAction<Nothing>(project) {
-            override fun run(result: Result<Nothing>) {
-                val compilerExtension = CompilerProjectExtension.getInstance(project)!!
-                compilerExtension.compilerOutputUrl = projectRule.fixture.tempDirFixture.findOrCreateDir("out").url
-                val sdk = JavaAwareProjectJdkTableImpl.getInstanceEx().internalJdk
+        writeCommandAction(project).run<Nothing> {
+            val compilerExtension = CompilerProjectExtension.getInstance(project)!!
+            compilerExtension.compilerOutputUrl = projectRule.fixture.tempDirFixture.findOrCreateDir("out").url
+            val sdk = JavaAwareProjectJdkTableImpl.getInstanceEx().internalJdk
 
-                for (module in modules) {
-                    ModuleRootModificationUtil.setModuleSdk(module, sdk)
-                }
+            for (module in modules) {
+                ModuleRootModificationUtil.setModuleSdk(module, sdk)
             }
-        }.execute()
+        }
 
         runInEdtAndWait {
             PlatformTestUtil.saveProject(project)

--- a/jetbrains-ultimate/build.gradle
+++ b/jetbrains-ultimate/build.gradle
@@ -3,7 +3,7 @@ intellij {
     version "IU-" + ideaVersion
     updateSinceUntilBuild false
     downloadSources = System.getenv("CI") == null
-    plugins = ["org.jetbrains.plugins.go:181.4203.564.171"]
+    plugins = ["org.jetbrains.plugins.go:182.3684.111.849"]
 }
 
 jar.baseName = 'aws-jetbrains-toolkit-ultimate'

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/ultimate/services/lambda/GoExtensions.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/ultimate/services/lambda/GoExtensions.kt
@@ -10,7 +10,6 @@ import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -78,10 +77,7 @@ class GoLambdaPackager : LambdaPackager {
                                     createZip(tempFile, future)
                                 }
                             }
-                        }).executeWithProgress(
-                                true, true, EmptyConsumer.getInstance<ProgressIndicator>(),
-                                EmptyConsumer.getInstance<Boolean>() // TODO: Put this in our own log tab...not Run's
-                        )
+                        }).executeWithProgress(true, true, EmptyConsumer.getInstance<Boolean>())
             } catch (e: Exception) {
                 future.completeExceptionally(e)
             }


### PR DESCRIPTION
* Go code got broken due to method signature changed
* WriteActionCommand had deprecated methods, migrate to non-deprecated