### PR TITLE
Adding the ability to have 'view' of cached resources

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/resources/LambdaResources.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/resources/LambdaResources.kt
@@ -4,14 +4,8 @@
 package software.aws.toolkits.jetbrains.services.lambda.resources
 
 import software.amazon.awssdk.services.lambda.LambdaClient
-import software.amazon.awssdk.services.lambda.model.FunctionConfiguration
-import software.aws.toolkits.jetbrains.core.CachedResourceBase
-import software.aws.toolkits.jetbrains.core.CachedResource
+import software.aws.toolkits.jetbrains.core.ClientBackedCachedResource
 
 object LambdaResources {
-    val LIST_FUNCTIONS: CachedResource<List<FunctionConfiguration>> = LambdaCachedResource { listFunctionsPaginator().functions().toList() }
-
-    private class LambdaCachedResource<T>(private val call: LambdaClient.() -> T) : CachedResourceBase<T, LambdaClient>(LambdaClient::class) {
-        override fun fetch(client: LambdaClient): T = call(client)
-    }
+    val LIST_FUNCTIONS = ClientBackedCachedResource(LambdaClient::class) { listFunctionsPaginator().functions().toList() }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
@@ -20,7 +20,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPointerManager
 import icons.AwsIcons
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
+import software.aws.toolkits.jetbrains.core.getResource
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplateIndex.Companion.listFunctions
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
@@ -98,7 +98,7 @@ class LambdaLineMarker : LineMarkerProviderDescriptor() {
     // Handler defined in remote Lambda with the same runtime group is valid
     private fun handlerInRemote(psiFile: PsiFile, handler: String, runtimeGroup: RuntimeGroup): Boolean =
         try {
-            val result = AwsResourceCache.getInstance(psiFile.project).getResource(LambdaResources.LIST_FUNCTIONS).toCompletableFuture()
+            val result = psiFile.project.getResource(LambdaResources.LIST_FUNCTIONS).toCompletableFuture()
             if (result.isDone) {
                 result.getNow(null)?.any {
                     it.handler() == handler && it.runtime().runtimeGroup == runtimeGroup

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
@@ -13,21 +13,21 @@ import java.util.concurrent.CompletionStage
 @Suppress("UNCHECKED_CAST")
 class MockResourceCache : AwsResourceCache {
 
-    override fun <T> getResource(resource: CachedResource<T>, useStale: Boolean, forceFetch: Boolean) = resourceFuture as CompletionStage<T>
+    override fun <T> getResource(resource: Resource<T>, useStale: Boolean, forceFetch: Boolean) = resourceFuture as CompletionStage<T>
 
     override fun <T> getResource(
-        resource: CachedResource<T>,
+        resource: Resource<T>,
         region: AwsRegion,
         credentialProvider: ToolkitCredentialsProvider,
         useStale: Boolean,
         forceFetch: Boolean
     ): CompletionStage<T> = resourceFuture as CompletionStage<T>
 
-    override fun clear(resource: CachedResource<*>) {
+    override fun clear(resource: Resource<*>) {
         TODO("not implemented")
     }
 
-    override fun clear(resource: CachedResource<*>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider) {
+    override fun clear(resource: Resource<*>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider) {
         TODO("not implemented")
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Builds on #1102 adds the ability to define views on top of `CachedResources` that mean the underlying raw data is only cached once. Views are applied in memory at the point of cache retrieval.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new tests for the view logic.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
