### PR TITLE
Bump AWS Java SDK to 2.4.12

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ publishChannel=
 # Common dependencies
 ideaVersion=2018.3
 kotlinVersion=1.3.21
-awsSdkVersion=2.4.4
+awsSdkVersion=2.4.12
 ideaPluginVersion=0.4.2
 ktlintVersion=0.30.0
 junitVersion=4.12


### PR DESCRIPTION
Contains clock-skew fix.

./gradlew check && ./gradlew integrationTest

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
