### PR TITLE
Fix PyCharm UI issue where components overflow out of the containing …

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/python/SamInitDirectoryBasedSettingsPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/python/SamInitDirectoryBasedSettingsPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.ui.wizard.python.SamInitDirectoryBasedSettingsPanel">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="696" height="400"/>
@@ -17,15 +17,6 @@
         <properties>
           <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="aws.settings.sam.location"/>
           <toolTipText resource-bundle="software/aws/toolkits/resources/localized_messages" key="aws.settings.sam.find.description"/>
-        </properties>
-      </component>
-      <component id="f3cdd" class="javax.swing.JTextField" binding="samExecutableField">
-        <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <editable value="false"/>
-          <enabled value="false"/>
         </properties>
       </component>
       <component id="e1f8b" class="com.intellij.ui.components.JBLabel">
@@ -45,21 +36,38 @@
           </grid>
         </constraints>
       </vspacer>
+      <grid id="d36c9" layout-manager="BorderLayout" hgap="0" vgap="0">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <minimum-size width="0" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="f3cdd" class="javax.swing.JTextField" binding="samExecutableField">
+            <constraints border-constraint="Center"/>
+            <properties>
+              <editable value="false"/>
+              <enabled value="false"/>
+            </properties>
+          </component>
+          <component id="73c0e" class="com.intellij.openapi.ui.FixedSizeButton" binding="editSamExecutableButton">
+            <constraints border-constraint="East"/>
+            <properties>
+              <toolTipText resource-bundle="software/aws/toolkits/resources/localized_messages" key="aws.settings.sam.find.description"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
       <component id="fd04c" class="com.intellij.openapi.ui.ComboBox" binding="templateField">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
+            <minimum-size width="0" height="-1"/>
+          </grid>
         </constraints>
         <properties>
           <model/>
-        </properties>
-      </component>
-      <component id="dc232" class="javax.swing.JButton" binding="editSamExecutableButton">
-        <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sam.init.edit_sam_executable"/>
-          <toolTipText resource-bundle="software/aws/toolkits/resources/localized_messages" key="aws.settings.sam.find.description"/>
         </properties>
       </component>
     </children>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/python/SamInitDirectoryBasedSettingsPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/python/SamInitDirectoryBasedSettingsPanel.java
@@ -6,13 +6,13 @@ package software.aws.toolkits.jetbrains.ui.wizard.python;
 import com.intellij.facet.ui.ValidationResult;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.ui.FixedSizeButton;
 import com.intellij.ui.components.JBLabel;
 import org.jetbrains.annotations.NotNull;
 import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommon;
 import software.aws.toolkits.jetbrains.ui.wizard.SamInitProjectBuilderCommon;
 import software.aws.toolkits.jetbrains.ui.wizard.SamProjectTemplate;
 
-import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import java.util.List;
@@ -21,7 +21,7 @@ public class SamInitDirectoryBasedSettingsPanel {
     private JTextField samExecutableField;
     private ComboBox<SamProjectTemplate> templateField;
     private JPanel mainPanel;
-    private JButton editSamExecutableButton;
+    private FixedSizeButton editSamExecutableButton;
     private JBLabel samLabel;
 
     private SamInitProjectBuilderPyCharm builder;


### PR DESCRIPTION
…panel

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/742829/48804623-04084580-ecca-11e8-955e-dac887a73047.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
