### PR TITLE
Fixing travis build so that when region isn't available

### DIFF
--- a/core/src/software/aws/toolkits/core/credentials/AwsProfile.kt
+++ b/core/src/software/aws/toolkits/core/credentials/AwsProfile.kt
@@ -61,8 +61,12 @@ class ProfileToolkitCredentialsProvider(
                     .externalId(externalId)
                     .build()
 
-                val stsRegion = DefaultAwsRegionProviderChain().region?.let {
-                    regionProvider.regions()[it.id()]
+                val stsRegion = try {
+                    DefaultAwsRegionProviderChain().region?.let {
+                        regionProvider.regions()[it.id()]
+                    }
+                } catch (_: Exception) {
+                    null
                 } ?: AwsRegion.GLOBAL
 
                 // Override the default SPI for getting the active credentials since we are making an internal


### PR DESCRIPTION
#218

<!--- Provide a general summary of your changes in the Title above -->
Previously we were failing to load profile credentials if `DefaultAwsRegionProviderChain` did not find AWS_REGION (and thus threw an exception).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Previously we were failing to load profile credentials if `DefaultAwsRegionProviderChain` did not find AWS_REGION (and thus threw an exception).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Exposed as part of Travis CI build

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->
#128

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally using Travis Docker container

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
