### PR TITLE
Fix the refresh vfs in ReadAction bug.

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
@@ -179,7 +179,7 @@ abstract class LambdaBuilder {
     private fun getOrCreateBuildDirectory(module: Module): File {
         val contentRoot = module.rootManager.contentRoots.firstOrNull()
             ?: throw IllegalStateException(message("lambda.build.module_with_no_content_root", module.name))
-        val buildFolder = File(contentRoot.path, ".aws-toolkit")
+        val buildFolder = File(contentRoot.path, ".aws-sam/build")
         FileUtil.createDirectory(buildFolder)
         return buildFolder
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
@@ -10,7 +10,6 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessHandlerFactory
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
-import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.rootManager
@@ -70,11 +69,14 @@ abstract class LambdaBuilder {
         onStart: (ProcessHandler) -> Unit = {}
     ): CompletionStage<BuiltLambda> {
         val future = CompletableFuture<BuiltLambda>()
+
+        val functions = SamTemplateUtils.findFunctionsFromTemplate(
+            module.project,
+            templateLocation.toFile()
+        )
+
         val codeLocation = ReadAction.compute<String, Throwable> {
-            SamTemplateUtils.findFunctionsFromTemplate(
-                module.project,
-                templateLocation.toFile()
-            ).find { it.logicalName == logicalId }
+            functions.find { it.logicalName == logicalId }
                 ?.codeLocation()
                 ?: throw RuntimeConfigurationError(
                     message(
@@ -174,14 +176,13 @@ abstract class LambdaBuilder {
     /**
      * Returns the build directory of the project. Create this if it doesn't exist yet.
      */
-    private fun getOrCreateBuildDirectory(module: Module): File =
-        WriteAction.computeAndWait<File, Throwable> {
-            val contentRoot = module.rootManager.contentRoots.firstOrNull()
-                ?: throw IllegalStateException(message("lambda.build.module_with_no_content_root", module.name))
-            val buildFolder = File(contentRoot.path, ".aws-toolkit")
-            FileUtil.createDirectory(buildFolder)
-            buildFolder
-        }
+    private fun getOrCreateBuildDirectory(module: Module): File {
+        val contentRoot = module.rootManager.contentRoots.firstOrNull()
+            ?: throw IllegalStateException(message("lambda.build.module_with_no_content_root", module.name))
+        val buildFolder = File(contentRoot.path, ".aws-toolkit")
+        FileUtil.createDirectory(buildFolder)
+        return buildFolder
+    }
 
     companion object : RuntimeGroupExtensionPointObject<LambdaBuilder>(
         ExtensionPointName("aws.toolkit.lambda.builder")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
`refreshAndFindFileByIoFile` should be called in `WriteAction` when the `refresh` is triggered, otherwise, exception will be thrown with error message `Do not call synchronous refresh under read lock (except from EDT) `

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
