### PR TITLE
Increase minimum SAM CLI version to 0.13.0

### DIFF
--- a/.changes/next-release/breaking-2a3130b9-050c-449a-b84a-b5386870fbc5.json
+++ b/.changes/next-release/breaking-2a3130b9-050c-449a-b84a-b5386870fbc5.json
@@ -1,0 +1,4 @@
+{
+  "type" : "breaking",
+  "description" : "Minimum SAM CLI version has been increased to 0.13.0"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
@@ -31,7 +31,7 @@ class SamCommon {
         const val SAM_INVALID_OPTION_SUBSTRING = "no such option"
 
         // Inclusive
-        val expectedSamMinVersion = SemVer("0.7.0", 0, 7, 0)
+        val expectedSamMinVersion = SemVer("0.13.0", 0, 13, 0)
 
         // Exclusive
         val expectedSamMaxVersion = SemVer("0.16.0", 0, 16, 0)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTest.kt
@@ -64,14 +64,12 @@ class SamCommonTest {
     @Test
     fun compatableSamVersion() {
         val versions = arrayOf(
-            "0.7.0",
-            "0.7.123",
-            "0.7.999999999",
-            "0.7.0-beta",
-            "0.7.0-beta+build",
-            "0.8.0",
-            "0.9.0",
-            "0.10.0"
+            "0.${SamCommon.expectedSamMinVersion.minor}.0",
+            "0.${SamCommon.expectedSamMinVersion.minor}.123",
+            "0.${SamCommon.expectedSamMinVersion.minor}.999999999",
+            "0.${SamCommon.expectedSamMinVersion.minor}.0-beta",
+            "0.${SamCommon.expectedSamMinVersion.minor}.0-beta+build",
+            "0.${SamCommon.expectedSamMaxVersion.minor - 1}.0"
         )
         for (version in versions) {
             assertNull(SamCommon.validate(makeATestSam(getVersionAsJson(version)).toString()))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
- Breaking change

## Description
Increasing minimum required SAM version to 0.13.0

## Motivation and Context
As we migrate to sam build (python #811) (java #soon), we need to raise the minimum version to keep the toolkit working correctly.

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
