### PR TITLE
Add region selecting to Lambda run configuration

### DIFF
--- a/.changes/next-release/feature-55f36b5e-3d67-4732-b751-2f304981c5dd.json
+++ b/.changes/next-release/feature-55f36b5e-3d67-4732-b751-2f304981c5dd.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Add region selection to Lambda local"
+}

--- a/core/src/software/aws/toolkits/core/region/ToolkitRegionProvider.kt
+++ b/core/src/software/aws/toolkits/core/region/ToolkitRegionProvider.kt
@@ -13,7 +13,7 @@ interface ToolkitRegionProvider {
     fun regions(): Map<String, AwsRegion>
     fun defaultRegion(): AwsRegion
 
-    fun lookupRegionById(regionId: String): AwsRegion {
+    fun lookupRegionById(regionId: String?): AwsRegion {
         return regions()[regionId] ?: defaultRegion()
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/JavaExtensions.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/JavaExtensions.kt
@@ -255,10 +255,10 @@ class JavaLambdaHandlerResolver : LambdaHandlerResolver {
 
 class JavaLambdaLocalRunProvider : LambdaLocalRunProvider {
     override fun createRunProfileState(environment: ExecutionEnvironment, project: Project, settings: LambdaRunSettings): RunProfileState =
-        LambdaJavaCommandLineState(environment, project, settings)
+        LambdaJavaCommandLineState(environment, settings)
 }
 
-internal class LambdaJavaCommandLineState(environment: ExecutionEnvironment, private val project: Project, private val settings: LambdaRunSettings) :
+internal class LambdaJavaCommandLineState(environment: ExecutionEnvironment, private val settings: LambdaRunSettings) :
     JavaCommandLineState(environment) {
     override fun createJavaParameters(): JavaParameters {
         return JavaParameters().apply {
@@ -267,7 +267,8 @@ internal class LambdaJavaCommandLineState(environment: ExecutionEnvironment, pri
             classPath.addFirst(InvokerJar.jar)
             mainClass = InvokerJar.mainClass
             env = settings.environmentVariables
-            isPassParentEnvs = true
+            // Do not inherit the System env var, they should configure through run config just like Lambda does
+            isPassParentEnvs = false
             programParametersList.add("-h", settings.handler)
             settings.input?.run { programParametersList.add("-i", this) }
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LocalLambdaRunSettingsEditorPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LocalLambdaRunSettingsEditorPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.lambda.local.LocalLambdaRunSettingsEditorPanel">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="645" height="605"/>
@@ -54,7 +54,7 @@
       </component>
       <component id="4160d" class="javax.swing.JLabel">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.input.label"/>
@@ -63,7 +63,7 @@
       <grid id="6ee9b" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -117,6 +117,19 @@
           </grid>
         </children>
       </grid>
+      <component id="dc226" class="software.aws.toolkits.jetbrains.ui.RegionSelector" binding="regionSelector">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </component>
+      <component id="9e917" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.run_configuration.region.label"/>
+        </properties>
+      </component>
     </children>
   </grid>
   <buttonGroups>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LocalLambdaRunSettingsEditorPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/local/LocalLambdaRunSettingsEditorPanel.java
@@ -22,6 +22,7 @@ import javax.swing.JRadioButton;
 import software.amazon.awssdk.services.lambda.model.Runtime;
 import software.aws.toolkits.core.lambda.LambdaSampleEvent;
 import software.aws.toolkits.jetbrains.ui.EnvironmentVariablesTextField;
+import software.aws.toolkits.jetbrains.ui.RegionSelector;
 
 public final class LocalLambdaRunSettingsEditorPanel {
     JPanel panel;
@@ -33,6 +34,7 @@ public final class LocalLambdaRunSettingsEditorPanel {
     JRadioButton useInputFile;
     JRadioButton useInputText;
     TextFieldWithBrowseButton inputFile;
+    RegionSelector regionSelector;
     ComboBox<LambdaSampleEvent> eventComboBox;
     SortedComboBoxModel<LambdaSampleEvent> eventComboBoxModel;
     private final Project project;

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/RegionSelector.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/RegionSelector.kt
@@ -1,0 +1,53 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.ui
+
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.CollectionComboBoxModel
+import com.intellij.ui.ListCellRendererWrapper
+import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.jetbrains.utils.ui.selected
+import javax.swing.JList
+
+/**
+ * Combo box used to select a region
+ * TODO: Determine the UX for the box, do we want to categorize?
+ */
+class RegionSelector : ComboBox<AwsRegion>() {
+    private val comboBoxModel = object : CollectionComboBoxModel<AwsRegion>() {
+        fun setItems(newItems: List<AwsRegion>) {
+            internalList.apply {
+                clear()
+                addAll(newItems)
+            }
+        }
+    }
+
+    init {
+        model = comboBoxModel
+        setRenderer(Renderer()) // use the setter, not protected field
+    }
+
+    var regions: List<AwsRegion>
+        get() {
+            return comboBoxModel.toList()
+        }
+        set(value) {
+            comboBoxModel.items = value
+        }
+
+    var selectedRegion: AwsRegion?
+        get() {
+            return selected()
+        }
+        set(value) {
+            selectedItem = value
+        }
+
+    private inner class Renderer : ListCellRendererWrapper<AwsRegion>() {
+        override fun customize(list: JList<*>?, value: AwsRegion, index: Int, selected: Boolean, hasFocus: Boolean) {
+            setText(value.displayName)
+        }
+    }
+}

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -78,3 +78,5 @@ lambda.run_configuration.no_runtime_specified=Must specify runtime.
 lambda.run_configuration.input_file_error=Failed to load input file: {0}
 lambda.run_configuration.input.file.lable=Use file:
 lambda.run_configuration.input.text.lable=Use text:
+lambda.run_configuration.region.label=Region:
+lambda.run_configuration.no_region_specified=Must specify a region.


### PR DESCRIPTION
* Create a reuseable region selector
* Add region selection to run configuration that gets passed in as the standard env vars
* Don't inherit the system env vars when executing

Fixes #168