### PR TITLE
Make PathMapper case insensitive on Windows

### DIFF
--- a/.changes/next-release/bugfix-2bf7ae73-4417-4d26-8754-c00930666ee1.json
+++ b/.changes/next-release/bugfix-2bf7ae73-4417-4d26-8754-c00930666ee1.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix being unable to add breakpoints to Python Lambdas on Windows, Fixes #908"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
On Windows, PyCharm will lowercase the path before asking us convert the path using PathMapper. We will lowercase all local paths if the host OS is Windows

See https://github.com/JetBrains/intellij-community/blob/9d1d1a0b6e1661c14370e39e6c0d325879a615cc/python/src/com/jetbrains/python/debugger/PyLocalPositionConverter.java#L33

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#908

## Testing
Used an m5.metal Windows machine to test

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
