### PR TITLE
Downgrade to 2.6.x branch of SDK

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ publishChannel=
 # Common dependencies
 ideProfileName=2019.1
 kotlinVersion=1.3.21
-awsSdkVersion=2.7.6
+awsSdkVersion=2.6.5
 ideaPluginVersion=0.4.9
 ktlintVersion=0.32.0
 junitVersion=4.12


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* 2.7.x introduces a new Apache version. This version of Apache breaks URLs that have no path, but have query parameters.

## Motivation and Context
192 breaks with 2.7.x, (most likely due to classloader changes in the plugin system so our Apache version is used and not theirs).

Traced the logic through the SDK down into Apache. It seems it no longer handles URLs that are "foo.com?blah" the same as it did before. SDK team is aware and working on fixes.

## Related Issue(s)
SDK reported issue shows same behavior: https://github.com/aws/aws-sdk-java-v2/issues/1363

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
