### PR TITLE
Always show the Go To Source action, just disable it if multi-select

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/GoToHandlerAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/GoToHandlerAction.kt
@@ -8,23 +8,27 @@ import com.intellij.idea.ActionsBundle
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.psi.NavigatablePsiElement
 import com.intellij.util.OpenSourceUtil
-import software.aws.toolkits.jetbrains.core.explorer.SingleResourceNodeAction
+import software.aws.toolkits.jetbrains.core.explorer.ResourceNodeAction
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunctionNode
 
-class GoToHandlerAction : SingleResourceNodeAction<LambdaFunctionNode>() {
-    override fun update(selected: LambdaFunctionNode, e: AnActionEvent) {
+class GoToHandlerAction : ResourceNodeAction<LambdaFunctionNode>() {
+    override fun update(selected: List<LambdaFunctionNode>, e: AnActionEvent) {
         super.update(selected, e)
 
         val presentation = e.presentation
         presentation.icon = AllIcons.Actions.EditSource
         presentation.text = ActionsBundle.actionText("EditSource")
         presentation.description = ActionsBundle.actionText("EditSource")
-        presentation.isEnabled = getHandler(selected)?.isNotEmpty() ?: false
+        if (selected.size == 1) {
+            presentation.isEnabled = getHandler(selected.first())?.isNotEmpty() ?: false
+        } else {
+            presentation.isEnabled = false
+        }
         presentation.isVisible = true
     }
 
-    override fun actionPerformed(selected: LambdaFunctionNode, e: AnActionEvent) {
-        getHandler(selected)?.let {
+    override fun actionPerformed(selected: List<LambdaFunctionNode>, e: AnActionEvent) {
+        getHandler(selected.first())?.let {
             OpenSourceUtil.navigate(true, *it)
         }
     }


### PR DESCRIPTION
This will prevent the odd looking UI caused by multi-select in #215 

![screen shot 2018-09-14 at 3 35 14 pm](https://user-images.githubusercontent.com/8992246/45578003-d5866e00-b833-11e8-904b-97b6a3d9b84b.png)
