### PR TITLE
Enable Python 3.7 support

### DIFF
--- a/.changes/next-release/feature-f9ffdfa6-05a4-4c63-a8df-31f51838fa5f.json
+++ b/.changes/next-release/feature-f9ffdfa6-05a4-4c63-a8df-31f51838fa5f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Enable support for running, debugging, and deploying Python 3.7 lambdas"
+}

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -17,6 +17,15 @@ phases:
       - make -j8
       - make altinstall
       - ldconfig
+      - PYTHON_VERSION=3.7.2
+      - cd /tmp
+      - wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz
+      - tar -xvf Python-$PYTHON_VERSION.tgz
+      - cd Python-$PYTHON_VERSION
+      - ./configure --enable-loadable-sqlite-extensions --enable-shared
+      - make -j8
+      - make altinstall
+      - ldconfig
       - cd $CODEBUILD_SRC_DIR
       - export KEY_ID=`jq -r '.Credentials.AccessKeyId' creds.json`
       - export SECRET=`jq -r '.Credentials.SecretAccessKey' creds.json`

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLamdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLamdaRunConfigurationIntegrationTest.kt
@@ -22,9 +22,9 @@ import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
 import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.createHandlerBasedRunConfiguration
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.jetbrains.services.lambda.sam.checkBreakPointHit
 import software.aws.toolkits.jetbrains.services.lambda.sam.executeLambda
-import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.jetbrains.settings.SamSettings
 import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
 
@@ -35,7 +35,8 @@ class PythonLocalLamdaRunConfigurationIntegrationTest(private val runtime: Runti
         @Parameterized.Parameters(name = "{0}")
         fun data(): Collection<Array<Runtime>> = listOf(
             arrayOf(Runtime.PYTHON2_7),
-            arrayOf(Runtime.PYTHON3_6)
+            arrayOf(Runtime.PYTHON3_6),
+            arrayOf(Runtime.PYTHON3_7)
         )
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkType
 import com.jetbrains.python.PythonLanguage
 import com.jetbrains.python.PythonModuleTypeBase
+import com.jetbrains.python.psi.LanguageLevel
 import com.jetbrains.python.sdk.PythonSdkType
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroupInformation
@@ -16,7 +17,8 @@ class PythonRuntimeGroup : SdkBasedRuntimeGroupInformation() {
 
     override val runtimes: Set<Runtime> = setOf(
         Runtime.PYTHON2_7,
-        Runtime.PYTHON3_6
+        Runtime.PYTHON3_6,
+        Runtime.PYTHON3_7
     )
 
     override val languageIds: Set<String> = setOf(PythonLanguage.INSTANCE.id)
@@ -31,6 +33,7 @@ class PythonRuntimeGroup : SdkBasedRuntimeGroupInformation() {
 
     companion object {
         fun determineRuntimeForSdk(sdk: Sdk) = when {
+            sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON37) -> Runtime.PYTHON3_7
             sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isPy3K -> Runtime.PYTHON3_6
             sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isPython2 -> Runtime.PYTHON2_7
             else -> null

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroupTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroupTest.kt
@@ -16,8 +16,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.utils.rules.PyTestSdk2x
-import software.aws.toolkits.jetbrains.utils.rules.PyTestSdk3x
+import software.aws.toolkits.jetbrains.utils.rules.PyTestSdk
 import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
 
 class RuntimeGroupTest {
@@ -28,7 +27,7 @@ class RuntimeGroupTest {
 
     @Test
     fun canDetermineRuntimeFromAnActionEventUsingModule() {
-        ModuleRootModificationUtil.setModuleSdk(projectRule.module, PyTestSdk2x())
+        ModuleRootModificationUtil.setModuleSdk(projectRule.module, PyTestSdk("2.7.0"))
         val event: AnActionEvent = mock {
             on { getData(LangDataKeys.LANGUAGE) }.thenReturn(PythonLanguage.INSTANCE)
             on { getData(LangDataKeys.MODULE) }.thenReturn(projectRule.module)
@@ -39,14 +38,14 @@ class RuntimeGroupTest {
 
     @Test
     fun canDetermineRuntimeFromAnActionEventUsingProject() {
-        val sdk = PyTestSdk3x()
+        val sdk = PyTestSdk("3.6.0")
 
         val project = projectRule.project
 
         runInEdtAndWait {
             runWriteAction {
                 ProjectJdkTable.getInstance().addJdk(sdk, projectRule.fixture.projectDisposable)
-                ProjectRootManager.getInstance(project).projectSdk = sdk
+                ProjectRootManager.getInstance(project).projectSdk = PyTestSdk("3.6.0")
             }
 
             val event: AnActionEvent = mock {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroupTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroupTest.kt
@@ -8,12 +8,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.utils.rules.PyTestSdk2x
-import software.aws.toolkits.jetbrains.utils.rules.PyTestSdk3x
+import software.aws.toolkits.jetbrains.utils.rules.PyTestSdk
 import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
 
 class PythonRuntimeGroupTest {
-
     @Rule
     @JvmField
     val projectRule = PythonCodeInsightTestFixtureRule()
@@ -23,16 +21,24 @@ class PythonRuntimeGroupTest {
     @Test
     fun testRuntimeDetection2x() {
         val module = projectRule.module
-        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk2x())
+        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk("2.7.0"))
 
         assertThat(sut.determineRuntime(module)).isEqualTo(Runtime.PYTHON2_7)
     }
 
     @Test
-    fun testRuntimeDetection3x() {
+    fun testRuntimeDetection36() {
         val module = projectRule.module
-        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk3x())
+        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk("3.6.0"))
 
         assertThat(sut.determineRuntime(module)).isEqualTo(Runtime.PYTHON3_6)
+    }
+
+    @Test
+    fun testRuntimeDetection37() {
+        val module = projectRule.module
+        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk("3.7.0"))
+
+        assertThat(sut.determineRuntime(module)).isEqualTo(Runtime.PYTHON3_7)
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/PythonCodeInsightTestFixtureRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/PythonCodeInsightTestFixtureRule.kt
@@ -4,17 +4,11 @@
 package software.aws.toolkits.jetbrains.utils.rules
 
 import com.intellij.ide.util.projectWizard.EmptyModuleBuilder
-import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleType
 import com.intellij.openapi.module.ModuleTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.util.Disposer
-import com.intellij.openapi.util.io.FileUtil
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.builders.ModuleFixtureBuilder
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
@@ -28,10 +22,7 @@ import com.jetbrains.python.PythonModuleTypeBase
 import com.jetbrains.python.sdk.PythonSdkAdditionalData
 import com.jetbrains.python.sdk.PythonSdkType
 import com.jetbrains.python.sdk.flavors.CPythonSdkFlavor
-import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.annotations.NotNull
-import java.io.File
-import java.nio.file.Paths
 
 /**
  * JUnit test Rule that will create a Light [Project] and [CodeInsightTestFixture] with Python support. Projects are
@@ -57,7 +48,7 @@ class PythonCodeInsightTestFixtureRule : CodeInsightTestFixtureRule() {
         val projectRoot = newFixture.tempDirFixture.getFile(".")!!
         PsiTestUtil.addContentRoot(module, projectRoot)
 
-        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk3x())
+        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk("3.6.0"))
 
         return newFixture
     }
@@ -84,51 +75,12 @@ internal class PlatformPythonModuleType : PythonModuleTypeBase<EmptyModuleBuilde
     }
 }
 
-class PyTestSdk2x : PyTestSdk("PyTestSdk2x") {
-    override fun getVersionString(): String? = "FakeCPython 2.6.0"
-}
-
-class PyTestSdk3x : PyTestSdk("PyTestSdk3x") {
-    override fun getVersionString(): String? = "FakeCPython 3.7.0"
-}
-
-class PyVirtualEnvSdk(module: Module) : PyTestSdk("PyVirtEnv") {
-    private val envHome = Paths.get(ModuleRootManager.getInstance(module).contentRoots[0].path, "venv")
-    private val pythonExecutable = envHome.resolve(Paths.get("bin", "python"))
-    private val envSitePackages = envHome.resolve("lib").resolve("site-packages")
-
-    init {
-        Disposer.register(module, this)
-
-        createFileIfNotExists(pythonExecutable.toFile())
-        createFileIfNotExists(envHome.resolve("pyvenv.cfg").toFile())
-        createDirIfNotExists(envSitePackages.toFile())
-
-        addRoot(LocalFileSystem.getInstance().findFileByIoFile(envSitePackages.toFile())!!, OrderRootType.CLASSES)
-
-        homePath = pythonExecutable.toString()
-    }
-
-    override fun getVersionString(): String? = "FakeCPython 3.7.0 [virtual-env]"
-
-    fun addSitePackage(libName: String) {
-        assertThat(createFileIfNotExists(envSitePackages.resolve(libName).resolve("__init__.py").toFile()))
-            .isTrue()
-    }
-
-    private fun createFileIfNotExists(file: File) = createDirIfNotExists(file.parentFile) && FileUtil.createIfNotExists(file).also {
-        LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file)
-    }
-
-    private fun createDirIfNotExists(dir: File) = FileUtil.createDirectory(dir).also {
-        LocalFileSystem.getInstance().refreshAndFindFileByIoFile(dir)
-    }
-}
-
-abstract class PyTestSdk(name: String) : ProjectJdkImpl(name, PythonSdkType.getInstance()) {
+class PyTestSdk(private val version: String) : ProjectJdkImpl("PySdk $version", PythonSdkType.getInstance()) {
     init {
         sdkAdditionalData = PythonSdkAdditionalData(FakeCPython())
     }
+
+    override fun getVersionString(): String = "FakeCPython $version"
 }
 
 internal class FakeCPython : CPythonSdkFlavor() {


### PR DESCRIPTION
* This enables deploying and run/debug of Python 3.7

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#657 	
Requires https://github.com/awslabs/aws-sam-cli/pull/1055/ and https://github.com/lambci/docker-lambda/pull/172

## Testing
```
2019-03-20 10:47:46 Invoking app.lambda_handler (python3.7)
2019-03-20 10:47:46 Requested to skip pulling images ...

2019-03-20 10:47:46 Mounting /private/var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/lambdaBuild5/HelloWorldFunction as /var/task:ro inside runtime container
Connected to pydev debugger (build 183.5912.21)
START RequestId: 52fdfc07-2182-154f-163f-5f0f9a621d72 Version: $LATEST
{"statusCode":200,"body":"{\"message\": \"hello world\"}"}
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
