### PR TITLE
Add exception handling logic for blank credentials file

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CreateOrUpdateCredentialProfilesActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CreateOrUpdateCredentialProfilesActionTest.kt
@@ -62,4 +62,13 @@ class CreateOrUpdateCredentialProfilesActionTest {
 
         verifyZeroInteractions(writer)
     }
+
+    @Test(expected = RuntimeException::class)
+    fun exceptionThrownIfFileIsEmpty() {
+        val file = File(folderRule.newFolder(), "credentials")
+        file.createNewFile()
+        val sut = CreateOrUpdateCredentialProfilesAction(mock(), file)
+
+        sut.actionPerformed(TestActionEvent(DataContext { projectRule.project }))
+    }
 }

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -111,3 +111,5 @@ lambda.sam.template_not_yaml=Sam template {0} is not Yaml.
 lambda.run_configuration.local=Local
 lambda.run_configuration.remote=Remote
 template_utils.key_not_found={0} not found on {1}
+credentials.could_not_open=Could not open credential file {0} for editing
+credentials.empty_file=Could not open empty credential file {0} for editing, please delete the file and try again


### PR DESCRIPTION
Fixes #336

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Throw exception when attempting to open a blank credentials file (rather than current behaviour of "no action").

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
IntelliJ can't detect the file type when the file is blank (and has no extension).

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added additional unit tests.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
