### PR TITLE
Switch UI tests to use a regex for SDK selection

### DIFF
--- a/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/fixtures/NewProjectDialogModelUtil.kt
+++ b/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/fixtures/NewProjectDialogModelUtil.kt
@@ -16,6 +16,7 @@ import com.intellij.testGuiFramework.util.scenarios.selectSdk
 import com.intellij.testGuiFramework.util.scenarios.typeProjectNameAndLocation
 import com.intellij.testGuiFramework.util.scenarios.waitLoadingTemplates
 import com.intellij.testGuiFramework.util.step
+import kotlin.test.assertNotNull
 
 private const val AWS_GROUP = "AWS"
 
@@ -24,7 +25,7 @@ data class ServerlessProjectOptions(val runtime: String, val template: String)
 fun NewProjectDialogModel.createServerlessProject(
     projectPath: String,
     templateOptions: ServerlessProjectOptions,
-    projectSdk: String
+    sdkRegex: Regex
 ) {
     with(guiTestCase) {
         fileSystemUtils.assertProjectPathExists(projectPath)
@@ -56,9 +57,10 @@ fun NewProjectDialogModel.createServerlessProject(
                     combobox("SAM Template:").selectItem(templateOptions.template)
                 }
 
-                if (projectSdk.isNotEmpty()) {
-                    selectSdk(projectSdk)
-                }
+                val sdkCandidates = sdkChooser().contents()
+                val sdkChoice = sdkCandidates.firstOrNull { it.matches(sdkRegex) }
+                assertNotNull(sdkChoice, "No valid SDK found, choices are: $sdkCandidates")
+                selectSdk(sdkChoice)
 
                 step("close New Project dialog with Finish") {
                     button(buttonFinish).click()

--- a/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderIntelliJTest.kt
+++ b/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderIntelliJTest.kt
@@ -30,7 +30,7 @@ class SamInitProjectBuilderIntelliJTest(private val testParameters: TestParamete
     data class TestParameters(
         val runtime: String,
         val templateName: String,
-        val sdk: String,
+        val sdkRegex: Regex,
         val libraries: Set<String> = emptySet(),
         val runConfigNames: Set<String> = emptySet()
     ) : Serializable {
@@ -44,7 +44,7 @@ class SamInitProjectBuilderIntelliJTest(private val testParameters: TestParamete
             newProjectDialogModel.createServerlessProject(
                 projectFolder,
                 ServerlessProjectOptions(testParameters.runtime, testParameters.templateName),
-                testParameters.sdk
+                testParameters.sdkRegex
             )
         }
 
@@ -66,7 +66,7 @@ class SamInitProjectBuilderIntelliJTest(private val testParameters: TestParamete
 
                             step("check the project SDK is correct") {
                                 projectStructureDialogModel.checkProject {
-                                    sdkChooser().requireSelection("${testParameters.sdk}.*".toPattern())
+                                    sdkChooser().requireSelection(testParameters.sdkRegex.toPattern())
                                 }
                             }
                         }
@@ -101,26 +101,26 @@ class SamInitProjectBuilderIntelliJTest(private val testParameters: TestParamete
             TestParameters(
                 runtime = "java8",
                 templateName = "AWS SAM Hello World (Maven)",
-                sdk = "1.8",
+                sdkRegex = Regex(".*java.*"),
                 libraries = setOf("Maven: com.amazonaws:aws-lambda-java-core:"),
                 runConfigNames = setOf("[Local] HelloWorldFunction")
             ),
             TestParameters(
                 runtime = "java8",
                 templateName = "AWS SAM Hello World (Gradle)",
-                sdk = "1.8",
+                sdkRegex = Regex(".*java.*"),
                 runConfigNames = setOf("[Local] HelloWorldFunction")
             ),
             TestParameters(
                 runtime = "python3.6",
                 templateName = "AWS SAM Hello World",
-                sdk = "Python",
+                sdkRegex = Regex("Python .*"),
                 runConfigNames = setOf("[Local] HelloWorldFunction")
             ),
             TestParameters(
                 runtime = "python3.6",
                 templateName = "AWS SAM DynamoDB Event Example",
-                sdk = "Python",
+                sdkRegex = Regex("Python .*"),
                 runConfigNames = setOf("[Local] ReadDynamoDBEvent")
             )
         )

--- a/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderIntelliJTest.kt
+++ b/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderIntelliJTest.kt
@@ -84,6 +84,9 @@ class SamInitProjectBuilderIntelliJTest(private val testParameters: TestParamete
                 }
             }
 
+            // Double check that all background tasks are done
+            waitAMoment()
+
             step("check the run configuration is created") {
                 assertTrue(runConfigurationList.getRunConfigurationList().containsAll(testParameters.runConfigNames))
             }
@@ -114,13 +117,13 @@ class SamInitProjectBuilderIntelliJTest(private val testParameters: TestParamete
             TestParameters(
                 runtime = "python3.6",
                 templateName = "AWS SAM Hello World",
-                sdkRegex = Regex("Python .*"),
+                sdkRegex = Regex("Python.*"),
                 runConfigNames = setOf("[Local] HelloWorldFunction")
             ),
             TestParameters(
                 runtime = "python3.6",
                 templateName = "AWS SAM DynamoDB Event Example",
-                sdkRegex = Regex("Python .*"),
+                sdkRegex = Regex("Python.*"),
                 runConfigNames = setOf("[Local] ReadDynamoDBEvent")
             )
         )


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
* This allows tests to run with Java 11 or Java 8

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
