### PR TITLE
Fix being unable to set active creds, if there has never been any

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSettingsPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSettingsPanel.kt
@@ -26,6 +26,7 @@ import com.intellij.util.Consumer
 import software.aws.toolkits.core.credentials.CredentialProviderNotFound
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.core.utils.tryOrNull
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager.AccountSettingsChangedNotifier
@@ -214,7 +215,8 @@ private class ChangeRegionAction(val region: AwsRegion) : ToggleAction(region.di
 
 private class ChangeCredentialsAction(val credentialsProvider: ToolkitCredentialsProvider) : ToggleAction(credentialsProvider.displayName), DumbAware {
 
-    override fun isSelected(e: AnActionEvent): Boolean = getAccountSetting(e).activeCredentialProvider == credentialsProvider
+    override fun isSelected(e: AnActionEvent): Boolean =
+        tryOrNull { getAccountSetting(e).activeCredentialProvider == credentialsProvider } ?: false
 
     override fun setSelected(e: AnActionEvent, selected: Boolean) {
         if (selected) {


### PR DESCRIPTION
Also cache the lookup of credential factories

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
If the active cred provider was null (never set, no default profile), we would crash when trying to determine which of the credentials should be selected in the pop ups.

If there was no default profile, we also paid an expensive cost (and locked up the UI)  due to re-creating all the credential providers and parsing of the profile file for each possible profile. We instead cache the profile factories so they are only ever created once.

## Related Issue(s)
#563

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
