### PR TITLE
Auto-detect SAM CLI if not set manually

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,3 +9,16 @@ dependencies {
     compile("software.amazon.awssdk:sts:$awsSdkVersion")
     testCompile("software.amazon.awssdk:service-test-utils:$awsSdkVersion")
 }
+
+configurations {
+    testArtifacts
+}
+
+task testJar (type: Jar) {
+    baseName = "${project.name}-test"
+    from sourceSets.test.output
+}
+
+artifacts {
+    testArtifacts testJar
+}

--- a/jetbrains-core/build.gradle
+++ b/jetbrains-core/build.gradle
@@ -49,5 +49,6 @@ dependencies {
     compile("software.amazon.awssdk:iam:$awsSdkVersion") {
         exclude group: 'org.slf4j'
     }
+    testCompile project(path: ":core", configuration: 'testArtifacts')
     testCompile project(":jetbrains-testutils")
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunConfiguration.kt
@@ -148,7 +148,7 @@ class SamRunConfiguration(project: Project, factory: ConfigurationFactory) :
         var logicalFunctionName: String? = null
     ) : MutableLambdaRunSettings(input, inputIsFile) {
         fun validateAndCreateImmutable(project: Project): SamRunSettings {
-            if (SamSettings.getInstance().executablePath.isEmpty()) {
+            if (SamSettings.getInstance().executablePath.isNullOrEmpty()) {
                 throw RuntimeConfigurationError(message("lambda.run_configuration.sam.not_specified")) {
                     ShowSettingsUtil.getInstance().showSettingsDialog(project, AwsSettingsConfigurable::class.java)
                 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettingsConfigurable.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettingsConfigurable.form
@@ -21,7 +21,7 @@
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="c0258" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="samExecutablePath">
+      <component id="c0258" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="samExecutablePath" custom-create="true">
         <constraints>
           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/SamExecutableDetector.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/SamExecutableDetector.kt
@@ -1,0 +1,70 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.settings
+
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.text.StringUtil
+import java.io.File
+
+open class SamExecutableDetector {
+    fun detect(): String? = if (SystemInfo.isWindows) {
+        detectForWindows()
+    } else {
+        detectForUnix()
+    }
+
+    private fun detectForWindows(): String? {
+        WINDOWS_PATHS.forEach { path ->
+            WINDOWS_EXECUTABLES.forEach { executable ->
+                val file = file(path, executable)
+                if (file.exists()) {
+                    return file.path
+                }
+            }
+        }
+
+        WINDOWS_EXECUTABLES.forEach { executable ->
+            val result = checkInPath(executable)
+            if (result != null) {
+                return result
+            }
+        }
+
+        return null
+    }
+
+    private fun detectForUnix(): String? {
+        UNIX_PATHS.forEach { path ->
+            val file = file(path, UNIX_EXECUTABLE)
+            if (file.exists()) {
+                return file.path
+            }
+        }
+        return checkInPath(UNIX_EXECUTABLE)
+    }
+
+    private fun checkInPath(executableName: String): String? {
+        val pathEnvVar = System.getenv(PATH_ENV) ?: return null
+        val pathEntries = StringUtil.split(pathEnvVar, File.pathSeparator)
+        pathEntries.forEach { pathEntry ->
+            val f = file(pathEntry, executableName)
+            if (f.exists()) {
+                return f.path
+            }
+        }
+        return null
+    }
+
+    protected open fun file(folder: String, name: String) = File(folder, name)
+
+    private companion object {
+        val UNIX_PATHS = arrayOf("/usr/local/bin", "/usr/bin")
+        const val UNIX_EXECUTABLE = "sam"
+
+        val WINDOWS_PATHS = arrayOf("C:\\Program Files\\Amazon\\AWSSAMCLI\\bin", "C:\\Program Files (x86)\\Amazon\\AWSSAMCLI\\bin")
+        val WINDOWS_EXECUTABLES = arrayOf("sam.cmd", "sam.exe")
+
+        const val PATH_ENV = "PATH"
+    }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/SamSettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/SamSettings.kt
@@ -18,10 +18,24 @@ class SamSettings : PersistentStateComponent<SamConfiguration> {
         this.state = state
     }
 
-    var executablePath: String
-        get() = state.executablePath
+    /**
+     * Returns the path to the SAM CLI executable by first using the manual value,
+     * if it is not set attempts to auto-detect it
+     */
+    val executablePath: String?
+        get() = if (state.savedExecutablePath.isNullOrEmpty()) {
+            SamExecutableDetector().detect()
+        } else {
+            state.savedExecutablePath
+        }
+
+    /**
+     * Exposes the saved (aka manually set) path to SAM CLI executable
+     */
+    var savedExecutablePath: String?
+        get() = state.savedExecutablePath
         set(value) {
-            state.executablePath = value
+            state.savedExecutablePath = value
         }
 
     companion object {
@@ -31,5 +45,5 @@ class SamSettings : PersistentStateComponent<SamConfiguration> {
 }
 
 data class SamConfiguration(
-    var executablePath: String = ""
+    var savedExecutablePath: String? = null
 )

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunConfigurationTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunConfigurationTest.kt
@@ -16,6 +16,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+import software.aws.toolkits.core.rules.EnvironmentVariableHelper
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
 import software.aws.toolkits.jetbrains.settings.SamSettings
 import software.aws.toolkits.jetbrains.testutils.rules.JavaCodeInsightTestFixtureRule
@@ -26,9 +27,13 @@ class SamRunConfigurationTest {
     @JvmField
     val projectRule = JavaCodeInsightTestFixtureRule()
 
+    @Rule
+    @JvmField
+    val envHelper = EnvironmentVariableHelper()
+
     @Before
     fun setUp() {
-        SamSettings.getInstance().executablePath = "sam"
+        SamSettings.getInstance().savedExecutablePath = "sam"
         MockCredentialsManager.getInstance().reset()
 
         projectRule.fixture.addClass(
@@ -46,7 +51,8 @@ class SamRunConfigurationTest {
 
     @Test
     fun samIsNotSet() {
-        SamSettings.getInstance().executablePath = ""
+        SamSettings.getInstance().savedExecutablePath = null
+        envHelper.remove("PATH")
 
         runInEdtAndWait {
             val runConfiguration = createRunConfiguration(project = projectRule.project)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/settings/SamExecutableDetectorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/settings/SamExecutableDetectorTest.kt
@@ -1,0 +1,140 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.settings
+
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.io.FileUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import software.aws.toolkits.core.rules.EnvironmentVariableHelper
+import java.io.File
+
+abstract class SamExecutableDetectorTestBase {
+    @Rule
+    @JvmField
+    val envHelper = EnvironmentVariableHelper()
+
+    @Rule
+    @JvmField
+    val tempFolderRule = TemporaryFolder()
+
+    lateinit var detector: SamExecutableDetector
+    lateinit var tempFolder: String
+
+    @Before
+    open fun setUp() {
+        Assume.assumeTrue(SystemInfo.isUnix)
+        envHelper.remove("PATH")
+
+        tempFolder = "${tempFolderRule.newFolder()}${File.separator}"
+
+        detector = object : SamExecutableDetector() {
+            override fun file(folder: String, name: String): File {
+                // Used to "mount" the expected folders in a temp dir
+                val actualPath = super.file(folder, name)
+                return File(tempFolder, sanitizePath(actualPath.absolutePath))
+            }
+        }
+    }
+
+    private fun sanitizePath(original: String): String = original
+        .trimStart(File.separatorChar)
+        .replace(":", "_")
+
+    private fun unsanitizePath(sanitized: String?): String? {
+        val suffix = sanitized?.removePrefix(tempFolder)?.replace("_", ":")
+        return suffix?.let { "${File.separator}$suffix" }
+    }
+
+    protected fun assertExecutable(expected: String?) {
+        assertThat(unsanitizePath(detector.detect())).isEqualTo(expected)
+    }
+
+    protected fun touch(vararg paths: String) {
+        for (path in paths) {
+            val sanitized = sanitizePath(path)
+            assertThat(FileUtil.createIfDoesntExist(File(tempFolder, sanitized))).isTrue()
+        }
+    }
+}
+
+class SamExecutableDetectorUnixTest : SamExecutableDetectorTestBase() {
+    @Before
+    override fun setUp() {
+        Assume.assumeTrue(SystemInfo.isUnix)
+        super.setUp()
+    }
+
+    @Test
+    fun testUserBin() {
+        touch("/usr/local/bin/sam")
+        assertExecutable("/usr/local/bin/sam")
+    }
+
+    @Test
+    fun testPath() {
+        val tempDirectory = FileUtil.createTempDirectory("tempSam", null)
+        val expected = File(tempDirectory, "sam").absolutePath
+        touch(expected)
+        envHelper["PATH"] = tempDirectory.absolutePath
+
+        assertExecutable(expected)
+    }
+}
+
+class SamExecutableDetectorWindowsTest : SamExecutableDetectorTestBase() {
+    @Before
+    override fun setUp() {
+        Assume.assumeTrue(SystemInfo.isWindows)
+        super.setUp()
+    }
+
+    @Test
+    fun testProgramFilesX86Cmd() {
+        touch("C:\\Program Files (x86)\\Amazon\\AWSSAMCLI\\bin\\sam.cmd")
+        assertExecutable("C:\\Program Files (x86)\\Amazon\\AWSSAMCLI\\bin\\sam.cmd")
+    }
+
+    @Test
+    fun testProgramFilesX86Exe() {
+        touch("C:\\Program Files (x86)\\Amazon\\AWSSAMCLI\\bin\\sam.exe")
+        assertExecutable("C:\\Program Files (x86)\\Amazon\\AWSSAMCLI\\bin\\sam.exe")
+    }
+
+    @Test
+    fun testProgramFilesCmd() {
+        touch("C:\\Program Files\\Amazon\\AWSSAMCLI\\bin\\sam.cmd")
+        assertExecutable("C:\\Program Files\\Amazon\\AWSSAMCLI\\bin\\sam.cmd")
+    }
+
+    @Test
+    fun testProgramFilesExe() {
+        touch("C:\\Program Files\\Amazon\\AWSSAMCLI\\bin\\sam.exe")
+        assertExecutable("C:\\Program Files\\Amazon\\AWSSAMCLI\\bin\\sam.exe")
+    }
+
+    @Test
+    fun testPathCmd() {
+        val tempDirectory = FileUtil.createTempDirectory("tempSam", null)
+        val expected = File(tempDirectory, "sam.cmd").absolutePath
+        touch(expected)
+        envHelper["PATH"] = tempDirectory.absolutePath
+
+        assertExecutable(expected)
+    }
+
+    @Test
+    fun testPathExe() {
+        val tempDirectory = FileUtil.createTempDirectory("tempSam", null)
+        val expected = File(tempDirectory, "sam.exe").absolutePath
+        touch(expected)
+        envHelper["PATH"] = tempDirectory.absolutePath
+
+        assertExecutable(expected)
+    }
+}

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -129,3 +129,4 @@ cloudformation.yaml.invalid_root_type=Template does not start with a mapping
 lambda.create.memory.label=Memory (MB):
 lambda.upload_validation.memory=Memory must be between {0} and {1} and an increment of {2}
 lambda.sam.cli.install_url=https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html
+aws.settings.sam.auto_detect=Auto-detected: {0}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Add a SAM CLI detector that looks in common OS-specific locations if the customer did not configure it manually

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#253

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
![screen shot 2018-11-06 at 1 53 06 pm](https://user-images.githubusercontent.com/8992246/48096441-f8962400-e1cb-11e8-804e-f2bd83261018.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
