### PR TITLE
Fix README not opening after project init

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/SamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/SamProjectWizard.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import icons.AwsIcons
@@ -26,6 +27,7 @@ import software.aws.toolkits.jetbrains.ui.wizard.AwsModuleType
 import software.aws.toolkits.jetbrains.ui.wizard.SamInitRunner
 import software.aws.toolkits.jetbrains.ui.wizard.SamProjectGenerator
 import software.aws.toolkits.jetbrains.ui.wizard.SdkSelectionPanel
+import java.io.File
 
 /**
  * Used to manage SAM project information for different [RuntimeGroup]s
@@ -85,7 +87,8 @@ abstract class SamProjectTemplate {
     }
 
     private fun openReadmeFile(contentRoot: VirtualFile, project: Project) {
-        VfsUtil.findRelativeFile(contentRoot, "README.md")?.let {
+        val ioFile = VfsUtil.virtualToIoFile(contentRoot)
+        LocalFileSystem.getInstance().refreshAndFindFileByIoFile(File(ioFile, "README.md"))?.let {
             val fileEditorManager = FileEditorManager.getInstance(project)
             fileEditorManager.openTextEditor(OpenFileDescriptor(project, it), true) ?: LOG.warn { "Failed to open README.md" }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
The VFS does not always know about the README yet, so we need to refresh and look for it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
UI tests are happy

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
