### PR TITLE
Adding issue link to the plugin page.

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -20,6 +20,8 @@
     <li><strong>Deploy SAM-based Applications</strong> - (<strong>Python only</strong>) Package, deploy & track SAM-based applications</li>
 </ul>
 </p>
+
+If you come across bugs with the toolkit or have feature requests, please raise an <a href="https://github.com/aws/aws-toolkit-jetbrains/issues">issue</a>.
     ]]></description>
 
     <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://aws.amazon.com/">Amazon Web Services</vendor>


### PR DESCRIPTION
We've had several people raise bugs on the plugin's repository as comments - we really want to direct people to the github issues page.