### PR TITLE
Remove the ability for a sam template from LambdaBuilder to be null

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLocalLambdaRunConfigurationIntegrationTest.kt
@@ -24,7 +24,7 @@ import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtu
 import software.aws.toolkits.jetbrains.utils.rules.addClass
 import software.aws.toolkits.jetbrains.utils.rules.addModule
 
-class JavaLocalLamdaRunConfigurationIntegrationTest {
+class JavaLocalLambdaRunConfigurationIntegrationTest {
     @Rule
     @JvmField
     val projectRule = HeavyJavaCodeInsightTestFixtureRule()

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaTestUtils.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaTestUtils.kt
@@ -69,6 +69,10 @@ private fun copyGradleFiles(fixtureRule: HeavyJavaCodeInsightTestFixtureRule) {
 private fun copyPath(fixtureRule: HeavyJavaCodeInsightTestFixtureRule, root: Path, path: Path) {
     if (path.isDirectory()) {
         Files.list(path).forEach {
+            // Skip over files like .DS_Store. No gradlew related files start with a "." so safe to skip
+            if (it.fileName.toString().startsWith(".")) {
+                return@forEach
+            }
             copyPath(fixtureRule, root, it)
         }
     } else {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
@@ -153,12 +153,12 @@ abstract class LambdaBuilder {
 /**
  * Represents the result of building a Lambda
  *
- * @param templateLocation The path to the build generated template TODO: Currently nullable during the sam build migration
+ * @param templateLocation The path to the build generated template
  * @param codeLocation The path to the built lambda directory
  * @param mappings Source mappings from original codeLocation to the path inside of the archive
  */
 data class BuiltLambda(
-    val templateLocation: Path?,
+    val templateLocation: Path,
     val codeLocation: Path,
     val mappings: List<PathMapping> = emptyList()
 )

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamRunningState.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamRunningState.kt
@@ -8,15 +8,9 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessHandlerFactory
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.util.io.FileUtil
-import com.intellij.openapi.vfs.LocalFileSystem
 import software.aws.toolkits.jetbrains.core.credentials.toEnvironmentVariables
-import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplate
-import software.aws.toolkits.jetbrains.services.cloudformation.Function
 import software.aws.toolkits.jetbrains.services.lambda.BuiltLambda
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
-import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils.writeDummySamTemplate
-import java.io.File
-import java.nio.file.Path
 
 class SamRunningState(
     environment: ExecutionEnvironment,
@@ -30,13 +24,11 @@ class SamRunningState(
         totalEnvVars += settings.credentials.resolveCredentials().toEnvironmentVariables()
         totalEnvVars += settings.region.toEnvironmentVariables()
 
-        val template = builtLambda.templateLocation ?: samTemplate()
-
         val commandLine = SamCommon.getSamCommandLine()
             .withParameters("local")
             .withParameters("invoke")
             .withParameters("--template")
-            .withParameters(template.toString())
+            .withParameters(builtLambda.templateLocation.toString())
             .withParameters("--event")
             .withParameters(createEventFile())
             .apply { settings.templateDetails?.run { withParameters(logicalName) } }
@@ -58,34 +50,6 @@ class SamRunningState(
         runner.patchCommandLine(this, commandLine)
 
         return ProcessHandlerFactory.getInstance().createColoredProcessHandler(commandLine)
-    }
-
-    private fun samTemplate(): Path {
-        val tempFile = FileUtil.createTempFile("${environment.runProfile.name}-template", ".yaml", true)
-        when {
-            settings.templateDetails != null -> substituteCodeUri(tempFile, settings.templateDetails)
-            else -> writeDummySamTemplate(
-                tempFile,
-                "Function",
-                settings.runtime,
-                builtLambda.codeLocation.toString(),
-                settings.handler,
-                settings.environmentVariables
-            )
-        }
-
-        return tempFile.toPath()
-    }
-
-    private fun substituteCodeUri(tempFile: File, templateDetails: SamTemplateDetails) {
-        val file = LocalFileSystem.getInstance().refreshAndFindFileByPath(templateDetails.templateFile)
-                ?: throw IllegalStateException("Failed to load the template file: ${templateDetails.templateFile}")
-        val template = CloudFormationTemplate.parse(environment.project, file)
-        val function = template.getResourceByName(templateDetails.logicalName) as? Function
-                ?: throw IllegalStateException("Failed to locate the resource: ${templateDetails.logicalName}")
-        function.setCodeLocation(builtLambda.codeLocation.toString())
-
-        template.saveTo(tempFile)
     }
 
     private fun createEventFile(): String {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now that we have switch everything over to sam build, we can treat the template as `@NotNull` and remove some dead code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
