### PR TITLE
Add CODEOWNERS to auto-add the team as a reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws/aws-ides-team


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
