### PR TITLE
Add the ability to run python unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,13 +205,13 @@ publishedProjects.forEach {
 }
 check.dependsOn coverageReport
 
-// Workaround for runIde being defined in multiple projects, if we request the root project runIde, all others will
-// be disabled
+// Workaround for runIde being defined in multiple projects, if we request the root project runIde, "alias" it to
+// community edition
 if (gradle.startParameter.taskNames.contains("runIde")) {
     println("Top level runIde selected, excluding sub-projects' runIde")
     gradle.taskGraph.whenReady { graph ->
         graph.allTasks.forEach {
-            if (it.name == "runIde" && it.project != gradle.rootProject) {
+            if (it.name == "runIde" && it.project != project(':jetbrains-core')) {
                 it.enabled = false
             }
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/PythonExtensions.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/PythonExtensions.kt
@@ -78,14 +78,20 @@ class PythonLambdaPackager : LambdaPackager {
 }
 
 class PythonLambdaHandlerResolver : LambdaHandlerResolver {
-    override fun findPsiElements(project: Project, handler: String, searchScope: GlobalSearchScope): Array<NavigatablePsiElement> {
+    override fun findPsiElements(
+        project: Project,
+        handler: String,
+        searchScope: GlobalSearchScope
+    ): Array<NavigatablePsiElement> {
         val psiFacade = PyPsiFacade.getInstance(project)
-        val module = handler.substringBeforeLast(".")
+        val lambdaModule = handler.substringBeforeLast(".")
         val function = handler.substringAfterLast(".")
-        return ModuleManager.getInstance(project).modules.flatMap {
-            psiFacade.resolveQualifiedName(QualifiedName.fromDottedString(module), fromModule(it)).flatMap {
-                it.children.filterIsInstance<NavigatablePsiElement>().filter { it.name == function }
-            }
+        return ModuleManager.getInstance(project).modules.flatMap { module ->
+            psiFacade.resolveQualifiedName(QualifiedName.fromDottedString(lambdaModule), fromModule(module))
+                .filterIsInstance<PyFile>()
+                .flatMap { pyFile ->
+                    pyFile.children.filterIsInstance<NavigatablePsiElement>().filter { it.name == function }
+                }
         }.toTypedArray()
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/PythonLambdaHandlerResolverTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/PythonLambdaHandlerResolverTest.kt
@@ -1,0 +1,54 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda
+
+import com.intellij.openapi.application.runReadAction
+import com.jetbrains.python.psi.PyFunction
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
+
+class PythonLambdaHandlerResolverTest {
+    @Rule
+    @JvmField
+    val projectRule = PythonCodeInsightTestFixtureRule()
+
+    @Test
+    fun testPythonFunctionResolves() {
+        projectRule.fixture.addFileToProject(
+            "hello_world/app.py",
+            """
+            def handle(event, context):
+                return "HelloWorld"
+            """.trimIndent()
+        )
+
+        runReadAction {
+            val elements =
+                Lambda.findPsiElementsForHandler(projectRule.project, Runtime.PYTHON3_6, "hello_world.app.handle")
+            assertThat(elements).hasSize(1)
+            assertThat(elements[0]).isInstanceOfSatisfying(PyFunction::class.java) {
+                assertThat(it.qualifiedName).isEqualTo("hello_world.app.handle")
+            }
+        }
+    }
+
+    @Test
+    fun testInvalidHandlerReturnsNothing() {
+        projectRule.fixture.addFileToProject(
+            "hello_world/app.py",
+            """
+            def handle(event, context):
+                return "HelloWorld"
+            """.trimIndent()
+        )
+
+        runReadAction {
+            val elements = Lambda.findPsiElementsForHandler(projectRule.project, Runtime.PYTHON3_6, "hello_world")
+            assertThat(elements).hasSize(0)
+        }
+    }
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/PythonCodeInsightTestFixtureRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/PythonCodeInsightTestFixtureRule.kt
@@ -1,0 +1,99 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.utils.rules
+
+import com.intellij.ide.util.projectWizard.EmptyModuleBuilder
+import com.intellij.openapi.module.ModuleType
+import com.intellij.openapi.module.ModuleTypeManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.builders.ModuleFixtureBuilder
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import com.intellij.testFramework.fixtures.ModuleFixture
+import com.intellij.testFramework.fixtures.TestFixtureBuilder
+import com.intellij.testFramework.fixtures.impl.ModuleFixtureBuilderImpl
+import com.intellij.testFramework.fixtures.impl.ModuleFixtureImpl
+import com.jetbrains.python.PythonModuleTypeBase
+import com.jetbrains.python.sdk.PythonSdkAdditionalData
+import com.jetbrains.python.sdk.PythonSdkType
+import com.jetbrains.python.sdk.flavors.CPythonSdkFlavor
+import org.jetbrains.annotations.NotNull
+import software.aws.toolkits.jetbrains.testutils.rules.CodeInsightTestFixtureRule
+
+/**
+ * JUnit test Rule that will create a Light [Project] and [CodeInsightTestFixture] with Python support. Projects are
+ * lazily created and are torn down after each test.
+ *
+ * If you wish to have just a [Project], you may use Intellij's [com.intellij.testFramework.ProjectRule]
+ */
+class PythonCodeInsightTestFixtureRule : CodeInsightTestFixtureRule() {
+    override fun createTestFixture(): CodeInsightTestFixture {
+        val fixtureFactory = IdeaTestFixtureFactory.getFixtureFactory()
+        fixtureFactory.registerFixtureBuilder(
+            PythonModuleFixtureBuilder::class.java,
+            PythonModuleFixtureBuilder::class.java
+        )
+        val fixtureBuilder = fixtureFactory.createFixtureBuilder(testName)
+        fixtureBuilder.addModule(PythonModuleFixtureBuilder::class.java)
+        val newFixture = fixtureFactory.createCodeInsightFixture(fixtureBuilder.fixture)
+        newFixture.testDataPath = testDataPath
+        newFixture.setUp()
+
+        val module = newFixture.module
+
+        val projectRoot = newFixture.tempDirFixture.getFile(".")
+        PsiTestUtil.addSourceRoot(module, projectRoot)
+        PsiTestUtil.addContentRoot(module, projectRoot)
+
+        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk())
+
+        return newFixture
+    }
+
+    override val fixture: CodeInsightTestFixture
+        get() = lazyFixture.value
+}
+
+internal class PythonModuleFixtureBuilder(fixtureBuilder: TestFixtureBuilder<out IdeaProjectTestFixture>) :
+    ModuleFixtureBuilderImpl<ModuleFixture>(PlatformPythonModuleType(), fixtureBuilder),
+    ModuleFixtureBuilder<ModuleFixture> {
+
+    override fun instantiateFixture(): ModuleFixture {
+        return ModuleFixtureImpl(this)
+    }
+}
+
+internal class PlatformPythonModuleType : PythonModuleTypeBase<EmptyModuleBuilder>() {
+    override fun createModuleBuilder(): EmptyModuleBuilder {
+        return object : EmptyModuleBuilder() {
+            override fun getModuleType(): ModuleType<EmptyModuleBuilder> {
+                return instance
+            }
+        }
+    }
+
+    companion object {
+        val instance: PlatformPythonModuleType
+            get() = ModuleTypeManager.getInstance().findByID(PYTHON_MODULE) as PlatformPythonModuleType
+    }
+}
+
+internal class PyTestSdk() : ProjectJdkImpl("Fake CPython", PythonSdkType.getInstance()) {
+    init {
+        sdkAdditionalData = PythonSdkAdditionalData(object : CPythonSdkFlavor() {
+            @NotNull
+            override fun getName(): String {
+                return "Fake CPython"
+            }
+        })
+    }
+
+    override fun getVersionString(): String? {
+        return "Fake CPython 3.7.0"
+    }
+}

--- a/jetbrains-testutils/src/software/aws/toolkits/jetbrains/testutils/rules/CodeInsightTestFixtureRule.kt
+++ b/jetbrains-testutils/src/software/aws/toolkits/jetbrains/testutils/rules/CodeInsightTestFixtureRule.kt
@@ -28,7 +28,7 @@ open class CodeInsightTestFixtureRule(protected val testDescription: LightProjec
     TestWatcher() {
     private lateinit var description: Description
     private val appRule = ApplicationRule()
-    internal val lazyFixture = ClearableLazy {
+    protected val lazyFixture = ClearableLazy {
         invokeAndWait {
             createTestFixture()
         }
@@ -82,7 +82,7 @@ open class CodeInsightTestFixtureRule(protected val testDescription: LightProjec
     }
 }
 
-internal class ClearableLazy<out T>(private val initializer: () -> T) {
+class ClearableLazy<out T>(private val initializer: () -> T) {
     private var _value: T? = null
     private var isSet = false
 


### PR DESCRIPTION
* Also alias runIde to jetbrains-core:runIde so plugins are installed
* Fix #269

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Add a unit test example for testing python code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#269 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
