### PR TITLE
Add a field to be explict if we are using a template in local lambda …

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/sam/JavaSamRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/sam/JavaSamRunConfigurationIntegrationTest.kt
@@ -82,7 +82,7 @@ class JavaSamRunConfigurationIntegrationTest {
 
     @Test
     fun samIsExecuted() {
-        val runConfiguration = createRunConfiguration(project = projectRule.project, input = "\"Hello World\"")
+        val runConfiguration = createHandlerBasedRunConfiguration(project = projectRule.project, input = "\"Hello World\"")
         assertThat(runConfiguration).isNotNull
 
         val executeLambda = executeLambda(runConfiguration)
@@ -105,7 +105,7 @@ class JavaSamRunConfigurationIntegrationTest {
         """.trimIndent()
         )
 
-        val runConfiguration = createRunConfiguration(
+        val runConfiguration = createTemplateRunConfiguration(
             project = projectRule.project,
             templateFile = templateFile.containingFile.virtualFile.path,
             logicalFunctionName = "SomeFunction",
@@ -134,7 +134,7 @@ class JavaSamRunConfigurationIntegrationTest {
             )
         }
 
-        val runConfiguration = createRunConfiguration(project = projectRule.project, input = "\"Hello World\"")
+        val runConfiguration = createHandlerBasedRunConfiguration(project = projectRule.project, input = "\"Hello World\"")
         assertThat(runConfiguration).isNotNull
 
         val debuggerIsHit = checkBreakPointHit(projectRule.project)

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/sam/PythonSamRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/sam/PythonSamRunConfigurationIntegrationTest.kt
@@ -191,7 +191,7 @@ class PythonSamRunConfigurationIntegrationTest(private val runtime: Runtime) {
         handler: String,
         environmentVariables: MutableMap<String, String> = mutableMapOf()
     ): SamRunConfiguration =
-        createRunConfiguration(
+        createHandlerBasedRunConfiguration(
             project = projectRule.project,
             input = "\"Hello World\"",
             handler = handler,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/LambdaSamRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/LambdaSamRunConfigurationProducer.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import org.jetbrains.yaml.psi.YAMLKeyValue
 import org.jetbrains.yaml.psi.YAMLPsiElement
-import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
@@ -58,7 +57,12 @@ class LambdaSamRunConfigurationProducer : RunConfigurationProducer<SamRunConfigu
 
         val runtime = RuntimeGroup.determineRuntime(context.module) ?: RuntimeGroup.determineRuntime(context.project)
         val settings = accountSettings(element.project)
-        configuration.configure(runtime, handler, credentialsProviderId = settings.first, region = settings.second)
+        configuration.configureForHandler(
+            runtime = runtime,
+            handler = handler,
+            credentialsProviderId = settings.first,
+            region = settings.second
+        )
         return true
     }
 
@@ -66,10 +70,9 @@ class LambdaSamRunConfigurationProducer : RunConfigurationProducer<SamRunConfigu
         val file = element.containingFile?.virtualFile?.path ?: return false
         val function = functionFromElement(element) ?: return false
         val settings = accountSettings(element.project)
-        configuration.configure(
+        configuration.configureForTemplate(
             templateFile = file,
             logicalFunctionName = function.logicalName,
-            runtime = Runtime.fromValue(function.runtime()),
             credentialsProviderId = settings.first,
             region = settings.second
         )

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/sam/CreateRunConfiguration.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/sam/CreateRunConfiguration.kt
@@ -9,7 +9,32 @@ import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfiguration
 
-fun createRunConfiguration(
+fun createTemplateRunConfiguration(
+    project: Project,
+    input: String? = "inputText",
+    templateFile: String? = null,
+    logicalFunctionName: String? = null,
+    inputIsFile: Boolean = false,
+    credentialsProviderId: String? = null,
+    region: AwsRegion? = AwsRegion("us-east-1", "us-east-1"),
+    environmentVariables: MutableMap<String, String> = mutableMapOf()
+): SamRunConfiguration {
+    val runConfiguration = samRunConfiguration(project)
+
+    runConfiguration.configureForTemplate(
+        templateFile = templateFile,
+        logicalFunctionName = logicalFunctionName,
+        input = input,
+        inputIsFile = inputIsFile,
+        envVars = environmentVariables,
+        credentialsProviderId = credentialsProviderId,
+        region = region
+    )
+
+    return runConfiguration
+}
+
+fun createHandlerBasedRunConfiguration(
     project: Project,
     runtime: Runtime? = Runtime.JAVA8,
     handler: String? = "com.example.LambdaHandler::handleRequest",
@@ -17,18 +42,29 @@ fun createRunConfiguration(
     inputIsFile: Boolean = false,
     credentialsProviderId: String? = null,
     region: AwsRegion? = AwsRegion("us-east-1", "us-east-1"),
-    environmentVariables: MutableMap<String, String> = mutableMapOf(),
-    templateFile: String? = null,
-    logicalFunctionName: String? = null
+    environmentVariables: MutableMap<String, String> = mutableMapOf()
 ): SamRunConfiguration {
+    val runConfiguration = samRunConfiguration(project)
+
+    runConfiguration.configureForHandler(
+        runtime = runtime,
+        handler = handler,
+        input = input,
+        inputIsFile = inputIsFile,
+        envVars = environmentVariables,
+        credentialsProviderId = credentialsProviderId,
+        region = region
+    )
+
+    return runConfiguration
+}
+
+private fun samRunConfiguration(project: Project): SamRunConfiguration {
     val runManager = RunManager.getInstance(project)
     val topLevelFactory = runManager.configurationFactories.first { it is LambdaRunConfiguration }
     val factory = topLevelFactory.configurationFactories.first { it is SamRunConfigurationFactory }
     val runConfigurationAndSettings = runManager.createRunConfiguration("Test", factory)
     val runConfiguration = runConfigurationAndSettings.configuration as SamRunConfiguration
     runManager.addConfiguration(runConfigurationAndSettings)
-
-    runConfiguration.configure(runtime, handler, input, inputIsFile, environmentVariables, credentialsProviderId, region, templateFile, logicalFunctionName)
-
     return runConfiguration
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/sam/LambdaSamRunConfigurationProducerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/sam/LambdaSamRunConfigurationProducerTest.kt
@@ -45,7 +45,7 @@ class LambdaSamRunConfigurationProducerTest {
             val runConfiguration = createRunConfiguration(lambdaMethod)
             assertThat(runConfiguration).isNotNull
             val configuration = runConfiguration?.configuration as SamRunConfiguration
-            assertThat(configuration.getHandler()).isEqualTo("com.example.LambdaHandler::handleRequest")
+            assertThat(configuration.settings().handler).isEqualTo("com.example.LambdaHandler::handleRequest")
             assertThat(configuration.name).isEqualTo("[Local] LambdaHandler.handleRequest")
         }
     }


### PR DESCRIPTION
…run config

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Introduces the useTemplate boolean
* Simplify logic to base all template vs handler logic around new boolean
* Don't persist computed values from template if using template (i.e. handler / runtime)
* Don't persist template fields if checkbox is not selected
* Split the configure() method by use case
* Add tests to make sure de-serialization is backwards compatible

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#477 

## Testing
New tests

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
