### PR TITLE
Improve the CodeURI -> VirutalFile converter to prevent source roots …

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamCommonTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamCommonTest.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.lambda.execution.sam
 
 import com.intellij.openapi.application.runReadAction
-import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.psi.PsiFile
 import com.intellij.testFramework.runInEdtAndGet
@@ -231,15 +230,8 @@ Resources:
         projectRule.fixture.addFileToProject(filename, template)
     }
 
-    private fun createChildren(directory: String, file: String? = null) {
-        runInEdtAndWait {
-            runWriteAction {
-                val dir = projectRule.project.baseDir.createChildDirectory(null, directory)
-                if (file != null) {
-                    dir.createChildData(null, file)
-                }
-            }
-        }
+    private fun createChildren(directory: String, file: String = "TestFile") {
+        projectRule.fixture.addFileToProject("$directory/$file", "")
     }
 
     private companion object {


### PR DESCRIPTION
…from not being marked

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Will now use Path to build the full file, then use that to refresh the VFS.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
