### PR TITLE
Correcting threading issue where network call was being made inside EDT

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormation.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormation.kt
@@ -3,9 +3,11 @@
 
 package software.aws.toolkits.jetbrains.services.cloudformation
 
+import com.intellij.openapi.application.ApplicationManager
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.amazon.awssdk.services.cloudformation.model.CloudFormationException
 import software.amazon.awssdk.services.cloudformation.model.DescribeStacksRequest
+import software.amazon.awssdk.services.cloudformation.model.Stack
 import software.amazon.awssdk.services.cloudformation.model.StackStatus
 import software.amazon.awssdk.services.cloudformation.model.StackSummary
 import software.aws.toolkits.core.utils.wait
@@ -34,6 +36,13 @@ fun CloudFormationClient.executeChangeSetAndWait(stackName: String, changeSet: S
         this.waitForStackCreateComplete(stackName)
     } else {
         this.waitForStackUpdateComplete(stackName)
+    }
+}
+
+fun CloudFormationClient.describeStack(stackName: String, callback: (Stack?) -> Unit) {
+    ApplicationManager.getApplication().executeOnPooledThread {
+        val stack = this.describeStacks { it.stackName(stackName) }.stacks().firstOrNull()
+        callback(stack)
     }
 }
 

--- a/ktlint-rules/src/software/aws/toolkits/ktlint/rules/CustomRuleSetProvider.kt
+++ b/ktlint-rules/src/software/aws/toolkits/ktlint/rules/CustomRuleSetProvider.kt
@@ -12,6 +12,7 @@ class CustomRuleSetProvider : RuleSetProvider {
         CopyrightHeaderRule(),
         BannedPatternRule(BannedPatternRule.DEFAULT_PATTERNS),
         ExpressionBodyRule(),
-        LazyLogRule()
+        LazyLogRule(),
+        DialogModalityRule()
     )
 }

--- a/ktlint-rules/src/software/aws/toolkits/ktlint/rules/DialogModalityRule.kt
+++ b/ktlint-rules/src/software/aws/toolkits/ktlint/rules/DialogModalityRule.kt
@@ -1,0 +1,34 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.ktlint.rules
+
+import com.github.shyiko.ktlint.core.Rule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
+import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
+
+class DialogModalityRule : Rule("run-in-edt-wo-modality-in-dialog") {
+    override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        val element = node.psi ?: return
+
+        when (element) {
+            is KtCallExpression -> {
+                val callee = element.calleeExpression as? KtNameReferenceExpression ?: return
+                if (callee.getReferencedName() != "runInEdt") return
+                val clz = element.containingClass() ?: return
+                if (clz.getSuperNames().none { it in KNOWN_DIALOG_SUPER_TYPES }) return
+
+                if (element.valueArguments.none { it.text == "ModalityState.any()" }) {
+                    emit(node.startOffset, "Call to runInEdt without ModalityState.any() within Dialog will not run until Dialog exits.", false)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val KNOWN_DIALOG_SUPER_TYPES = setOf("DialogWrapper", "LoggingDialogWrapper")
+    }
+}

--- a/ktlint-rules/tst/software/aws/toolkits/ktlint/rules/DialogModalityRuleTest.kt
+++ b/ktlint-rules/tst/software/aws/toolkits/ktlint/rules/DialogModalityRuleTest.kt
@@ -1,0 +1,64 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.ktlint.rules
+
+import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.test.lint
+import org.assertj.core.api.Assertions
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class DialogModalityRuleTest {
+
+    private val rule = DialogModalityRule()
+
+    @Test
+    fun runInEdtCallsShouldSpecifyModalityWhenCalledWithinDialog() {
+        assertExpected(
+                """
+            class Blah : DialogWrapper {
+              fun blah() {
+                runInEdt { }
+              }
+            }
+        """, 3 to 5
+        )
+    }
+
+    @Test
+    fun callsThatSpecifyModalityAnyAreFine() {
+        assertExpected(
+                """
+            class Blah : DialogWrapper {
+              fun blah() {
+                runInEdt(ModalityState.any()) { }
+              }
+            }
+        """)
+    }
+
+    @Test
+    fun callsThatSpecifyWrongModalityAreNotFine() {
+        assertExpected(
+                """
+            class Blah : LoggingDialogWrapper() {
+              fun blah() {
+                runInEdt(ModalityState.current()) { }
+              }
+            }
+        """, 3 to 5
+        )
+    }
+
+    private fun assertExpected(@Language("kotlin") kotlinText: String, vararg expectedErrors: Pair<Int, Int>) {
+        Assertions.assertThat(rule.lint(kotlinText.trimIndent())).containsExactly(*expectedErrors.map {
+            LintError(
+                    it.first,
+                    it.second,
+                    rule.id,
+                    "Call to runInEdt without ModalityState.any() within Dialog will not run until Dialog exits."
+            )
+        }.toTypedArray())
+    }
+}


### PR DESCRIPTION
Fixes #898

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
The `CloudFormationClient.describeStack` call inside the deploy dialog was being made on the UI thread.


