### PR TITLE
Fix the NPE caused by the env var table in unit tests

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationDialog.kt
@@ -186,8 +186,10 @@ class DeploySamApplicationValidator {
 
         if (unsetParameters.any()) {
             return ValidationInfo(
-                    message("serverless.application.deploy.validation.template.values.missing", unsetParameters.joinToString(", ")),
-                    view.templateEditorComponent
+                message(
+                    "serverless.application.deploy.validation.template.values.missing",
+                    unsetParameters.joinToString(", ")
+                )
             )
         }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationPanel.java
@@ -76,10 +76,6 @@ public class DeployServerlessApplicationPanel {
         return parameters;
     }
 
-    public JComponent getTemplateEditorComponent() {
-        return environmentVariablesTable.getComponent();
-    }
-
     private void createUIComponents() {
         environmentVariablesTable = new EnvVariablesTable();
         stackParameters = new Wrapper();


### PR DESCRIPTION
* Removed the reference to the JComponent in the validation info, it did not render correctly anyway and swallowed the root causing making it look like there was no issue

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
Tested the UI to make sure the error message gets shown correctly now, unit tests no longer throw NPE

## Screenshots (if appropriate)
![Screen Shot 2019-03-21 at 2 46 48 PM](https://user-images.githubusercontent.com/8992246/54787185-2febf700-4be8-11e9-842f-7f250c0b2cdb.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
