### PR TITLE
Adding CloudFront url for toolkit endpoint file.

### DIFF
--- a/core/src/software/aws/toolkits/core/region/Partitions.kt
+++ b/core/src/software/aws/toolkits/core/region/Partitions.kt
@@ -51,7 +51,10 @@ object PartitionParser {
 }
 
 object ServiceEndpointResource : RemoteResource {
-    override val urls: List<String> = listOf("https://aws-toolkit-endpoints.s3.amazonaws.com/endpoints.json")
+    override val urls: List<String> = listOf(
+        "http://idetoolkits.amazonwebservices.com/endpoints.json",
+        "https://aws-toolkit-endpoints.s3.amazonaws.com/endpoints.json"
+    )
     override val name: String = "service-endpoints.json"
     override val ttl: Duration? = Duration.ofHours(24)
     override val initialValue: (() -> InputStream)? = { BundledResources.ENDPOINTS_FILE }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The CloudFront CNAME alias for the S3 origin is public. We should prefer this over the original S3 URL.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
