### PR TITLE
Fix Jacoco report failing to run due to including the resources folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,12 +164,16 @@ check.dependsOn ktlint
 
 def publishedProjects = subprojects.findAll { !it.name.contains("test")}
 
+jacoco {
+    toolVersion = "0.8.2"
+}
+
 task coverageReport(type: JacocoReport) {
     executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
 
     additionalSourceDirs = files(publishedProjects.sourceSets.main.java.srcDirs)
     sourceDirectories = files(publishedProjects.sourceSets.main.java.srcDirs)
-    classDirectories = files(publishedProjects.sourceSets.main.output)
+    classDirectories = files(publishedProjects.sourceSets.main.output.classesDirs)
 
     reports {
         html.enabled true
@@ -178,6 +182,7 @@ task coverageReport(type: JacocoReport) {
 publishedProjects.forEach {
     coverageReport.mustRunAfter(it.tasks.withType(Test))
 }
+check.dependsOn coverageReport
 
 // Workaround for runIde being defined in multiple projects, if we request the root project runIde, all others will
 // be disabled


### PR DESCRIPTION
The resources folder contains the same classes as the Lambda JVM invoker so it failed to build the report

```
 ./gradlew coverageReport

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.9/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3s
23 actionable tasks: 2 executed, 21 up-to-date
```