### PR TITLE
Disable auto-detecting proxy through system properties

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSdkClient.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSdkClient.kt
@@ -14,6 +14,7 @@ import software.amazon.awssdk.http.ExecutableHttpRequest
 import software.amazon.awssdk.http.HttpExecuteRequest
 import software.amazon.awssdk.http.SdkHttpClient
 import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.http.apache.ProxyConfiguration
 import software.aws.toolkits.core.utils.assertTrue
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
@@ -26,6 +27,7 @@ class AwsSdkClient : Disposable {
     val sdkHttpClient: SdkHttpClient by lazy {
         LOG.info { "Create new Apache client" }
         val httpClientBuilder = ApacheHttpClient.builder()
+                .proxyConfiguration(ProxyConfiguration.builder().useSystemPropertyValues(false).build())
                 .httpRoutePlanner(SystemDefaultRoutePlanner(CommonProxy.getInstance()))
                 .credentialsProvider(SystemDefaultCredentialsProvider())
 
@@ -53,7 +55,6 @@ class AwsSdkClient : Disposable {
     companion object {
         private val LOG = getLogger<AwsSdkClient>()
         private const val WRONG_THREAD = "Network calls can't be made inside read/write action"
-        private const val EXPERIMENT_ID = "aws.toolkit.useProxy"
 
         fun getInstance(): AwsSdkClient = ServiceManager.getService(AwsSdkClient::class.java)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Disable AWS sdk pulling proxy settings from system properties

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#936

## Testing
Added the following to runIde to test it.

```
    systemProperty("http.proxyHost", "localhost")
    systemProperty("http.proxyPort", "999")
```

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
