### PR TITLE
Fix ToolkitCredentialsProviderManager init error

### DIFF
--- a/core/src/software/aws/toolkits/core/credentials/ToolkitCredentialsProviderManager.kt
+++ b/core/src/software/aws/toolkits/core/credentials/ToolkitCredentialsProviderManager.kt
@@ -35,8 +35,12 @@ interface ToolkitCredentialsProviderManager : ToolkitCredentialsChangeListener {
 
 class DefaultToolkitCredentialsProviderManager(registry: ToolkitCredentialsProviderRegistry) :
     ToolkitCredentialsProviderManager {
-    private val factories = registry.listFactories(this)
     private val listeners = ConcurrentHashMap.newKeySet<ToolkitCredentialsChangeListener>()
+    private val factories = mutableListOf<ToolkitCredentialsProviderFactory<*>>()
+
+    init {
+        reloadFactories(registry)
+    }
 
     @Throws(CredentialProviderNotFound::class)
     override fun getCredentialProvider(id: String): ToolkitCredentialsProvider = factories.asSequence().mapNotNull { it.get(id) }.firstOrNull()
@@ -74,6 +78,11 @@ class DefaultToolkitCredentialsProviderManager(registry: ToolkitCredentialsProvi
                 it.providerRemoved(providerId)
             }
         }
+    }
+
+    fun reloadFactories(registry: ToolkitCredentialsProviderRegistry) {
+        factories.clear()
+        factories.addAll(registry.listFactories(this))
     }
 
     /**

--- a/core/tst/software/aws/toolkits/core/credentials/ToolkitCredentialsProviderManagerTest.kt
+++ b/core/tst/software/aws/toolkits/core/credentials/ToolkitCredentialsProviderManagerTest.kt
@@ -31,6 +31,7 @@ class ToolkitCredentialsProviderManagerTest {
     fun setUp() {
         mockRegistry.createMockProviderFactory("Mock1", manager)
         mockRegistry.createMockProviderFactory("Mock2", manager)
+        manager.reloadFactories(mockRegistry)
     }
 
     @Test
@@ -59,6 +60,7 @@ class ToolkitCredentialsProviderManagerTest {
     @Test
     fun testListenerIsCalledOnRemove() {
         val mockProviderFactory = mockRegistry.createMockProviderFactory("Mock3", manager)
+        manager.reloadFactories(mockRegistry)
         mockProviderFactory.remove("Mock3:Cred1")
         verify(mockChangeListener).providerRemoved("Mock3:Cred1")
     }
@@ -66,6 +68,7 @@ class ToolkitCredentialsProviderManagerTest {
     @Test
     fun testListenerIsCalledOnModification() {
         val mockProviderFactory = mockRegistry.createMockProviderFactory("Mock3", manager)
+        manager.reloadFactories(mockRegistry)
         mockProviderFactory.modify("Mock3:Cred1")
         verify(mockChangeListener).providerModified(any())
     }


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
