### PR TITLE
Remove the Env Var and Sys Prop credential providers

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -84,8 +84,6 @@
 
     <extensions defaultExtensionNs="aws.toolkit">
         <credentialProviderFactory implementation="software.aws.toolkits.jetbrains.core.credentials.ProfileCredentialProviderFactory"/>
-        <credentialProviderFactory implementation="software.aws.toolkits.jetbrains.core.credentials.EnvironmentCredentialProviderFactory"/>
-        <credentialProviderFactory implementation="software.aws.toolkits.jetbrains.core.credentials.SystemPropertyCredentialProviderFactory"/>
     </extensions>
 
     <actions>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactory.kt
@@ -3,9 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.credentials
 
-import software.aws.toolkits.core.credentials.EnvironmentVariableToolkitCredentialsProviderFactory
 import software.aws.toolkits.core.credentials.ProfileToolkitCredentialsProviderFactory
-import software.aws.toolkits.core.credentials.SystemPropertyToolkitCredentialsProviderFactory
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProviderFactory
 import software.aws.toolkits.jetbrains.core.AwsSdkClient
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
@@ -16,17 +14,5 @@ class ProfileCredentialProviderFactory : CredentialProviderFactory {
             AwsSdkClient.getInstance().sdkHttpClient,
             AwsRegionProvider.getInstance()
         )
-    }
-}
-
-class EnvironmentCredentialProviderFactory : CredentialProviderFactory {
-    override fun createToolkitCredentialProviderFactory(): ToolkitCredentialsProviderFactory {
-        return EnvironmentVariableToolkitCredentialsProviderFactory()
-    }
-}
-
-class SystemPropertyCredentialProviderFactory : CredentialProviderFactory {
-    override fun createToolkitCredentialProviderFactory(): ToolkitCredentialsProviderFactory {
-        return SystemPropertyToolkitCredentialsProviderFactory()
     }
 }


### PR DESCRIPTION
## Types of changes
Breaking change

## Description
Remove the env var and system property credential providers

## Motivation and Context
The use case of editing system properties on IntelliJ or env variables to get credentials to work is odd. We can add it back if customers wish.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
