### PR TITLE
Deploy Sam Application by right clicking module node

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.services.lambda.actions
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.vfs.VirtualFile
 import icons.AwsIcons
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplate
 import software.aws.toolkits.jetbrains.services.lambda.deploy.DeployServerlessApplicationDialog
@@ -17,12 +18,11 @@ class DeployServerlessApplicationAction : AnAction(
         AwsIcons.Resources.LAMBDA_FUNCTION) {
     private var templateYamlRegex = Regex("template\\.y[a]?ml", RegexOption.IGNORE_CASE)
 
-    override fun actionPerformed(e: AnActionEvent?) {
+    override fun actionPerformed(e: AnActionEvent) {
 
-        val project = e?.getRequiredData(PlatformDataKeys.PROJECT) ?: throw Exception("Unable to determine project")
+        val project = e.getRequiredData(PlatformDataKeys.PROJECT)
 
-        val virtualFiles = e.getData(PlatformDataKeys.VIRTUAL_FILE_ARRAY) ?: throw Exception("Could not detect template file")
-        val samTemplateFile = virtualFiles[0]
+        val samTemplateFile = getSamTemplateFile(e) ?: throw Exception("Could not detect template file")
         val template = CloudFormationTemplate.parse(project, samTemplateFile)
 
         // TODO : Validate the template file (this is likely too slow to do in update())
@@ -30,11 +30,29 @@ class DeployServerlessApplicationAction : AnAction(
         DeployServerlessApplicationDialog(project, template.parameters()).show()
     }
 
-    override fun update(e: AnActionEvent?) {
+    override fun update(e: AnActionEvent) {
         super.update(e)
 
-        val virtualFiles = e?.getData(PlatformDataKeys.VIRTUAL_FILE_ARRAY)
+        e.presentation.isVisible = getSamTemplateFile(e) != null
+    }
 
-        e?.presentation?.isVisible = virtualFiles?.size == 1 && templateYamlRegex.matches(virtualFiles[0].name)
+    /**
+     * Determines the relevant Sam Template, returns null if one can't be found.
+     */
+    private fun getSamTemplateFile(e: AnActionEvent): VirtualFile? {
+        val virtualFiles = e.getData(PlatformDataKeys.VIRTUAL_FILE_ARRAY) ?: return null
+        val virtualFile = virtualFiles.singleOrNull() ?: return null
+
+        if (templateYamlRegex.matches(virtualFile.name)) {
+            return virtualFile
+        }
+
+        // If the module node was selected, see if there is a template file in the top level folder
+        val project = e.getData(PlatformDataKeys.PROJECT) ?: return null
+        if (virtualFile == project.baseDir) {
+            return virtualFile.children.singleOrNull { templateYamlRegex.matches(it.name) }
+        }
+
+        return null
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
When you right click on a module node, if that folder contains a Sam Template, the context menu will have an item to Deploy Serverless Application. Right clicking on the template file continues to allow this item as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->
#427 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Right click in project explorer:
* on a sam template = can see Deploy menu item
* on a non-sam template = can not see Deploy menu item
* on a module that contains a template.yaml file = can see Deploy menu item
* on a module that contains a template.yaml file and a template.yml file = can not see Deploy menu item
* on a module that does not contain a sam template file = can not see Deploy menu item

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/39839589/48381161-98055c00-e68f-11e8-9ce6-37b76b4f629c.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
