### PR TITLE
Fixing alternative IDE logic so that it runs for every runTask defined in the project.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,15 @@ allprojects {
 
     apply plugin: "com.adarshr.test-logger"
     apply plugin: 'jacoco'
+
+    tasks.withType(org.jetbrains.intellij.tasks.RunIdeTask) {
+        systemProperty("aws.toolkits.enableTelemetry", false)
+        intellij {
+            if (System.env.ALTERNATIVE_IDE) {
+                alternativeIdePath = System.env.ALTERNATIVE_IDE
+            }
+        }
+    }
 }
 
 // Kotlin plugin seems to be bugging out when there are no kotlin sources
@@ -180,9 +189,6 @@ intellij {
     pluginName 'aws-jetbrains-toolkit'
     updateSinceUntilBuild false
     downloadSources = System.getenv("CI") == null
-    if (System.env.ALTERNATIVE_IDE) {
-        alternativeIdePath = System.env.ALTERNATIVE_IDE
-    }
 }
 
 publishPlugin {

--- a/jetbrains-core/build.gradle
+++ b/jetbrains-core/build.gradle
@@ -12,10 +12,6 @@ intellij {
     plugins = idePlugins("IC")
 }
 
-runIde {
-    systemProperty("aws.toolkits.enableTelemetry", false)
-}
-
 publishPlugin.enabled = false
 buildSearchableOptions.enabled = false
 


### PR DESCRIPTION

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
