### PR TITLE
Fix bug when creating SAM run configuration directly Run/Debug config…

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunConfiguration.kt
@@ -180,7 +180,7 @@ class RemoteLambdaRunSettingsEditor(project: Project) : SettingsEditor<LambdaRem
 
         settings.credentialProviderId?.let {
             try {
-                view.credentialSelector.setSelectedInvalidCredentialsProvider(credentialManager.getCredentialProvider(it))
+                view.credentialSelector.setSelectedCredentialsProvider(credentialManager.getCredentialProvider(it))
             } catch (e: CredentialProviderNotFound) {
                 // Use the raw string here to not munge what the customer had, will also allow it to show the error
                 // that it could not be found

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunConfiguration.kt
@@ -236,6 +236,7 @@ class SamRunSettingsEditor(project: Project) : SettingsEditor<SamRunConfiguratio
         view.regionSelector.selectedRegion = ProjectAccountSettingsManager.getInstance(project).activeRegion
 
         view.credentialSelector.setCredentialsProviders(credentialManager.getCredentialProviders())
+        view.credentialSelector.setSelectedCredentialsProvider(ProjectAccountSettingsManager.getInstance(project).activeCredentialProvider)
     }
 
     override fun createEditor(): JPanel = view.panel
@@ -258,7 +259,7 @@ class SamRunSettingsEditor(project: Project) : SettingsEditor<SamRunConfiguratio
 
         settings.credentialProviderId?.let {
             try {
-                view.credentialSelector.setSelectedInvalidCredentialsProvider(credentialManager.getCredentialProvider(it))
+                view.credentialSelector.setSelectedCredentialsProvider(credentialManager.getCredentialProvider(it))
             } catch (e: CredentialProviderNotFound) {
                 // Use the raw string here to not munge what the customer had, will also allow it to show the error
                 // that it could not be found

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/CredentialProviderSelector.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/CredentialProviderSelector.kt
@@ -39,7 +39,7 @@ class CredentialProviderSelector() : ComboBox<Any>() {
         }
     }
 
-    fun setSelectedInvalidCredentialsProvider(provider: ToolkitCredentialsProvider) {
+    fun setSelectedCredentialsProvider(provider: ToolkitCredentialsProvider) {
         selectedItem = provider
     }
 


### PR DESCRIPTION
…uration page, default credentials are not prefilled.

<!--- Provide a general summary of your changes in the Title above -->
Just found a bug when you create a SAM run configuration directly from the Run/Debug page, the current active credential is not populated to the UI. See screenshots below:

This PR fixes the bug.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Screenshots (if appropriate)
<img width="1074" alt="screen shot 2018-11-12 at 11 34 12 am" src="https://user-images.githubusercontent.com/7167513/48370712-f241f500-e66e-11e8-880a-d6e756595631.png">
<img width="1073" alt="screen shot 2018-11-12 at 11 34 24 am" src="https://user-images.githubusercontent.com/7167513/48370713-f241f500-e66e-11e8-92f3-9bd43ccc74a8.png">

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
