### PR TITLE
SAM Local Run Configuration environment variables substitution

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationTemplate.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationTemplate.kt
@@ -54,12 +54,22 @@ interface NamedMap {
 interface Resource : NamedMap {
     fun isType(requestedType: String): Boolean
     fun type(): String?
+
+    fun getEnvironmentVariables(): Sequence<EnvironmentVariable>
 }
 
 interface Parameter : NamedMap {
     fun defaultValue(): String?
     fun description(): String?
     fun constraintDescription(): String?
+}
+
+
+interface EnvironmentVariable {
+    val variableName: String
+    val variableValue: String
+
+    fun isReference(): Boolean
 }
 
 class CloudFormationParameter(private val delegate: NamedMap) : NamedMap by delegate, Parameter {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationTemplate.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationTemplate.kt
@@ -55,7 +55,7 @@ interface Resource : NamedMap {
     fun isType(requestedType: String): Boolean
     fun type(): String?
 
-    fun getEnvironmentVariables(): Sequence<EnvironmentVariable>
+    fun getEnvironmentVariables(): Sequence<Variable>
 }
 
 interface Parameter : NamedMap {
@@ -64,8 +64,7 @@ interface Parameter : NamedMap {
     fun constraintDescription(): String?
 }
 
-
-interface EnvironmentVariable {
+interface Variable {
     val variableName: String
     val variableValue: String
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/ResourceMapping.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/ResourceMapping.kt
@@ -1,0 +1,86 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cloudformation
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.util.containers.MultiMap
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient
+import software.amazon.awssdk.services.cloudformation.model.*
+import software.aws.toolkits.jetbrains.core.AwsClientManager
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.stream.Stream
+
+interface ResourceMapping {
+    fun listAllSummaries(logicalResource: String): Collection<StackResourceSummary>
+
+    fun guessPhysicalResourceId(logicalResource: String): String?
+
+    fun isEmpty(): Boolean
+
+    object EMPTY : ResourceMapping {
+        override fun listAllSummaries(logicalResource: String): Collection<StackResourceSummary> = Collections.emptyList()
+
+        override fun guessPhysicalResourceId(logicalResource: String): String? = null
+
+        override fun isEmpty(): Boolean = true
+    }
+}
+
+internal class ResourceMappingImpl : ResourceMapping {
+    private val logicalToSummary: MultiMap<String, StackResourceSummary> = MultiMap.createLinked()
+
+    override fun listAllSummaries(logicalResource: String): Collection<StackResourceSummary> {
+        return logicalToSummary.get(logicalResource)
+    }
+
+    override fun guessPhysicalResourceId(logicalResource: String): String? {
+        return listAllSummaries(logicalResource).firstOrNull()?.physicalResourceId()
+    }
+
+    private fun registerResource(resourceSummary: StackResourceSummary) {
+        resourceSummary.logicalResourceId()?.let { logicalToSummary.putValue(it, resourceSummary) }
+    }
+
+    override fun isEmpty(): Boolean = logicalToSummary.isEmpty
+
+    companion object {
+        @JvmStatic
+        fun promiseMapping(project: Project): CompletionStage<ResourceMapping> {
+            val client: CloudFormationClient = AwsClientManager.getInstance(project).getClient()
+            return promiseMapping(client)
+        }
+
+        @JvmStatic
+        fun promiseMapping(client: CloudFormationClient): CompletionStage<ResourceMapping> {
+            val promise = CompletableFuture<ResourceMapping>()
+
+            ApplicationManager.getApplication().executeOnPooledThread {
+                val result = ResourceMappingImpl()
+                try {
+                    val stackRequest = ListStacksRequest.builder()
+                            .stackStatusFilters(StackStatus.CREATE_COMPLETE, StackStatus.UPDATE_COMPLETE)
+                            .build()
+                    client.listStacksPaginator(stackRequest).stream()
+                            .flatMap { it.stackSummaries().stream() }
+                            .flatMap { client.listResourcesForStack(it) }
+                            .forEach { result.registerResource(it) }
+
+                    promise.complete(result)
+                } catch (e: Exception) {
+                    promise.completeExceptionally(e)
+                }
+            }
+            return promise
+        }
+
+        private fun CloudFormationClient.listResourcesForStack(stackSummary: StackSummary): Stream<StackResourceSummary> {
+            val request = ListStackResourcesRequest.builder().stackName(stackSummary.stackId()).build()
+            return this.listStackResourcesPaginator(request).stream()
+                    .flatMap { it -> it.stackResourceSummaries().stream() }
+        }
+    }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/ResourceMapping.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/ResourceMapping.kt
@@ -7,9 +7,13 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.containers.MultiMap
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
-import software.amazon.awssdk.services.cloudformation.model.*
+import software.amazon.awssdk.services.cloudformation.model.ListStackResourcesRequest
+import software.amazon.awssdk.services.cloudformation.model.ListStacksRequest
+import software.amazon.awssdk.services.cloudformation.model.StackResourceSummary
+import software.amazon.awssdk.services.cloudformation.model.StackStatus
+import software.amazon.awssdk.services.cloudformation.model.StackSummary
 import software.aws.toolkits.jetbrains.core.AwsClientManager
-import java.util.*
+import java.util.Collections
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.stream.Stream
@@ -33,17 +37,13 @@ interface ResourceMapping {
 internal class ResourceMappingImpl : ResourceMapping {
     private val logicalToSummary: MultiMap<String, StackResourceSummary> = MultiMap.createLinked()
 
-    override fun listAllSummaries(logicalResource: String): Collection<StackResourceSummary> {
-        return logicalToSummary.get(logicalResource)
-    }
+    override fun listAllSummaries(logicalResource: String): Collection<StackResourceSummary> = logicalToSummary.get(logicalResource)
 
-    override fun guessPhysicalResourceId(logicalResource: String): String? {
-        return listAllSummaries(logicalResource).firstOrNull()?.physicalResourceId()
-    }
+    override fun guessPhysicalResourceId(logicalResource: String): String? =
+            listAllSummaries(logicalResource).firstOrNull()?.physicalResourceId()
 
-    private fun registerResource(resourceSummary: StackResourceSummary) {
-        resourceSummary.logicalResourceId()?.let { logicalToSummary.putValue(it, resourceSummary) }
-    }
+    private fun registerResource(resourceSummary: StackResourceSummary) =
+            resourceSummary.logicalResourceId()?.let { logicalToSummary.putValue(it, resourceSummary) }
 
     override fun isEmpty(): Boolean = logicalToSummary.isEmpty
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/yaml/YamlCloudFormationTemplate.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/yaml/YamlCloudFormationTemplate.kt
@@ -18,7 +18,7 @@ import org.jetbrains.yaml.psi.YAMLMapping
 import org.jetbrains.yaml.psi.YAMLScalar
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationParameter
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplate
-import software.aws.toolkits.jetbrains.services.cloudformation.EnvironmentVariable
+import software.aws.toolkits.jetbrains.services.cloudformation.Variable
 import software.aws.toolkits.jetbrains.services.cloudformation.NamedMap
 import software.aws.toolkits.jetbrains.services.cloudformation.Parameter
 import software.aws.toolkits.jetbrains.services.cloudformation.Resource
@@ -74,7 +74,7 @@ class YamlCloudFormationTemplate(template: YAMLFile) : CloudFormationTemplate {
             properties().putKeyValue(newKeyValue)
         }
 
-        override fun getEnvironmentVariables(): Sequence<EnvironmentVariable> {
+        override fun getEnvironmentVariables(): Sequence<Variable> {
             val variables = properties().childMapping("Environment")?.childMapping("Variables") ?: return emptySequence()
             return variables.keyValues.asSequence().mapNotNull { it -> it.asEnvironmentVariable()}
         }
@@ -84,7 +84,7 @@ class YamlCloudFormationTemplate(template: YAMLFile) : CloudFormationTemplate {
 
     }
 
-    private class YamlEnvironmentVariable(override val variableName: String, val isScalarValue: Boolean, valueScalar : YAMLScalar) : EnvironmentVariable {
+    private class YamlVariable(override val variableName: String, val isScalarValue: Boolean, valueScalar : YAMLScalar) : Variable {
 
         override val variableValue = valueScalar.textValue
 
@@ -134,14 +134,14 @@ class YamlCloudFormationTemplate(template: YAMLFile) : CloudFormationTemplate {
             null
         }
 
-        private fun YAMLKeyValue.asEnvironmentVariable(): EnvironmentVariable? {
+        private fun YAMLKeyValue.asEnvironmentVariable(): Variable? {
             val name = this.keyText
             val value = this.value
 
             return when(value){
-                is YAMLScalar -> YamlEnvironmentVariable(name, true, value)
+                is YAMLScalar -> YamlVariable(name, true, value)
                 is YAMLMapping -> (value.getKeyValueByKey("Ref")?.value as? YAMLScalar)?.let {
-                    YamlEnvironmentVariable(name, false, it)
+                    YamlVariable(name, false, it)
                 }
                 else -> null
             }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/ResourceEnvironmentVariableField.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/ResourceEnvironmentVariableField.kt
@@ -1,0 +1,117 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+
+import com.intellij.execution.util.EnvVariablesTable
+import com.intellij.execution.util.EnvironmentVariable
+import com.intellij.util.ui.ColumnInfo
+import com.intellij.util.ui.ComboBoxCellEditor
+import software.aws.toolkits.jetbrains.services.cloudformation.Resource
+import software.aws.toolkits.jetbrains.services.cloudformation.ResourceMapping
+import software.aws.toolkits.jetbrains.services.cloudformation.Variable
+import software.aws.toolkits.jetbrains.ui.EnvironmentVariablesTextField
+import software.aws.toolkits.jetbrains.ui.ExtensibleEnvVariablesTable
+import java.util.*
+import javax.swing.table.TableCellEditor
+
+class ResourceEnvironmentVariablesField : EnvironmentVariablesTextField() {
+    private var resourceMapping: ResourceMapping = ResourceMapping.EMPTY
+    private var variablesToBind: Map<String, Variable> = Collections.emptyMap()
+
+    fun setResourceMapping(mapping: ResourceMapping) {
+        resourceMapping = mapping
+        updateAutomaticValues()
+    }
+
+    fun setFunctionToBind(function: Resource?) {
+        setVariablesToBind(function?.getEnvironmentVariables() ?: emptySequence())
+    }
+
+    fun setVariablesToBind(models: Sequence<Variable>) {
+        variablesToBind = models.filter { it.isReference() }
+                .associate { it.variableName to it }
+
+        protectVariables(variablesToBind.keys)
+        updateAutomaticValues()
+    }
+
+    private fun updateAutomaticValues() {
+        val guesses = computeGuesses()
+
+        if (guesses.isNotEmpty()) {
+            val newData = mutableMapOf<String, String>() + envVars + guesses
+            envVars = newData
+        }
+    }
+
+    private fun computeGuesses(): Map<String, String> {
+        if (variablesToBind.isEmpty() || resourceMapping.isEmpty()) {
+            return Collections.emptyMap()
+        }
+
+        val guessedValues = mutableMapOf<String, String>()
+        val allNeedsValue = variablesToBind.filter { (name, _) -> needsValue(name) }
+        allNeedsValue.forEach { (name, variable) ->
+            val nextPhysical = resourceMapping.guessPhysicalResourceId(variable.variableValue)
+            nextPhysical?.apply { guessedValues[name] = nextPhysical }
+        }
+        return guessedValues
+    }
+
+    private fun needsValue(varName: String): Boolean = envVars.getOrDefault(varName, "").isBlank()
+
+    override fun createProtectedVariable(name: String, value: String): EnvironmentVariable {
+        val model = variablesToBind[name]
+        return model?.let { ResourceReferenceVariable(name, value, it) }
+                ?: throw IllegalArgumentException("Unexpected variable name: $name")
+    }
+
+    override fun createDialogTable(): EnvVariablesTable {
+        return HintedEnvVariablesTable()
+    }
+
+    private inner class HintedEnvVariablesTable : ExtensibleEnvVariablesTable() {
+        override fun createValueColumn(): ColumnInfo<EnvironmentVariable, String> {
+            return HintedValueColumn()
+        }
+
+        private inner class HintedValueColumn : ValueColumn() {
+
+            override fun isCellEditable(environmentVariable: EnvironmentVariable): Boolean {
+                return true
+            }
+
+            override fun getEditor(variable: EnvironmentVariable): TableCellEditor {
+                return when (variable) {
+                    is ResourceReferenceVariable -> getComboBoxEditor(variable.model)
+                    else -> super.getEditor(variable)
+                }
+            }
+
+            private fun getComboBoxEditor(model: Variable): TableCellEditor {
+                val logicalResource = model.variableValue
+                val result = object : ComboBoxCellEditor() {
+                    override fun getComboBoxItems(): List<String> {
+                        return resourceMapping.listAllSummaries(logicalResource)
+                                .map { it.physicalResourceId() }
+                                .toList()
+                    }
+
+                    override fun isComboboxEditable() = true
+                }
+                result.clickCountToStart = 1
+                return result
+            }
+        }
+    }
+
+    private class ResourceReferenceVariable(name: String, value: String, internal val model: Variable) :
+            EnvironmentVariable(name, value, true) {
+
+        override fun getNameIsWriteable(): Boolean {
+            return false
+        }
+    }
+
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/ResourceEnvironmentVariablesField.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/ResourceEnvironmentVariablesField.kt
@@ -12,7 +12,7 @@ import software.aws.toolkits.jetbrains.services.cloudformation.ResourceMapping
 import software.aws.toolkits.jetbrains.services.cloudformation.Variable
 import software.aws.toolkits.jetbrains.ui.EnvironmentVariablesTextField
 import software.aws.toolkits.jetbrains.ui.ExtensibleEnvVariablesTable
-import java.util.*
+import java.util.Collections
 import javax.swing.table.TableCellEditor
 
 class ResourceEnvironmentVariablesField : EnvironmentVariablesTextField() {
@@ -67,36 +67,27 @@ class ResourceEnvironmentVariablesField : EnvironmentVariablesTextField() {
                 ?: throw IllegalArgumentException("Unexpected variable name: $name")
     }
 
-    override fun createDialogTable(): EnvVariablesTable {
-        return HintedEnvVariablesTable()
-    }
+    override fun createDialogTable(): EnvVariablesTable = HintedEnvVariablesTable()
 
     private inner class HintedEnvVariablesTable : ExtensibleEnvVariablesTable() {
-        override fun createValueColumn(): ColumnInfo<EnvironmentVariable, String> {
-            return HintedValueColumn()
-        }
+        override fun createValueColumn(): ColumnInfo<EnvironmentVariable, String> = HintedValueColumn()
 
         private inner class HintedValueColumn : ValueColumn() {
 
-            override fun isCellEditable(environmentVariable: EnvironmentVariable): Boolean {
-                return true
-            }
+            override fun isCellEditable(environmentVariable: EnvironmentVariable): Boolean = true
 
-            override fun getEditor(variable: EnvironmentVariable): TableCellEditor {
-                return when (variable) {
-                    is ResourceReferenceVariable -> getComboBoxEditor(variable.model)
-                    else -> super.getEditor(variable)
-                }
-            }
+            override fun getEditor(variable: EnvironmentVariable): TableCellEditor =
+                    when (variable) {
+                        is ResourceReferenceVariable -> getComboBoxEditor(variable.model)
+                        else -> super.getEditor(variable)
+                    }
 
             private fun getComboBoxEditor(model: Variable): TableCellEditor {
                 val logicalResource = model.variableValue
                 val result = object : ComboBoxCellEditor() {
-                    override fun getComboBoxItems(): List<String> {
-                        return resourceMapping.listAllSummaries(logicalResource)
-                                .map { it.physicalResourceId() }
-                                .toList()
-                    }
+                    override fun getComboBoxItems(): List<String> = resourceMapping.listAllSummaries(logicalResource)
+                            .map { it.physicalResourceId() }
+                            .toList()
 
                     override fun isComboboxEditable() = true
                 }
@@ -109,9 +100,6 @@ class ResourceEnvironmentVariablesField : EnvironmentVariablesTextField() {
     private class ResourceReferenceVariable(name: String, value: String, internal val model: Variable) :
             EnvironmentVariable(name, value, true) {
 
-        override fun getNameIsWriteable(): Boolean {
-            return false
-        }
+        override fun getNameIsWriteable(): Boolean = false
     }
-
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunConfiguration.kt
@@ -13,6 +13,7 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
@@ -215,6 +216,8 @@ class SamRunSettingsEditor(project: Project) : SettingsEditor<SamRunConfiguratio
     private val credentialManager = CredentialManager.getInstance()
 
     init {
+        Disposer.register(this, view)
+
         val supported = LambdaPackager.supportedRuntimeGroups
             .flatMap { it.runtimes }
             .sorted()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunSettingsEditorPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunSettingsEditorPanel.form
@@ -46,7 +46,7 @@
           <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.create.env_vars.label"/>
         </properties>
       </component>
-      <component id="c2e65" class="software.aws.toolkits.jetbrains.ui.EnvironmentVariablesTextField" binding="environmentVariables">
+      <component id="c2e65" class="software.aws.toolkits.jetbrains.ui.EnvironmentVariablesTextField" binding="environmentVariables" custom-create="true">
         <constraints>
           <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/EnvironmentVariablesTextField.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/EnvironmentVariablesTextField.kt
@@ -8,23 +8,30 @@ import com.intellij.execution.util.EnvVariablesTable
 import com.intellij.execution.util.EnvironmentVariable
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import org.jetbrains.annotations.TestOnly
 import software.aws.toolkits.resources.message
 import java.awt.Component
-import java.util.LinkedHashMap
+import java.util.*
 import javax.swing.JComponent
 
 /**
  * Our version of [com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton] to fit our
- * needs but with same UX so users are used to it. Namely we do not support inheriting system env vars, but rest
- * of UX is the same
+ * needs but with similar UX so users are used to it. Namely we
+ * <ul>
+ * <li>do not support inheriting system env vars</li>
+ * <li>have an optional notion of "protected" variables, which have read-only names, can't be removed and should be shown above the others</li>
+ * </ul>
+ * When there are no protection, UX is the same
  */
-class EnvironmentVariablesTextField : TextFieldWithBrowseButton() {
+open class EnvironmentVariablesTextField : TextFieldWithBrowseButton() {
+    private var protectedVarNames = emptyList<String>()
+
     private var data = EnvironmentVariablesData.create(emptyMap(), false)
     var envVars: Map<String, String>
         get() = data.envs
         set(value) {
             data = EnvironmentVariablesData.create(value, false)
-            text = stringify(data.envs)
+            text = stringify()
         }
 
     init {
@@ -34,31 +41,50 @@ class EnvironmentVariablesTextField : TextFieldWithBrowseButton() {
         }
     }
 
-    private fun convertToVariables(envVars: Map<String, String>, readOnly: Boolean): List<EnvironmentVariable> = envVars.map { (key, value) ->
-        object : EnvironmentVariable(key, value, readOnly) {
-            override fun getNameIsWriteable(): Boolean = !readOnly
-        }
+    fun protectVariables(varNames: List<String>) {
+        protectedVarNames = varNames
+        text = stringify()
     }
 
-    private fun stringify(envVars: Map<String, String>): String {
-        if (envVars.isEmpty()) {
-            return ""
-        }
+    private fun isProtectedVar(varName: String) = protectedVarNames.contains(varName)
 
+    private fun protectedEntries(): List<Pair<String, String>> =
+            protectedVarNames.map { name -> name to envVars.getOrDefault(name, "") }
+
+    private fun unprotectedEntries(): List<Pair<String, String>> =
+            envVars.filter { (name, _) -> !isProtectedVar(name) }
+                    .map { (name, value) -> name to value }
+
+    fun convertToVariables(): List<EnvironmentVariable> =
+            protectedEntries().map { (name, value) -> VariableWithProtection(name, value, true) } +
+                    unprotectedEntries().map { (name, value) -> VariableWithProtection(name, value, false) }
+
+    private fun stringify(): String {
         val buf = StringBuilder()
-        for ((key, value) in envVars) {
-            if (buf.isNotEmpty()) {
-                buf.append(";")
-            }
-            buf.append(key).append("=").append(value)
-        }
 
-        return buf.toString()
+        val entries = protectedEntries().filter { (_, value) -> value.isNotBlank() } + unprotectedEntries()
+        return entries.joinTo(buf, ";") { (key, value) -> "$key=$value" }
+                .toString()
     }
+
+    private fun acceptEditedVariables(editedVariables: List<EnvironmentVariable>) {
+        val newEnvVars = LinkedHashMap<String, String>()
+        editedVariables
+                .filter { it -> !isProtectedVar(it.name) || it.value.isNotBlank() }
+                .forEach { it -> newEnvVars[it.name] = it.value.trim() }
+
+        envVars = newEnvVars
+    }
+
+    @TestOnly
+    fun acceptEditedVariablesForTesting(testVariables: List<EnvironmentVariable>) =
+            acceptEditedVariables(testVariables)
+
+    protected fun createDialogTable(): EnvVariablesTable = EnvVariablesTable()
 
     private inner class EnvironmentVariablesDialog(private val parent: Component) : DialogWrapper(parent, true) {
-        private val envVarTable = EnvVariablesTable().apply {
-            setValues(convertToVariables(data.envs, false))
+        private val envVarTable = createDialogTable().apply {
+            setValues(convertToVariables())
         }
 
         init {
@@ -70,12 +96,16 @@ class EnvironmentVariablesTextField : TextFieldWithBrowseButton() {
 
         override fun doOKAction() {
             envVarTable.stopEditing()
-            val newEnvVars = LinkedHashMap<String, String>()
-            for (variable in envVarTable.environmentVariables) {
-                newEnvVars[variable.name] = variable.value
-            }
-            envVars = newEnvVars
+            acceptEditedVariables(envVarTable.environmentVariables)
             super.doOKAction()
         }
+    }
+}
+
+private class VariableWithProtection(name: String, value: String, val nameProtected: Boolean)
+    : EnvironmentVariable(name, value, nameProtected) {
+
+    override fun getNameIsWriteable(): Boolean {
+        return !nameProtected
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/EnvironmentVariablesTextField.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/EnvironmentVariablesTextField.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import org.jetbrains.annotations.TestOnly
 import software.aws.toolkits.resources.message
 import java.awt.Component
-import java.util.*
+import java.util.LinkedHashMap
 import javax.swing.JComponent
 
 /**
@@ -55,18 +55,14 @@ open class EnvironmentVariablesTextField : TextFieldWithBrowseButton() {
             envVars.filter { (name, _) -> !isProtectedVar(name) }
                     .map { (name, value) -> name to value }
 
-    fun convertToVariables(): List<EnvironmentVariable> {
-        return protectedEntries().map { (name, value) -> createProtectedVariable(name, value) } +
-                unprotectedEntries().map { (name, value) -> EnvironmentVariable(name, value, false) }
-    }
+    fun convertToVariables(): List<EnvironmentVariable> =
+            protectedEntries().map { (name, value) -> createProtectedVariable(name, value) } +
+                    unprotectedEntries().map { (name, value) -> EnvironmentVariable(name, value, false) }
 
-    protected open fun createProtectedVariable(name: String, value: String): EnvironmentVariable {
-        return object : EnvironmentVariable(name, value, true) {
-            override fun getNameIsWriteable(): Boolean {
-                return false
+    protected open fun createProtectedVariable(name: String, value: String): EnvironmentVariable =
+            object : EnvironmentVariable(name, value, true) {
+                override fun getNameIsWriteable(): Boolean = false
             }
-        }
-    }
 
     private fun stringify(): String {
         val entries = protectedEntries().filter { (_, value) -> value.isNotBlank() } + unprotectedEntries()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ExtensibleEnvVariablesTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ExtensibleEnvVariablesTable.kt
@@ -1,0 +1,73 @@
+package software.aws.toolkits.jetbrains.ui
+
+import com.intellij.execution.util.EnvVariablesTable
+import com.intellij.execution.util.EnvironmentVariable
+import com.intellij.execution.util.StringWithNewLinesCellEditor
+import com.intellij.util.ui.ColumnInfo
+import com.intellij.util.ui.ListTableModel
+import javax.swing.table.TableCellEditor
+
+/**
+ * More extensible version of the platform EnvVariablesTable, allowing to customise separate columns.
+ * Still extends the platform super-class to avoid copy-paste of the actions related code.
+ */
+open class ExtensibleEnvVariablesTable : EnvVariablesTable() {
+
+    override fun createListModel(): ListTableModel<EnvironmentVariable> {
+        return ListTableModel(createNameColumn(), createValueColumn())
+    }
+
+    protected open fun createNameColumn(): ColumnInfo<EnvironmentVariable, String> = NameColumn()
+
+    protected open fun createValueColumn(): ColumnInfo<EnvironmentVariable, String> = ValueColumn()
+
+    protected inner class NameColumn(name: String = "Name") : ElementsColumnInfoBase<EnvironmentVariable>(name) {
+        override fun valueOf(environmentVariable: EnvironmentVariable): String? {
+            return environmentVariable.name
+        }
+
+        override fun isCellEditable(environmentVariable: EnvironmentVariable): Boolean {
+            return environmentVariable.nameIsWriteable
+        }
+
+        override fun setValue(environmentVariable: EnvironmentVariable, s: String?) {
+            if (s == valueOf(environmentVariable)) {
+                return
+            }
+            environmentVariable.name = s
+            setModified()
+        }
+
+        override fun getDescription(environmentVariable: EnvironmentVariable): String? {
+            return environmentVariable.description
+        }
+    }
+
+    protected inner class ValueColumn(name: String = "Value") : ElementsColumnInfoBase<EnvironmentVariable>(name) {
+        override fun valueOf(environmentVariable: EnvironmentVariable): String? {
+            return environmentVariable.value
+        }
+
+        override fun isCellEditable(environmentVariable: EnvironmentVariable): Boolean {
+            return !environmentVariable.isPredefined
+        }
+
+        override fun setValue(environmentVariable: EnvironmentVariable, s: String?) {
+            if (s == valueOf(environmentVariable)) {
+                return
+            }
+            environmentVariable.value = s
+            setModified()
+        }
+
+        override fun getDescription(environmentVariable: EnvironmentVariable): String? {
+            return environmentVariable.description
+        }
+
+        override fun getEditor(variable: EnvironmentVariable): TableCellEditor {
+            val editor = StringWithNewLinesCellEditor()
+            editor.clickCountToStart = 1
+            return editor
+        }
+    }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ExtensibleEnvVariablesTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ExtensibleEnvVariablesTable.kt
@@ -16,22 +16,18 @@ import javax.swing.table.TableCellEditor
  */
 open class ExtensibleEnvVariablesTable : EnvVariablesTable() {
 
-    override fun createListModel(): ListTableModel<EnvironmentVariable> {
-        return ListTableModel(createNameColumn(), createValueColumn())
-    }
+    override fun createListModel(): ListTableModel<EnvironmentVariable> =
+            ListTableModel(createNameColumn(), createValueColumn())
 
     protected open fun createNameColumn(): ColumnInfo<EnvironmentVariable, String> = NameColumn()
 
     protected open fun createValueColumn(): ColumnInfo<EnvironmentVariable, String> = ValueColumn()
 
     protected open inner class NameColumn(name: String = "Name") : ElementsColumnInfoBase<EnvironmentVariable>(name) {
-        override fun valueOf(environmentVariable: EnvironmentVariable): String? {
-            return environmentVariable.name
-        }
+        override fun valueOf(environmentVariable: EnvironmentVariable): String? = environmentVariable.name
 
-        override fun isCellEditable(environmentVariable: EnvironmentVariable): Boolean {
-            return environmentVariable.nameIsWriteable
-        }
+        override fun isCellEditable(environmentVariable: EnvironmentVariable): Boolean =
+                environmentVariable.nameIsWriteable
 
         override fun setValue(environmentVariable: EnvironmentVariable, s: String?) {
             if (s == valueOf(environmentVariable)) {
@@ -41,19 +37,14 @@ open class ExtensibleEnvVariablesTable : EnvVariablesTable() {
             setModified()
         }
 
-        override fun getDescription(environmentVariable: EnvironmentVariable): String? {
-            return environmentVariable.description
-        }
+        override fun getDescription(environmentVariable: EnvironmentVariable): String? = environmentVariable.description
     }
 
     protected open inner class ValueColumn(name: String = "Value") : ElementsColumnInfoBase<EnvironmentVariable>(name) {
-        override fun valueOf(environmentVariable: EnvironmentVariable): String? {
-            return environmentVariable.value
-        }
+        override fun valueOf(environmentVariable: EnvironmentVariable): String? = environmentVariable.value
 
-        override fun isCellEditable(environmentVariable: EnvironmentVariable): Boolean {
-            return !environmentVariable.isPredefined
-        }
+        override fun isCellEditable(environmentVariable: EnvironmentVariable): Boolean =
+                !environmentVariable.isPredefined
 
         override fun setValue(environmentVariable: EnvironmentVariable, s: String?) {
             if (s == valueOf(environmentVariable)) {
@@ -63,9 +54,7 @@ open class ExtensibleEnvVariablesTable : EnvVariablesTable() {
             setModified()
         }
 
-        override fun getDescription(environmentVariable: EnvironmentVariable): String? {
-            return environmentVariable.description
-        }
+        override fun getDescription(environmentVariable: EnvironmentVariable): String? = environmentVariable.description
 
         override fun getEditor(variable: EnvironmentVariable): TableCellEditor {
             val editor = StringWithNewLinesCellEditor()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ExtensibleEnvVariablesTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ExtensibleEnvVariablesTable.kt
@@ -1,3 +1,6 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package software.aws.toolkits.jetbrains.ui
 
 import com.intellij.execution.util.EnvVariablesTable
@@ -21,7 +24,7 @@ open class ExtensibleEnvVariablesTable : EnvVariablesTable() {
 
     protected open fun createValueColumn(): ColumnInfo<EnvironmentVariable, String> = ValueColumn()
 
-    protected inner class NameColumn(name: String = "Name") : ElementsColumnInfoBase<EnvironmentVariable>(name) {
+    protected open inner class NameColumn(name: String = "Name") : ElementsColumnInfoBase<EnvironmentVariable>(name) {
         override fun valueOf(environmentVariable: EnvironmentVariable): String? {
             return environmentVariable.name
         }
@@ -43,7 +46,7 @@ open class ExtensibleEnvVariablesTable : EnvVariablesTable() {
         }
     }
 
-    protected inner class ValueColumn(name: String = "Value") : ElementsColumnInfoBase<EnvironmentVariable>(name) {
+    protected open inner class ValueColumn(name: String = "Value") : ElementsColumnInfoBase<EnvironmentVariable>(name) {
         override fun valueOf(environmentVariable: EnvironmentVariable): String? {
             return environmentVariable.value
         }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/yaml/YamlCloudFormationTemplateTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/yaml/YamlCloudFormationTemplateTest.kt
@@ -14,8 +14,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplate
-import software.aws.toolkits.jetbrains.services.cloudformation.Variable
 import software.aws.toolkits.jetbrains.services.cloudformation.Resource
+import software.aws.toolkits.jetbrains.services.cloudformation.Variable
 import software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule
 import java.io.File
 import kotlin.test.assertNotNull
@@ -115,7 +115,7 @@ Parameters:
         }
 
         assertThat(updatedTemplate).isEqualTo(
-            """
+                """
 Description: "Some description"
 Parameters:
     TableName:
@@ -166,32 +166,6 @@ Resources:
         }
 
         assertThat(tempFile).hasContent(TEST_TEMPLATE)
-    }
-
-    @Test
-    fun canParseByExtension() {
-        val fakeFileType = object : FakeFileType() {
-            override fun isMyFileType(@NotNull file: VirtualFile): Boolean = true
-
-            @NotNull
-            override fun getName(): String = "foo"
-
-            @NotNull
-            override fun getDescription(): String = ""
-        }
-
-        runInEdtAndWait {
-            try {
-                FileTypeManagerEx.getInstanceEx().registerFileType(fakeFileType)
-                setOf("template.yaml", "template.yml").forEach {
-                    val yamlFile = projectRule.fixture.addFileToProject(it, TEST_TEMPLATE)
-                    assertThat(yamlFile.fileType).isEqualTo(fakeFileType)
-                    assertThat(CloudFormationTemplate.parse(projectRule.project, yamlFile.virtualFile)).isNotNull
-                }
-            } finally {
-                FileTypeManagerEx.getInstanceEx().unregisterFileType(fakeFileType)
-            }
-        }
     }
 
     @Test
@@ -247,7 +221,7 @@ Resources:
 
     private companion object {
         val TEST_TEMPLATE =
-            """
+                """
 Description: "Some description"
 Parameters:
     TableName:
@@ -286,7 +260,7 @@ Resources:
                 WriteCapacityUnits: 1
             """.trimIndent()
 
-        private fun Resource.findEnvironmentVariable(name : String): Variable? =
+        private fun Resource.findEnvironmentVariable(name: String): Variable? =
                 this.getEnvironmentVariables().first { it -> it.variableName == name }
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/yaml/YamlCloudFormationTemplateTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/yaml/YamlCloudFormationTemplateTest.kt
@@ -14,7 +14,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplate
-import software.aws.toolkits.jetbrains.services.cloudformation.EnvironmentVariable
+import software.aws.toolkits.jetbrains.services.cloudformation.Variable
 import software.aws.toolkits.jetbrains.services.cloudformation.Resource
 import software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule
 import java.io.File
@@ -286,7 +286,7 @@ Resources:
                 WriteCapacityUnits: 1
             """.trimIndent()
 
-        private fun Resource.findEnvironmentVariable(name : String): EnvironmentVariable? =
+        private fun Resource.findEnvironmentVariable(name : String): Variable? =
                 this.getEnvironmentVariables().first { it -> it.variableName == name }
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/EnvironmentVariablesTextFieldTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/EnvironmentVariablesTextFieldTest.kt
@@ -1,3 +1,6 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package software.aws.toolkits.jetbrains.ui
 
 import com.intellij.execution.util.EnvironmentVariable
@@ -23,7 +26,7 @@ class EnvironmentVariablesTextFieldTest {
         assertThat(a.nameIsWriteable).isFalse()
         assertThat(b.nameIsWriteable).isFalse()
 
-        //can't be removed
+        // can't be removed
         assertThat(a.isPredefined).isTrue()
         assertThat(b.isPredefined).isTrue()
 
@@ -92,7 +95,7 @@ class EnvironmentVariablesTextFieldTest {
 
         field.acceptEditedVariablesForTesting(vars.filter { it -> it.name != "<unprotected-remove>" })
 
-        assertThat(field.text).doesNotContain("<clear>=") //cleared protected values considered as kinda removed
+        assertThat(field.text).doesNotContain("<clear>=") // cleared protected values considered as kinda removed
         assertThat(field.text).contains("<unprotected-clear>=")
 
         assertThat(field.text).isEqualTo("<edit>=BB;<unprotected-edit>=BB;<unprotected-clear>=")
@@ -108,7 +111,5 @@ class EnvironmentVariablesTextFieldTest {
 
         private fun List<EnvironmentVariable>.require(name: String): EnvironmentVariable =
                 this.first { it -> it.name == name }
-
     }
-
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/EnvironmentVariablesTextFieldTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/EnvironmentVariablesTextFieldTest.kt
@@ -1,0 +1,114 @@
+package software.aws.toolkits.jetbrains.ui
+
+import com.intellij.execution.util.EnvironmentVariable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class EnvironmentVariablesTextFieldTest {
+
+    @Test
+    fun protectedVars() {
+        val field = EnvironmentVariablesTextField()
+        field.protectVariables(listOf("A", "B"))
+        field.envVars = mapOf("xx" to "1", "yy" to "2")
+
+        val shownInTable: List<EnvironmentVariable> = field.convertToVariables()
+        assertThat(shownInTable).hasSize(4)
+        assertThat(shownInTable.asKeyValueMap())
+                .isEqualTo(mapOf("A" to "", "B" to "", "xx" to "1", "yy" to "2"))
+
+        val a = shownInTable.require("A")
+        val b = shownInTable.require("B")
+
+        assertThat(a.nameIsWriteable).isFalse()
+        assertThat(b.nameIsWriteable).isFalse()
+
+        //can't be removed
+        assertThat(a.isPredefined).isTrue()
+        assertThat(b.isPredefined).isTrue()
+
+        assertThat(shownInTable.require("xx").nameIsWriteable).isTrue()
+        assertThat(shownInTable.require("yy").isPredefined).isFalse()
+    }
+
+    @Test
+    fun protectedVarsWithData() {
+        val field = EnvironmentVariablesTextField()
+        field.protectVariables(listOf("A", "B"))
+        field.envVars = mapOf("X" to "xx", "B" to "bb")
+
+        val shownInTable = field.convertToVariables()
+        assertThat(shownInTable).hasSize(3)
+        assertThat(shownInTable.asKeyValueMap())
+                .isEqualTo(mapOf("A" to "", "B" to "bb", "X" to "xx"))
+    }
+
+    @Test
+    fun thatEmptyProtectedVarsExcludedFromStringify() {
+        val field = EnvironmentVariablesTextField()
+
+        field.protectVariables(listOf("AA", "BB", "CC"))
+        field.envVars = mapOf("AA" to "aa", "CC" to "", "XX" to "xx")
+
+        assertThat(field.text).isEqualTo("AA=aa;XX=xx")
+    }
+
+    @Test
+    fun thatStringifyDoesNotDependOnCallOrder() {
+        val protectedNames = listOf("AA", "BB", "CC")
+        val data = mapOf("AA" to "aa", "CC" to "", "XX" to "xx")
+
+        val protectThanSet = EnvironmentVariablesTextField()
+        protectThanSet.protectVariables(protectedNames)
+        protectThanSet.envVars = data
+
+        val setThenProtect = EnvironmentVariablesTextField()
+        setThenProtect.envVars = data
+        setThenProtect.protectVariables(protectedNames)
+    }
+
+    @Test
+    fun testAfterEditing() {
+        val protectedNames = listOf("<clear>", "<edit>", "<empty>")
+        val data = mapOf(
+                "<clear>" to "AA",
+                "<edit>" to "AA",
+                "<unprotected-edit>" to "AA",
+                "<unprotected-remove>" to "AA",
+                "<unprotected-clear>" to "AA"
+        )
+
+        val field = EnvironmentVariablesTextField()
+        field.envVars = data
+        field.protectVariables(protectedNames)
+
+        val vars = field.convertToVariables()
+
+        vars.require("<clear>").value = ""
+        vars.require("<edit>").value = "BB"
+
+        vars.require("<unprotected-edit>").value = "BB"
+        vars.require("<unprotected-clear>").value = ""
+
+        field.acceptEditedVariablesForTesting(vars.filter { it -> it.name != "<unprotected-remove>" })
+
+        assertThat(field.text).doesNotContain("<clear>=") //cleared protected values considered as kinda removed
+        assertThat(field.text).contains("<unprotected-clear>=")
+
+        assertThat(field.text).isEqualTo("<edit>=BB;<unprotected-edit>=BB;<unprotected-clear>=")
+        assertThat(field.envVars).isEqualTo(mapOf(
+                "<edit>" to "BB",
+                "<unprotected-edit>" to "BB",
+                "<unprotected-clear>" to ""))
+    }
+
+    companion object {
+        private fun List<EnvironmentVariable>.asKeyValueMap(): Map<String, String> =
+                this.associate { it -> it.name to it.value }
+
+        private fun List<EnvironmentVariable>.require(name: String): EnvironmentVariable =
+                this.first { it -> it.name == name }
+
+    }
+
+}


### PR DESCRIPTION
#386 - SAM Local Run Configuration environment variables substitution

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
- Yaml model extended to support resource Environment Variable's 
- environment variables defined in a resource with the `Ref` to local name considered as "predefined" in the local SAM run config 
- - user can't delete them or change their names 
- - user can add any other variables which are not managed by the feature
- Value column of the environment table is changed to have combobox editor 
- - combo values are matching physical resource IDs 
- - combobox is soft [editable], user may override the value if needed
- - the full resource mapping is requested every time on run-config reopening, from all resources in all available stacks
- - if value is not set (or cleared) the next reopening will set the value to the first physical ID found 
- - the existing values are never cleared even if there are no matching physical resources

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->
#386 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
see screen cast in #386 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
