### PR TITLE
Fixing the exception thrown from `activeCredentialProvider` call

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsClientManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsClientManager.kt
@@ -12,11 +12,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import software.amazon.awssdk.core.SdkClient
 import software.aws.toolkits.core.ToolkitClientManager
+import software.aws.toolkits.core.credentials.CredentialProviderNotFound
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.AwsToolkit
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
-import javax.security.auth.login.CredentialNotFoundException
 
 open class AwsClientManager(project: Project, sdkClient: AwsSdkClient) :
     ToolkitClientManager(sdkClient.sdkHttpClient), Disposable {
@@ -41,7 +41,7 @@ open class AwsClientManager(project: Project, sdkClient: AwsSdkClient) :
     override fun getCredentialsProvider(): ToolkitCredentialsProvider {
         try {
             return accountSettingsManager.activeCredentialProvider
-        } catch (e: CredentialNotFoundException) {
+        } catch (e: CredentialProviderNotFound) {
             // TODO: Notify user
 
             // Throw canceled exception to stop any task relying on this call


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Was using a javax security inadvertently

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
