### PR TITLE
Force committing envvar values when getting the values.

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationPanel.java
@@ -69,6 +69,7 @@ public class DeployServerlessApplicationPanel {
     public Map<String, String> getTemplateParameters() {
         Map<String, String> parameters = new HashMap<>();
 
+        environmentVariablesTable.stopEditing();
         environmentVariablesTable.getEnvironmentVariables()
                 .forEach(envVar -> parameters.put(envVar.getName(), envVar.getValue()));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the bug that when the env var values are changed but not clicking anywhere before hitting the deploy button, the values are not committed, ie the new deploy still uses previous values.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->
#576 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
