### PR TITLE
Do not cache telemetry service as a static

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/components/telemetry/ActionWrappers.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/components/telemetry/ActionWrappers.kt
@@ -27,17 +27,16 @@ object ToolkitActionPlaces {
 //  public AnAction(@Nullable String text, @Nullable String description, @Nullable Icon icon) {
 //    <logic>
 //  }
-abstract class AnActionWrapper : TelemetryNamespace, AnAction {
-    constructor() : super()
-    constructor(text: String? = null, description: String? = null, icon: Icon? = null) :
-            super(text, description, icon)
+abstract class AnActionWrapper(text: String? = null, description: String? = null, icon: Icon? = null) :
+    TelemetryNamespace,
+    AnAction(text, description, icon) {
 
     /**
      * Consumers should use doActionPerformed(e: AnActionEvent)
      */
     final override fun actionPerformed(e: AnActionEvent) {
         doActionPerformed(e)
-        telemetry.record(getNamespace()) {
+        TelemetryService.getInstance().record(getNamespace()) {
             datum(e.place) {
                 count()
             }
@@ -45,10 +44,6 @@ abstract class AnActionWrapper : TelemetryNamespace, AnAction {
     }
 
     abstract fun doActionPerformed(e: AnActionEvent)
-
-    companion object {
-        protected val telemetry = TelemetryService.getInstance()
-    }
 }
 
 abstract class ComboBoxActionWrapper : TelemetryNamespace, ComboBoxAction() {
@@ -57,7 +52,7 @@ abstract class ComboBoxActionWrapper : TelemetryNamespace, ComboBoxAction() {
      */
     final override fun actionPerformed(e: AnActionEvent) {
         doActionPerformed(e)
-        telemetry.record(getNamespace()) {
+        TelemetryService.getInstance().record(getNamespace()) {
             datum(e.place) {
                 count()
             }
@@ -65,16 +60,11 @@ abstract class ComboBoxActionWrapper : TelemetryNamespace, ComboBoxAction() {
     }
 
     open fun doActionPerformed(e: AnActionEvent) = super.actionPerformed(e)
-
-    companion object {
-        protected val telemetry = TelemetryService.getInstance()
-    }
 }
 
-abstract class ToogleActionWrapper : TelemetryNamespace, ToggleAction {
-    constructor() : super()
-    constructor(text: String? = null, description: String? = null, icon: Icon? = null) :
-            super(text, description, icon)
+abstract class ToogleActionWrapper(text: String? = null, description: String? = null, icon: Icon? = null) :
+    TelemetryNamespace,
+    ToggleAction(text, description, icon) {
 
     // this will be repeatedly called by the IDE, so we likely do not want telemetry on this,
     // but keeping this to maintain API consistency
@@ -82,7 +72,7 @@ abstract class ToogleActionWrapper : TelemetryNamespace, ToggleAction {
 
     final override fun setSelected(e: AnActionEvent, state: Boolean) {
         doSetSelected(e, state)
-        telemetry.record(getNamespace()) {
+        TelemetryService.getInstance().record(getNamespace()) {
             datum(e.place) {
                 count()
             }
@@ -92,8 +82,4 @@ abstract class ToogleActionWrapper : TelemetryNamespace, ToggleAction {
     abstract fun doIsSelected(e: AnActionEvent): Boolean
 
     abstract fun doSetSelected(e: AnActionEvent, state: Boolean)
-
-    companion object {
-        protected val telemetry = TelemetryService.getInstance()
-    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/components/telemetry/LoggingDialogWrapper.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/components/telemetry/LoggingDialogWrapper.kt
@@ -52,7 +52,7 @@ abstract class LoggingDialogWrapper : DialogWrapper, TelemetryNamespace {
     override fun doOKAction() {
         super.doOKAction()
 
-        telemetry.record(getNamespace()) {
+        TelemetryService.getInstance().record(getNamespace()) {
             datum("OKAction") {
                 count()
             }
@@ -62,14 +62,10 @@ abstract class LoggingDialogWrapper : DialogWrapper, TelemetryNamespace {
     override fun doCancelAction() {
         super.doCancelAction()
 
-        telemetry.record(getNamespace()) {
+        TelemetryService.getInstance().record(getNamespace()) {
             datum("CancelAction") {
                 count()
             }
         }
-    }
-
-    companion object {
-        protected val telemetry = TelemetryService.getInstance()
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
@@ -214,7 +214,7 @@ open class SamDeployDialog(
         }
 
         return future.whenComplete { _, exception ->
-            telemetry.record("SamDeploy") {
+            TelemetryService.getInstance().record("SamDeploy") {
                 datum(title) {
                     count()
                     // exception can be null but is not annotated as nullable
@@ -231,6 +231,5 @@ open class SamDeployDialog(
     private companion object {
         const val NUMBER_OF_STEPS = 3.0
         val LOG = getLogger<SamDeployDialog>()
-        val telemetry = TelemetryService.getInstance()
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamInvokeRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamInvokeRunner.kt
@@ -95,7 +95,7 @@ class SamInvokeRunner : AsyncProgramRunner<RunnerSettings>() {
                 buildingPromise.setError(it)
                 null
             }.whenComplete { _, exception ->
-                telemetry.record("SamInvoke") {
+                TelemetryService.getInstance().record("SamInvoke") {
                     val type = if (environment.isDebug()) "Debug" else "Run"
                     datum(type) {
                         count()
@@ -116,7 +116,6 @@ class SamInvokeRunner : AsyncProgramRunner<RunnerSettings>() {
 
     private companion object {
         val LOG = getLogger<SamInvokeRunner>()
-        val telemetry = TelemetryService.getInstance()
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderCommon.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderCommon.kt
@@ -30,7 +30,7 @@ abstract class SamProjectTemplate {
 
     fun build(runtime: Runtime, outputDir: VirtualFile) {
         doBuild(runtime, outputDir)
-        telemetry.record("SamProjectInit") {
+        TelemetryService.getInstance().record("SamProjectInit") {
             datum(getName()) {
                 metadata("runtime", runtime.name)
                 metadata("samVersion", SamCommon.getVersionString())
@@ -43,10 +43,6 @@ abstract class SamProjectTemplate {
     }
 
     open fun supportedRuntimes(): Set<Runtime> = Runtime.knownValues().toSet()
-
-    companion object {
-        private val telemetry = TelemetryService.getInstance()
-    }
 }
 
 @JvmOverloads


### PR DESCRIPTION
Always fetch telemetry so we don't keep references around we don't need as well as not slowing down start up

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Noticed in the stack trace posted in #803 that we were spinning up telemetry when creating our actions due to our AnActionWrapper. That ends up downloading region data and blocking until it is done. Switch all instances of TelemetryService to be done on demand instead of early.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#803

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
