### PR TITLE
Added notification when starting up to an invalid credential, or when selecting an invalid credential

### DIFF
--- a/.changes/next-release/feature-a9973ebf-9ae4-47d5-8917-7256f1ba9635.json
+++ b/.changes/next-release/feature-a9973ebf-9ae4-47d5-8917-7256f1ba9635.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Added AWS Credential validation when changing profiles"
+}

--- a/core/src/software/aws/toolkits/core/credentials/AwsProfile.kt
+++ b/core/src/software/aws/toolkits/core/credentials/AwsProfile.kt
@@ -205,5 +205,6 @@ class ProfileToolkitCredentialsProviderFactory(
         private val LOG = LoggerFactory.getLogger(ProfileToolkitCredentialsProviderFactory::class.java)
 
         const val TYPE = "profile"
+        const val DEFAULT_PROFILE_DISPLAY_NAME = "$TYPE:default"
     }
 }

--- a/core/src/software/aws/toolkits/core/credentials/ToolkitCredentialsProvider.kt
+++ b/core/src/software/aws/toolkits/core/credentials/ToolkitCredentialsProvider.kt
@@ -4,6 +4,8 @@
 package software.aws.toolkits.core.credentials
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.http.SdkHttpClient
+import software.amazon.awssdk.services.sts.StsClient
 
 abstract class ToolkitCredentialsProvider : AwsCredentialsProvider {
     /**
@@ -31,6 +33,20 @@ abstract class ToolkitCredentialsProvider : AwsCredentialsProvider {
     override fun hashCode(): Int = id.hashCode()
 
     override fun toString(): String = "${this::class.simpleName}(id='$id')"
+
+    open fun isValid(sdkHttpClient: SdkHttpClient): Boolean {
+        val client = StsClient.builder()
+            .httpClient(sdkHttpClient)
+            .credentialsProvider(this)
+            .build()
+
+        try {
+            client.getCallerIdentity()
+            return true
+        } catch (e: Exception) {
+            return false
+        }
+    }
 }
 
 /**

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSettingsPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSettingsPanel.kt
@@ -4,9 +4,6 @@
 package software.aws.toolkits.jetbrains.core
 
 import com.intellij.ide.DataManager
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationType
-import com.intellij.notification.Notifications.Bus.notify
 import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
@@ -35,6 +32,7 @@ import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsMa
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager.AccountSettingsChangedNotifier
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.utils.createNotificationExpiringAction
+import software.aws.toolkits.jetbrains.utils.notifyWarn
 import software.aws.toolkits.resources.message
 import java.awt.Component
 import java.awt.event.MouseEvent
@@ -225,17 +223,12 @@ private class ChangeCredentialsAction(val credentialsProvider: ToolkitCredential
     override fun setSelected(e: AnActionEvent, selected: Boolean) {
         if (selected) {
             if (!credentialsProvider.isValid(AwsSdkClient.getInstance().sdkHttpClient)) {
-                notify(
-                    Notification(
-                        GROUP_DISPLAY_ID,
-                        message("credentials.invalid.title"),
-                        message("credentials.invalid.notification", credentialsProvider.displayName),
-                        NotificationType.WARNING
-                    ).addAction(
-                        createNotificationExpiringAction(
-                            ActionManager.getInstance().getAction("aws.settings.upsertCredentials")
-                        )
-                    )
+                notifyWarn(
+                    title = message("credentials.invalid.title"),
+                    content = message("credentials.invalid.notification", credentialsProvider.displayName),
+                    notificationActions = listOf(createNotificationExpiringAction(
+                        ActionManager.getInstance().getAction("aws.settings.upsertCredentials")
+                    ))
                 )
             } else {
                 getAccountSetting(e).activeCredentialProvider = credentialsProvider

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialWriter.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialWriter.kt
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.TestOnly
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting
 import software.amazon.awssdk.utils.JavaSystemSetting
 import software.amazon.awssdk.utils.StringUtils
+import software.aws.toolkits.jetbrains.utils.notifyInfo
 import software.aws.toolkits.resources.message
 import java.io.File
 import java.nio.file.FileSystems
@@ -56,6 +57,9 @@ class CreateOrUpdateCredentialProfilesAction @TestOnly constructor(
         localFileSystem.refreshFiles(listOf(virtualFile), false, false) {
             fileEditorManager.openTextEditor(OpenFileDescriptor(project, virtualFile), true)
                 ?: throw RuntimeException(message("credentials.could_not_open", file))
+
+            // TODO : remove message (and localized string) when credentials auto-refreshing is supported
+            notifyInfo("", message("credentials.notification.restart.ide"))
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
@@ -15,9 +15,11 @@ import software.aws.toolkits.core.credentials.ProfileToolkitCredentialsProviderF
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.tryOrNull
+import software.aws.toolkits.jetbrains.core.AwsSdkClient
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager.Companion.ACCOUNT_SETTINGS_CHANGED
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.utils.MRUList
+import software.aws.toolkits.jetbrains.utils.notifyWarn
 import software.aws.toolkits.resources.message
 
 interface ProjectAccountSettingsManager {
@@ -94,6 +96,7 @@ class DefaultProjectAccountSettingsManager(private val project: Project) :
     private var activeProfileInternal: ToolkitCredentialsProvider? = null
     private val recentlyUsedProfiles = MRUList<ToolkitCredentialsProvider>(MAX_HISTORY)
     private val recentlyUsedRegions = MRUList<AwsRegion>(MAX_HISTORY)
+    private val knownInvalidProfiles: MutableList<String> = mutableListOf()
 
     override var activeRegion: AwsRegion
         get() = activeRegionInternal
@@ -107,7 +110,9 @@ class DefaultProjectAccountSettingsManager(private val project: Project) :
         @Throws(CredentialProviderNotFound::class)
         get() = activeProfileInternal
             ?: tryOrNull {
-                getCredentialProviderOrNull("${ProfileToolkitCredentialsProviderFactory.TYPE}:default")
+                getCredentialProviderOrNull(ProfileToolkitCredentialsProviderFactory.DEFAULT_PROFILE_DISPLAY_NAME)
+            }?.takeIf {
+                isCredentialsValid(it)
             }?.apply {
                 updateActiveProfile(this)
             }
@@ -130,7 +135,22 @@ class DefaultProjectAccountSettingsManager(private val project: Project) :
 
     override fun loadState(state: AccountState) {
         activeRegionInternal = regionProvider.lookupRegionById(state.activeRegion)
-        activeProfileInternal = state.activeProfile?.let { getCredentialProviderOrNull(it) }
+        state.activeProfile?.let { getCredentialProviderOrNull(it) }?.run {
+            if (this.isValid(AwsSdkClient.getInstance().sdkHttpClient)) {
+                activeProfileInternal = this
+            } else {
+                val content = if (this.displayName.toLowerCase() == ProfileToolkitCredentialsProviderFactory.DEFAULT_PROFILE_DISPLAY_NAME.toLowerCase()) {
+                    message("credentials.default.profile.invalid.no.fallback.notification")
+                } else {
+                    message("credentials.profile.invalid.notification", this.displayName)
+                }
+
+                notifyWarn(
+                    title = message("credentials.invalid.title"),
+                    content = content
+                )
+            }
+        }
 
         state.recentlyUsedRegions.reversed().mapNotNull { regionProvider.regions()[it] }
             .forEach { recentlyUsedRegions.add(it) }
@@ -146,6 +166,20 @@ class DefaultProjectAccountSettingsManager(private val project: Project) :
 
     private fun getCredentialProviderOrNull(id: String): ToolkitCredentialsProvider? = tryOrNull {
         credentialManager.getCredentialProvider(id)
+    }
+
+    private fun isCredentialsValid(toolkitCredentialsProvider: ToolkitCredentialsProvider): Boolean {
+        // Prevent repeated checks when a provider is known to be invalid
+        // TODO : When profile refreshing is supported, this will need to be revisited
+        if (!knownInvalidProfiles.contains(toolkitCredentialsProvider.id)) {
+            if (toolkitCredentialsProvider.isValid(AwsSdkClient.getInstance().sdkHttpClient)) {
+                return true
+            }
+
+            knownInvalidProfiles.add(toolkitCredentialsProvider.id)
+        }
+
+        return false
     }
 
     companion object {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
@@ -33,10 +33,8 @@ fun notifyInfo(title: String, content: String = "", project: Project? = null, li
 fun notifyWarn(title: String, content: String = "", project: Project? = null, notificationActions: Collection<AnAction>) {
     val notification = Notification(GROUP_DISPLAY_ID, title, content, NotificationType.WARNING)
 
-    if (notificationActions != null) {
-        notificationActions.forEach {
-            notification.addAction(it)
-        }
+    notificationActions.forEach {
+        notification.addAction(it)
     }
 
     notify(notification, project)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
@@ -30,6 +30,18 @@ fun Exception.notifyError(title: String = "", project: Project? = null) =
 fun notifyInfo(title: String, content: String = "", project: Project? = null, listener: NotificationListener? = null) =
     notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.INFORMATION, listener), project)
 
+fun notifyWarn(title: String, content: String = "", project: Project? = null, notificationActions: Collection<AnAction>) {
+    val notification = Notification(GROUP_DISPLAY_ID, title, content, NotificationType.WARNING)
+
+    if (notificationActions != null) {
+        notificationActions.forEach {
+            notification.addAction(it)
+        }
+    }
+
+    notify(notification, project)
+}
+
 fun notifyWarn(title: String, content: String = "", project: Project? = null, listener: NotificationListener? = null) =
     notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.WARNING, listener), project)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.utils
 
 import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications.Bus.notify
@@ -17,26 +18,26 @@ import software.aws.toolkits.resources.message
 const val GROUP_DISPLAY_ID = "AWS Toolkit"
 
 fun Exception.notifyError(title: String = "", project: Project? = null) =
-        notify(
-                Notification(
-                        GROUP_DISPLAY_ID,
-                        title,
-                        this.message ?: "${this::class.java.name}${this.stackTrace?.joinToString("\n", prefix = "\n")}",
-                        NotificationType.ERROR
-                ), project
-        )
+    notify(
+        Notification(
+            GROUP_DISPLAY_ID,
+            title,
+            this.message ?: "${this::class.java.name}${this.stackTrace?.joinToString("\n", prefix = "\n")}",
+            NotificationType.ERROR
+        ), project
+    )
 
 fun notifyInfo(title: String, content: String = "", project: Project? = null, listener: NotificationListener? = null) =
-        notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.INFORMATION, listener), project)
+    notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.INFORMATION, listener), project)
 
 fun notifyWarn(title: String, content: String = "", project: Project? = null, listener: NotificationListener? = null) =
     notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.WARNING, listener), project)
 
 fun notifyError(title: String, content: String = "", project: Project? = null, action: AnAction) =
-        notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.ERROR).addAction(action), project)
+    notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.ERROR).addAction(action), project)
 
 fun notifyError(title: String, content: String = "", project: Project? = null, listener: NotificationListener? = null) =
-        notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.ERROR, listener), project)
+    notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.ERROR, listener), project)
 
 /**
  * Notify error that AWS credentials are not configured.
@@ -78,4 +79,14 @@ fun <T> tryNotify(message: String, block: () -> T): T? = try {
 } catch (e: Exception) {
     e.notifyError(message)
     null
+}
+
+/**
+ * Creates a Notification Action that will expire a notification after performing some AnAction
+ */
+fun createNotificationExpiringAction(action: AnAction): NotificationAction = NotificationAction.create(
+    action.templatePresentation.text
+) { actionEvent, notification ->
+    action.actionPerformed(actionEvent)
+    notification.expire()
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
@@ -29,6 +29,9 @@ fun Exception.notifyError(title: String = "", project: Project? = null) =
 fun notifyInfo(title: String, content: String = "", project: Project? = null, listener: NotificationListener? = null) =
         notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.INFORMATION, listener), project)
 
+fun notifyWarn(title: String, content: String = "", project: Project? = null, listener: NotificationListener? = null) =
+    notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.WARNING, listener), project)
+
 fun notifyError(title: String, content: String = "", project: Project? = null, action: AnAction) =
         notify(Notification(GROUP_DISPLAY_ID, title, content, NotificationType.ERROR).addAction(action), project)
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
@@ -292,7 +292,7 @@ class DefaultProjectAccountSettingsManagerTest {
             </AccountState>
         """.toElement()
 
-        val credentials = mockCredentialManager.addCredentials(
+        mockCredentialManager.addCredentials(
             "Mock",
             AwsBasicCredentials.create("Access", "Secret"),
             false

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
@@ -278,6 +278,38 @@ class DefaultProjectAccountSettingsManagerTest {
         assertThatThrownBy { manager.activeCredentialProvider }
             .isInstanceOf(CredentialProviderNotFound::class.java)
     }
+
+    @Test
+    fun testLoadingInvalidActiveCredentialNotSelected() {
+        val element = """
+            <AccountState>
+                <option name="activeProfile" value="Mock" />
+                <option name="recentlyUsedProfiles">
+                    <list>
+                        <option value="Mock" />
+                    </list>
+                </option>
+            </AccountState>
+        """.toElement()
+
+        val credentials = mockCredentialManager.addCredentials(
+            "Mock",
+            AwsBasicCredentials.create("Access", "Secret"),
+            false
+        )
+
+        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
+        manager.loadState(element.deserialize())
+
+        assertThat(manager.hasActiveCredentials()).isFalse()
+    }
+
+    @Test
+    fun testInvalidDefaultProfileCredentialNotSelected() {
+        mockCredentialManager.addCredentials("profile:default", AwsBasicCredentials.create("Access", "Secret"), false)
+        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
+        assertThat(manager.hasActiveCredentials()).isFalse()
+    }
 }
 
 private fun Element?.string(): String = XMLOutputter().outputString(this)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -5,6 +5,7 @@ package software.aws.toolkits.jetbrains.core.credentials
 
 import com.intellij.openapi.components.ServiceManager
 import software.amazon.awssdk.auth.credentials.AwsCredentials
+import software.amazon.awssdk.http.SdkHttpClient
 import software.aws.toolkits.core.credentials.CredentialProviderNotFound
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 
@@ -20,7 +21,7 @@ class MockCredentialsManager : CredentialManager {
         providers.clear()
     }
 
-    fun addCredentials(id: String, credentials: AwsCredentials): ToolkitCredentialsProvider = MockCredentialsProvider(id, id, credentials).also {
+    fun addCredentials(id: String, credentials: AwsCredentials, isValid: Boolean = true): ToolkitCredentialsProvider = MockCredentialsProvider(id, id, credentials, isValid).also {
         providers[id] = it
     }
 
@@ -31,8 +32,10 @@ class MockCredentialsManager : CredentialManager {
     private inner class MockCredentialsProvider(
         override val id: String,
         override val displayName: String,
-        private val credentials: AwsCredentials
+        private val credentials: AwsCredentials,
+        private val isValid: Boolean
     ) : ToolkitCredentialsProvider() {
         override fun resolveCredentials(): AwsCredentials = credentials
+        override fun isValid(sdkHttpClient: SdkHttpClient): Boolean = isValid
     }
 }

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -63,11 +63,11 @@ explorer.node.lambda=Lambda
 explorer.refresh.title=Refresh
 explorer.refresh.description=Refresh explorer resources
 explorer.stack.no.serverless.resources=Stack has no Lambda Functions
-credentials.notification.restart.ide=You will need to restart the IDE for any credentials changes to take effect.
-credentials.invalid.title=Invalid AWS Credentials
-credentials.invalid.notification=The credentials do not appear to be valid for {0}. Click <a href="">here</a> to edit credentials.
-credentials.profile.invalid.notification=The credentials do not appear to be valid for {0}. Click on the AWS portion of the status bar to change or modify AWS profiles.
-credentials.default.profile.invalid.no.fallback.notification=You do not appear to have a valid default credentials profile. You will need to select a credentials profile before the Toolkit has a connection to AWS. Click on the AWS portion of the status bar to change or modify AWS profiles.
+credentials.notification.restart.ide=After modifying AWS credentials, you will need to restart the IDE for the toolkit to use your changes.
+credentials.invalid.title=Invalid AWS Credential
+credentials.invalid.notification=The AWS credential {0} does not appear to be valid.
+credentials.profile.invalid.notification=The AWS credential {0} does not appear to be valid. Click on the AWS portion of the status bar to change or modify AWS credentials profiles.
+credentials.default.profile.invalid.no.fallback.notification=You do not appear to have a valid default AWS credentials profile. You will need to select a credentials profile before the Toolkit has a connection to AWS. Click on the AWS portion of the status bar to change or modify AWS credential profiles.
 credentials.profile.not_configured=No active credential provider configured
 credentials.profile.missing_property=Profile {0} is missing required property {1}
 credentials.profile.failed_load=Failed to load AWS profiles

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -62,6 +62,11 @@ explorer.node.lambda=Lambda
 explorer.refresh.title=Refresh
 explorer.refresh.description=Refresh explorer resources
 explorer.stack.no.serverless.resources=Stack has no Lambda Functions
+credentials.notification.restart.ide=You will need to restart the IDE for any credentials changes to take effect.
+credentials.invalid.title=Invalid AWS Credentials
+credentials.invalid.notification=The credentials do not appear to be valid for {0}. Click <a href="">here</a> to edit credentials.
+credentials.profile.invalid.notification=The credentials do not appear to be valid for {0}. Click on the AWS portion of the status bar to change or modify AWS profiles.
+credentials.default.profile.invalid.no.fallback.notification=You do not appear to have a valid default credentials profile. You will need to select a credentials profile before the Toolkit has a connection to AWS. Click on the AWS portion of the status bar to change or modify AWS profiles.
 credentials.profile.not_configured=No active credential provider configured
 credentials.profile.missing_property=Profile {0} is missing required property {1}
 credentials.profile.failed_load=Failed to load AWS profiles


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

Added STS getCallerIdentity validation

* If user tries to switch to a credential profile that is not valid:
  * they get a notification indicating the credential appears invalid
  * the credential profile is not changed
* If toolkit starts up and the previously used profile is not valid:
  * they get a notification indicating the credential appears invalid
  * the toolkit's active credential profile is not set 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

* reduce the amount of downstream errors due to invalid credentials
* inform users that something does not seem right and requires action

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->
#578 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Unit Tests
* Loading toolkit and switching to an invalid credential
* Exiting toolkit on a valid credential profile, then making that profile invalid locally, then restarting toolkit

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
