### PR TITLE
Fix exceptions thrown in a run config breaking the Run Config action …

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/BaseLambdaBuilderTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/BaseLambdaBuilderTest.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiElement
-import com.intellij.testFramework.runInEdtAndGet
 import com.intellij.util.io.isFile
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
@@ -21,7 +20,6 @@ import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.jetbrains.settings.SamSettings
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.concurrent.TimeUnit
 import kotlin.streams.toList
 
 abstract class BaseLambdaBuilderTest {
@@ -41,12 +39,8 @@ abstract class BaseLambdaBuilderTest {
     ): BuiltLambda {
         val samOptions = SamOptions()
         samOptions.buildInContainer = useContainer
-        val completableFuture = runInEdtAndGet {
-            lambdaBuilder.buildLambda(module, handlerElement, handler, runtime, emptyMap(), samOptions)
-                .toCompletableFuture()
-        }
 
-        return completableFuture.get(3, TimeUnit.MINUTES)
+        return lambdaBuilder.buildLambda(module, handlerElement, handler, runtime, emptyMap(), samOptions)
     }
 
     protected fun buildLambdaFromTemplate(
@@ -57,11 +51,8 @@ abstract class BaseLambdaBuilderTest {
     ): BuiltLambda {
         val samOptions = SamOptions()
         samOptions.buildInContainer = useContainer
-        val completableFuture = runInEdtAndGet {
-            lambdaBuilder.buildLambdaFromTemplate(module, template, logicalId, samOptions).toCompletableFuture()
-        }
 
-        return completableFuture.get(3, TimeUnit.MINUTES)
+        return lambdaBuilder.buildLambdaFromTemplate(module, template, logicalId, samOptions)
     }
 
     protected fun packageLambda(
@@ -73,11 +64,8 @@ abstract class BaseLambdaBuilderTest {
     ): Path {
         val samOptions = SamOptions()
         samOptions.buildInContainer = useContainer
-        val completableFuture = runInEdtAndGet {
-            lambdaBuilder.packageLambda(module, handlerElement, handler, runtime, samOptions).toCompletableFuture()
-        }
 
-        return completableFuture.get(3, TimeUnit.MINUTES)
+        return lambdaBuilder.packageLambda(module, handlerElement, handler, runtime, samOptions)
     }
 
     protected fun verifyEntries(builtLambda: BuiltLambda, vararg entries: String) {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaCreatorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaCreatorTest.kt
@@ -32,7 +32,6 @@ import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRul
 import java.nio.file.Path
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 abstract class LambdaCreatorTestBase(private val functionDetails: FunctionUploadDetails) {
@@ -81,7 +80,7 @@ abstract class LambdaCreatorTestBase(private val functionDetails: FunctionUpload
         val tempFile = FileUtil.createTempFile("lambda", ".zip")
 
         val lambdaBuilder = mock<LambdaBuilder> {
-            on { packageLambda(any(), any(), any(), any(), any(), any()) } doReturn CompletableFuture.completedFuture(tempFile.toPath())
+            on { packageLambda(any(), any(), any(), any(), any(), any()) } doReturn tempFile.toPath()
         }
 
         val psiFile = projectRule.fixture.addClass(
@@ -158,7 +157,7 @@ abstract class LambdaCreatorTestBase(private val functionDetails: FunctionUpload
         val tempFile = FileUtil.createTempFile("lambda", ".zip")
 
         val lambdaBuilder = mock<LambdaBuilder> {
-            on { packageLambda(any(), any(), any(), any(), any(), any()) } doReturn CompletableFuture.completedFuture(tempFile.toPath())
+            on { packageLambda(any(), any(), any(), any(), any(), any()) } doReturn tempFile.toPath()
         }
 
         val psiFile = projectRule.fixture.addClass(


### PR DESCRIPTION
…button

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Resolve some TODOs to simplify the LambdaBuilder logic
* Make sure all exceptions get mapped into CompletableFuture.completeExceptionally

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#868

## Testing
Forced exceptions to be thrown, action button still works after

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
