### PR TITLE
Add Run to Lambda explorer context menu

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -81,6 +81,7 @@
         <codeInsight.lineMarkerProvider language="" implementationClass="software.aws.toolkits.jetbrains.services.lambda.upload.LambdaLineMarker"/>
         <configurationType implementation="software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfiguration"/>
         <runConfigurationProducer implementation="software.aws.toolkits.jetbrains.services.lambda.execution.local.LambdaLocalRunConfigurationProducer"/>
+        <runConfigurationProducer implementation="software.aws.toolkits.jetbrains.services.lambda.execution.remote.LambdaRemoteRunConfigurationProducer"/>
     </extensions>
 
     <extensions defaultExtensionNs="aws.toolkit">
@@ -91,6 +92,8 @@
 
     <actions>
         <group id="aws.toolkit.explorer.lambda.function" popup="true" compact="false">
+            <reference ref="RunContextGroupInner"/>
+            <separator/>
             <action id="lambda.function.gotohandler"
                     class="software.aws.toolkits.jetbrains.services.lambda.actions.GoToHandlerAction"/>
             <separator/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
@@ -37,10 +37,16 @@ class DefaultAwsResourceCache(
             return emptyList()
         }
 
-        val resourceKey = "${accountSettingsManager.activeRegion}:${credentialProvider.id}:lambdafunctions"
-        return cache.computeIfAbsent(resourceKey) {
+        val region = accountSettingsManager.activeRegion
+        val credentialProviderId = credentialProvider.id
+
+        val resourceKey = "$region:$credentialProviderId:lambdafunctions"
+        return cache.computeIfAbsent(resourceKey) { _ ->
             val client = clientManager.getClient<LambdaClient>()
-            client.listFunctionsPaginator().functions().map { it.toDataClass(client) }.toList()
+
+            return@computeIfAbsent client.listFunctionsPaginator().functions()
+                .map { it.toDataClass(credentialProviderId, region) }
+                .toList()
         } as List<LambdaFunction>
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.explorer
 
+import com.intellij.execution.Location
 import com.intellij.ide.util.treeView.AbstractTreeBuilder
 import com.intellij.ide.util.treeView.NodeDescriptor
 import com.intellij.ide.util.treeView.NodeRenderer
@@ -27,6 +28,8 @@ import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsMa
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager.AccountSettingsChangedNotifier
 import software.aws.toolkits.jetbrains.core.explorer.ExplorerDataKeys.SELECTED_RESOURCE_NODES
 import software.aws.toolkits.jetbrains.core.explorer.ExplorerDataKeys.SELECTED_SERVICE_NODE
+import software.aws.toolkits.jetbrains.services.lambda.LambdaFunctionNode
+import software.aws.toolkits.jetbrains.services.lambda.execution.remote.RemoteLambdaLocation
 import java.awt.Component
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
@@ -129,6 +132,14 @@ class ExplorerToolWindow(val project: Project) : SimpleToolWindowPanel(true, tru
         }
         if (SELECTED_SERVICE_NODE.`is`(dataId)) {
             return getSelectedServiceNode()
+        }
+        if (Location.DATA_KEY.`is`(dataId)) {
+            val lambdas = getSelectedNodesSameType<LambdaFunctionNode>()
+            if (lambdas?.size != 1) {
+                return null
+            }
+
+            return RemoteLambdaLocation(project, lambdas.first().function)
         }
 
         return super.getData(dataId)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
@@ -9,10 +9,10 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.search.GlobalSearchScope
-import software.amazon.awssdk.services.lambda.LambdaClient
 import software.amazon.awssdk.services.lambda.model.CreateFunctionResponse
 import software.amazon.awssdk.services.lambda.model.FunctionConfiguration
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.region.AwsRegion
 
 object Lambda {
     fun findPsiElementsForHandler(project: Project, runtime: Runtime, handler: String): Array<NavigatablePsiElement> {
@@ -27,28 +27,31 @@ data class LambdaFunction(
     val arn: String,
     val lastModified: String,
     val handler: String,
-    val client: LambdaClient,
-    val runtime: Runtime
+    val runtime: Runtime,
+    val region: AwsRegion,
+    val credentialProviderId: String
 )
 
-fun FunctionConfiguration.toDataClass(client: LambdaClient) = LambdaFunction(
+fun FunctionConfiguration.toDataClass(credentialProviderId: String, region: AwsRegion) = LambdaFunction(
     name = this.functionName(),
     description = this.description(),
     arn = this.functionArn(),
     lastModified = this.lastModified(),
     handler = this.handler(),
     runtime = this.runtime(),
-    client = client
+    credentialProviderId = credentialProviderId,
+    region = region
 )
 
-fun CreateFunctionResponse.toDataClass(client: LambdaClient) = LambdaFunction(
+fun CreateFunctionResponse.toDataClass(credentialProviderId: String, region: AwsRegion) = LambdaFunction(
     name = this.functionName(),
     description = this.description(),
     arn = this.functionArn(),
     lastModified = this.lastModified(),
     handler = this.handler(),
     runtime = this.runtime(),
-    client = client
+    credentialProviderId = credentialProviderId,
+    region = region
 )
 
 /**

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfigurationBase.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfigurationBase.kt
@@ -39,10 +39,7 @@ abstract class LambdaRunConfigurationBase<T : LambdaRunConfigurationBase.Mutable
         return copy
     }
 
-    final override fun suggestedName(): String? = settings.handler
-
     abstract class MutableLambdaRunSettings(
-        var handler: String?,
         var input: String?,
         var inputIsFile: Boolean
     ) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LambdaLocalRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LambdaLocalRunConfiguration.kt
@@ -133,15 +133,17 @@ class LambdaLocalRunConfiguration(project: Project, factory: ConfigurationFactor
         return settings.handler
     }
 
+    override fun suggestedName(): String? = settings.handler
+
     class MutableLambdaLocalRunSettings(
         var runtime: String? = null,
-        handler: String? = null,
+        var handler: String? = null,
         input: String? = null,
         inputIsFile: Boolean = false,
         var environmentVariables: MutableMap<String, String> = mutableMapOf(),
         var regionId: String? = null,
         var credentialProviderId: String? = null
-    ) : MutableLambdaRunSettings(handler, input, inputIsFile) {
+    ) : MutableLambdaRunSettings(input, inputIsFile) {
         fun validateAndCreateImmutable(project: Project): LambdaLocalRunSettings {
             val handler =
                 handler ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_handler_specified"))

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunConfiguration.kt
@@ -53,13 +53,14 @@ class LambdaRemoteRunConfiguration(project: Project, factory: ConfigurationFacto
         return RemoteLambdaState(environment, settings.validateAndCreateImmutable())
     }
 
-    @TestOnly
+    override fun suggestedName() = settings.functionName
+
     fun configure(
         credentialProviderId: String?,
         regionId: String?,
         functionName: String?,
-        input: String,
-        inputIsFile: Boolean
+        input: String? = null,
+        inputIsFile: Boolean = false
     ) {
         settings.credentialProviderId = credentialProviderId
         settings.regionId = regionId
@@ -68,13 +69,16 @@ class LambdaRemoteRunConfiguration(project: Project, factory: ConfigurationFacto
         settings.inputIsFile = inputIsFile
     }
 
+    @TestOnly
+    fun getInternalSettings() = settings
+
     class MutableRemoteLambdaSettings(
         var credentialProviderId: String? = null,
         var regionId: String? = null,
         var functionName: String? = null,
         input: String? = null,
         inputIsFile: Boolean = false
-    ) : MutableLambdaRunSettings(functionName, input, inputIsFile) {
+    ) : MutableLambdaRunSettings(input, inputIsFile) {
         fun validateAndCreateImmutable(): LambdaRemoteRunSettings {
             val credProviderId = credentialProviderId
                     ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_credentials_specified"))

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunConfigurationProducer.kt
@@ -1,0 +1,52 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution.remote
+
+import com.intellij.execution.RunManager
+import com.intellij.execution.RunnerAndConfigurationSettings
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.execution.actions.RunConfigurationProducer
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.PsiElement
+import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfiguration
+
+class LambdaRemoteRunConfigurationProducer : RunConfigurationProducer<LambdaRemoteRunConfiguration>(getFactory()) {
+    override fun getConfigurationSettingsList(runManager: RunManager): List<RunnerAndConfigurationSettings> {
+        // Filter all Lambda run configurations down to only ones that are Lambda remote for this run producer
+        return super.getConfigurationSettingsList(runManager)
+            .filter { it.configuration is LambdaRemoteRunConfiguration }
+    }
+
+    override fun setupConfigurationFromContext(
+        configuration: LambdaRemoteRunConfiguration,
+        context: ConfigurationContext,
+        sourceElement: Ref<PsiElement>
+    ): Boolean {
+        val location = context.location as? RemoteLambdaLocation ?: return false
+        val function = location.lambdaFunction
+
+        configuration.configure(function.credentialProviderId, function.region.id, function.name)
+        configuration.setGeneratedName()
+        return true
+    }
+
+    override fun isConfigurationFromContext(
+        configuration: LambdaRemoteRunConfiguration,
+        context: ConfigurationContext
+    ): Boolean {
+        val location = context.location as? RemoteLambdaLocation ?: return false
+        val function = location.lambdaFunction
+        return configuration.settings.functionName == function.name &&
+                configuration.settings.credentialProviderId == function.credentialProviderId &&
+                configuration.settings.regionId == function.region.id
+    }
+
+    companion object {
+        private fun getFactory(): ConfigurationFactory {
+            return LambdaRunConfiguration.getInstance()
+                .configurationFactories.first { it is LambdaRemoteRunConfigurationFactory }
+        }
+    }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaLocation.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaLocation.kt
@@ -1,0 +1,65 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution.remote
+
+import com.intellij.execution.Location
+import com.intellij.lang.ASTNode
+import com.intellij.lang.Language
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.PsiElementBase
+import software.aws.toolkits.jetbrains.services.lambda.LambdaFunction
+import software.aws.toolkits.jetbrains.services.lambda.execution.remote.RemoteLambdaLocation.PsiLambda
+
+/**
+ * Custom [Location] to represent the Lambda elements in the explorer so the Remote rune configurations work. A fake
+ * PSI element is also used since no valid PSI can exist to represent a remote Lambda
+ */
+class RemoteLambdaLocation(private val project: Project, val lambdaFunction: LambdaFunction) : Location<PsiLambda>() {
+    private val element = PsiLambda(project)
+
+    override fun getProject(): Project = project
+
+    override fun getModule(): Module? = null
+
+    override fun <T : PsiElement?> getAncestors(
+        ancestorClass: Class<T>?,
+        strict: Boolean
+    ): MutableIterator<Location<T>> = throw UnsupportedOperationException()
+
+    override fun getPsiElement(): PsiLambda = element
+
+    class PsiLambda(private val project: Project) : PsiElementBase() {
+        override fun getProject(): Project = project
+
+        override fun getContainingFile(): PsiFile? = null
+
+        override fun getText(): String = throw UnsupportedOperationException()
+
+        override fun getStartOffsetInParent(): Int = throw UnsupportedOperationException()
+
+        override fun getLanguage(): Language = Language.ANY
+
+        override fun isValid(): Boolean = true
+
+        override fun getTextRange(): TextRange = throw UnsupportedOperationException()
+
+        override fun findElementAt(offset: Int): PsiElement? = throw UnsupportedOperationException()
+
+        override fun getTextLength(): Int = throw UnsupportedOperationException()
+
+        override fun getTextOffset(): Int = throw UnsupportedOperationException()
+
+        override fun textToCharArray(): CharArray = throw UnsupportedOperationException()
+
+        override fun getNode(): ASTNode? = null
+
+        override fun getParent(): PsiElement? = null
+
+        override fun getChildren(): Array<PsiElement> = PsiElement.EMPTY_ARRAY
+    }
+}


### PR DESCRIPTION
    Add Run to Lambda explorer context menu

    * Change Lamda function data classes to take cred ID and region instead of client
    * Create fake LambdaPsi and Lambda Location to represent a remote Lambda to RunConfigurationProducer
    * Inject in the dynamiclly build ActionGroup RunContextGroupInner. Using Inner instead ofRunContextGroup due to the additional CreateAction is confusing, especially since it inherits the Lambda icon and reads as if we are going to create a Lambda, not a Run Configuration

    Fixes #213 

Note: Just realized I built this on top of #212 so will rebase onto master once that is reviewed.
Note 2: Still looking into best way to write tests for this

![screen shot 2018-09-14 at 2 08 01 pm](https://user-images.githubusercontent.com/8992246/45575225-a0741e80-b827-11e8-8ee8-c66d2c57d077.png)
