### PR TITLE
Add test artifact saving for linux-based CI jobs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,10 @@ subprojects {
 
     testlogger {
         showFullStackTraces true
+        showStandardStreams true
+        showPassedStandardStreams false
+        showSkippedStandardStreams true
+        showFailedStandardStreams true
     }
 
     test {
@@ -106,6 +110,11 @@ subprojects {
             // don't instrument sdk, icons, ktlint, etc.
             includes = ["software.aws.toolkits.*"]
             excludes = ["software.aws.toolkits.ktlint"]
+        }
+
+        reports {
+            junitXml.enabled = false
+            html.enabled = true
         }
     }
 
@@ -133,13 +142,6 @@ subprojects {
         description = "Runs the integration tests."
         testClassesDirs = sourceSets.integrationTest.output.classesDirs
         classpath = sourceSets.integrationTest.runtimeClasspath
-
-        binResultsDir = file("$buildDir/integration-test-results/binary/integrationTest")
-
-        reports {
-            html.destination file("$buildDir/reports/integration-test")
-            junitXml.destination file("$buildDir/integration-test-results")
-        }
 
         jacoco {
             excludes = ["com.sun.*"] // See https://groups.google.com/forum/#!topic/jacoco/H0gDwxNuhK4

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -30,3 +30,15 @@ phases:
       - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
       - curl -s https://codecov.io/bash > codecov.sh
       - if [ "$CODE_COV_TOKEN" ]; then bash ./codecov.sh -t $CODE_COV_TOKEN -F integtest || true; fi
+
+  post_build:
+    commands:
+      - TEST_ARTIFACTS="/tmp/testArtifacts"
+      - mkdir $TEST_ARTIFACTS
+      - rsync -rmv --include='*/' --include '**/build/idea-sandbox/system*/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmv --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+
+artifacts:
+  files:
+    - "**/*"
+  base-directory: /tmp/testArtifacts

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -23,3 +23,15 @@ phases:
       - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
       - curl -s https://codecov.io/bash > codecov.sh
       - if [ "$CODE_COV_TOKEN" ]; then bash ./codecov.sh -t $CODE_COV_TOKEN -F unittest || true; fi
+
+  post_build:
+    commands:
+      - TEST_ARTIFACTS="/tmp/testArtifacts"
+      - mkdir $TEST_ARTIFACTS
+      - rsync -rmv --include='*/' --include '**/build/idea-sandbox/system*/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmv --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+
+artifacts:
+  files:
+    - "**/*"
+  base-directory: /tmp/testArtifacts

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -53,6 +53,6 @@ phases:
       - if [ "$CODEBUILD_BUILD_SUCCEEDING" ] && [ "$CODE_COV_TOKEN" ]; then bash ./codecov.sh -t $CODE_COV_TOKEN -F uitest || true; fi
 
 artifacts:
+  base-directory: /tmp/testArtifacts
   files:
     - "**/*"
-  base-directory: /tmp/testArtifacts

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -19,6 +19,7 @@ phases:
       - apt-get update
       - apt-get install -y xvfb icewm procps ffmpeg libswt-gtk-3-java
       - pip install --user aws-sam-cli
+
   build:
     commands:
       - Xvfb :99 -screen 0 1920x1080x24 &
@@ -33,16 +34,25 @@ phases:
         ffmpeg -f x11grab -video_size 1920x1080 -i :99 -codec:v libx264 -r 12 /tmp/screen_recording.mp4 &
         fi
       - ./gradlew guiTest coverageReport --info --console plain
+
   post_build:
     commands:
+      - TEST_ARTIFACTS="/tmp/testArtifacts"
+      - mkdir $TEST_ARTIFACTS
+      - rsync -r guitest.log $TEST_ARTIFACTS/gui/ || true
+      - rsync -rmv --include='*/' --include '**/build/idea-sandbox/system*/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmv --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+
       - if [ "$RECORD_UI" ]; then pkill -2 ffmpeg; while pgrep ffmpeg > /dev/null; do sleep 1; done; fi
-      - if [ "$RECORD_UI" ]; then cp /tmp/screen_recording.mp4 jetbrains-core-gui/build/idea-sandbox/system/log/screen_recording.mp4; fi
+      - if [ "$RECORD_UI" ]; then cp /tmp/screen_recording.mp4 $TEST_ARTIFACTS/gui/; fi
+
       - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
       - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
       - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
       - curl -s https://codecov.io/bash > codecov.sh
       - if [ "$CODEBUILD_BUILD_SUCCEEDING" ] && [ "$CODE_COV_TOKEN" ]; then bash ./codecov.sh -t $CODE_COV_TOKEN -F uitest || true; fi
+
 artifacts:
   files:
-    - guitest.log
-    - jetbrains-core-gui/build/idea-sandbox/system/log/**/*
+    - "**/*"
+  base-directory: /tmp/testArtifacts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In our CodeBuild jobs, we now save CI artifacts to an S3 bucket. This changes the buildspecs to save our reports to a folder which will become a Zip in S3.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
