### PR TITLE
Re-work credential switching to work asynchronously

### DIFF
--- a/core/src/software/aws/toolkits/core/credentials/ToolkitCredentialsProvider.kt
+++ b/core/src/software/aws/toolkits/core/credentials/ToolkitCredentialsProvider.kt
@@ -4,8 +4,7 @@
 package software.aws.toolkits.core.credentials
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.http.SdkHttpClient
-import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.services.sts.StsClient
 
 abstract class ToolkitCredentialsProvider : AwsCredentialsProvider {
@@ -39,15 +38,12 @@ abstract class ToolkitCredentialsProvider : AwsCredentialsProvider {
      * Returns true or throws an Exception
      */
     @Throws(Exception::class)
-    open fun isValidOrThrow(sdkHttpClient: SdkHttpClient): Boolean {
-        val client = StsClient.builder()
-            .region(Region.US_EAST_1)
-            .httpClient(sdkHttpClient)
-            .credentialsProvider(this)
-            .build()
-
-        client.callerIdentity
-        return true
+    open fun isValidOrThrow(stsClient: StsClient) {
+        stsClient.getCallerIdentity {
+            it.overrideConfiguration { overrides ->
+                overrides.credentialsProvider(StaticCredentialsProvider.create(resolveCredentials()))
+            }
+        }
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSettingsPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSettingsPanel.kt
@@ -32,9 +32,6 @@ import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager.AccountSettingsChangedNotifier
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
-import software.aws.toolkits.jetbrains.utils.createNotificationExpiringAction
-import software.aws.toolkits.jetbrains.utils.createShowMoreInfoDialogAction
-import software.aws.toolkits.jetbrains.utils.notifyWarn
 import software.aws.toolkits.resources.message
 import java.awt.Component
 import java.awt.event.MouseEvent
@@ -87,11 +84,7 @@ private class AwsSettingsPanel(private val project: Project) : StatusBarWidget,
         updateWidget()
     }
 
-    override fun activeRegionChanged(value: AwsRegion) {
-        updateWidget()
-    }
-
-    override fun activeCredentialsChanged(credentialsProvider: ToolkitCredentialsProvider?) {
+    override fun settingsChanged(event: AccountSettingsChangedNotifier.AccountSettingsEvent) {
         updateWidget()
     }
 
@@ -213,7 +206,7 @@ private class ChangeRegionAction(val region: AwsRegion) : ToogleActionWrapper(re
 
     override fun doSetSelected(e: AnActionEvent, state: Boolean) {
         if (state) {
-            getAccountSetting(e).activeRegion = region
+            getAccountSetting(e).changeRegion(region)
         }
     }
 }
@@ -225,23 +218,7 @@ private class ChangeCredentialsAction(val credentialsProvider: ToolkitCredential
 
     override fun doSetSelected(e: AnActionEvent, state: Boolean) {
         if (state) {
-            try {
-                if (credentialsProvider.isValidOrThrow(AwsSdkClient.getInstance().sdkHttpClient)) {
-                    getAccountSetting(e).activeCredentialProvider = credentialsProvider
-                }
-            } catch (ex: Exception) {
-                val title = message("credentials.invalid.title")
-                val message = message("credentials.profile.validation_error", credentialsProvider.displayName)
-                notifyWarn(
-                    title = title,
-                    content = message,
-                    project = e.project,
-                    notificationActions = listOf(
-                        createShowMoreInfoDialogAction(message("credentials.invalid.more_info"), title, message, ex.localizedMessage),
-                        createNotificationExpiringAction(ActionManager.getInstance().getAction("aws.settings.upsertCredentials"))
-                    )
-                )
-            }
+            getAccountSetting(e).changeCredentialProvider(credentialsProvider)
         }
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerFactory.kt
@@ -12,8 +12,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.openapi.wm.ex.ToolWindowEx
-import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
-import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.ChangeAccountSettingsAction
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import software.aws.toolkits.resources.message
@@ -46,15 +44,7 @@ class AwsSettingsMenu(private val project: Project) : DefaultActionGroup(message
         add(ChangeAccountSettingsAction(project).createPopupActionGroup())
     }
 
-    override fun activeCredentialsChanged(credentialsProvider: ToolkitCredentialsProvider?) {
-        clearAndReAddActions()
-    }
-
-    override fun activeRegionChanged(value: AwsRegion) {
-        clearAndReAddActions()
-    }
-
-    private fun clearAndReAddActions() {
+    override fun settingsChanged(event: ProjectAccountSettingsManager.AccountSettingsChangedNotifier.AccountSettingsEvent) {
         removeAll()
         add(ChangeAccountSettingsAction(project).createPopupActionGroup())
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -21,12 +21,11 @@ import com.intellij.ui.components.panels.Wrapper
 import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.JBSwingUtilities
 import com.intellij.util.ui.UIUtil
-import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
-import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.components.telemetry.ToolkitActionPlaces
 import software.aws.toolkits.jetbrains.core.SettingsSelector
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager.AccountSettingsChangedNotifier
+import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager.AccountSettingsChangedNotifier.AccountSettingsEvent
 import software.aws.toolkits.jetbrains.core.explorer.ExplorerDataKeys.SELECTED_RESOURCE_NODES
 import software.aws.toolkits.jetbrains.core.explorer.ExplorerDataKeys.SELECTED_SERVICE_NODE
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunctionNode
@@ -42,8 +41,9 @@ import javax.swing.event.TreeWillExpandListener
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
 
-class ExplorerToolWindow(val project: Project) : SimpleToolWindowPanel(true, true), AccountSettingsChangedNotifier {
+class ExplorerToolWindow(private val project: Project) : SimpleToolWindowPanel(true, true), AccountSettingsChangedNotifier {
     private val actionManager = ActionManagerEx.getInstanceEx()
+    private val projectAccountSettingsManager = ProjectAccountSettingsManager.getInstance(project)
 
     private val treePanelWrapper: Wrapper = Wrapper()
     private val errorPanel: JPanel
@@ -66,16 +66,12 @@ class ExplorerToolWindow(val project: Project) : SimpleToolWindowPanel(true, tru
         updateModel()
     }
 
-    override fun activeCredentialsChanged(credentialsProvider: ToolkitCredentialsProvider?) {
-        updateModel()
-    }
-
-    override fun activeRegionChanged(value: AwsRegion) {
+    override fun settingsChanged(event: AccountSettingsEvent) {
         updateModel()
     }
 
     internal fun updateModel() {
-        if (!ProjectAccountSettingsManager.getInstance(project).hasActiveCredentials()) {
+        if (!projectAccountSettingsManager.hasActiveCredentials()) {
             treePanelWrapper.setContent(errorPanel)
             return
         }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -80,10 +80,12 @@ class AwsClientManagerTest {
     fun oldClientsAreRemovedWhenProfilesAreRemoved() {
         val sut = getClientManager()
         val testSettings = MockProjectAccountSettingsManager.getInstance(projectRule.project)
-        testSettings.activeCredentialProvider = mockCredentialManager.addCredentials(
-            "profile:admin",
-            AwsBasicCredentials.create("Access", "Secret"),
-            true
+        testSettings.changeCredentialProvider(
+            mockCredentialManager.addCredentials(
+                "profile:admin",
+                AwsBasicCredentials.create("Access", "Secret"),
+                true
+            )
         )
 
         sut.getClient<DummyServiceClient>()
@@ -138,8 +140,7 @@ class AwsClientManagerTest {
         val first = sut.getClient<DummyServiceClient>()
 
         val testSettings = ProjectAccountSettingsManager.getInstance(projectRule.project)
-
-        testSettings.activeRegion = AwsRegion("us-east-1", "US-east-1")
+        testSettings.changeRegion(AwsRegion("us-west-2", "us-west-2"))
 
         val afterRegionUpdate = sut.getClient<DummyServiceClient>()
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
@@ -7,6 +7,7 @@ import com.intellij.configurationStore.deserialize
 import com.intellij.configurationStore.serialize
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.testFramework.ProjectRule
+import com.intellij.util.messages.MessageBusConnection
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jdom.Element
@@ -16,11 +17,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.services.sts.StsClient
 import software.aws.toolkits.core.credentials.CredentialProviderNotFound
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.utils.delegateMock
 import software.aws.toolkits.jetbrains.utils.toElement
 
 class DefaultProjectAccountSettingsManagerTest {
@@ -30,11 +33,24 @@ class DefaultProjectAccountSettingsManagerTest {
 
     private lateinit var mockRegionManager: MockRegionProvider
     private lateinit var mockCredentialManager: MockCredentialsManager
+    private lateinit var manager: DefaultProjectAccountSettingsManager
+    private lateinit var messageBusConnection: MessageBusConnection
+    private lateinit var queue: MutableList<Any>
 
     @Before
     fun setUp() {
+        queue = mutableListOf()
+
         mockRegionManager = AwsRegionProvider.getInstance() as MockRegionProvider
         mockCredentialManager = CredentialManager.getInstance() as MockCredentialsManager
+        manager = DefaultProjectAccountSettingsManager(projectRule.project, delegateMock<StsClient>())
+        messageBusConnection = projectRule.project.messageBus.connect()
+        messageBusConnection.subscribe(ProjectAccountSettingsManager.ACCOUNT_SETTINGS_CHANGED, object :
+            ProjectAccountSettingsManager.AccountSettingsChangedNotifier {
+            override fun settingsChanged(event: ProjectAccountSettingsManager.AccountSettingsChangedNotifier.AccountSettingsEvent) {
+                queue.add(event)
+            }
+        })
 
         for (i in 1..5) {
             val mockRegion = "MockRegion-$i"
@@ -46,11 +62,11 @@ class DefaultProjectAccountSettingsManagerTest {
     fun tearDown() {
         mockRegionManager.reset()
         mockCredentialManager.reset()
+        messageBusConnection.disconnect()
     }
 
     @Test
     fun testNoActiveCredentials() {
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
         assertThat(manager.hasActiveCredentials()).isFalse()
         assertThat(manager.recentlyUsedCredentials()).isEmpty()
         assertThatThrownBy { manager.activeCredentialProvider }
@@ -58,25 +74,14 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun defaultProfileCredentialSelectedIfExists() {
-        mockCredentialManager.addCredentials("profile:default", AwsBasicCredentials.create("Access", "Secret"))
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
-        assertThat(manager.hasActiveCredentials()).isTrue()
-        assertThat(manager.recentlyUsedCredentials()).hasOnlyOneElementSatisfying { assertThat(it.id).isEqualTo("profile:default") }
-        assertThat(manager.activeCredentialProvider.id).isEqualTo("profile:default")
-    }
-
-    @Test
     fun testMakingCredentialActive() {
-        val project = projectRule.project
-        val manager = DefaultProjectAccountSettingsManager(project)
         assertThat(manager.recentlyUsedCredentials()).isEmpty()
 
         val credentials = mockCredentialManager.addCredentials(
             "Mock1",
             AwsBasicCredentials.create("Access", "Secret")
         )
-        manager.activeCredentialProvider = credentials
+        changeCredentialProvider(credentials)
 
         assertThat(manager.hasActiveCredentials()).isTrue()
         assertThat(manager.activeCredentialProvider).isEqualTo(credentials)
@@ -86,7 +91,7 @@ class DefaultProjectAccountSettingsManagerTest {
             "Mock2",
             AwsBasicCredentials.create("Access", "Secret")
         )
-        manager.activeCredentialProvider = credentials2
+        changeCredentialProvider(credentials2)
 
         assertThat(manager.recentlyUsedCredentials()).element(0).isEqualTo(credentials2)
         assertThat(manager.recentlyUsedCredentials()).element(1).isEqualTo(credentials)
@@ -94,18 +99,16 @@ class DefaultProjectAccountSettingsManagerTest {
 
     @Test
     fun testMakingRegionActive() {
-        val project = projectRule.project
-        val manager = DefaultProjectAccountSettingsManager(project)
         assertThat(manager.recentlyUsedCredentials()).isEmpty()
 
         val region = mockRegionManager.lookupRegionById("MockRegion-1")
-        manager.activeRegion = region
+        changeRegion(region)
 
         assertThat(manager.activeRegion).isEqualTo(region)
         assertThat(manager.recentlyUsedRegions()).element(0).isEqualTo(region)
 
         val region2 = mockRegionManager.lookupRegionById("MockRegion-2")
-        manager.activeRegion = region2
+        changeRegion(region2)
 
         assertThat(manager.recentlyUsedRegions()).element(0).isEqualTo(region2)
         assertThat(manager.recentlyUsedRegions()).element(1).isEqualTo(region)
@@ -114,19 +117,18 @@ class DefaultProjectAccountSettingsManagerTest {
     @Test
     fun testMakingRegionActiveFiresNotification() {
         val project = projectRule.project
-        val manager = DefaultProjectAccountSettingsManager(project)
 
         var gotNotification = false
 
         val busConnection = project.messageBus.connect()
         busConnection.subscribe(ProjectAccountSettingsManager.ACCOUNT_SETTINGS_CHANGED, object :
             ProjectAccountSettingsManager.AccountSettingsChangedNotifier {
-            override fun activeRegionChanged(value: AwsRegion) {
+            override fun settingsChanged(event: ProjectAccountSettingsManager.AccountSettingsChangedNotifier.AccountSettingsEvent) {
                 gotNotification = true
             }
         })
 
-        manager.activeRegion = mockRegionManager.lookupRegionById("MockRegion-1")
+        changeRegion(mockRegionManager.lookupRegionById("MockRegion-1"))
 
         assertThat(gotNotification).isTrue()
     }
@@ -134,21 +136,22 @@ class DefaultProjectAccountSettingsManagerTest {
     @Test
     fun testMakingCredentialsActiveFiresNotification() {
         val project = projectRule.project
-        val manager = DefaultProjectAccountSettingsManager(project)
 
         var gotNotification = false
 
         val busConnection = project.messageBus.connect()
         busConnection.subscribe(ProjectAccountSettingsManager.ACCOUNT_SETTINGS_CHANGED, object :
             ProjectAccountSettingsManager.AccountSettingsChangedNotifier {
-            override fun activeCredentialsChanged(credentialsProvider: ToolkitCredentialsProvider?) {
+            override fun settingsChanged(event: ProjectAccountSettingsManager.AccountSettingsChangedNotifier.AccountSettingsEvent) {
                 gotNotification = true
             }
         })
 
-        manager.activeCredentialProvider = mockCredentialManager.addCredentials(
-            "Mock",
-            AwsBasicCredentials.create("Access", "Secret")
+        changeCredentialProvider(
+            mockCredentialManager.addCredentials(
+                "Mock",
+                AwsBasicCredentials.create("Access", "Secret")
+            )
         )
 
         assertThat(gotNotification).isTrue()
@@ -156,8 +159,7 @@ class DefaultProjectAccountSettingsManagerTest {
 
     @Test
     fun testSavingActiveRegion() {
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
-        manager.activeRegion = AwsRegion.GLOBAL
+        manager.changeRegion(AwsRegion.GLOBAL)
         val element = manager.state.serialize()
         assertThat(element.string()).isEqualToIgnoringWhitespace(
             """
@@ -175,10 +177,11 @@ class DefaultProjectAccountSettingsManagerTest {
 
     @Test
     fun testSavingActiveCredential() {
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
-        manager.activeCredentialProvider = mockCredentialManager.addCredentials(
-            "Mock",
-            AwsBasicCredentials.create("Access", "Secret")
+        changeCredentialProvider(
+            mockCredentialManager.addCredentials(
+                "Mock",
+                AwsBasicCredentials.create("Access", "Secret")
+            )
         )
         val element = manager.state.serialize()
         assertThat(element.string()).isEqualToIgnoringWhitespace(
@@ -213,8 +216,9 @@ class DefaultProjectAccountSettingsManagerTest {
             AwsBasicCredentials.create("Access", "Secret")
         )
 
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
         manager.loadState(element.deserialize())
+
+        waitForEvents(2)
 
         assertThat(manager.activeCredentialProvider).isEqualTo(credentials)
         assertThat(manager.recentlyUsedCredentials()).element(0).isEqualTo(credentials)
@@ -232,7 +236,6 @@ class DefaultProjectAccountSettingsManagerTest {
                 </option>
             </AccountState>
         """.toElement()
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
         manager.loadState(element.deserialize())
 
         val region = mockRegionManager.lookupRegionById("MockRegion-1")
@@ -252,7 +255,6 @@ class DefaultProjectAccountSettingsManagerTest {
                 </option>
             </AccountState>
         """.toElement()
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
         manager.loadState(element.deserialize())
 
         assertThat(manager.activeRegion).isEqualTo(AwsRegionProvider.getInstance().defaultRegion())
@@ -271,7 +273,6 @@ class DefaultProjectAccountSettingsManagerTest {
                 </option>
             </AccountState>
         """.toElement()
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
         manager.loadState(element.deserialize())
 
         assertThat(manager.hasActiveCredentials()).isFalse()
@@ -299,43 +300,41 @@ class DefaultProjectAccountSettingsManagerTest {
             false
         )
 
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
         manager.loadState(element.deserialize())
 
         assertThat(manager.hasActiveCredentials()).isFalse()
     }
 
     @Test
-    fun testInvalidDefaultProfileCredentialNotSelected() {
-        mockCredentialManager.addCredentials("profile:default", AwsBasicCredentials.create("Access", "Secret"), false)
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
-        assertThat(manager.hasActiveCredentials()).isFalse()
-    }
+    fun testLoadingDefaultProfileIfNoPrevious() {
+        mockCredentialManager.addCredentials("profile:default", AwsBasicCredentials.create("Access", "Secret"))
 
-    @Test
-    fun testRemovingActiveProfileFallsBackToDefaultIfExists() {
-        mockCredentialManager.addCredentials("profile:default", AwsBasicCredentials.create("Access", "Secret"), true)
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
-        manager.activeCredentialProvider = mockCredentialManager.addCredentials(
-            "profile:admin",
-            AwsBasicCredentials.create("Access", "Secret"),
-            true
-        )
+        val element = """
+            <AccountState/>
+        """.toElement()
 
-        assertThat(manager.activeCredentialProvider.id).isEqualTo("profile:admin")
+        manager.loadState(element.deserialize())
 
-        ApplicationManager.getApplication().messageBus.syncPublisher(CredentialManager.CREDENTIALS_CHANGED)
-            .providerRemoved("profile:admin")
+        assertThat(manager.hasActiveCredentials()).isTrue()
+        assertThat(manager.recentlyUsedCredentials()).hasOnlyOneElementSatisfying { assertThat(it.id).isEqualTo("profile:default") }
         assertThat(manager.activeCredentialProvider.id).isEqualTo("profile:default")
     }
 
     @Test
-    fun testRemovingActiveProfileFallsBackToNothingIfNoDefault() {
-        val manager = DefaultProjectAccountSettingsManager(projectRule.project)
-        manager.activeCredentialProvider = mockCredentialManager.addCredentials(
-            "profile:admin",
-            AwsBasicCredentials.create("Access", "Secret"),
-            true
+    fun testInvalidDefaultProfileCredentialNotSelected() {
+        mockCredentialManager.addCredentials("profile:default", AwsBasicCredentials.create("Access", "Secret"), false)
+        assertThat(manager.hasActiveCredentials()).isFalse()
+    }
+
+    @Test
+    fun testRemovingActiveProfileFallsBackToNothing() {
+        mockCredentialManager.addCredentials("profile:default", AwsBasicCredentials.create("Access", "Secret"), true)
+        changeCredentialProvider(
+            mockCredentialManager.addCredentials(
+                "profile:admin",
+                AwsBasicCredentials.create("Access", "Secret"),
+                true
+            )
         )
 
         assertThat(manager.activeCredentialProvider.id).isEqualTo("profile:admin")
@@ -344,6 +343,28 @@ class DefaultProjectAccountSettingsManagerTest {
             .providerRemoved("profile:admin")
         assertThat(manager.hasActiveCredentials()).isFalse()
     }
-}
 
-private fun Element?.string(): String = XMLOutputter().outputString(this)
+    private fun changeCredentialProvider(credentialsProvider: ToolkitCredentialsProvider) {
+        manager.changeCredentialProvider(credentialsProvider)
+        waitForEvents(2)
+    }
+
+    private fun changeRegion(region: AwsRegion) {
+        manager.changeRegion(region)
+        waitForEvents(1)
+    }
+
+    private fun waitForEvents(eventCount: Int) {
+        for (i in 1..5) {
+            if (queue.size >= eventCount) {
+                queue.clear()
+                return
+            }
+            Thread.sleep(200)
+        }
+
+        throw IllegalStateException("Max wait time reached")
+    }
+
+    private fun Element?.string(): String = XMLOutputter().outputString(this)
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.jetbrains.core.credentials
 
 import com.intellij.openapi.components.ServiceManager
 import software.amazon.awssdk.auth.credentials.AwsCredentials
-import software.amazon.awssdk.http.SdkHttpClient
+import software.amazon.awssdk.services.sts.StsClient
 import software.aws.toolkits.core.credentials.CredentialProviderNotFound
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 
@@ -21,9 +21,10 @@ class MockCredentialsManager : CredentialManager {
         providers.clear()
     }
 
-    fun addCredentials(id: String, credentials: AwsCredentials, isValid: Boolean = true): ToolkitCredentialsProvider = MockCredentialsProvider(id, id, credentials, isValid).also {
-        providers[id] = it
-    }
+    fun addCredentials(id: String, credentials: AwsCredentials, isValid: Boolean = true): ToolkitCredentialsProvider =
+        MockCredentialsProvider(id, id, credentials, isValid).also {
+            providers[id] = it
+        }
 
     companion object {
         fun getInstance(): MockCredentialsManager = ServiceManager.getService(CredentialManager::class.java) as MockCredentialsManager
@@ -36,6 +37,10 @@ class MockCredentialsManager : CredentialManager {
         private val isValid: Boolean
     ) : ToolkitCredentialsProvider() {
         override fun resolveCredentials(): AwsCredentials = credentials
-        override fun isValidOrThrow(sdkHttpClient: SdkHttpClient): Boolean = isValid
+        override fun isValidOrThrow(stsClient: StsClient) {
+            if (!isValid) {
+                throw IllegalStateException("$displayName is not valid")
+            }
+        }
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/explorer/AwsSettingsMenuTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/explorer/AwsSettingsMenuTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.credentials.MockProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
+import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager.AccountSettingsChangedNotifier.AccountSettingsEvent
 
 class AwsSettingsMenuTest {
 
@@ -25,8 +26,9 @@ class AwsSettingsMenuTest {
     fun itemsAreRefreshedWhenSettingsChange() {
         val sut = AwsSettingsMenu(projectRule.project)
 
-        mockSettingsManager.internalRecentlyUsedRegions.add(AwsRegion.GLOBAL)
-        projectRule.project.messageBus.syncPublisher(ProjectAccountSettingsManager.ACCOUNT_SETTINGS_CHANGED).activeRegionChanged(AwsRegion.GLOBAL)
+        mockSettingsManager.changeRegion(AwsRegion.GLOBAL)
+        val accountSettingsEvent = AccountSettingsEvent(false, null, AwsRegion.GLOBAL)
+        projectRule.project.messageBus.syncPublisher(ProjectAccountSettingsManager.ACCOUNT_SETTINGS_CHANGED).settingsChanged(accountSettingsEvent)
 
         val actionGroup = sut.getChildren(null).first() as DefaultActionGroup
         val separators = actionGroup.getChildren(null).filterIsInstance<Separator>()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Cut down on the number of validation calls we make
* Tweak when we fall back to the default profile
* Re-work the settings notification bus
* More info in #865

## Motivation and Context
This moves the STS calls off the UI thread

## Related Issue(s)
#865

## Testing

## Screenshots (if appropriate)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
