### PR TITLE
Fix issue where changing radio buttons with keyboard does not trigger the enabled state of corresponding controls.

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationDialog.kt
@@ -47,14 +47,12 @@ class DeployServerlessApplicationDialog(
         setOKButtonText(message("serverless.application.deploy.action.name"))
         setOKButtonTooltip(message("serverless.application.deploy.action.description"))
 
-        view.createStack.addActionListener {
-            view.newStackName.isEnabled = true
-            view.stacks.isEnabled = false
+        view.createStack.addChangeListener {
+            updateStackEnabledStates()
         }
 
-        view.updateStack.addActionListener {
-            view.newStackName.isEnabled = false
-            view.stacks.isEnabled = true
+        view.updateStack.addChangeListener {
+            updateStackEnabledStates()
         }
 
         // If the module has been deployed once, select the updateStack radio instead
@@ -119,6 +117,11 @@ class DeployServerlessApplicationDialog(
 
     val parameters: Map<String, String>
         get() = view.templateParameters
+
+    private fun updateStackEnabledStates() {
+        view.newStackName.isEnabled = view.createStack.isSelected
+        view.stacks.isEnabled = view.updateStack.isSelected
+    }
 }
 
 class DeploySamApplicationValidator {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

When you click on the radio buttons, the new/existing stack controls properly set enabled state.
When you use the keyboard (up/down arrows), the enabled state does not update. This change fixes this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
