### PR TITLE
Use a cached action group for credential switcing

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSettingsPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsSettingsPanel.kt
@@ -7,10 +7,12 @@ import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.actionSystem.Separator
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -20,6 +22,7 @@ import com.intellij.openapi.ui.popup.ListPopup
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.WindowManager
+import com.intellij.psi.util.CachedValueProvider
 import com.intellij.util.Consumer
 import software.aws.toolkits.core.credentials.CredentialProviderNotFound
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
@@ -32,6 +35,7 @@ import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager.AccountSettingsChangedNotifier
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
+import software.aws.toolkits.jetbrains.utils.actions.ComputableActionGroup
 import software.aws.toolkits.resources.message
 import java.awt.Component
 import java.awt.event.MouseEvent
@@ -155,13 +159,13 @@ class ChangeAccountSettingsAction(
         val usedCredentials = accountSettingsManager.recentlyUsedCredentials()
         if (usedCredentials.isEmpty()) {
             group.addSeparator(message("settings.credentials"))
-            group.addAll(createShowAllCredentials())
+            group.add(createShowAllCredentials(false))
         } else {
             group.addSeparator(message("settings.credentials.recent"))
             usedCredentials.forEach {
                 group.add(ChangeCredentialsAction(it))
             }
-            group.add(createShowAllCredentials())
+            group.add(createShowAllCredentials(true))
         }
 
         return group
@@ -181,18 +185,22 @@ class ChangeAccountSettingsAction(
         return showAll
     }
 
-    private fun createShowAllCredentials(): ActionGroup {
-        val credentialManager = CredentialManager.getInstance()
-        val showAll = DefaultActionGroup(message("settings.credentials.profile_sub_menu"), true)
+    private fun createShowAllCredentials(popup: Boolean): ActionGroup = object : ComputableActionGroup(
+        message("settings.credentials.profile_sub_menu"),
+        popup
+    ), DumbAware {
+            override fun createChildrenProvider(actionManager: ActionManager?): CachedValueProvider<Array<AnAction>> = CachedValueProvider {
+                val credentialManager = CredentialManager.getInstance()
 
-        credentialManager.getCredentialProviders().forEach {
-            showAll.add(ChangeCredentialsAction(it))
-        }
+                val actions = mutableListOf<AnAction>()
+                credentialManager.getCredentialProviders().forEach {
+                    actions.add(ChangeCredentialsAction(it))
+                }
+                actions.add(Separator.create())
+                actions.add(ActionManager.getInstance().getAction("aws.settings.upsertCredentials"))
 
-        showAll.addSeparator()
-        showAll.add(ActionManager.getInstance().getAction("aws.settings.upsertCredentials"))
-
-        return showAll
+                CachedValueProvider.Result.create(actions.toTypedArray(), credentialManager)
+            }
     }
 
     companion object {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/actions/ComputableActionGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/actions/ComputableActionGroup.kt
@@ -1,0 +1,25 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.utils.actions
+
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.util.CachedValueImpl
+
+abstract class ComputableActionGroup(shortName: String, popup: Boolean) : ActionGroup(shortName, popup) {
+    private lateinit var children: CachedValue<Array<AnAction>>
+
+    override fun getChildren(e: AnActionEvent?): Array<AnAction> {
+        if (!this::children.isInitialized) {
+            children = CachedValueImpl(createChildrenProvider(e?.actionManager))
+        }
+        return children.value
+    }
+
+    protected abstract fun createChildrenProvider(actionManager: ActionManager?): CachedValueProvider<Array<AnAction>>
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -9,7 +9,7 @@ import software.amazon.awssdk.services.sts.StsClient
 import software.aws.toolkits.core.credentials.CredentialProviderNotFound
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 
-class MockCredentialsManager : CredentialManager {
+class MockCredentialsManager : CredentialManager() {
     private val providers = mutableMapOf<String, ToolkitCredentialsProvider>()
 
     override fun getCredentialProviders(): List<ToolkitCredentialsProvider> = providers.values.toList()
@@ -18,11 +18,13 @@ class MockCredentialsManager : CredentialManager {
         ?: throw CredentialProviderNotFound("$providerId not found")
 
     fun reset() {
+        incModificationCount()
         providers.clear()
     }
 
     fun addCredentials(id: String, credentials: AwsCredentials, isValid: Boolean = true): ToolkitCredentialsProvider =
         MockCredentialsProvider(id, id, credentials, isValid).also {
+            incModificationCount()
             providers[id] = it
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Use a computed action group that tracks the credential manager getting updated in order to invalidate the cache

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#895

## Testing

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
