### PR TITLE
Rename the local and remote lambda class names to be more con…

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -180,7 +180,7 @@
         <runLineMarkerContributor language="yaml" implementationClass="software.aws.toolkits.jetbrains.services.lambda.execution.template.YamlLambdaRunLineMarkerContributor"/>
         <configurationType implementation="software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfiguration"/>
         <runConfigurationProducer implementation="software.aws.toolkits.jetbrains.services.lambda.execution.local.LocalLambdaRunConfigurationProducer"/>
-        <runConfigurationProducer implementation="software.aws.toolkits.jetbrains.services.lambda.execution.remote.LambdaRemoteRunConfigurationProducer"/>
+        <runConfigurationProducer implementation="software.aws.toolkits.jetbrains.services.lambda.execution.remote.RemoteLambdaRunConfigurationProducer"/>
 
         <!-- Project Wizard components -->
         <moduleType id="AWS" implementationClass="software.aws.toolkits.jetbrains.ui.wizard.AwsModuleType" />

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfiguration.kt
@@ -8,7 +8,7 @@ import com.intellij.execution.configurations.ConfigurationTypeUtil
 import icons.AwsIcons
 import software.aws.toolkits.jetbrains.core.help.HelpIds
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.LocalLambdaRunConfigurationFactory
-import software.aws.toolkits.jetbrains.services.lambda.execution.remote.LambdaRemoteRunConfigurationFactory
+import software.aws.toolkits.jetbrains.services.lambda.execution.remote.RemoteLambdaRunConfigurationFactory
 import software.aws.toolkits.resources.message
 
 class LambdaRunConfiguration :
@@ -20,7 +20,7 @@ class LambdaRunConfiguration :
     ) {
     init {
         addFactory(LocalLambdaRunConfigurationFactory(this))
-        addFactory(LambdaRemoteRunConfigurationFactory(this))
+        addFactory(RemoteLambdaRunConfigurationFactory(this))
     }
 
     override fun getHelpTopic(): String? = HelpIds.RUN_DEBUG_CONFIGURATIONS_DIALOG.id

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
@@ -105,7 +105,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
             val psiElement = handlerPsiElement(handler, runtime)
                 ?: throw RuntimeConfigurationError(message("lambda.run_configuration.handler_not_found", handler))
 
-            val samRunSettings = LocalLambdaSettings(
+            val samRunSettings = LocalLambdaRunSettings(
                 runtime,
                 handler,
                 resolveInput(),
@@ -269,7 +269,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
     }
 }
 
-class LocalLambdaSettings(
+data class LocalLambdaRunSettings(
     val runtime: Runtime,
     val handler: String,
     val input: String,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamRunningState.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamRunningState.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 
 class SamRunningState(
     environment: ExecutionEnvironment,
-    val settings: LocalLambdaSettings
+    val settings: LocalLambdaRunSettings
 ) : CommandLineState(environment) {
     internal lateinit var builtLambda: BuiltLambda
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfiguration.kt
@@ -1,0 +1,67 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution.remote
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.RuntimeConfigurationError
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.project.Project
+import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
+import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfiguration
+import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfigurationBase
+import software.aws.toolkits.resources.message
+
+class RemoteLambdaRunConfigurationFactory(configuration: LambdaRunConfiguration) : ConfigurationFactory(configuration) {
+    override fun createTemplateConfiguration(project: Project) = RemoteLambdaRunConfiguration(project, this)
+
+    override fun getName(): String = "Remote"
+}
+
+class RemoteLambdaRunConfiguration(project: Project, factory: ConfigurationFactory) :
+    LambdaRunConfigurationBase<RemoteLambdaOptions>(project, factory, "Remote") {
+
+    override val lambdaOptions = RemoteLambdaOptions()
+
+    override fun getConfigurationEditor() = RemoteLambdaRunSettingsEditor(project)
+
+    override fun checkConfiguration() {
+        functionName() ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_function_specified"))
+
+        resolveCredentials()
+        regionId() ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_region_specified"))
+        checkInput()
+    }
+
+    override fun getState(executor: Executor, environment: ExecutionEnvironment): RemoteLambdaState {
+        try {
+            val functionName = functionName()
+                ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_function_specified"))
+
+            return RemoteLambdaState(
+                environment,
+                RemoteLambdaRunSettings(resolveCredentials(), resolveRegion(), functionName, resolveInput())
+            )
+        } catch (e: Exception) {
+            throw ExecutionException(e.message, e)
+        }
+    }
+
+    override fun suggestedName() = "[${message("lambda.run_configuration.remote")}] ${functionName()}"
+
+    fun functionName(): String? = lambdaOptions.functionOptions.functionName
+
+    fun functionName(name: String?) {
+        lambdaOptions.functionOptions.functionName = name
+    }
+}
+
+data class RemoteLambdaRunSettings(
+    val credentialProvider: ToolkitCredentialsProvider,
+    val region: AwsRegion,
+    val functionName: String,
+    val input: String
+)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationProducer.kt
@@ -13,13 +13,13 @@ import com.intellij.psi.PsiElement
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfiguration
 
 @Suppress("DEPRECATION") // LazyRunConfigurationProducer not added till 2019.1 FIX_WHEN_MIN_IS_192
-class LambdaRemoteRunConfigurationProducer : RunConfigurationProducer<LambdaRemoteRunConfiguration>(getFactory()) {
+class RemoteLambdaRunConfigurationProducer : RunConfigurationProducer<RemoteLambdaRunConfiguration>(getFactory()) {
     // Filter all Lambda run configurations down to only ones that are Lambda remote for this run producer
     override fun getConfigurationSettingsList(runManager: RunManager): List<RunnerAndConfigurationSettings> =
-        super.getConfigurationSettingsList(runManager).filter { it.configuration is LambdaRemoteRunConfiguration }
+        super.getConfigurationSettingsList(runManager).filter { it.configuration is RemoteLambdaRunConfiguration }
 
     override fun setupConfigurationFromContext(
-        configuration: LambdaRemoteRunConfiguration,
+        configuration: RemoteLambdaRunConfiguration,
         context: ConfigurationContext,
         sourceElement: Ref<PsiElement>
     ): Boolean {
@@ -35,7 +35,7 @@ class LambdaRemoteRunConfigurationProducer : RunConfigurationProducer<LambdaRemo
     }
 
     override fun isConfigurationFromContext(
-        configuration: LambdaRemoteRunConfiguration,
+        configuration: RemoteLambdaRunConfiguration,
         context: ConfigurationContext
     ): Boolean {
         val location = context.location as? RemoteLambdaLocation ?: return false
@@ -48,6 +48,6 @@ class LambdaRemoteRunConfigurationProducer : RunConfigurationProducer<LambdaRemo
     companion object {
         private fun getFactory(): ConfigurationFactory = LambdaRunConfiguration.getInstance()
             .configurationFactories
-            .first { it is LambdaRemoteRunConfigurationFactory }
+            .first { it is RemoteLambdaRunConfigurationFactory }
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunner.kt
@@ -13,5 +13,5 @@ class RemoteLambdaRunner : DefaultProgramRunner() {
     override fun canRun(
         executorId: String,
         profile: RunProfile
-    ): Boolean = DefaultRunExecutor.EXECUTOR_ID == executorId && profile is LambdaRemoteRunConfiguration
+    ): Boolean = DefaultRunExecutor.EXECUTOR_ID == executorId && profile is RemoteLambdaRunConfiguration
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaState.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaState.kt
@@ -31,7 +31,7 @@ import java.util.Base64
 
 class RemoteLambdaState(
     private val environment: ExecutionEnvironment,
-    val settings: LambdaRemoteRunSettings
+    val settings: RemoteLambdaRunSettings
 ) : RunProfileState {
     private val consoleBuilder: TextConsoleBuilder
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/CreateRunConfiguration.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/CreateRunConfiguration.kt
@@ -16,13 +16,13 @@ fun createRunConfiguration(
     regionId: AwsRegion? = MockRegionProvider.US_EAST_1,
     credentialId: String? = "MockCredentials",
     functionName: String? = "DummyFunction"
-): LambdaRemoteRunConfiguration {
+): RemoteLambdaRunConfiguration {
     val runManager = RunManager.getInstance(project)
     val factory = LambdaRunConfiguration.getInstance()
         .configurationFactories
-        .first { it is LambdaRemoteRunConfigurationFactory }
+        .first { it is RemoteLambdaRunConfigurationFactory }
     val runConfigurationAndSettings = runManager.createConfiguration("Test", factory)
-    val runConfiguration = runConfigurationAndSettings.configuration as LambdaRemoteRunConfiguration
+    val runConfiguration = runConfigurationAndSettings.configuration as RemoteLambdaRunConfiguration
     runManager.addConfiguration(runConfigurationAndSettings)
 
     runConfiguration.credentialProviderId(credentialId)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationProducerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationProducerTest.kt
@@ -19,7 +19,7 @@ import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.services.iam.IamRole
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunction
 
-class LambdaRemoteRunConfigurationProducerTest {
+class RemoteLambdaRunConfigurationProducerTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
@@ -49,7 +49,7 @@ class LambdaRemoteRunConfigurationProducerTest {
         runInEdtAndWait {
             val runConfiguration = createRunConfiguration(lambdaLocation)
             assertThat(runConfiguration).isNotNull
-            val configuration = runConfiguration?.configuration as LambdaRemoteRunConfiguration
+            val configuration = runConfiguration?.configuration as RemoteLambdaRunConfiguration
             assertThat(configuration.functionName()).isEqualTo(functionName)
             assertThat(configuration.credentialProviderId()).isEqualTo(credentialProviderId)
             assertThat(configuration.regionId()).isEqualTo(region.id)
@@ -60,7 +60,7 @@ class LambdaRemoteRunConfigurationProducerTest {
     private fun createRunConfiguration(function: LambdaFunction): ConfigurationFromContext? {
         val dataContext = MapDataContext()
         val context = createContext(function, dataContext)
-        val producer = RunConfigurationProducer.getInstance(LambdaRemoteRunConfigurationProducer::class.java)
+        val producer = RunConfigurationProducer.getInstance(RemoteLambdaRunConfigurationProducer::class.java)
         return producer.createConfigurationFromContext(context)
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationTest.kt
@@ -211,7 +211,7 @@ class RemoteLambdaRunConfigurationTest {
                 input = "{}"
             )
 
-            val clonedConfiguration = runConfiguration.clone() as LambdaRemoteRunConfiguration
+            val clonedConfiguration = runConfiguration.clone() as RemoteLambdaRunConfiguration
             clonedConfiguration.name = "Cloned"
 
             clonedConfiguration.useInputText("Changed input")
@@ -220,7 +220,7 @@ class RemoteLambdaRunConfigurationTest {
         }
     }
 
-    private fun getState(runConfiguration: LambdaRemoteRunConfiguration): RemoteLambdaState {
+    private fun getState(runConfiguration: RemoteLambdaRunConfiguration): RemoteLambdaState {
         val executor = ExecutorRegistry.getInstance().getExecutorById(DefaultRunExecutor.EXECUTOR_ID)
         val environmentMock = mock<ExecutionEnvironment> {
             on { project } doReturn projectRule.project


### PR DESCRIPTION
…sistent.

## Description
* Classes **LambdaRemoteRun*** -> **RemoteLambdaRun***
* Class **LocalLambdaSettings** -> **LocalLambdaRunSettings**
* Change `*LambdaRunSettings` classes to `data class`

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
