### PR TITLE
Fix integration test failing due to renamed init wizard name

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamInitProjectWizardTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamInitProjectWizardTest.kt
@@ -19,6 +19,7 @@ import software.aws.toolkits.jetbrains.settings.SamSettings
 import software.aws.toolkits.jetbrains.ui.wizard.java.SamInitModuleBuilder
 import software.aws.toolkits.jetbrains.ui.wizard.java.SamInitTemplateSelectionStep
 import software.aws.toolkits.jetbrains.utils.rules.PyTestSdk3x
+import software.aws.toolkits.resources.message
 import kotlin.reflect.KClass
 
 // must be castable to ProjectJdkImpl
@@ -43,7 +44,7 @@ class SamInitProjectWizardTest : NewProjectWizardTestCase() {
         assertThatExceptionOfType(RuntimeException::class.java).isThrownBy {
             createProject { step ->
                 if (step is ProjectTypeStep) {
-                    assertTrue(step.setSelectedTemplate("SAM", null))
+                    assertTrue(step.setSelectedTemplate(message("sam.init.name"), null))
                     val builder = myWizard.projectBuilder as SamInitModuleBuilder
                     builder.runtimeSelectionPanel.samExecutableField.text = ""
                 }
@@ -74,7 +75,7 @@ class SamInitProjectWizardTest : NewProjectWizardTestCase() {
             when (step) {
                 is ProjectTypeStep -> { // Wizard first page
                     assertEquals(0, stepNum)
-                    assertTrue(step.setSelectedTemplate("SAM", null))
+                    assertTrue(step.setSelectedTemplate(message("sam.init.name"), null))
                     // step count changes after we select SAM
                     assertEquals("Found steps: ${myWizard.sequence.selectedSteps}.", 4, myWizard.sequence.selectedSteps.size)
 
@@ -94,7 +95,7 @@ class SamInitProjectWizardTest : NewProjectWizardTestCase() {
                     val builder = myWizard.projectBuilder as SamInitModuleBuilder
                     assertEquals(runtime, builder.runtimeSelectionPanel.runtime.selectedItem)
                     assertInstanceOf(builder.getSdkType(), sdkType.java)
-                    assertEquals("AWS SAM Hello World", step.templateSelectionPanel.selectedTemplate!!.name)
+                    assertEquals(message("sam.init.template.hello_world.name"), step.templateSelectionPanel.selectedTemplate!!.name)
                 }
                 is ProjectSettingsStep -> {
                     assertEquals(3, stepNum)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

`./gradlew check && ./gradlew integrationTest` passes

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
