### PR TITLE
Remove the insets around remote Lambda input box

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunSettingsEditorPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunSettingsEditorPanel.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="645" height="483"/>
+      <xy x="20" y="20" width="744" height="517"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -69,7 +69,7 @@
       </grid>
       <vspacer id="a7182">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="10"/>
           </grid>
         </constraints>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunSettingsEditorPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/LambdaRemoteRunSettingsEditorPanel.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.SortedComboBoxModel;
+import com.intellij.util.ui.JBUI;
 import java.util.List;
 import javax.swing.JPanel;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +32,9 @@ public class LambdaRemoteRunSettingsEditorPanel {
     public LambdaRemoteRunSettingsEditorPanel(Project project) {
         this.project = project;
 
-        lambdaInputPanel.setBorder(IdeBorderFactory.createTitledBorder(message("lambda.input.label")));
+        lambdaInputPanel.setBorder(IdeBorderFactory.createTitledBorder(message("lambda.input.label"),
+                                                                       false,
+                                                                       JBUI.emptyInsets()));
     }
 
     private void createUIComponents() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Removing the insets to match local UI, and gain a few more needed pixels

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Screenshots (if appropriate)
Before:
![screen shot 2019-03-08 at 10 26 13 am](https://user-images.githubusercontent.com/8992246/54047776-cfdb6680-418c-11e9-95b4-40da8af25c50.png)
After:
![screen shot 2019-03-08 at 10 22 54 am](https://user-images.githubusercontent.com/8992246/54047770-c9e58580-418c-11e9-9195-dad0f39d93f2.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
