### PR TITLE
Fix java invalid base dir

### DIFF
--- a/.changes/next-release/bugfix-9f501098-c835-469e-b7af-3bf4f9f9da16.json
+++ b/.changes/next-release/bugfix-9f501098-c835-469e-b7af-3bf4f9f9da16.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix building of a Java Lambda handler failing due to unable to locate build.gradle/pom.xml Fixes #868, #857"
+}

--- a/intellijJVersions.gradle
+++ b/intellijJVersions.gradle
@@ -5,7 +5,10 @@ static def ideProfiles() {
                             version: "IC-2018.3.5",
                             plugins: [
                                     "yaml",
-                                    "PythonCore:2018.3.183.4284.148"
+                                    "PythonCore:2018.3.183.4284.148",
+                                    "gradle",
+                                    "maven",
+                                    "properties" // Used by Maven
                             ]
                     ]
             ],
@@ -14,7 +17,10 @@ static def ideProfiles() {
                             version: "IC-2019.1",
                             plugins: [
                                     "yaml",
-                                    "PythonCore:2019.1.191.6183.53"
+                                    "PythonCore:2019.1.191.6183.53",
+                                    "gradle",
+                                    "maven",
+                                    "properties" // Used by Maven
                             ]
                     ]
             ]

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilderTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilderTest.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.java
 
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -11,6 +12,7 @@ import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.addFileToModule
 import software.aws.toolkits.jetbrains.utils.rules.addModule
+import software.aws.toolkits.resources.message
 import java.nio.file.Paths
 
 class JavaLambdaBuilderTest : BaseLambdaBuilderTest() {
@@ -129,5 +131,25 @@ class JavaLambdaBuilderTest : BaseLambdaBuilderTest() {
             "com/example/SomeClass.class",
             "lib/aws-lambda-java-core-1.2.0.jar"
         )
+    }
+
+    @Test
+    fun unsupportedSystem() {
+        val handlerPsi = projectRule.fixture.addClass(
+            """
+            package com.example;
+
+            public class SomeClass {
+                public static String upperCase(String input) {
+                    return input.toUpperCase();
+                }
+            }
+            """.trimIndent()
+        )
+
+        assertThatThrownBy {
+            buildLambda(projectRule.module, handlerPsi, Runtime.JAVA8, "com.example.SomeClass")
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageEndingWith(message("lambda.build.java.unsupported_build_system", projectRule.module))
     }
 }

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -31,8 +31,13 @@ If you come across bugs with the toolkit or have feature requests, please raise 
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
+    <!-- All dependencies have to be defined here, you can't define more in an optional config-file,
+        See PluginManagerCore#mergeOptionalConfigs -->
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
+
+    <depends optional="true">org.jetbrains.idea.maven</depends>
+    <depends optional="true">com.intellij.modules.externalSystem</depends>>
     <depends optional="true" config-file="ext-java.xml">com.intellij.modules.java</depends>
     <depends optional="true" config-file="ext-python.xml">com.intellij.modules.python</depends>
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilder.kt
@@ -4,11 +4,14 @@
 package software.aws.toolkits.jetbrains.services.lambda.java
 
 import com.intellij.execution.process.ProcessHandler
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.util.io.FileUtil
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
+import org.jetbrains.idea.maven.project.MavenProjectsManager
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltLambda
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
@@ -27,7 +30,11 @@ class JavaLambdaBuilder : LambdaBuilder() {
         samOptions: SamOptions,
         onStart: (ProcessHandler) -> Unit
     ): CompletionStage<BuiltLambda> {
-        val baseDir = getBaseDirectory(module).path
+        val baseDir = when {
+            isGradle(module) -> getGradleProjectLocation(module)
+            isMaven(module) -> getPomLocation(module)
+            else -> throw IllegalStateException(message("lambda.build.java.unsupported_build_system", module))
+        }
         val customTemplate = FileUtil.createTempFile("template", ".yaml", true)
         val logicalId = "Function"
         SamTemplateUtils.writeDummySamTemplate(customTemplate, logicalId, runtime, baseDir, handler, envVars)
@@ -35,12 +42,23 @@ class JavaLambdaBuilder : LambdaBuilder() {
         return buildLambdaFromTemplate(module, customTemplate.toPath(), logicalId, samOptions, onStart)
     }
 
-    private fun getBaseDirectory(module: Module): VirtualFile {
-        val rootManager = ModuleRootManager.getInstance(module)
-        val contentRoots = rootManager.contentRoots
-        return when (contentRoots.size) {
-            1 -> contentRoots[0]
-            else -> throw IllegalArgumentException(message("lambda.build.too_many_content_roots"))
+    private fun isGradle(module: Module): Boolean = ExternalSystemModulePropertyManager.getInstance(module)
+        .getExternalSystemId() == "GRADLE"
+
+    private fun getGradleProjectLocation(module: Module): String =
+        ExternalSystemApiUtil.getExternalProjectPath(module)
+            ?: throw IllegalStateException(message("lambda.build.unable_to_locate_project_root", module))
+
+    private fun isMaven(module: Module): Boolean {
+        if (PluginManager.getPlugin(PluginId.getId("org.jetbrains.idea.maven"))?.isEnabled == true) {
+            return MavenProjectsManager.getInstance(module.project).isMavenizedModule(module)
         }
+
+        return false
     }
+
+    private fun getPomLocation(module: Module): String =
+        MavenProjectsManager.getInstance(module.project).findProject(module)?.directory ?: throw IllegalStateException(
+            message("lambda.build.unable_to_locate_project_root", module)
+        )
 }

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -248,4 +248,5 @@ cloudformation.execute_change_set.success=Successfully executed change set again
 cloudformation.execute_change_set.success.title=Successfully executed change set
 cloudformation.execute_change_set.failed=Failed to execute change set against {0}
 cloudformation.toolwindow.label=CloudFormation
-lambda.build.too_many_content_roots=Module can only have 1 content root
+lambda.build.unable_to_locate_project_root=Unable to locate project diretory for Module ''%s''
+lambda.build.java.unsupported_build_system=Module ''%s'' is not managed by Maven or Gradle


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Query project root from Maven/Gradle to determine the base directory for Java

When using Java handler based build, query Maven/Gradle for the project root.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#868, #857

## Testing
We now actually import the projects and then try to build them

## Screenshots (if appropriate)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
