### PR TITLE
Add support for using templates or files in Lambda run configurations

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/iam/CreateIamRoleDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/iam/CreateIamRoleDialog.kt
@@ -3,19 +3,15 @@ package software.aws.toolkits.jetbrains.services.iam
 import com.intellij.json.JsonLanguage
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.application.runWriteAction
-import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
-import com.intellij.psi.codeStyle.CodeStyleManager
-import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
-import com.intellij.ui.EditorTextField
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.TestOnly
 import software.amazon.awssdk.services.iam.IamClient
 import software.aws.toolkits.jetbrains.services.lambda.upload.IamRole
+import software.aws.toolkits.jetbrains.utils.ui.formatAndSet
 import software.aws.toolkits.resources.message
 import java.awt.Component
 import javax.swing.JComponent
@@ -37,30 +33,10 @@ class CreateIamRoleDialog(
         title = message("iam.create.role.title")
         setOKButtonText(message("iam.create.role.create"))
 
-        formatDocument(defaultPolicyDocument, view.policyDocument)
-        formatDocument(defaultAssumeRolePolicyDocument, view.assumeRolePolicyDocument)
+        view.policyDocument.formatAndSet(defaultPolicyDocument, JsonLanguage.INSTANCE)
+        view.assumeRolePolicyDocument.formatAndSet(defaultAssumeRolePolicyDocument, JsonLanguage.INSTANCE)
 
         init()
-    }
-
-    private fun formatDocument(jsonDocument: String, editor: EditorTextField) {
-        // Initial docs can't be undo'ed
-        CommandProcessor.getInstance().runUndoTransparentAction {
-            runWriteAction {
-                val formatted =
-                    LanguageCodeStyleSettingsProvider.createFileFromText(
-                        JsonLanguage.INSTANCE,
-                        project,
-                        jsonDocument
-                    )?.let {
-                        CodeStyleManager.getInstance(project).reformat(it)
-                        it.text
-                    } ?: jsonDocument
-
-                val document = editor.document
-                document.replaceString(0, document.textLength, formatted)
-            }
-        }
     }
 
     override fun createCenterPanel(): JComponent? {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LambdaLocalRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LambdaLocalRunConfiguration.kt
@@ -16,10 +16,20 @@ import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.json.JsonFileType
+import com.intellij.json.JsonLanguage
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.ui.ComponentWithBrowseButton
+import com.intellij.openapi.ui.TextComponentAccessor
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
@@ -32,14 +42,19 @@ import icons.AwsIcons
 import org.jdom.Element
 import org.jetbrains.annotations.TestOnly
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaSampleEventProvider
+import software.aws.toolkits.jetbrains.core.RemoteResourceResolverProvider
 import software.aws.toolkits.jetbrains.services.lambda.Lambda.findPsiElementsForHandler
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerIndex
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPointObject
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
+import software.aws.toolkits.jetbrains.utils.ui.formatAndSet
 import software.aws.toolkits.jetbrains.utils.ui.populateValues
 import software.aws.toolkits.resources.message
+import java.nio.charset.StandardCharsets
+import javax.swing.JComboBox
 import javax.swing.JPanel
 
 class LambdaRunConfiguration :
@@ -138,6 +153,7 @@ class LambdaLocalRunConfiguration(project: Project, factory: ConfigurationFactor
         var runtime: String? = null,
         var handler: String? = null,
         var input: String? = null,
+        var inputIsFile: Boolean = false,
         var environmentVariables: MutableMap<String, String> = mutableMapOf()
     ) {
         fun validateAndCreateImmutable(project: Project): LambdaRunSettings {
@@ -145,13 +161,30 @@ class LambdaLocalRunConfiguration(project: Project, factory: ConfigurationFactor
             val runtime = runtime?.let { Runtime.valueOf(it) } ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_runtime_specified"))
             val element = findPsiElementsForHandler(project, runtime, handler).firstOrNull()
                 ?: throw RuntimeConfigurationError(message("lambda.run_configuration.handler_not_found", handler))
-            return LambdaRunSettings(runtime, handler, input, environmentVariables, element)
+            val inputValue = input
+
+            val inputText = if (inputIsFile && inputValue?.isNotEmpty() == true) {
+                try {
+                    LocalFileSystem.getInstance()
+                        .refreshAndFindFileByPath(inputValue)
+                        ?.contentsToByteArray(false)
+                        ?.toString(StandardCharsets.UTF_8)
+                            ?: throw RuntimeConfigurationError(message("lambda.run_configuration.input_file_error", inputValue))
+                } catch (e: Exception) {
+                    throw RuntimeConfigurationError(message("lambda.run_configuration.input_file_error", inputValue))
+                }
+            } else {
+                inputValue
+            }
+
+            return LambdaRunSettings(runtime, handler, inputText, environmentVariables, element)
         }
     }
 }
 
 class LocalLambdaRunSettingsEditor(project: Project) : SettingsEditor<LambdaLocalRunConfiguration>() {
     private val view = LocalLambdaRunSettingsEditorPanel(project, HandlerCompletionProvider(project))
+    private val eventProvider = LambdaSampleEventProvider(RemoteResourceResolverProvider.getInstance().get())
 
     init {
         val supported = LambdaLocalRunProvider.supportedRuntimeGroups.flatMap { it.runtimes }.map { it }.sorted()
@@ -160,13 +193,68 @@ class LocalLambdaRunSettingsEditor(project: Project) : SettingsEditor<LambdaLoca
                 ?.let { RuntimeGroup.runtimeForSdk(it) }
                 ?.let { if (it in supported) it else null }
         view.runtime.populateValues(selected = selected) { supported }
+
+        view.inputFile.addBrowseFolderListener(null, null, project, FileChooserDescriptorFactory.createSingleFileDescriptor(JsonFileType.INSTANCE))
+
+        val actionListener = object : ComponentWithBrowseButton.BrowseFolderActionListener<JComboBox<*>>(
+            null,
+            null,
+            view.inputTemplates,
+            project,
+            FileChooserDescriptorFactory.createSingleFileDescriptor(JsonFileType.INSTANCE),
+            TextComponentAccessor.STRING_COMBOBOX_WHOLE_TEXT
+        ) {
+            override fun getInitialFile(): VirtualFile? {
+                val file = project.baseDir
+                if (file != null) {
+                    return file
+                }
+                return super.getInitialFile()
+            }
+
+            override fun onFileChosen(chosenFile: VirtualFile) {
+                view.eventComboBoxModel.selectedItem = null
+
+                val contents = chosenFile.contentsToByteArray(false).toString(StandardCharsets.UTF_8)
+                val cleanedUp = StringUtil.convertLineSeparators(contents)
+                if (chosenFile.extension == "json") {
+                    view.inputText.formatAndSet(cleanedUp, JsonLanguage.INSTANCE)
+                } else {
+                    view.inputText.text = cleanedUp
+                }
+            }
+        }
+        view.inputTemplates.addActionListener(actionListener)
+
+        eventProvider.get().thenAccept { events ->
+            runInEdt(ModalityState.any()) {
+                view.eventComboBoxModel.setAll(events)
+                view.eventComboBox.selectedItem = null
+            }
+        }
+
+        view.eventComboBox.addActionListener { _ ->
+            view.eventComboBoxModel.selectedItem?.let { event ->
+                event.content.thenApply { content ->
+                    val cleanedUp = StringUtil.convertLineSeparators(content)
+                    runInEdt(ModalityState.any()) {
+                        view.inputText.formatAndSet(cleanedUp, JsonLanguage.INSTANCE)
+                    }
+                }
+            }
+        }
     }
 
     override fun resetEditorFrom(configuration: LambdaLocalRunConfiguration) {
         view.runtime.selectedItem = configuration.settings.runtime?.let { Runtime.valueOf(it) }
         view.handler.setText(configuration.settings.handler)
-        view.input.setText(configuration.settings.input)
         view.environmentVariables.envVars = configuration.settings.environmentVariables
+        view.isUsingInputFile = configuration.settings.inputIsFile
+        if (configuration.settings.inputIsFile) {
+            view.inputFile.setText(configuration.settings.input)
+        } else {
+            view.inputText.setText(configuration.settings.input)
+        }
     }
 
     override fun createEditor(): JPanel = view.panel
@@ -174,8 +262,14 @@ class LocalLambdaRunSettingsEditor(project: Project) : SettingsEditor<LambdaLoca
     override fun applyEditorTo(configuration: LambdaLocalRunConfiguration) {
         configuration.settings.runtime = (view.runtime.selectedItem as? Runtime)?.name
         configuration.settings.handler = view.handler.text
-        configuration.settings.input = view.input.text
+        configuration.settings.input = view.inputText.text
         configuration.settings.environmentVariables = view.environmentVariables.envVars.toMutableMap()
+        configuration.settings.inputIsFile = view.isUsingInputFile
+        configuration.settings.input = if (view.isUsingInputFile) {
+            view.inputFile.text.trim()
+        } else {
+            view.inputText.text.trim()
+        }
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LocalLambdaRunSettingsEditorPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LocalLambdaRunSettingsEditorPanel.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="645" height="605"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -16,41 +16,11 @@
           <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.handler.label"/>
         </properties>
       </component>
-      <component id="af549" class="com.intellij.ui.EditorTextField" binding="input" custom-create="true" default-binding="true">
-        <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <preferred-size width="-1" height="150"/>
-          </grid>
-        </constraints>
-        <properties/>
-      </component>
-      <component id="4160d" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.input.label"/>
-        </properties>
-      </component>
       <component id="58044" class="com.intellij.ui.EditorTextField" binding="handler" custom-create="true">
         <constraints>
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
-        </constraints>
-        <properties/>
-      </component>
-      <component id="7c830" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.create.env_vars.label"/>
-        </properties>
-      </component>
-      <component id="c2e65" class="software.aws.toolkits.jetbrains.ui.EnvironmentVariablesTextField" binding="environmentVariables">
-        <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -68,6 +38,93 @@
         </constraints>
         <properties/>
       </component>
+      <component id="7c830" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.create.env_vars.label"/>
+        </properties>
+      </component>
+      <component id="c2e65" class="software.aws.toolkits.jetbrains.ui.EnvironmentVariablesTextField" binding="environmentVariables">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="4160d" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.input.label"/>
+        </properties>
+      </component>
+      <grid id="6ee9b" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="7031a" class="javax.swing.JRadioButton" binding="useInputFile">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.run_configuration.input.file.lable"/>
+            </properties>
+          </component>
+          <component id="bfec3" class="javax.swing.JRadioButton" binding="useInputText">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="true"/>
+              <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.run_configuration.input.text.lable"/>
+            </properties>
+          </component>
+          <component id="1cd85" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="inputFile">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <grid id="6fbe" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="15f5e" class="com.intellij.ui.ComboboxWithBrowseButton" binding="inputTemplates" custom-create="true">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+              </component>
+              <component id="af549" class="com.intellij.ui.EditorTextField" binding="inputText" custom-create="true">
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                    <preferred-size width="-1" height="300"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
+            </children>
+          </grid>
+        </children>
+      </grid>
     </children>
   </grid>
+  <buttonGroups>
+    <group name="inputButtonGroup">
+      <member id="b28f6"/>
+      <member id="a8cbd"/>
+      <member id="7031a"/>
+      <member id="bfec3"/>
+    </group>
+  </buttonGroups>
 </form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LocalLambdaRunSettingsEditorPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LocalLambdaRunSettingsEditorPanel.java
@@ -4,32 +4,77 @@ import com.intellij.json.JsonLanguage;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.ComboboxWithBrowseButton;
 import com.intellij.ui.EditorTextField;
 import com.intellij.ui.EditorTextFieldProvider;
+import com.intellij.ui.SortedComboBoxModel;
 import com.intellij.util.textCompletion.TextCompletionProvider;
 import com.intellij.util.textCompletion.TextFieldWithCompletion;
+import com.intellij.util.ui.UIUtil;
 import java.util.Collections;
+import java.util.Comparator;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import software.amazon.awssdk.services.lambda.model.Runtime;
+import software.aws.toolkits.core.lambda.LambdaSampleEvent;
 import software.aws.toolkits.jetbrains.ui.EnvironmentVariablesTextField;
 
 public final class LocalLambdaRunSettingsEditorPanel {
     JPanel panel;
     EditorTextField handler;
-    EditorTextField input;
+    EditorTextField inputText;
     EnvironmentVariablesTextField environmentVariables;
     ComboBox<Runtime> runtime;
+    ComboboxWithBrowseButton inputTemplates;
+    JRadioButton useInputFile;
+    JRadioButton useInputText;
+    TextFieldWithBrowseButton inputFile;
+    ComboBox<LambdaSampleEvent> eventComboBox;
+    SortedComboBoxModel<LambdaSampleEvent> eventComboBoxModel;
     private final Project project;
     private final TextCompletionProvider handlerCompletionProvider;
 
     public LocalLambdaRunSettingsEditorPanel(Project project, TextCompletionProvider handlerCompletionProvider) {
         this.project = project;
         this.handlerCompletionProvider = handlerCompletionProvider;
+
+        useInputText.addActionListener(e -> updateComponents());
+        useInputFile.addActionListener(e -> updateComponents());
+
+        updateComponents();
     }
 
     private void createUIComponents() {
         EditorTextFieldProvider textFieldProvider = ServiceManager.getService(project, EditorTextFieldProvider.class);
-        input = textFieldProvider.getEditorField(JsonLanguage.INSTANCE, project, Collections.emptyList());
+        inputText = textFieldProvider.getEditorField(JsonLanguage.INSTANCE, project, Collections.emptyList());
         handler = new TextFieldWithCompletion(project, handlerCompletionProvider, "", true, true, true, true);
+
+        eventComboBoxModel = new SortedComboBoxModel<>(Comparator.comparing(LambdaSampleEvent::getName));
+        eventComboBox = new ComboBox<>(eventComboBoxModel);
+        inputTemplates = new ComboboxWithBrowseButton(eventComboBox);
+    }
+
+    private void updateComponents() {
+        inputTemplates.setEnabled(useInputText.isSelected());
+        inputText.setEnabled(useInputText.isSelected());
+        if(inputText.isEnabled()) {
+            inputText.setBackground(UIUtil.getTextFieldBackground());
+        } else {
+            inputText.setBackground(panel.getBackground());
+        }
+
+        inputFile.setEnabled(useInputFile.isSelected());
+    }
+
+    public boolean isUsingInputFile() {
+        return useInputFile.isSelected();
+    }
+
+    public void setUsingInputFile(boolean value) {
+        useInputFile.setSelected(value);
+        useInputText.setSelected(!value);
+
+        updateComponents();
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
@@ -1,8 +1,14 @@
 package software.aws.toolkits.jetbrains.utils.ui
 
+import com.intellij.lang.Language
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
+import com.intellij.ui.EditorTextField
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JComboBox
 import javax.swing.JTextField
@@ -39,3 +45,23 @@ fun JTextField?.blankAsNull(): String? = if (this?.text?.isNotBlank() == true) {
 
 @Suppress("UNCHECKED_CAST")
 fun <T> JComboBox<T>?.selected(): T? = this?.selectedItem as? T
+
+fun EditorTextField.formatAndSet(content: String, language: Language) {
+    // Initial docs can't be undo'ed
+    CommandProcessor.getInstance().runUndoTransparentAction {
+        runWriteAction {
+            val formatted =
+                LanguageCodeStyleSettingsProvider.createFileFromText(
+                    language,
+                    project,
+                    content
+                )?.let {
+                    CodeStyleManager.getInstance(project).reformat(it)
+                    it.text
+                } ?: content
+
+            val document = this.document
+            document.replaceString(0, document.textLength, formatted)
+        }
+    }
+}

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -72,3 +72,6 @@ lambda.environment.label=Environment Variables:
 lambda.run_configuration.no_handler_specified=Must specify a handler.
 lambda.run_configuration.handler_not_found=Cannot find handler ''{0}'' in project.
 lambda.run_configuration.no_runtime_specified=Must specify runtime.
+lambda.run_configuration.input_file_error=Failed to load input file: {0}
+lambda.run_configuration.input.file.lable=Use file:
+lambda.run_configuration.input.text.lable=Use text:


### PR DESCRIPTION
* Add the Lambda input templates to run configuration editor
* Add the ability to load template from a file
* Add the ability to use a static input file

Fixes #150, #151

![screen shot 2018-08-24 at 2 12 57 pm](https://user-images.githubusercontent.com/8992246/44608551-f7e31980-a7a8-11e8-927b-42d75e6c2319.png)

![screen shot 2018-08-24 at 2 22 03 pm](https://user-images.githubusercontent.com/8992246/44608817-139aef80-a7aa-11e8-9f80-be2c861d990b.png)