### PR TITLE
Use a cached action group for credential switcing

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerFactory.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.openapi.wm.ex.ToolWindowEx
 import software.aws.toolkits.jetbrains.core.ChangeAccountSettingsAction
-import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.core.help.HelpIds
 import software.aws.toolkits.jetbrains.utils.actions.OpenBrowserAction
 import software.aws.toolkits.resources.message
@@ -57,15 +56,8 @@ class AwsExplorerFactory : ToolWindowFactory, DumbAware {
     }
 }
 
-class AwsSettingsMenu(private val project: Project) : DefaultActionGroup(message("settings.title"), true),
-    ProjectAccountSettingsManager.AccountSettingsChangedNotifier {
+class AwsSettingsMenu(private val project: Project) : DefaultActionGroup(message("settings.title"), true) {
     init {
-        project.messageBus.connect().subscribe(ProjectAccountSettingsManager.ACCOUNT_SETTINGS_CHANGED, this)
-        add(ChangeAccountSettingsAction(project).createPopupActionGroup())
-    }
-
-    override fun settingsChanged(event: ProjectAccountSettingsManager.AccountSettingsChangedNotifier.AccountSettingsEvent) {
-        removeAll()
         add(ChangeAccountSettingsAction(project).createPopupActionGroup())
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -9,7 +9,7 @@ import software.amazon.awssdk.services.sts.StsClient
 import software.aws.toolkits.core.credentials.CredentialProviderNotFound
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 
-class MockCredentialsManager : CredentialManager {
+class MockCredentialsManager : CredentialManager() {
     private val providers = mutableMapOf<String, ToolkitCredentialsProvider>()
 
     override fun getCredentialProviders(): List<ToolkitCredentialsProvider> = providers.values.toList()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Use a computed action group that tracks the credential manager getting updated in order to invalidate the cache

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#895

## Testing

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
