### PR TITLE
Fix Java UI tests on 2018.3

### DIFF
--- a/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderIntelliJTest.kt
+++ b/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/ui/wizard/SamInitProjectBuilderIntelliJTest.kt
@@ -84,9 +84,6 @@ class SamInitProjectBuilderIntelliJTest(private val testParameters: TestParamete
                 }
             }
 
-            // Double check that all background tasks are done
-            waitAMoment()
-
             step("check the run configuration is created") {
                 assertTrue(runConfigurationList.getRunConfigurationList().containsAll(testParameters.runConfigNames))
             }
@@ -104,26 +101,26 @@ class SamInitProjectBuilderIntelliJTest(private val testParameters: TestParamete
             TestParameters(
                 runtime = "java8",
                 templateName = "AWS SAM Hello World (Maven)",
-                sdkRegex = Regex(".*java.*"),
+                sdkRegex = """.*(1\.8|11).*""".toRegex(),
                 libraries = setOf("Maven: com.amazonaws:aws-lambda-java-core:"),
                 runConfigNames = setOf("[Local] HelloWorldFunction")
             ),
             TestParameters(
                 runtime = "java8",
                 templateName = "AWS SAM Hello World (Gradle)",
-                sdkRegex = Regex(".*java.*"),
+                sdkRegex = """.*(1\.8|11).*""".toRegex(),
                 runConfigNames = setOf("[Local] HelloWorldFunction")
             ),
             TestParameters(
                 runtime = "python3.6",
                 templateName = "AWS SAM Hello World",
-                sdkRegex = Regex("Python.*"),
+                sdkRegex = "Python.*".toRegex(),
                 runConfigNames = setOf("[Local] HelloWorldFunction")
             ),
             TestParameters(
                 runtime = "python3.6",
                 templateName = "AWS SAM DynamoDB Event Example",
-                sdkRegex = Regex("Python.*"),
+                sdkRegex = "Python.*".toRegex(),
                 runConfigNames = setOf("[Local] ReadDynamoDBEvent")
             )
         )


### PR DESCRIPTION
## Testing Done

Ran `ALTERNATIVE_IDE_PROFILE_NAME=2018.3 ./gradlew jetbrains-core-gui:guiTest` locally

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
