### PR TITLE
Use Java File  to find the template instead of VFS

### DIFF
--- a/.changes/next-release/bugfix-f9290c9c-94ce-4c02-8b67-cc2a72163b3a.json
+++ b/.changes/next-release/bugfix-f9290c9c-94ce-4c02-8b67-cc2a72163b3a.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix template not found after creating a project, fixes #856"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
There is no guarantee the VFS is up to date at that point, and we don't want to do a full recursive synchronous refresh, so use Java File to list files instead

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#856 

## Testing
Ran a python init after and it succeeded. (Was not able to reproduce the error though)

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
