### PR TITLE
Add action that opens (creating if necessary) aws credentials file

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -98,6 +98,8 @@
                     text="Delete Function"
                     icon="AllIcons.Actions.Cancel"/>
         </group>
+        <action class="software.aws.toolkits.jetbrains.core.SettingsSelectorAction" id="aws.settings.selector" icon="AwsIcons.Logos.AWS"/>
+        <action class="software.aws.toolkits.jetbrains.core.credentials.CreateOrUpdateCredentialProfilesAction" id="aws.settings.upsertCredentials" icon="AwsIcons.Logos.AWS"/>
     </actions>
 
 </idea-plugin>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialWriter.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialWriter.kt
@@ -1,0 +1,147 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.credentials
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataKeys
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.LocalFileSystem
+import org.jetbrains.annotations.TestOnly
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting
+import software.amazon.awssdk.utils.JavaSystemSetting
+import software.amazon.awssdk.utils.StringUtils
+import software.aws.toolkits.resources.message
+import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.regex.Pattern
+
+class CreateOrUpdateCredentialProfilesAction @TestOnly constructor(
+    private val writer: CredentialFileWriter,
+    private val file: File
+) : AnAction(message("configure.toolkit.upsert_credentials.action")), DumbAware {
+    constructor() : this(DefaultCredentialFileWriter, FileLocation.credentialsFileLocationPath().toFile())
+
+    private val localFileSystem = LocalFileSystem.getInstance()
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.getRequiredData(DataKeys.PROJECT)
+
+        if (!file.exists()) {
+            if (confirm(project, file)) {
+                writer.createFile(file)
+            } else {
+                return
+            }
+        }
+
+        val virtualFile = localFileSystem.refreshAndFindFileByIoFile(file) ?: throw RuntimeException("Could not open $file")
+        virtualFile.isWritable = true
+        val fileEditorManager = FileEditorManager.getInstance(project)
+
+        localFileSystem.refreshFiles(listOf(virtualFile), false, false) {
+            fileEditorManager.openFile(virtualFile, true)
+        }
+    }
+
+    private fun confirm(project: Project, file: File): Boolean = Messages.showOkCancelDialog(
+        project,
+        message("configure.toolkit.upsert_credentials.confirm_file_create", file),
+        message("configure.toolkit.upsert_credentials.confirm_file_create.title"),
+        AllIcons.General.QuestionDialog
+    ) == Messages.OK
+}
+
+interface CredentialFileWriter {
+    fun createFile(file: File)
+}
+
+object DefaultCredentialFileWriter : CredentialFileWriter {
+    override fun createFile(file: File) {
+        val parent = file.parentFile
+        if (parent.mkdirs()) {
+            parent.setReadable(false, false)
+            parent.setReadable(true)
+            parent.setWritable(false, false)
+            parent.setWritable(true)
+            parent.setExecutable(false, false)
+            parent.setExecutable(true)
+        }
+
+        file.writeText(
+            """
+                [default]
+                aws_access_key_id=
+                aws_secret_access_key=
+            """.trimIndent()
+        )
+
+        file.setReadable(false, false)
+        file.setReadable(true)
+        file.setWritable(false, false)
+        file.setWritable(true)
+        file.setExecutable(false, false)
+        file.setExecutable(false)
+    }
+}
+
+// TODO: remove this, when https://github.com/aws/aws-sdk-java-v2/pull/730 is merged & released
+private object FileLocation {
+    private val HOME_DIRECTORY_PATTERN = Pattern.compile("^~(/|" + Pattern.quote(FileSystems.getDefault().separator) + ").*$")
+
+    /**
+     * Load the location for the credentials file, regardless of whether it actually exists
+     */
+    fun credentialsFileLocationPath() = resolveProfileFilePath(
+        ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE.stringValue
+            .orElse(Paths.get(userHomeDirectory(), ".aws", "credentials").toString())
+    )
+
+    private fun userHomeDirectory(): String {
+        val isWindows = JavaSystemSetting.OS_NAME.stringValue
+            .map { s -> StringUtils.lowerCase(s).startsWith("windows") }
+            .orElse(false)
+
+        // To match the logic of the CLI we have to consult environment variables directly.
+        // CHECKSTYLE:OFF
+        val home = System.getenv("HOME")
+
+        if (home != null) {
+            return home
+        }
+
+        if (isWindows) {
+            val userProfile = System.getenv("USERPROFILE")
+
+            if (userProfile != null) {
+                return userProfile
+            }
+
+            val homeDrive = System.getenv("HOMEDRIVE")
+            val homePath = System.getenv("HOMEPATH")
+
+            if (homeDrive != null && homePath != null) {
+                return homeDrive + homePath
+            }
+        }
+
+        return JavaSystemSetting.USER_HOME.stringValueOrThrow
+        // CHECKSTYLE:ON
+    }
+
+    private fun resolveProfileFilePath(path: String): Path {
+        var pathBuilder = path
+        // Resolve ~ using the CLI's logic, not whatever Java decides to do with it.
+        if (HOME_DIRECTORY_PATTERN.matcher(path).matches()) {
+            pathBuilder = userHomeDirectory() + path.substring(1)
+        }
+        return Paths.get(pathBuilder)
+    }
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CreateOrUpdateCredentialProfilesActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CreateOrUpdateCredentialProfilesActionTest.kt
@@ -1,0 +1,65 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.credentials
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.ui.TestDialog
+import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.TestActionEvent
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class CreateOrUpdateCredentialProfilesActionTest {
+
+    @Rule
+    @JvmField
+    val folderRule = TemporaryFolder()
+
+    @Rule
+    @JvmField
+    val projectRule = ProjectRule()
+
+    private val fileEditorManager = FileEditorManager.getInstance(projectRule.project)
+
+    @Test
+    fun confirmCalledIfFileDoesNotExist() {
+        val writer = mock<CredentialFileWriter> {
+            on { createFile(any()) }.doAnswer { it.getArgument<File>(0).writeText("hello") }
+        }
+
+        val file = File(folderRule.newFolder(), "credentials")
+
+        val sut = CreateOrUpdateCredentialProfilesAction(writer, file)
+        Messages.setTestDialog(TestDialog.OK)
+
+        sut.actionPerformed(TestActionEvent(DataContext { projectRule.project }))
+
+        verify(writer).createFile(file)
+
+        assertThat(fileEditorManager.openFiles).hasOnlyOneElementSatisfying { assertThat(it.name).isEqualTo("credentials") }
+    }
+
+    @Test
+    fun negativeConfirmationDoesNotCreateFile() {
+        val writer = mock<CredentialFileWriter>()
+
+        val file = File(folderRule.newFolder(), "credentials")
+        val sut = CreateOrUpdateCredentialProfilesAction(writer, file)
+        Messages.setTestDialog(TestDialog.NO)
+
+        sut.actionPerformed(TestActionEvent(DataContext { projectRule.project }))
+
+        verifyZeroInteractions(writer)
+    }
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultCredentialFileWriterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultCredentialFileWriterTest.kt
@@ -1,0 +1,76 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.credentials
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.IterableAssert
+import org.junit.Assume
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+
+class DefaultCredentialFileWriterTest {
+
+    @Rule
+    @JvmField
+    val folderRule = TemporaryFolder()
+
+    @Test
+    fun canCreateCredentialsFileTemplateWithAppropriatePermissions() {
+        val baseFolder = folderRule.newFolder()
+        val file = Paths.get(baseFolder.absolutePath, ".aws", "credentials").toFile()
+        val sut = DefaultCredentialFileWriter
+        sut.createFile(file)
+
+        assertThat(file).exists().hasContent(
+            """
+            [default]
+            aws_access_key_id=
+            aws_secret_access_key=
+        """.trimIndent()
+        )
+
+        assumeNoException<UnsupportedOperationException> {
+            assertThat(Files.getPosixFilePermissions(file.toPath())).matches("rw-------")
+            assertThat(Files.getPosixFilePermissions(file.parentFile.toPath())).matches("rwx------")
+        }
+    }
+
+    @Test
+    fun existingFolderPermissionsAreNotModified() {
+        val baseFolder = folderRule.newFolder()
+        baseFolder.setExecutable(true, false)
+        baseFolder.setWritable(true, false)
+        baseFolder.setReadable(true, false)
+        val file = Paths.get(baseFolder.absolutePath, "credentials").toFile()
+
+        val sut = DefaultCredentialFileWriter
+        sut.createFile(file)
+
+        assumeNoException<UnsupportedOperationException> {
+            assertThat(Files.getPosixFilePermissions(file.toPath())).matches("rw-------")
+            assertThat(Files.getPosixFilePermissions(file.parentFile.toPath())).matches("rwxrwxrwx")
+        }
+    }
+
+    private fun IterableAssert<PosixFilePermission>.matches(permissionString: String) {
+        containsOnly(*PosixFilePermissions.fromString(permissionString).toTypedArray())
+    }
+
+    private inline fun <reified T> assumeNoException(block: () -> Unit) {
+        try {
+            block()
+        } catch (e: Exception) {
+            if (e is T) {
+                Assume.assumeNoException(e)
+            } else {
+                throw e
+            }
+        }
+    }
+}

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -93,3 +93,7 @@ lambda.execute.logs=Logs: \n{0}
 lambda.execute.function_error=Function error: {0}
 lambda.execute.service_error=Error invoking Lambda: {0}
 lambda.execute.output=Output: \n{0}
+configure.toolkit=Configure AWS Connection
+configure.toolkit.upsert_credentials.action=Create/Update AWS Credential Profiles
+configure.toolkit.upsert_credentials.confirm_file_create=Credentials file {0} does not exist. Create it?
+configure.toolkit.upsert_credentials.confirm_file_create.title=Create Credential File


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Allow customers to edit their credentials file inside the IDE, creating a template file if it the file does not already exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->
#163

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests added to cover this feature

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
