### PR TITLE
Add support to nodejs10.x and fix a bug when inferring nodejs lambda

### DIFF
--- a/.changes/next-release/breaking-c6d09d5f-2ef8-45b3-9155-35c4e40603f2.json
+++ b/.changes/next-release/breaking-c6d09d5f-2ef8-45b3-9155-35c4e40603f2.json
@@ -1,0 +1,4 @@
+{
+  "type" : "breaking",
+  "description" : "Minimum SAM CLI version has been increased to 0.16.0"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ publishChannel=
 # Common dependencies
 ideProfileName=2019.1
 kotlinVersion=1.3.21
-awsSdkVersion=2.5.30
+awsSdkVersion=2.5.44
 ideaPluginVersion=0.4.7
 ktlintVersion=0.30.0
 junitVersion=4.12

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamDebugSupport.kt
@@ -22,8 +22,7 @@ class JavaSamDebugSupport : SamDebugSupport {
         state: SamRunningState,
         debugPort: Int
     ): XDebugProcessStarter? {
-        val connection =
-            RemoteConnection(true, "localhost", debugPort.toString(), false)
+        val connection = RemoteConnection(true, "localhost", debugPort.toString(), false)
         val debugEnvironment = DefaultDebugEnvironment(environment, state, connection, true)
         val debuggerManager = DebuggerManagerEx.getInstanceEx(environment.project)
         val debuggerSession = debuggerManager.attachVirtualMachine(debugEnvironment) ?: return null

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
@@ -32,7 +32,7 @@ class SamCommon {
         const val SAM_INVALID_OPTION_SUBSTRING = "no such option"
 
         // Inclusive
-        val expectedSamMinVersion = SemVer("0.14.1", 0, 14, 1)
+        val expectedSamMinVersion = SemVer("0.16.0", 0, 16, 0)
 
         // Exclusive
         val expectedSamMaxVersion = SemVer("0.23.0", 0, 23, 0)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjects.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjects.kt
@@ -91,8 +91,7 @@ class SamDynamoDBCookieCutter : SamPythonProjectTemplate() {
 }
 
 abstract class SamNodeJsProjectTemplate : SamProjectTemplate() {
-    // TODO support NodeJs 10.10 at some point
-    override fun supportedRuntimes(): Set<Runtime> = setOf(Runtime.NODEJS8_10)
+    override fun supportedRuntimes(): Set<Runtime> = setOf(Runtime.NODEJS8_10, Runtime.NODEJS10_X)
 }
 
 class SamHelloWorldNodeJs : SamNodeJsProjectTemplate() {

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsHelper.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsHelper.kt
@@ -17,10 +17,11 @@ import com.intellij.openapi.vfs.VirtualFile
  * @return The inferred source root that contains package.json file, or content root of the file.
  * @throws IllegalStateException If the contentRoot cannot be located
  */
-fun inferSourceRoot(project: Project, virtualFile: VirtualFile): VirtualFile {
+fun inferSourceRoot(project: Project, virtualFile: VirtualFile): VirtualFile? {
     val projectFileIndex = ProjectFileIndex.getInstance(project)
-    val contentRoot = projectFileIndex.getContentRootForFile(virtualFile) ?: throw IllegalStateException("Cannot locate content root for file")
-    return findChildPackageJson(virtualFile.parent, contentRoot)
+    return projectFileIndex.getContentRootForFile(virtualFile)?.let {
+        findChildPackageJson(virtualFile.parent, it)
+    }
 }
 
 private fun findChildPackageJson(file: VirtualFile, contentRoot: VirtualFile): VirtualFile =

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilder.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilder.kt
@@ -40,5 +40,6 @@ class NodeJsLambdaBuilder : LambdaBuilder() {
         return buildLambdaFromTemplate(module, customTemplate.toPath(), logicalId, samOptions, onStart)
     }
 
-    private fun getBaseDirectory(project: Project, virtualFile: VirtualFile): VirtualFile = inferSourceRoot(project, virtualFile)
+    private fun getBaseDirectory(project: Project, virtualFile: VirtualFile): VirtualFile =
+        inferSourceRoot(project, virtualFile) ?: throw IllegalStateException("Cannot locate content root for file")
 }

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolver.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolver.kt
@@ -44,7 +44,7 @@ class NodeJsLambdaHandlerResolver : LambdaHandlerResolver {
      */
     private fun PsiElement.isValidHandlerElement(fileName: String): Boolean {
         val virtualFile = this.containingFile.virtualFile ?: return false
-        val sourceRoot = inferSourceRoot(project, virtualFile)
+        val sourceRoot = inferSourceRoot(project, virtualFile) ?: return false
 
         val relativePath = VfsUtilCore.findRelativePath(sourceRoot, virtualFile, '/') ?: return false
         return this is NavigatablePsiElement &&
@@ -61,7 +61,7 @@ class NodeJsLambdaHandlerResolver : LambdaHandlerResolver {
 
         val virtualFile = element.containingFile.virtualFile ?: return null
 
-        val sourceRoot = inferSourceRoot(element.project, virtualFile)
+        val sourceRoot = inferSourceRoot(element.project, virtualFile) ?: return null
         val relativePath = VfsUtilCore.findRelativePath(sourceRoot, virtualFile, '/') ?: return null
         val prefix = FileUtilRt.getNameWithoutExtension(relativePath)
         val handlerName = element.text

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
@@ -16,8 +16,8 @@ import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroupInfor
 
 class NodeJsRuntimeGroup : SdkBasedRuntimeGroupInformation() {
     override val runtimes: Set<Runtime> = setOf(
-        // TODO add nodejs10 support
-        Runtime.NODEJS8_10
+        Runtime.NODEJS8_10,
+        Runtime.NODEJS10_X
     )
 
     override val languageIds: Set<String> = setOf(
@@ -30,9 +30,8 @@ class NodeJsRuntimeGroup : SdkBasedRuntimeGroupInformation() {
     override fun determineRuntime(project: Project): Runtime? =
         NodeJsInterpreterManager.getInstance(project).interpreter?.cachedVersion?.get()?.let {
             when {
-                // How do we decide which runtime to use?
                 it.major <= 8 -> Runtime.NODEJS8_10
-                // TODO add nodejs10 support
+                it.major <= 10 -> Runtime.NODEJS10_X
                 else -> null
             }
         }

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroupTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroupTest.kt
@@ -44,6 +44,13 @@ class NodeJsRuntimeGroupTest {
     fun testRuntime10_10() {
         projectRule.project.setNodeJsInterpreterVersion(SemVer("v10.10.0", 10, 10, 0))
         val runtime = sut.determineRuntime(projectRule.project)
+        assertThat(runtime).isEqualTo(Runtime.NODEJS10_X)
+    }
+
+    @Test
+    fun testRuntime11_12() {
+        projectRule.project.setNodeJsInterpreterVersion(SemVer("v11.12.0", 11, 12, 0))
+        val runtime = sut.determineRuntime(projectRule.project)
         assertThat(runtime).isNull()
     }
 }


### PR DESCRIPTION
handler source root.

When the target potential lambda handler is from the dependency lib, the content root cannot be inferred. It should return null for it's source root instead of throwing exception.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
