### PR TITLE
Enable using the presence of a requirements.txt to determine if a met…

### DIFF
--- a/.changes/next-release/feature-fef50b12-5667-41c0-b71d-6ea69062a04d.json
+++ b/.changes/next-release/feature-fef50b12-5667-41c0-b71d-6ea69062a04d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Enable searching for `requirements.txt` when determining if a python method is a handler to match SAM build"
+}

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilderTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilderTest.kt
@@ -64,7 +64,7 @@ class PythonLambdaBuilderTest : BaseLambdaBuilderTest() {
     }
 
     @Test
-    fun baseDirBasedOnRequreimentsFileAtRootOfHandler() {
+    fun baseDirBasedOnRequirementsFileAtRootOfHandler() {
         val module = projectRule.module
         val handler = addPythonHandler("src")
         addRequirementsFile("src")

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilderTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilderTest.kt
@@ -64,6 +64,26 @@ class PythonLambdaBuilderTest : BaseLambdaBuilderTest() {
     }
 
     @Test
+    fun baseDirBasedOnRequreimentsFileAtRootOfHandler() {
+        val module = projectRule.module
+        val handler = addPythonHandler("src")
+        addRequirementsFile("src")
+
+        val builtLambda = buildLambda(module, handler, Runtime.PYTHON3_6, "app.handle")
+        verifyEntries(
+            builtLambda,
+            "app.py",
+            "requirements.txt"
+        )
+        verifyPathMappings(
+            module,
+            builtLambda,
+            "%PROJECT_ROOT%/src" to "/",
+            "%BUILD_ROOT%" to "/"
+        )
+    }
+
+    @Test
     fun dependenciesAreAdded() {
         val module = projectRule.module
         val handler = addPythonHandler("hello_world")

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilder.kt
@@ -23,8 +23,22 @@ class PythonLambdaBuilder : LambdaBuilder() {
 
     private fun getBaseDirectory(project: Project, virtualFile: VirtualFile): VirtualFile {
         val fileIndex = ProjectFileIndex.getInstance(project)
-        return fileIndex.getSourceRootForFile(virtualFile)
-            ?: fileIndex.getContentRootForFile(virtualFile)
-            ?: throw IllegalStateException("Failed to locate the root of the handler")
+
+        fileIndex.getSourceRootForFile(virtualFile)?.let {
+            return it
+        }
+
+        fileIndex.getContentRootForFile(virtualFile)?.let { contentRoot ->
+            var dir: VirtualFile? = virtualFile
+            while (dir != null) {
+                if (dir == contentRoot || dir.findChild("requirements.txt") != null) {
+                    return dir
+                }
+
+                dir = dir.parent
+            }
+        }
+
+        throw IllegalStateException("Failed to locate the root of the handler")
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilder.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
+import software.aws.toolkits.resources.message
 
 class PythonLambdaBuilder : LambdaBuilder() {
     override fun baseDirectory(module: Module, handlerElement: PsiElement): String {
@@ -39,6 +40,6 @@ class PythonLambdaBuilder : LambdaBuilder() {
             }
         }
 
-        throw IllegalStateException("Failed to locate the root of the handler")
+        throw IllegalStateException(message("lambda.build.unable_to_locate_handler_root"))
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolver.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolver.kt
@@ -42,7 +42,7 @@ class PythonLambdaHandlerResolver : LambdaHandlerResolver {
         val moduleFolders = fullyQualifiedModule.take(fullyQualifiedModule.size - 1)
 
         // Find the module by the name
-        PyModuleNameIndex.find(moduleFile, project, true).forEach { pyModule ->
+        PyModuleNameIndex.find(moduleFile, project, false).forEach { pyModule ->
             val lambdaFunctionCandidate = pyModule.findTopLevelFunction(functionName) ?: return@forEach
 
             val module = ModuleUtilCore.findModuleForFile(lambdaFunctionCandidate.containingFile)
@@ -87,6 +87,10 @@ class PythonLambdaHandlerResolver : LambdaHandlerResolver {
             }
 
             if (rootManager.getSourceRoots(false).contains(rootVirtualFile)) {
+                return true
+            }
+
+            if (rootVirtualFile.findChild("requirements.txt") != null) {
                 return true
             }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolver.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolver.kt
@@ -93,11 +93,9 @@ class PythonLambdaHandlerResolver : LambdaHandlerResolver {
             if (rootVirtualFile.findChild("requirements.txt") != null) {
                 return true
             }
-
-            return false
         }
 
-        return true
+        return false
     }
 
     private fun directoryHasInitPy(psiDirectory: PsiDirectory) = psiDirectory.findFile("__init__.py") != null

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolverTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolverTest.kt
@@ -13,8 +13,8 @@ import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.services.lambda.Lambda
-import software.aws.toolkits.jetbrains.utils.rules.addFileToModule
 import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
+import software.aws.toolkits.jetbrains.utils.rules.addFileToModule
 
 class PythonLambdaHandlerResolverTest {
     @Rule
@@ -99,13 +99,14 @@ class PythonLambdaHandlerResolverTest {
     }
 
     @Test
-    fun findWorksIfParentIsASourceDirectory() {
+    fun findWorksIfHandlerRootIsASourceDirectory() {
         val virtualFile = createHandler("src/hello_world/foo_bar/app.py")
         createInitPy("src/hello_world/foo_bar")
+        createInitPy("src/hello_world")
 
-        markAsSourceRoot(virtualFile.parent.parent.parent)
+        markAsSourceRoot(virtualFile.parent.parent) // hello_world
 
-        assertHandler("hello_world.foo_bar.app.handle", false)
+        assertHandler("hello_world.foo_bar.app.handle", true)
     }
 
     @Test
@@ -128,6 +129,16 @@ class PythonLambdaHandlerResolverTest {
         createHandler("app.py")
 
         assertHandler("app.handle", true)
+    }
+
+    @Test
+    fun findWorkIfRequirementsFileIsFound() {
+        createHandler("src/hello_world/foo_bar/app.py")
+        createInitPy("src/hello_world/foo_bar")
+        createInitPy("src/hello_world")
+        projectRule.fixture.addFileToModule(projectRule.module, "src/requirements.txt", "")
+
+        assertHandler("hello_world.foo_bar.app.handle", true)
     }
 
     private fun createHandler(path: String): VirtualFile = projectRule.fixture.addFileToProject(

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolverTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolverTest.kt
@@ -112,9 +112,18 @@ class PythonLambdaHandlerResolverTest {
     @Test
     fun findDoesntWorkIfNotASourceOrContentRoot() {
         createHandler("src/hello_world/foo_bar/app.py")
+        createInitPy("src/hello_world")
         createInitPy("src/hello_world/foo_bar")
 
         assertHandler("hello_world.foo_bar.app.handle", false)
+    }
+
+    @Test
+    fun findDoesntWorkIfParentFolderDoesntExist() {
+        createHandler("src/hello_world/foo_bar/app.py")
+        createInitPy("src/hello_world/foo_bar")
+
+        assertHandler("doesnt_exist/foo_bar.app.handle", false)
     }
 
     @Test
@@ -134,8 +143,8 @@ class PythonLambdaHandlerResolverTest {
     @Test
     fun findWorkIfRequirementsFileIsFound() {
         createHandler("src/hello_world/foo_bar/app.py")
-        createInitPy("src/hello_world/foo_bar")
         createInitPy("src/hello_world")
+        createInitPy("src/hello_world/foo_bar")
         projectRule.fixture.addFileToModule(projectRule.module, "src/requirements.txt", "")
 
         assertHandler("hello_world.foo_bar.app.handle", true)

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -286,6 +286,7 @@ codepipeline.resource.operation.update=update
 codepipeline.resource.operation.delete=deletion
 codepipeline.resource.operation.deploy=deployment
 lambda.build.unable_to_locate_project_root=Unable to locate project diretory for Module ''{0}''
+lambda.build.unable_to_locate_handler_root=Unable to locate root directory of the handler
 lambda.build.java.unsupported_build_system=Module ''{0}'' is not managed by Maven or Gradle
 lambda.run_configuration.remote.function.tooltip=The name of the AWS Lambda function to use.
 lambda.build.module_with_no_content_root=Module ''{0}'' lacks a content root


### PR DESCRIPTION
…hod is a handler in Python

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
This allows us to not rely on source roots but instead matches what SAM build will do, which is look for the requirements.txt at the codeUri location

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#1054

## Testing
New unit tests
Manually tested that removing a source root can still run the Lambda handler

## Screenshots (if appropriate)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
