### PR TITLE
Make a new path mapper

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/PathMapper.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/PathMapper.kt
@@ -1,0 +1,52 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution
+
+import com.intellij.openapi.util.io.FileUtil
+import software.aws.toolkits.core.utils.getLogger
+import software.aws.toolkits.core.utils.info
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Maps a local path to a remote path. The order of the list indicates the order of priority where first possible
+ * candidate wins out. When mapping back to the local file system, the file must exist for it to count as a match.
+ */
+class PathMapper(private val mappings: List<PathMapping>) {
+    fun convertToLocal(remotePath: String): String? {
+        val normalizedRemote = FileUtil.normalize(remotePath)
+        for (mapping in mappings) {
+            if (normalizedRemote.startsWith(mapping.remoteRoot)) {
+                val localPath = normalizedRemote.replaceFirst(mapping.remoteRoot, mapping.localRoot)
+                if (Files.exists(Paths.get(FileUtil.toSystemDependentName(localPath)))) {
+                    return localPath
+                }
+            }
+        }
+        LOG.info { "Failed to map $remotePath to local file system: $mappings" }
+        return null
+    }
+
+    fun convertToRemote(localPath: String): String? {
+        val normalizedLocal = FileUtil.normalize(localPath)
+        for (mapping in mappings) {
+            if (normalizedLocal.startsWith(mapping.localRoot)) {
+                return normalizedLocal.replaceFirst(mapping.localRoot, mapping.remoteRoot)
+            }
+        }
+        LOG.info { "Failed to map $localPath to remote file system: $mappings" }
+        return null
+    }
+
+    private companion object {
+        val LOG = getLogger<PathMapper>()
+    }
+}
+
+class PathMapping(localPath: String, remotePath: String) {
+    internal val localRoot = FileUtil.normalize("$localPath/")
+    internal val remoteRoot = FileUtil.normalize("$remotePath/")
+
+    override fun toString() = "PathMapping(localRoot='$localRoot', remoteRoot='$remoteRoot')"
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/PathMapperTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/PathMapperTest.kt
@@ -1,0 +1,114 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution
+
+import com.intellij.openapi.util.io.FileUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Files
+
+class PathMapperTest {
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var mapper: PathMapper
+
+    @Test
+    fun firstMatchWinsLocally() {
+        initMapper {
+            addMapping("local", "remote")
+            addMapping("local2", "remote2")
+            addMapping("local2", "remote2/sub/")
+        }
+
+        createLocalFile("local2/foo")
+
+        assertThat(convertToLocal("remote2/foo")).isEqualTo("local2/foo")
+    }
+
+    @Test
+    fun firstMatchWinsRemotely() {
+        initMapper {
+            addMapping("local", "remote")
+            addMapping("local2", "remote2")
+            addMapping("local2", "remote2/sub/")
+        }
+
+        assertThat(mapper.convertToRemote(createLocalFile("local2/foo"))).isEqualTo("remote2/foo")
+    }
+
+    @Test
+    fun onlyPrefixIsReplaced() {
+        initMapper {
+            addMapping("local/sub", "remote/sub/sub")
+        }
+
+        assertThat(mapper.convertToRemote(createLocalFile("local/sub/foo"))).isEqualTo("remote/sub/sub/foo")
+    }
+
+    @Test
+    fun matchesAtFolderBoundary() {
+        initMapper {
+            addMapping("local", "remote")
+            addMapping("localFolder", "remote2")
+        }
+
+        assertThat(mapper.convertToRemote(createLocalFile("localFolder/foo"))).isEqualTo("remote2/foo")
+    }
+
+    @Test
+    fun fileMustExistLocally() {
+        initMapper {
+            addMapping("local1", "remote")
+            addMapping("local2", "remote")
+        }
+
+        createLocalFile("local2/foo")
+
+        assertThat(convertToLocal("remote/foo")).isEqualTo("local2/foo")
+    }
+
+    @Test
+    fun trailingSlashIsIgnored() {
+        initMapper {
+            addMapping("local/", "remote/")
+            addMapping("local2", "remote2")
+        }
+
+        assertThat(mapper.convertToRemote(createLocalFile("local/foo"))).isEqualTo("remote/foo")
+        assertThat(convertToLocal("remote/foo")).isEqualTo("local/foo")
+
+        assertThat(mapper.convertToRemote(createLocalFile("local2/foo"))).isEqualTo("remote2/foo")
+        assertThat(convertToLocal("remote2/foo")).isEqualTo("local2/foo")
+    }
+
+    private fun convertToLocal(remote: String) = mapper.convertToLocal(remote)
+        ?.removePrefix(FileUtil.normalize(tempFolder.root.absolutePath))
+        ?.removePrefix("/")
+
+    private fun createLocalFile(path: String): String {
+        val file = tempFolder.root.toPath().resolve(path)
+        Files.createDirectories(file.parent)
+        if (!Files.exists(file)) {
+            Files.createFile(file)
+        }
+
+        return file.toString()
+    }
+
+    private fun initMapper(init: MutableList<PathMapping>.() -> Unit) {
+        val mappings = mutableListOf<PathMapping>()
+        mappings.init()
+        mapper = PathMapper(mappings)
+    }
+
+    private fun MutableList<PathMapping>.addMapping(local: String, remote: String) {
+        val file = tempFolder.root.toPath().resolve(local)
+        Files.createDirectories(file.parent)
+        this.add(PathMapping(file.toString(), remote))
+    }
+}


### PR DESCRIPTION
We need a custom path mapper that can handle multiple local mappings going to a single remote location for sam build

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Extracting out from sam build migration since its standalone

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#811 

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
