### PR TITLE
Correct word error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Currently the only way to consume the plugin is to build the source and add it a
   gradlew buildPlugin
   ```
   
-3. In your JetBrains IDE (e.g. IntelliJ) navigate to `Settings/Preferences` -> `Plugins` and select "Install Plugin from Disk". Nagivate to the directory where you cloned the project and select the `build/distributions/aws-jetbrains-toolkit-0.1-SNAPSHOT.zip` file. 
+3. In your JetBrains IDE (e.g. IntelliJ) navigate to `Settings/Preferences` -> `Plugins` and select "Install Plugin from Disk". Navigate to the directory where you cloned the project and select the `build/distributions/aws-jetbrains-toolkit-0.1-SNAPSHOT.zip` file. 
 4. You will be prompted to restart your IDE.
 
 ## Contributing


### PR DESCRIPTION
Changed the use of "nagivate" to the more correct "navigate".

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Slang dictionaries define "nagivate (verb)" as a portmanteau of "nag" and "navigate", meaning "to offer unwanted or annoying advice on how to drive to the driver of a vehicle in which one is a passenger". In the context of this particular sentence it is instructing the customer to open menu items themselves. While the request in the context of the sentence itself could be considered "nagivating", it would be incorrect to tell the reader to, themselves, nagivate.

It is more likely that the intended word here would be "navigate", which traditionally meant to "plan and direct the route or course of a ship, aircraft, or other form of transportation, especially by using instruments or maps.", but has been colloquially adopted in modern day to also be used for software menu traversals.

## Motivation and Context
This change reduces the chance of customer confusion in which they might attempt to (likely ineffectually) nag their computer to perform the action instead of perform the action themselves.

## Testing
The definitions and origins of the words in question were reviewed, and I believe the new phrasing to be more correct and less confusing. 

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.