### PR TITLE
Remove LambdaHanderIndexTest#testVersionChangesIfExtensionsChange

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/LambdaHandlerIndexTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/LambdaHandlerIndexTest.kt
@@ -3,10 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.lambda
 
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.command.WriteCommandAction
-import com.intellij.openapi.extensions.ExtensionPointName
-import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -22,7 +19,6 @@ class LambdaHandlerIndexTest {
 
     @Before
     fun setUp() {
-
         projectRule.fixture.addClass(
             """
             package com.amazonaws.services.lambda.runtime;
@@ -259,25 +255,5 @@ class LambdaHandlerIndexTest {
         runInEdtAndWait {
             assertThat(LambdaHandlerIndex.listHandlers(projectRule.project)).isEmpty()
         }
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun testVersionChangesIfExtensionsChange() {
-        val initialVersion = LambdaHandlerIndex().version
-
-        val extensionPointName = ExtensionPointName.create<RuntimeGroupExtensionPoint<LambdaHandlerResolver>>("aws.toolkit.lambda.handlerResolver")
-        val extensionPoint = extensionPointName.getPoint(null)
-        val extensions = extensionPoint.extensions
-
-        Disposer.register(projectRule.fixture.testRootDisposable, Disposable {
-            extensions.forEach { extensionPoint.registerExtension(it) }
-        })
-
-        extensions.forEach { extensionPoint.unregisterExtension(it) }
-
-        val newVersion = LambdaHandlerIndex().version
-
-        assertThat(initialVersion).isNotEqualTo(newVersion)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
The APIs we were using were removed and the attempt to recreate them curropts the test run under 2019.1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
Tests pass under 2019.1

## Screenshots (if appropriate)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
