### PR TITLE
Move lambda.execution.sam to lambda.execution.local package

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/local/JavaLocalLamdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/local/JavaLocalLamdaRunConfigurationIntegrationTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.compiler.CompilerTestUtil
 import com.intellij.execution.executors.DefaultDebugExecutor
@@ -26,7 +26,7 @@ import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtu
 import software.aws.toolkits.jetbrains.utils.rules.addClass
 import software.aws.toolkits.jetbrains.utils.rules.addModule
 
-class JavaSamRunConfigurationIntegrationTest {
+class JavaLocalLamdaRunConfigurationIntegrationTest {
     @Rule
     @JvmField
     val projectRule = HeavyJavaCodeInsightTestFixtureRule()

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/local/PythonLocalLamdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/local/PythonLocalLamdaRunConfigurationIntegrationTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -25,7 +25,7 @@ import software.aws.toolkits.jetbrains.settings.SamSettings
 import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
 
 @RunWith(Parameterized::class)
-class PythonSamRunConfigurationIntegrationTest(private val runtime: Runtime) {
+class PythonLocalLamdaRunConfigurationIntegrationTest(private val runtime: Runtime) {
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamTestUtils.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamTestUtils.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.ExecutorRegistry
 import com.intellij.execution.Output

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -62,7 +62,7 @@ If you come across bugs with the toolkit or have feature requests, please raise 
         </extensionPoint>
 
         <extensionPoint qualifiedName="aws.toolkit.lambda.sam.debugSupport" beanClass="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPoint">
-            <with attribute="implementation" implements="software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamDebugSupport"/>
+            <with attribute="implementation" implements="software.aws.toolkits.jetbrains.services.lambda.execution.local.SamDebugSupport"/>
             <with attribute="runtimeGroup" implements="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup"/>
         </extensionPoint>
 
@@ -116,7 +116,7 @@ If you come across bugs with the toolkit or have feature requests, please raise 
                              key="aws.settings.title"
                              instance="software.aws.toolkits.jetbrains.settings.AwsSettingsConfigurable"/>
 
-        <programRunner implementation="software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamInvokeRunner"/>
+        <programRunner implementation="software.aws.toolkits.jetbrains.services.lambda.execution.local.SamInvokeRunner"/>
         <programRunner implementation="software.aws.toolkits.jetbrains.services.lambda.execution.remote.RemoteLambdaRunner"/>
         <fileBasedIndex implementation="software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerIndex"/>
         <fileBasedIndex implementation="software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplateIndex"/>
@@ -124,7 +124,7 @@ If you come across bugs with the toolkit or have feature requests, please raise 
         <codeInsight.lineMarkerProvider language="" implementationClass="software.aws.toolkits.jetbrains.services.lambda.upload.LambdaLineMarker"/>
         <runLineMarkerContributor language="yaml" implementationClass="software.aws.toolkits.jetbrains.services.lambda.execution.template.YamlLambdaRunLineMarkerContributor"/>
         <configurationType implementation="software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfiguration"/>
-        <runConfigurationProducer implementation="software.aws.toolkits.jetbrains.services.lambda.execution.sam.LambdaSamRunConfigurationProducer"/>
+        <runConfigurationProducer implementation="software.aws.toolkits.jetbrains.services.lambda.execution.local.LocalLambdaRunConfigurationProducer"/>
         <runConfigurationProducer implementation="software.aws.toolkits.jetbrains.services.lambda.execution.remote.LambdaRemoteRunConfigurationProducer"/>
 
         <registryKey key="aws.toolkit.useUrlConnection"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
@@ -19,8 +19,8 @@ import software.aws.toolkits.core.utils.exists
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.jetbrains.services.lambda.execution.PathMapping
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommon
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamTemplateUtils
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils
 import software.aws.toolkits.resources.message
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
@@ -22,7 +22,7 @@ import software.aws.toolkits.jetbrains.services.cloudformation.executeChangeSetA
 import software.aws.toolkits.jetbrains.services.cloudformation.validateSamTemplateLambdaRuntimes
 import software.aws.toolkits.jetbrains.services.lambda.deploy.DeployServerlessApplicationDialog
 import software.aws.toolkits.jetbrains.services.lambda.deploy.SamDeployDialog
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommon
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.jetbrains.settings.DeploySettings
 import software.aws.toolkits.jetbrains.settings.relativeSamPath
 import software.aws.toolkits.jetbrains.utils.notifyError

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
@@ -22,7 +22,7 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.core.credentials.toEnvironmentVariables
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommon
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.aws.toolkits.resources.message
 import java.nio.file.Files

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfiguration.kt
@@ -7,7 +7,7 @@ import com.intellij.execution.configurations.ConfigurationTypeBase
 import com.intellij.execution.configurations.ConfigurationTypeUtil
 import icons.AwsIcons
 import software.aws.toolkits.jetbrains.services.lambda.execution.remote.LambdaRemoteRunConfigurationFactory
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunConfigurationFactory
+import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamRunConfigurationFactory
 import software.aws.toolkits.resources.message
 
 class LambdaRunConfiguration :

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaOptions.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaOptions.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.openapi.components.BaseState
 import com.intellij.util.xmlb.annotations.OptionTag

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.RunManager
 import com.intellij.execution.RunnerAndConfigurationSettings
@@ -17,10 +17,10 @@ import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsMa
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfiguration
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamTemplateUtils.functionFromElement
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils.functionFromElement
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 
-class LambdaSamRunConfigurationProducer : RunConfigurationProducer<SamRunConfiguration>(getFactory()) {
+class LocalLambdaRunConfigurationProducer : RunConfigurationProducer<SamRunConfiguration>(getFactory()) {
     // Filter all Lambda run CONFIGURATIONS down to only ones that are Lambda SAM for this run producer
     override fun getConfigurationSettingsList(runManager: RunManager): List<RunnerAndConfigurationSettings> =
         super.getConfigurationSettingsList(runManager).filter { it.configuration is SamRunConfiguration }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditor.kt
@@ -1,0 +1,99 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
+
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.project.Project
+import software.aws.toolkits.core.credentials.CredentialProviderNotFound
+import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
+import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
+import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
+import software.aws.toolkits.jetbrains.services.lambda.HandlerCompletionProvider
+import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
+import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
+import software.aws.toolkits.jetbrains.utils.ui.selected
+import javax.swing.JComponent
+
+class LocalLambdaRunSettingsEditor(project: Project) : SettingsEditor<SamRunConfiguration>() {
+    private val view = LocalLambdaRunSettingsEditorPanel(
+        project,
+        HandlerCompletionProvider(project)
+    )
+    private val regionProvider = AwsRegionProvider.getInstance()
+    private val credentialManager =
+        CredentialManager.getInstance()
+
+    init {
+        val supported = LambdaBuilder.supportedRuntimeGroups
+            .flatMap { it.runtimes }
+            .sorted()
+
+        val selected = RuntimeGroup.determineRuntime(project)
+            ?.let { if (it in supported) it else null }
+        val accountSettingsManager =
+            ProjectAccountSettingsManager.getInstance(project)
+
+        view.setRuntimes(supported)
+        view.runtime.selectedItem = selected
+
+        view.regionSelector.setRegions(regionProvider.regions().values.toMutableList())
+        view.regionSelector.selectedRegion = accountSettingsManager.activeRegion
+
+        view.credentialSelector.setCredentialsProviders(credentialManager.getCredentialProviders())
+        if (accountSettingsManager.hasActiveCredentials()) {
+            view.credentialSelector.setSelectedCredentialsProvider(accountSettingsManager.activeCredentialProvider)
+        }
+    }
+
+    override fun createEditor(): JComponent = view.panel
+
+    override fun resetEditorFrom(configuration: SamRunConfiguration) {
+        view.useTemplate.isSelected = configuration.isUsingTemplate()
+        if (configuration.isUsingTemplate()) {
+            view.runtime.isEnabled = false
+            view.setTemplateFile(configuration.templateFile())
+            view.selectFunction(configuration.logicalId())
+        } else {
+            view.setTemplateFile(null) // Also clears the functions selector
+            view.runtime.model.selectedItem = configuration.runtime()
+            view.handler.setText(configuration.handler())
+        }
+
+        view.environmentVariables.envVars = configuration.environmentVariables()
+        view.regionSelector.selectedRegion = regionProvider.lookupRegionById(configuration.regionId())
+
+        configuration.credentialProviderId()?.let {
+            try {
+                view.credentialSelector.setSelectedCredentialsProvider(credentialManager.getCredentialProvider(it))
+            } catch (e: CredentialProviderNotFound) {
+                // Use the raw string here to not munge what the customer had, will also allow it to show the error
+                // that it could not be found
+                view.credentialSelector.setSelectedInvalidCredentialsProvider(it)
+            }
+        }
+
+        if (configuration.isUsingInputFile()) {
+            view.lambdaInput.inputFile = configuration.inputSource()
+        } else {
+            view.lambdaInput.inputText = configuration.inputSource()
+        }
+    }
+
+    override fun applyEditorTo(configuration: SamRunConfiguration) {
+        if (view.useTemplate.isSelected) {
+            configuration.useTemplate(view.templateFile.text, view.function.selected()?.logicalName)
+        } else {
+            configuration.useHandler(view.runtime.selected(), view.handler.text)
+        }
+
+        configuration.environmentVariables(view.environmentVariables.envVars)
+        configuration.regionId(view.regionSelector.selectedRegion?.id)
+        configuration.credentialProviderId(view.credentialSelector.getSelectedCredentialsProvider())
+        if (view.lambdaInput.isUsingFile) {
+            configuration.useInputFile(view.lambdaInput.inputFile)
+        } else {
+            configuration.useInputText(view.lambdaInput.inputText)
+        }
+    }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditorPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditorPanel.form
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunSettingsEditorPanel">
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.lambda.execution.local.LocalLambdaRunSettingsEditorPanel">
   <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="10" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditorPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditorPanel.java
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam;
+package software.aws.toolkits.jetbrains.services.lambda.execution.local;
 
 import static software.aws.toolkits.jetbrains.utils.ui.UiUtils.addQuickSelect;
 import static software.aws.toolkits.jetbrains.utils.ui.UiUtils.find;
@@ -36,11 +36,12 @@ import software.amazon.awssdk.services.lambda.model.Runtime;
 import software.aws.toolkits.jetbrains.services.cloudformation.Function;
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupUtil;
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaInputPanel;
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils;
 import software.aws.toolkits.jetbrains.ui.CredentialProviderSelector;
 import software.aws.toolkits.jetbrains.ui.EnvironmentVariablesTextField;
 import software.aws.toolkits.jetbrains.ui.RegionSelector;
 
-public final class SamRunSettingsEditorPanel {
+public final class LocalLambdaRunSettingsEditorPanel {
     public JPanel panel;
     public EditorTextField handler;
     public EnvironmentVariablesTextField environmentVariables;
@@ -58,7 +59,7 @@ public final class SamRunSettingsEditorPanel {
     private final Project project;
     private final TextCompletionProvider handlerCompletionProvider;
 
-    public SamRunSettingsEditorPanel(Project project, TextCompletionProvider handlerCompletionProvider) {
+    public LocalLambdaRunSettingsEditorPanel(Project project, TextCompletionProvider handlerCompletionProvider) {
         this.project = project;
         this.handlerCompletionProvider = handlerCompletionProvider;
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamDebugSupport.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.runners.ExecutionEnvironment

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunProfile
@@ -26,6 +26,8 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils
 import software.aws.toolkits.jetbrains.services.lambda.validOrNull
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import java.io.File

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamRunningState.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamRunningState.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.process.ProcessHandler
@@ -13,7 +13,8 @@ import software.aws.toolkits.jetbrains.core.credentials.toEnvironmentVariables
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplate
 import software.aws.toolkits.jetbrains.services.cloudformation.Function
 import software.aws.toolkits.jetbrains.services.lambda.BuiltLambda
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamTemplateUtils.writeDummySamTemplate
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils.writeDummySamTemplate
 import java.io.File
 import java.nio.file.Path
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilder.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.services.lambda.BuiltLambda
 import software.aws.toolkits.jetbrains.services.lambda.Lambda
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamTemplateUtils
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils
 import software.aws.toolkits.resources.message
 import java.io.File
 import java.nio.file.Path

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamDebugSupport.kt
@@ -13,8 +13,8 @@ import com.intellij.xdebugger.XDebugProcess
 import com.intellij.xdebugger.XDebugProcessStarter
 import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.impl.XDebugSessionImpl
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamDebugSupport
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunningState
+import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamDebugSupport
+import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamRunningState
 
 class JavaSamDebugSupport : SamDebugSupport {
     override fun createDebugProcess(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilder.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.PsiElement
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltLambda
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamTemplateUtils
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils
 import java.util.concurrent.CompletionStage
 
 class PythonLambdaBuilder : LambdaBuilder() {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamDebugSupport.kt
@@ -15,8 +15,8 @@ import com.jetbrains.python.debugger.PyLocalPositionConverter
 import com.jetbrains.python.debugger.PySourcePosition
 import software.aws.toolkits.jetbrains.services.lambda.execution.PathMapper
 import software.aws.toolkits.jetbrains.services.lambda.execution.PathMapping
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamDebugSupport
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunningState
+import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamDebugSupport
+import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamRunningState
 
 class PythonSamDebugSupport : SamDebugSupport {
     override fun patchCommandLine(debugPort: Int, state: SamRunningState, commandLine: GeneralCommandLine) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.sam
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.execution.configurations.GeneralCommandLine
@@ -38,7 +38,9 @@ class SamCommon {
 
         private val versionCache = object : FileInfoCache<SemVer>() {
             override fun getFileInfo(path: String): SemVer {
-                val commandLine = getSamCommandLine(path)
+                val commandLine = getSamCommandLine(
+                    path
+                )
                     .withParameters("--info")
 
                 val process = CapturingProcessHandler(commandLine).runProcess()
@@ -92,7 +94,9 @@ class SamCommon {
         }
 
         private fun checkVersion(semVer: SemVer): String? {
-            val samVersionOutOfRangeMessage = message("sam.executable.version_wrong", expectedSamMinVersion, expectedSamMaxVersion, semVer)
+            val samVersionOutOfRangeMessage = message("sam.executable.version_wrong",
+                expectedSamMinVersion,
+                expectedSamMaxVersion, semVer)
             if (semVer >= expectedSamMaxVersion) {
                 return "$samVersionOutOfRangeMessage ${message("sam.executable.version_too_high")}"
             } else if (semVer < expectedSamMinVersion) {
@@ -109,7 +113,11 @@ class SamCommon {
                 ?: return message("sam.cli_not_configured")
 
             return try {
-                checkVersion(versionCache.getResult(sanitizedPath))
+                checkVersion(
+                    versionCache.getResult(
+                        sanitizedPath
+                    )
+                )
             } catch (e: Exception) {
                 return e.message
             }
@@ -156,8 +164,15 @@ class SamCommon {
         }
 
         fun setSourceRoots(projectRoot: VirtualFile, project: Project, modifiableModel: ModifiableRootModel) {
-            val template = SamCommon.getTemplateFromDirectory(projectRoot)
-            val codeUris = SamCommon.getCodeUrisFromTemplate(project, template)
+            val template =
+                getTemplateFromDirectory(
+                    projectRoot
+                )
+            val codeUris =
+                getCodeUrisFromTemplate(
+                    project,
+                    template
+                )
             modifiableModel.contentEntries.forEach { contentEntry ->
                 if (contentEntry.file == projectRoot) {
                     codeUris.forEach { contentEntry.addSourceFolder(it, false) }
@@ -168,7 +183,9 @@ class SamCommon {
         fun excludeSamDirectory(projectRoot: VirtualFile, modifiableModel: ModifiableRootModel) {
             modifiableModel.contentEntries.forEach { contentEntry ->
                 if (contentEntry.file == projectRoot) {
-                    contentEntry.addExcludeFolder(VfsUtilCore.pathToUrl(Paths.get(projectRoot.path, SAM_BUILD_DIR).toString()))
+                    contentEntry.addExcludeFolder(VfsUtilCore.pathToUrl(Paths.get(projectRoot.path,
+                        SAM_BUILD_DIR
+                    ).toString()))
                 }
             }
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamTemplateUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamTemplateUtils.kt
@@ -1,6 +1,6 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.sam
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -12,6 +12,7 @@ import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplate
 import software.aws.toolkits.jetbrains.services.cloudformation.Function
 import software.aws.toolkits.jetbrains.services.cloudformation.SERVERLESS_FUNCTION_TYPE
+import software.aws.toolkits.jetbrains.utils.yamlWriter
 import software.aws.toolkits.resources.message
 import java.io.File
 
@@ -27,7 +28,10 @@ object SamTemplateUtils {
         val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file) ?: throw RuntimeException(
             message("lambda.sam.template_not_found", file)
         )
-        return findFunctionsFromTemplate(project, virtualFile)
+        return findFunctionsFromTemplate(
+            project,
+            virtualFile
+        )
     }
 
     @JvmStatic

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettingsConfigurable.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettingsConfigurable.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nls.Capitalization;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommon;
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon;
 import software.aws.toolkits.jetbrains.services.telemetry.MessageBusService;
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryEnabledChangedNotifier;
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderCommon.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderCommon.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
 import icons.AwsIcons
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommon
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.aws.toolkits.jetbrains.settings.AwsSettingsConfigurable
 import software.aws.toolkits.jetbrains.settings.SamSettings

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitRunner.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommon
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.resources.message
 
 class SamInitRunner(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamProjectGeneratorIntelliJShims.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamProjectGeneratorIntelliJShims.kt
@@ -18,7 +18,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.ProjectTemplatesFactory
 import icons.AwsIcons
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommon
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.resources.message
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/YamlWriter.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/YamlWriter.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.utils
 
 class YamlWriter internal constructor() {
     private val stringBuilder = StringBuilder()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/CreateRunConfiguration.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/CreateRunConfiguration.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.RunManager
 import com.intellij.openapi.project.Project

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducerTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.Location
 import com.intellij.execution.PsiLocation
@@ -19,10 +19,11 @@ import org.jetbrains.yaml.psi.YAMLFile
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.services.lambda.sam.findByLocation
 import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.openClass
 
-class LambdaSamRunConfigurationProducerTest {
+class LocalLambdaRunConfigurationProducerTest {
     @Rule
     @JvmField
     val projectRule = JavaCodeInsightTestFixtureRule()
@@ -93,7 +94,7 @@ Resources:
             val psiElement = psiFile.findByLocation("Resources.MyFunction")?.key ?: throw RuntimeException("Can't find function")
             val runConfiguration = createRunConfiguration(psiElement)
 
-            val sut = RunConfigurationProducer.getInstance(LambdaSamRunConfigurationProducer::class.java)
+            val sut = RunConfigurationProducer.getInstance(LocalLambdaRunConfigurationProducer::class.java)
 
             assertThat(
                 sut.isConfigurationFromContext(
@@ -127,7 +128,7 @@ Resources:
     private fun createRunConfiguration(psiElement: PsiElement): ConfigurationFromContext? {
         val dataContext = MapDataContext()
         val context = createContext(psiElement, dataContext)
-        val producer = RunConfigurationProducer.getInstance(LambdaSamRunConfigurationProducer::class.java)
+        val producer = RunConfigurationProducer.getInstance(LocalLambdaRunConfigurationProducer::class.java)
         return producer.createConfigurationFromContext(context)
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.ExecutorRegistry
@@ -28,7 +28,7 @@ import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRul
 import software.aws.toolkits.jetbrains.utils.toElement
 import software.aws.toolkits.resources.message
 
-class SamRunConfigurationTest {
+class LocalLambdaRunConfigurationTest {
     @Rule
     @JvmField
     val projectRule = JavaCodeInsightTestFixtureRule()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunnerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunnerTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.executors.DefaultRunExecutor

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.sam
 
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.util.SystemInfo
@@ -17,8 +17,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommonTestUtils.getVersionAsJson
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommonTestUtils.makeATestSam
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommonTestUtils.getVersionAsJson
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommonTestUtils.makeATestSam
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
 import software.aws.toolkits.resources.message
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTestUtils.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTestUtils.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.sam
 
 import com.intellij.openapi.util.SystemInfo
 import java.nio.file.Files
@@ -16,9 +16,11 @@ object SamCommonTestUtils {
         return SamCommon.mapper.writeValueAsString(tree)
     }
 
-    fun getMinVersionAsJson() = getVersionAsJson(SamCommon.expectedSamMinVersion.parsedVersion)
+    fun getMinVersionAsJson() =
+        getVersionAsJson(SamCommon.expectedSamMinVersion.parsedVersion)
 
-    fun getMaxVersionAsJson() = getVersionAsJson(SamCommon.expectedSamMaxVersion.parsedVersion)
+    fun getMaxVersionAsJson() =
+        getVersionAsJson(SamCommon.expectedSamMaxVersion.parsedVersion)
 
     fun makeATestSam(message: String, path: String? = null, exitCode: Int = 0): Path {
         val sam = path?.let {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamTemplateUtilsTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamTemplateUtilsTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.services.lambda.sam
 
 import com.intellij.psi.PsiFileFactory
 import com.intellij.testFramework.ProjectRule
@@ -16,8 +16,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import software.aws.toolkits.jetbrains.services.cloudformation.Function
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamTemplateUtils.findFunctionsFromTemplate
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamTemplateUtils.functionFromElement
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils.findFunctionsFromTemplate
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils.functionFromElement
 
 class SamTemplateUtilsTest {
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/settings/AwsSettingsConfigurableTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/settings/AwsSettingsConfigurableTest.kt
@@ -9,7 +9,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamCommonTestUtils
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommonTestUtils
 import java.nio.file.Path
 
 class AwsSettingsConfigurableTest : SamExecutableDetectorTestBase() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/YamlWriterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/YamlWriterTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.execution.sam
+package software.aws.toolkits.jetbrains.utils
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Rename classes that aren't tied to Sam to LocalLambda to match RemoteLambda
* Move utilities and common code not tied to locally executing a lambda from the package

## Motivation and Context
Improving the naming to make the code base more consistent. The classes that are sam specific like SamInoke, SamDebugSupport are kept alone

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
