### PR TITLE
Add option to --use-container during serverless app deployment

### DIFF
--- a/.changes/next-release/feature-bdf14d5b-5a4c-4c58-8e81-282fb482a1e1.json
+++ b/.changes/next-release/feature-bdf14d5b-5a4c-4c58-8e81-282fb482a1e1.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Add option to use a container-based build during serverless application deployment"
+}

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployTest.kt
@@ -153,6 +153,7 @@ class SamDeployTest {
                     templateFile,
                     parameters,
                     bucketRule.createBucket(stackName),
+                    false,
                     false
                 ) {
                     override fun createProcess(command: GeneralCommandLine): OSProcessHandler =

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
@@ -79,7 +79,8 @@ class DeployServerlessApplicationAction : AnActionWrapper(
             templateFile,
             stackDialog.parameters,
             stackDialog.bucket,
-            stackDialog.autoExecute
+            stackDialog.autoExecute,
+            stackDialog.useContainer
         )
 
         deployDialog.show()
@@ -141,6 +142,7 @@ class DeployServerlessApplicationAction : AnActionWrapper(
                     setSamStackName(samPath, stackDialog.stackName)
                     setSamBucketName(samPath, stackDialog.bucket)
                     setSamAutoExecute(samPath, stackDialog.autoExecute)
+                    setSamUseContainer(samPath, stackDialog.useContainer)
                 }
             }
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationDialog.kt
@@ -97,6 +97,8 @@ class DeployServerlessApplicationDialog(
         }
 
         view.requireReview.isSelected = !(settings?.samAutoExecute(samPath) ?: true)
+
+        view.useContainer.isSelected = (settings?.samUseContainer(samPath) ?: false)
     }
 
     override fun createCenterPanel(): JComponent? = view.content
@@ -122,6 +124,9 @@ class DeployServerlessApplicationDialog(
 
     val parameters: Map<String, String>
         get() = view.templateParameters
+
+    val useContainer: Boolean
+        get() = view.useContainer.isSelected
 
     private fun updateStackEnabledStates() {
         view.newStackName.isEnabled = view.createStack.isSelected

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.lambda.deploy.DeployServerlessApplicationPanel">
-  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="8" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="9" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="959" height="564"/>
@@ -119,6 +119,14 @@
         </constraints>
         <properties>
           <enabled value="false"/>
+        </properties>
+      </component>
+      <component id="37c38" class="javax.swing.JCheckBox" binding="useContainer">
+        <constraints>
+          <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="serverless.application.deploy.use_container"/>
         </properties>
       </component>
     </children>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationPanel.java
@@ -41,6 +41,7 @@ public class DeployServerlessApplicationPanel {
     @NotNull JRadioButton createStack;
     @NotNull JCheckBox requireReview;
     @NotNull JPanel parametersPanel;
+    @NotNull JCheckBox useContainer;
 
     public DeployServerlessApplicationPanel withTemplateParameters(final Collection<Parameter> parameters) {
         parametersPanel.setBorder(IdeBorderFactory.createTitledBorder(message("serverless.application.deploy.template.parameters"), false));

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
@@ -40,7 +40,8 @@ open class SamDeployDialog(
     private val template: VirtualFile,
     private val parameters: Map<String, String>,
     private val s3Bucket: String,
-    private val autoExecute: Boolean
+    private val autoExecute: Boolean,
+    private val useContainer: Boolean
 ) : DialogWrapper(project) {
     private val progressIndicator = ProgressIndicatorBase()
     private val view = SamDeployView(project, progressIndicator)
@@ -95,6 +96,11 @@ open class SamDeployDialog(
             .withParameters(template.path)
             .withParameters("--build-dir")
             .withParameters(buildDir.toString())
+            .apply {
+                if (useContainer) {
+                    withParameters("--use-container")
+                }
+            }
 
         val builtTemplate = buildDir.resolve("template.yaml")
         return runCommand(message("serverless.application.deploy.step_name.build"), command) { builtTemplate }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/DeploySettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/DeploySettings.kt
@@ -36,6 +36,11 @@ class DeploySettings : PersistentStateComponent<DeployConfigs> {
         state.samConfigs.computeIfAbsent(samPath) { DeploySamConfig() }.autoExecute = value
     }
 
+    fun samUseContainer(samPath: String): Boolean? = state.samConfigs[samPath]?.useContainer
+    fun setSamUseContainer(samPath: String, value: Boolean) {
+        state.samConfigs.computeIfAbsent(samPath) { DeploySamConfig() }.useContainer = value
+    }
+
     companion object {
         @JvmStatic
         fun getInstance(module: Module): DeploySettings? = ModuleServiceManager.getService(module, DeploySettings::class.java)
@@ -49,7 +54,8 @@ data class DeployConfigs(
 data class DeploySamConfig(
     var stackName: String? = null,
     var bucketName: String? = null,
-    var autoExecute: Boolean = false
+    var autoExecute: Boolean = false,
+    var useContainer: Boolean = false
 )
 
 /**

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -202,6 +202,7 @@ serverless.application.deploy.error.invalid_runtime=Invalid runtime {0} defined 
 serverless.application.deploy.error.invalid_runtime_group=Cannot find runtime group for runtime {0} in template {1}
 serverless.application.deploy.error.unsupported_runtime_group=The runtime {0} is not supported for deploying the SAM template {1}
 serverless.application.deploy.error.empty_runtime=The runtime is not defined for all functions in template {0}
+serverless.application.deploy.use_container=Build function inside a container
 sam.cli_not_configured=SAM CLI executable not configured
 sam.executable.unexpected_output=SAM CLI provided unexpected output. Please ensure that your SAM CLI is up-to-date: "{0}"
 sam.executable.empty_info=SAM CLI did not provide any output


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issue(s)
Resolves #749 

## Testing
* Visually confirmed that checking the box results in --use-container appended to the build command-line 

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/742829/52665196-d5ac9780-2ebf-11e9-96d5-b5bc2b1b6458.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
