### PR TITLE
Suppress Java constructor as handler

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolver.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolver.kt
@@ -179,6 +179,7 @@ class JavaLambdaHandlerResolver : LambdaHandlerResolver {
     private fun PsiMethod.isValidHandler(parentClass: PsiClass, file: VirtualFile) = this.isPublic &&
         this.hasRequiredParameters() &&
         (!this.isStatic || this.name != "main") &&
+        !this.isConstructor &&
         (this.isStatic || parentClass.canBeInstantiatedByLambda()) &&
         !(parentClass.implementsLambdaHandlerInterface(file) && this.name == HANDLER_NAME)
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaLineMarkerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaLineMarkerTest.kt
@@ -205,6 +205,32 @@ Resources:
     }
 
     @Test
+    fun constructorAreNotMarked() {
+        val fixture = projectRule.fixture
+
+        fixture.openClass(
+                """
+             package com.example;
+
+             public class UsefulUtils {
+
+                 public UsefulUtils() {}
+
+                 public UsefulUtils(String abc) {
+                     System.out.println(abc);
+                 }
+
+                 private String upperCase(String input) {
+                     return input.toUpperCase();
+                 }
+             }
+             """
+        )
+
+        findAndAssertMarks(fixture) { assert(it).isEmpty() }
+    }
+
+    @Test
     fun javaMainMethodIsNotMarked() {
         val fixture = projectRule.fixture
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
A Java constructor with valid parameter list would be regarded as a Lambda handler when the constructor with no parameter exists. This clearly should be filtered out.

## Screenshots (if appropriate)
Previously:
<img width="859" alt="before" src="https://user-images.githubusercontent.com/7167513/48095526-d56a7500-e1c9-11e8-9a05-83f6576ca6bc.png">

After the change:
<img width="851" alt="after" src="https://user-images.githubusercontent.com/7167513/48095535-da2f2900-e1c9-11e8-9877-0ee77da6960f.png">


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
