### PR TITLE
Remove the fat borders on tool window

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -28,7 +28,6 @@ import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsMa
 import software.aws.toolkits.jetbrains.core.explorer.ExplorerDataKeys.SELECTED_RESOURCE_NODES
 import software.aws.toolkits.jetbrains.core.explorer.ExplorerDataKeys.SELECTED_SERVICE_NODE
 import java.awt.Component
-import java.awt.FlowLayout
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.JPanel
@@ -36,12 +35,11 @@ import javax.swing.JTree
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
 
-class ExplorerToolWindow(val project: Project) : SimpleToolWindowPanel(true, false), AccountSettingsChangedNotifier {
+class ExplorerToolWindow(val project: Project) : SimpleToolWindowPanel(true, true), AccountSettingsChangedNotifier {
     private val actionManager = ActionManagerEx.getInstanceEx()
 
     private val treePanelWrapper: Wrapper = Wrapper()
     private val errorPanel: JPanel
-    private val mainPanel: JPanel
     private var awsTree: Tree? = null
 
     init {
@@ -50,8 +48,6 @@ class ExplorerToolWindow(val project: Project) : SimpleToolWindowPanel(true, fal
         errorPanel = JPanel()
         errorPanel.add(link)
 
-        mainPanel = JPanel(FlowLayout(FlowLayout.LEADING, 0, 0))
-        setToolbar(mainPanel)
         setContent(treePanelWrapper)
 
         project.messageBus.connect().subscribe(ProjectAccountSettingsManager.ACCOUNT_SETTINGS_CHANGED, this)


### PR DESCRIPTION
* Use borderless SimpleToolWindowPanel to match other windows
* Remove blank action toolbar that was causing a fatter header border

![screen shot 2018-09-13 at 12 59 32 pm](https://user-images.githubusercontent.com/8992246/45512650-368b4480-b755-11e8-8dbd-4c468e7631af.png)
