### PR TITLE
Alias Path.delete to Files.deleteIfExists instead to prevent FileNotF…

### DIFF
--- a/.changes/next-release/bugfix-6d0bd0da-0e2f-41f2-a67d-32ea0fc145e8.json
+++ b/.changes/next-release/bugfix-6d0bd0da-0e2f-41f2-a67d-32ea0fc145e8.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Suppress FileNotFoundException that can be thrown if the endpoints file fails to download"
+}

--- a/core/src/software/aws/toolkits/core/utils/PathUtils.kt
+++ b/core/src/software/aws/toolkits/core/utils/PathUtils.kt
@@ -11,7 +11,7 @@ import java.nio.file.attribute.FileTime
 
 fun Path.inputStream(): InputStream = Files.newInputStream(this)
 fun Path.exists() = Files.exists(this)
-fun Path.delete() = Files.delete(this)
+fun Path.deleteIfExists() = Files.deleteIfExists(this)
 fun Path.lastModified(): FileTime = Files.getLastModifiedTime(this)
 fun Path.readText(charset: Charset = Charsets.UTF_8) = toFile().readText(charset)
 fun Path.writeText(text: String, charset: Charset = Charsets.UTF_8) = toFile().writeText(text, charset)

--- a/core/src/software/aws/toolkits/core/utils/RemoteResourceResolver.kt
+++ b/core/src/software/aws/toolkits/core/utils/RemoteResourceResolver.kt
@@ -50,7 +50,7 @@ class DefaultRemoteResourceResolver(
             } catch (e: Exception) {
                 LOG.warn(e) { "Exception occurred downloading" }
                 lastException = e
-                tmpFile.delete()
+                tmpFile.deleteIfExists()
                 return@mapNotNull null
             }
             tmpFile


### PR DESCRIPTION
…oundExceptions

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
When we delete files we do not actually care if it existed in the first place (if we truly do we can check the result code) so instead switch to deleteIfExists since that suppresses the FileNotFoundException

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#721 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
