### PR TITLE
Release file lock during Packaging Lambda code

### DIFF
--- a/.changes/next-release/bugfix-80f780dc-3a12-4fd7-8b9c-1dde30397c09.json
+++ b/.changes/next-release/bugfix-80f780dc-3a12-4fd7-8b9c-1dde30397c09.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix case where packaging Java code was not releasing file locks #694"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaPackager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaPackager.kt
@@ -44,10 +44,12 @@ class JavaLambdaPackager : LambdaPackager {
                     entriesForModule(module, zipContents)
                     val zipFile = createTemporaryZipFile { zip ->
                         zipContents.forEach {
-                            zip.putNextEntry(
-                                it.pathInZip,
-                                it.sourceFile
-                            )
+                            it.sourceFile.use { sourceFile ->
+                                zip.putNextEntry(
+                                    it.pathInZip,
+                                    sourceFile
+                                )
+                            }
                         }
                     }
                     LOG.debug("Created temporary zip: $zipFile")

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaPackagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaPackagerTest.kt
@@ -214,6 +214,38 @@ class JavaLambdaPackagerTest {
         runAndVerifyExpectedEntries(module, mainClass, "com/example/UsefulUtils.class")
     }
 
+    @Test
+    fun packagedFilesHaveNoLock() {
+        val fixture = projectRule.fixture
+        val module = fixture.addModule("main")
+
+        val mainClass = fixture.addClass(
+            module, """
+            package com.example;
+
+            public class UsefulUtils {
+                public static String upperCase(String input) {
+                    return input.toUpperCase();
+                }
+            }
+            """
+        )
+
+        val mainClassFile = mainClass.containingFile
+
+        ModuleRootModificationUtil.addModuleLibrary(module, testDependencyJarName, mutableListOf(testDependencyJarPath), mutableListOf(), DependencyScope.TEST)
+
+        runAndVerifyExpectedEntries(module, mainClassFile, "com/example/UsefulUtils.class")
+
+        runInEdt {
+            // Modify the file that was compiled to verify there no lock remains on it
+            fixture.renameElement(
+                mainClass.findMethodsByName("upperCase", false)[0],
+                "foo"
+            )
+        }
+    }
+
     private fun runAndVerifyExpectedEntries(module: Module, mainClass: PsiFile, vararg entries: String) {
         setUpCompiler()
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaPackagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaPackagerTest.kt
@@ -238,7 +238,7 @@ class JavaLambdaPackagerTest {
         runAndVerifyExpectedEntries(module, mainClassFile, "com/example/UsefulUtils.class")
 
         runInEdt {
-            // Modify the file that was compiled to verify there no lock remains on it
+            // Modify the file that was compiled to verify there is no lock remaining
             fixture.renameElement(
                 mainClass.findMethodsByName("upperCase", false)[0],
                 "foo"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Windows machines were holding on to a file lock after packaging code. This change releases the lock after packaging.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->
#694 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
