### PR TITLE
Fix LocalLambdaRunConfiguration tests broken by async SAM version check

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
@@ -165,7 +165,7 @@ open class SamDeployDialog(
         val message = if (error.cause is ProcessCanceledException) {
             message("serverless.application.deploy.abort")
         } else {
-            ExceptionUtil.getMessage(error) ?: message("serverless.application.deploy.unknown_error")
+            ExceptionUtil.getMessage(error) ?: message("general.unknown_error")
         }
         setErrorText(message)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
@@ -95,7 +95,7 @@ class SamCommon {
 
             return try {
                 getInvalidVersionMessage(
-                    SamVersionCache.getResult(
+                    SamVersionCache.evaluateBlocking(
                         sanitizedPath
                     )
                 )
@@ -112,7 +112,7 @@ class SamCommon {
                 ?: return "UNKNOWN"
 
             return try {
-                SamVersionCache.getResult(sanitizedPath).rawVersion
+                SamVersionCache.evaluateBlocking(sanitizedPath).rawVersion
             } catch (e: Exception) {
                 logger.error(e) { "Error while getting SAM executable version." }
                 return "UNKNOWN"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCache.kt
@@ -4,24 +4,11 @@
 package software.aws.toolkits.jetbrains.services.lambda.sam
 
 import com.intellij.execution.process.CapturingProcessHandler
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.util.text.SemVer
-import org.jetbrains.annotations.TestOnly
-import org.jetbrains.concurrency.AsyncPromise
-import org.jetbrains.concurrency.Promise
-import software.aws.toolkits.core.utils.error
-import software.aws.toolkits.core.utils.getLogger
-import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.jetbrains.utils.FileInfoCache
 import software.aws.toolkits.resources.message
 
 object SamVersionCache : FileInfoCache<SemVer>() {
-
-    private val logger = getLogger<SamVersionCache>()
-    private val versionRequests = hashMapOf<String, Promise<SemVer>>()
-    private val lock = Object()
-
     override fun getFileInfo(path: String): SemVer {
         val commandLine = SamCommon.getSamCommandLine(path).withParameters("--info")
         val process = CapturingProcessHandler(commandLine).runProcess()
@@ -43,40 +30,4 @@ object SamVersionCache : FileInfoCache<SemVer>() {
                 ?: throw IllegalStateException(message("sam.executable.version_parse_error", version))
         }
     }
-
-    fun evaluate(samExecutablePath: String): Promise<SemVer> {
-        logger.info { "Evaluating SAM version string." }
-
-        val asyncPromise = AsyncPromise<SemVer>()
-        val promise = synchronized(lock) { versionRequests.getOrPut(samExecutablePath) { asyncPromise } }
-
-        if (promise == asyncPromise) {
-            ApplicationManager.getApplication().executeOnPooledThread {
-                try {
-                    val version = getFileInfo(samExecutablePath)
-                    asyncPromise.setResult(version)
-                } catch (t: Throwable) {
-                    asyncPromise.setError(t)
-                }
-            }
-
-            asyncPromise
-                .onSuccess { version ->
-                    logger.info { "SAM version evaluation is completed: '$version'" }
-                }
-                .onError { error ->
-                    if (error !is ProcessCanceledException) {
-                        logger.error(error) { "Failed to evaluate SAM version" }
-                    }
-                    clearCache(samExecutablePath)
-                }
-        }
-
-        return promise
-    }
-
-    private fun clearCache(key: String) = synchronized(lock) { versionRequests.remove(key) }
-
-    @TestOnly
-    fun testOnlyGetRequestCache() = versionRequests
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/FileInfoCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/FileInfoCache.kt
@@ -3,35 +3,104 @@
 
 package software.aws.toolkits.jetbrains.utils
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProcessCanceledException
+import org.jetbrains.annotations.TestOnly
+import org.jetbrains.concurrency.AsyncPromise
+import org.jetbrains.concurrency.Promise
+import org.jetbrains.concurrency.isPending
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.resources.message
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Paths
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 
+/**
+ * Stores data related to a file path. Cache is invalidated when the cache entry is detected as stale.  Errors are
+ * cached until the underlying path is detected as stale. Stale is defined as the cache entries (file modification time)[Files.getLastModifiedTime]
+ * is older than the path's current modification time.
+ */
 abstract class FileInfoCache<T> {
-    private val infoCache = mutableMapOf<String, InfoResult<T>>()
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val infoCache = hashMapOf<String, InfoResult<T>>()
+    private val lock = Object()
 
-    @Synchronized
-    fun getResult(path: String): T {
-        val cacheResult = infoCache.remove(path)
-        val currentLastModificationDate = try {
-            Files.getLastModifiedTime(Paths.get(path)).toInstant()
-        } catch (e: NoSuchFileException) {
-            throw IllegalStateException(message("general.file_not_found", path))
+    /**
+     * @return A promise for the requested file info. Promise will be resolved when the info is ready.
+     */
+    fun evaluate(path: String): Promise<T> {
+        logger.info { "Evaluating $path" }
+
+        val asyncPromise = AsyncPromise<T>()
+        asyncPromise
+            .onSuccess { result ->
+                logger.info { "File info evaluation is completed: '$result'" }
+            }
+            .onError { error -> // Need to set an error handler early, else the setError call will throw AssertionError
+                if (error !is ProcessCanceledException) {
+                    logger.info(error) { "Failed to evaluate $path" }
+                }
+            }
+
+        val infoResult = synchronized(lock) {
+            getCacheEntry(path, asyncPromise)
         }
 
-        val infoResult = if (cacheResult == null || currentLastModificationDate.isAfter(cacheResult.timestamp)) {
-            InfoResult(getFileInfo(path), currentLastModificationDate)
-        } else {
-            cacheResult
+        if (infoResult.result == asyncPromise && asyncPromise.isPending) {
+            ApplicationManager.getApplication().executeOnPooledThread {
+                try {
+                    val result = getFileInfo(path)
+                    asyncPromise.setResult(result)
+                } catch (t: Throwable) {
+                    asyncPromise.setError(t)
+                }
+            }
         }
-        infoCache[path] = infoResult
 
         return infoResult.result
     }
 
-    abstract fun getFileInfo(path: String): T
+    private fun getCacheEntry(path: String, asyncPromise: AsyncPromise<T>): InfoResult<T> {
+        val cacheEntry = infoCache[path]
 
-    private class InfoResult<T>(val result: T, val timestamp: Instant)
+        val currentLastModificationDate = try {
+            Files.getLastModifiedTime(Paths.get(path)).toInstant()
+        } catch (e: NoSuchFileException) {
+            // If unable to get the current time, override the cache entry that the file can't be found
+
+            asyncPromise.setError(IllegalStateException(message("general.file_not_found", path)))
+
+            val newResult = InfoResult(asyncPromise, Instant.MIN)
+            infoCache[path] = newResult
+            return newResult
+        }
+
+        // If the promise is fulfilled, and the path has been modified since last checking, we need to check again
+        return if (cacheEntry == null ||
+            (!cacheEntry.result.isPending && currentLastModificationDate.isAfter(cacheEntry.timestamp))
+        ) {
+            logger.info { "InfoResult for $path is either missing, or stale. Checking again" }
+
+            val newResult = InfoResult(asyncPromise, currentLastModificationDate)
+            infoCache[path] = newResult
+            newResult
+        } else {
+            cacheEntry
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun evaluateBlocking(path: String, blockingTime: Int = 500, blockingUnit: TimeUnit = TimeUnit.MILLISECONDS): T =
+        evaluate(path).blockingGet(blockingTime, blockingUnit) as T
+
+    @TestOnly
+    fun testOnlyGetRequestCache() = infoCache
+
+    protected abstract fun getFileInfo(path: String): T
+
+    data class InfoResult<T>(val result: Promise<T>, internal val timestamp: Instant)
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/FileInfoCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/FileInfoCache.kt
@@ -94,8 +94,14 @@ abstract class FileInfoCache<T> {
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun evaluateBlocking(path: String, blockingTime: Int = 500, blockingUnit: TimeUnit = TimeUnit.MILLISECONDS): T =
-        evaluate(path).blockingGet(blockingTime, blockingUnit) as T
+    fun evaluateBlocking(path: String, blockingTime: Int = 500, blockingUnit: TimeUnit = TimeUnit.MILLISECONDS): T {
+        val promise = evaluate(path)
+        return promise.blockingGet(blockingTime, blockingUnit).also {
+            if (!promise.isSucceeded) {
+                throw IllegalStateException("Promise did not succeed successfully")
+            }
+        } as T
+    }
 
     @TestOnly
     fun testOnlyGetRequestCache() = infoCache

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCacheTest.kt
@@ -3,8 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.sam
 
-import com.intellij.util.containers.ContainerUtil
-import com.intellij.util.text.SemVer
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.all
 import org.junit.After
@@ -31,97 +29,7 @@ class SamVersionCacheTest {
     }
 
     @Test
-    fun evaluate_EmptyCache_SingleExecutableRequest() {
-        val samPath = SamCommonTestUtils.makeATestSam(SamCommonTestUtils.getMinVersionAsJson()).toString()
-        val pathPromise = SamVersionCache.evaluate(samPath)
-        waitAll(listOf(pathPromise))
-
-        assertEquals(
-            "Not cached SAM CLI version value check failure",
-            SamCommon.expectedSamMinVersion.rawVersion,
-            pathPromise.blockingGet(0)?.rawVersion
-        )
-
-        val cache = SamVersionCache.testOnlyGetRequestCache()
-        assertEquals("Cache size does not match expected value", 1, cache.size)
-    }
-
-    @Test
-    fun evaluate_NonEmptyCache_SingleExecutableRequest() {
-        val samPath = SamCommonTestUtils.makeATestSam(SamCommonTestUtils.getMinVersionAsJson()).toString()
-        val pathPromise = SamVersionCache.evaluate(samPath)
-        waitAll(listOf(pathPromise))
-
-        // Get the value with no wait because the value should be already cached
-        val samePathPromise = SamVersionCache.evaluate(samPath).blockingGet(0)
-        assertEquals(
-            "Cached SAM CLI version value check failure",
-            SamCommon.expectedSamMinVersion.rawVersion,
-            samePathPromise?.rawVersion
-        )
-
-        val cache = SamVersionCache.testOnlyGetRequestCache()
-        assertEquals("Cache size does not match expected value", 1, cache.size)
-    }
-
-    @Test
-    fun evaluate_DifferentExecutableRequests() {
-        val samMinPath = SamCommonTestUtils.makeATestSam(SamCommonTestUtils.getMinVersionAsJson()).toString()
-        val samMaxPath = SamCommonTestUtils.makeATestSam(SamCommonTestUtils.getMaxVersionAsJson()).toString()
-
-        val pathMinPromise = SamVersionCache.evaluate(samMinPath)
-        val pathMaxPromise = SamVersionCache.evaluate(samMaxPath)
-        waitAll(listOf(pathMinPromise, pathMaxPromise))
-
-        assertEquals(
-            "SAM CLI (min) version check failure",
-            SamCommon.expectedSamMinVersion.rawVersion,
-            pathMinPromise.blockingGet(0)?.rawVersion
-        )
-
-        assertEquals(
-            "SAM CLI (max) version check failure",
-            SamCommon.expectedSamMaxVersion.rawVersion,
-            pathMaxPromise.blockingGet(0)?.rawVersion)
-
-        val cache = SamVersionCache.testOnlyGetRequestCache()
-        assertEquals("Cache size does not match expected value", 2, cache.size)
-    }
-
-    @Test
-    fun evaluate_MultipleThreads_SameSamPath() {
-        val threadsCount = 20
-        val samPath = SamCommonTestUtils.makeATestSam(SamCommonTestUtils.getMinVersionAsJson()).toString()
-        val results = ContainerUtil.newConcurrentSet<Promise<SemVer>>()
-
-        fun retrieveVersion() {
-            val promise = SamVersionCache.evaluate(samPath)
-            results.add(promise)
-        }
-
-        val threads = (1..threadsCount).map { Thread(::retrieveVersion).apply { start() } }.toList()
-        for (thread in threads) {
-            thread.join()
-        }
-
-        waitAll(results)
-
-        assertEquals("Number of threads does not match expected value", 1, results.size)
-
-        for (result in results) {
-            assertEquals(
-                "SAM CLI version check failure",
-                SamCommon.expectedSamMinVersion.rawVersion,
-                result.blockingGet(0)?.rawVersion
-            )
-        }
-
-        val cache = SamVersionCache.testOnlyGetRequestCache()
-        assertEquals("Cache size does not match expected value", 1, cache.size)
-    }
-
-    @Test
-    fun evaluate_InvalidSamExecutablePath() {
+    fun invalidSamExecutablePath() {
         val invalidPath = "invalid_path"
 
         expectedException.expect(IllegalStateException::class.java)
@@ -131,14 +39,14 @@ class SamVersionCacheTest {
     }
 
     @Test
-    fun getFileInfo_SamCliMinVersion() {
+    fun samCliMinVersion() {
         val samPath = SamCommonTestUtils.makeATestSam(SamCommonTestUtils.getMinVersionAsJson()).toString()
         val samVersion = SamVersionCache.evaluateBlocking(samPath)
         assertEquals("Mismatch SAM executable version", samVersion, SamCommon.expectedSamMinVersion)
     }
 
     @Test
-    fun getFileInfo_SamCliInvalidVersion() {
+    fun samCliInvalidVersion() {
         val version = "0.0.a"
 
         expectedException.expect(IllegalStateException::class.java)
@@ -149,7 +57,7 @@ class SamVersionCacheTest {
     }
 
     @Test
-    fun getFileInfo_ErrorCode_RandomError() {
+    fun errorCode_RandomError() {
         val message = "No such file or directory"
 
         expectedException.expect(IllegalStateException::class.java)
@@ -160,7 +68,7 @@ class SamVersionCacheTest {
     }
 
     @Test
-    fun getFileInfo_ErrorCode_InvalidOption() {
+    fun errorCode_InvalidOption() {
         val message = "Error: no such option: --some_option"
 
         expectedException.expect(IllegalStateException::class.java)
@@ -171,7 +79,7 @@ class SamVersionCacheTest {
     }
 
     @Test
-    fun getFileInfo_SuccessExecution_EmptyOutput() {
+    fun successExecution_EmptyOutput() {
         val message = ""
 
         expectedException.expect(IllegalStateException::class.java)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/FileInfoCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/FileInfoCacheTest.kt
@@ -4,11 +4,15 @@
 package software.aws.toolkits.jetbrains.utils
 
 import com.intellij.testFramework.ProjectRule
+import com.intellij.util.containers.ContainerUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.jetbrains.concurrency.Promise
+import org.jetbrains.concurrency.all
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import software.aws.toolkits.resources.message
 import java.io.File
 import java.time.Instant
 
@@ -97,5 +101,109 @@ class FileInfoCacheTest {
 
         assertThat(infoProvider.evaluateBlocking(filePath)).isEqualTo(info)
         assertThat(callCount).isEqualTo(2)
+    }
+
+    @Test
+    fun emptyCache_SingleExecutableRequest() {
+        val tempFile = tempFolder.newFile().also { it.writeText("tempFile") }
+        val infoProvider = TestFileInfoCache()
+        val pathPromise = infoProvider.evaluate(tempFile.absolutePath)
+        waitAll(listOf(pathPromise))
+
+        assertThat(pathPromise.blockingGet(0)).isEqualTo("tempFile")
+
+        assertThat(infoProvider.testOnlyGetRequestCache()).hasSize(1)
+            .describedAs("Cache size does not match expected value")
+    }
+
+    @Test
+    fun nonEmptyCache_SingleExecutableRequest() {
+        val tempFile = tempFolder.newFile().also { it.writeText("tempFile") }
+        val infoProvider = TestFileInfoCache()
+        val pathPromise = infoProvider.evaluate(tempFile.absolutePath)
+        waitAll(listOf(pathPromise))
+
+        // Get the value with no wait because the value should be already cached
+        val samePathPromise = infoProvider.evaluate(tempFile.absolutePath).blockingGet(0)
+        assertThat(samePathPromise).isEqualTo("tempFile")
+
+        assertThat(infoProvider.testOnlyGetRequestCache()).hasSize(1)
+            .describedAs("Cache size does not match expected value")
+    }
+
+    @Test
+    fun differentExecutableRequests() {
+        val tempFile1 = tempFolder.newFile().also { it.writeText("tempFile1") }
+        val tempFile2 = tempFolder.newFile().also { it.writeText("tempFile2") }
+        val infoProvider = TestFileInfoCache()
+
+        val pathTempFile1Promise = infoProvider.evaluate(tempFile1.absolutePath)
+        val pathTempFile2Promise = infoProvider.evaluate(tempFile2.absolutePath)
+        waitAll(listOf(pathTempFile1Promise, pathTempFile2Promise))
+
+        assertThat(pathTempFile1Promise.blockingGet(0)).isEqualTo("tempFile1")
+        assertThat(pathTempFile2Promise.blockingGet(0)).isEqualTo("tempFile2")
+
+        assertThat(infoProvider.testOnlyGetRequestCache()).hasSize(2)
+            .describedAs("Cache size does not match expected value")
+    }
+
+    @Test
+    fun multipleThreads_SameSamPath() {
+        val threadsCount = 20
+        val tempFile = tempFolder.newFile()
+        val results = ContainerUtil.newConcurrentSet<Promise<String>>()
+        val infoProvider = TestFileInfoCache()
+
+        val info = "v1"
+        tempFile.writeText(info)
+
+        fun retrieveVersion() {
+            val promise = infoProvider.evaluate(tempFile.absolutePath)
+            results.add(promise)
+        }
+
+        val threads = (1..threadsCount).map { Thread(::retrieveVersion).apply { start() } }.toList()
+        for (thread in threads) {
+            thread.join()
+        }
+
+        waitAll(results)
+
+        assertThat(results).hasSize(1).describedAs("Number of threads does not match expected value")
+
+        for (result in results) {
+            assertThat(result.blockingGet(0)).isEqualTo(info)
+        }
+
+        assertThat(infoProvider.testOnlyGetRequestCache()).hasSize(1)
+            .describedAs("Cache size does not match expected value")
+    }
+
+    @Test
+    fun invalidExecutablePath() {
+        val invalidPath = "invalid_path"
+
+        assertThatThrownBy { TestFileInfoCache().evaluateBlocking(invalidPath) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage(message("general.file_not_found", invalidPath))
+    }
+
+    private class TestFileInfoCache : FileInfoCache<String>() {
+        var callCount = 0
+            private set
+
+        override fun getFileInfo(path: String): String {
+            try {
+                return File(path).readText()
+            } finally {
+                callCount++
+            }
+        }
+    }
+
+    private fun waitAll(promises: Collection<Promise<*>>) {
+        val all = promises.all(null, ignoreErrors = true)
+        all.blockingGet(3000)
     }
 }

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -14,7 +14,7 @@ environment.variables.dialog.title=Environment Variables
 general.create_button=Create
 general.close_button=Close
 general.file_not_found=File not found: "{0}"
-
+general.unknown_error=Unknown error
 lambda.upload.create.title=Create Function
 lambda.upload.updateConfiguration.title=Update Configuration for {0}
 lambda.upload.updateCode.title=Update Code for {0}
@@ -241,7 +241,6 @@ serverless.application.deploy.step_name.create_change_set=Create Change Set
 serverless.application.deploy.execute_change_set=Continue Deployment
 serverless.application.deploy_in_progress.title=Deploying Application {0}
 serverless.application.deploy.abort=Process aborted
-serverless.application.deploy.unknown_error=Unknown error
 serverless.application.deploy.toast.template_file_failure=Could not detect template file
 serverless.application.deploy.error.invalid_runtime=Invalid runtime {0} defined in template {1}
 serverless.application.deploy.error.invalid_runtime_group=Cannot find runtime group for runtime {0} in template {1}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Move test back to unit test package
* Make FileIncoCache async based
* Move logic up from SAM version cache to FileInfoCache

## Motivation and Context
Fix the integration tests being broken

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
Ran unit and integ tests

## Screenshots (if appropriate)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
