### PR TITLE
Bump min version to 183.2153.8 to support getHelpTopic in LambdaRunCo…

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -65,7 +65,7 @@
     ]]></description>
 
     <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://aws.amazon.com/">Amazon Web Services</vendor>
-    <idea-version since-build="183" until-build="191.*"/>
+    <idea-version since-build="183.2153.8" until-build="191.*"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->


### PR DESCRIPTION
…nfiguration.

<!--- Provide a general summary of your changes in the Title above -->

The [getHelpTopic](https://github.com/JetBrains/intellij-community/blob/master/platform/lang-api/src/com/intellij/execution/configurations/ConfigurationType.java#L69-L77) API was introduced at the second release of version 183. We need to update the min version to support this.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
