### PR TITLE
Fix exceptions while generating project in Idea and Rider

### DIFF
--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
@@ -21,4 +21,6 @@ class DotNetRuntimeGroup : SdkBasedRuntimeGroupInformation() {
         get() = setOf(CSharpLanguage.id, VbLanguage.id)
 
     override fun runtimeForSdk(sdk: Sdk): Runtime? = null
+
+    override fun supportsSamBuild(): Boolean = true
 }

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -270,6 +270,7 @@ sam.init.error.no.project.basepath=Unable to determine project basepath
 sam.init.error.no.solution.basepath=Unable to determine solution basepath
 sam.init.error.no.virtual.file=Unable to resolve location
 sam.init.error.solution.create.fail=Unable to create solution
+sam.init.generating.template=Generating SAM template...
 sam.build.title=SAM build
 sam.build.running=Running SAM build
 sam.build.failed=SAM build command failed


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
- Fix exception on startu while gathering SAM CLI information
- Replace synchronous execution on EDT with modifying project model after project is initialized for IDEA; and wrap synchronous execution under progress for Rider
- Fix validation for template.yaml file to be able to call SAM deploy action

## Motivation and Context
Heavy operations like generating a project template from SAM CLI should not run in EDT to not freeze the app UI.

## Related Issue(s)
None.

## Testing
Environment:
```
Mac OS Mojave 10.14.5 (18F132)
```
- Create new project from SAM Template in IDEA, RIDER
- Open existing templates
- Create submodule pithing created module in IDEA to make sure project is generated for both cases.

## Screenshots (if appropriate)
None.

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.