### PR TITLE
Fix runtime ComboBox focus error in Edit Function Dialog.

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialog.kt
@@ -378,7 +378,7 @@ class UploadToLambdaValidator {
 
         runtime.runtimeGroup?.let { LambdaPackager.getInstance(it) } ?: return ValidationInfo(
             message("lambda.upload_validation.unsupported_runtime", runtime),
-            view.handler
+            view.runtime
         )
 
         findPsiElementsForHandler(project, runtime, handler).firstOrNull() ?: return ValidationInfo(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the bug that when creating a new Lambda function, runtime errors are not focusing on Runtime ComboBox. See screenshot for the bug

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Screenshots (if appropriate)
The screenshot before fixing the bug:
<img width="779" alt="runtimecombobox" src="https://user-images.githubusercontent.com/7167513/49052573-48e81c80-f1a1-11e8-9131-6527a63f221a.png">


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
