### PR TITLE
Remove dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
     dependencies {
         classpath "com.atlassian.commonmark:commonmark:0.11.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
         classpath "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:$ideaPluginVersion"
     }
 }
@@ -50,7 +49,6 @@ subprojects {
 
     apply plugin: 'java'
     apply plugin: 'idea'
-    apply plugin: 'org.jetbrains.dokka'
     apply plugin: 'signing'
 
     def isReleaseVersion = !version.endsWith("SNAPSHOT")

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,10 +12,8 @@ publishChannel=
 
 # Common dependencies
 ideaVersion=2018.3
-javaVersion=1.8
 kotlinVersion=1.3.11
 awsSdkVersion=2.2.0
-dokkaVersion=0.9.11
 ideaPluginVersion=0.3.12
 ktlintVersion=0.29.0
 junitVersion=4.12


### PR DESCRIPTION
We don't publish it, so remove it.
Also remove unused gradle property for Java version

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
