### PR TITLE
Fix Virtual File System refresh after new project is generated

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitRunner.kt
@@ -4,8 +4,6 @@
 package software.aws.toolkits.jetbrains.ui.wizard
 
 import com.intellij.execution.process.CapturingProcessHandler
-import com.intellij.openapi.application.runInEdt
-import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
@@ -55,11 +53,7 @@ object SamInitRunner {
             message("sam.init.error.subfolder_not_one", tempDir.name)
         }
 
-        runInEdt {
-            runWriteAction {
-                FileUtil.copyDirContent(subFolders[0], VfsUtil.virtualToIoFile(outputDir))
-                FileUtil.delete(tempDir)
-            }
-        }
+        FileUtil.copyDirContent(subFolders[0], VfsUtil.virtualToIoFile(outputDir))
+        FileUtil.delete(tempDir)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamProjectGeneratorIntelliJShims.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamProjectGeneratorIntelliJShims.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.startup.StartupManager
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.ProjectTemplatesFactory
 import icons.AwsIcons
@@ -60,6 +61,7 @@ class SamProjectBuilder(private val generator: SamProjectGenerator) : ModuleBuil
                     ModuleRootModificationUtil.updateModel(rootModel.module) { model ->
                         val samTemplate = settings.template
                         samTemplate.build(project, selectedRuntime, outputDir)
+                        VfsUtil.markDirtyAndRefresh(false, true, true, outputDir)
                         runInEdt {
                             try {
                                 samTemplate.postCreationAction(settings, outputDir, model)


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Refresh Vfs after project is updated from SAM CLI to sync it with File System

## Motivation and Context
Fix project initialization to refresh VFS with file system to be able to perform operations like opening file in editor from current VFS snapshot.

## Related Issue(s)
None.

## Testing
- Generate new SAM project
- Check README.md file is opened after project is generated

## Screenshots (if appropriate)
None.

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.