### PR TITLE
Change CloudFormationExplorerNodes to use a case-insensitive sort to …

### DIFF
--- a/.changes/next-release/bugfix-bc2adaeb-74f8-437c-9ca1-81b290f1549c.json
+++ b/.changes/next-release/bugfix-bc2adaeb-74f8-437c-9ca1-81b290f1549c.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix sort order for CloudFormation nodes in the AWS Explorer"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationExplorerNodes.kt
@@ -41,7 +41,7 @@ class CloudFormationServiceNode(project: Project) : AwsExplorerServiceRootNode(p
 
         val nodes = response.stacks().filterNotNull().asSequence()
             .filter { it.stackStatus() !in DELETING_STACK_STATES }
-            .sortedBy { it.stackName() }
+            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.stackName() })
             .map { it -> CloudFormationStackNode(nodeProject, it.stackName(), it.stackStatus()) }
             .toList()
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/ExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/ExplorerNodes.kt
@@ -29,7 +29,10 @@ class LambdaServiceNode(project: Project) : AwsExplorerServiceRootNode(project, 
 
         val response = client.listFunctions(request.build())
         val resources: MutableList<AwsExplorerNode<*>> =
-            response.functions().asSequence().sortedBy { it.functionName().toLowerCase() }.map { mapResourceToNode(it) }.toMutableList()
+            response.functions().asSequence()
+                .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.functionName() })
+                .map { mapResourceToNode(it) }
+                .toMutableList()
         response.nextMarker()?.let {
             resources.add(AwsTruncatedResultNode(this, it))
         }


### PR DESCRIPTION
…match LambdaExplorerNodes

<!--- Provide a general summary of your changes in the Title above -->
![image](https://user-images.githubusercontent.com/742829/51150119-d0edb880-1819-11e9-9525-296c620e6fd7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
