### PR TITLE
Fork JetBrains' AsyncTreeModel to remove the read action requirement

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -65,7 +65,7 @@
     ]]></description>
 
     <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://aws.amazon.com/">Amazon Web Services</vendor>
-    <idea-version since-build="183.2153.8" until-build="192.*"/>
+    <idea-version since-build="183.4284.*" until-build="192.*"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/AsyncTreeModel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/AsyncTreeModel.java
@@ -1,0 +1,984 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package software.aws.toolkits.jetbrains.ui.tree;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.LoadingNode;
+import com.intellij.ui.tree.AbstractTreeWalker;
+import com.intellij.ui.tree.ChildrenProvider;
+import com.intellij.ui.tree.Identifiable;
+import com.intellij.ui.tree.LeafState;
+import com.intellij.ui.tree.Navigatable;
+import com.intellij.ui.tree.Searchable;
+import com.intellij.ui.tree.TreePathUtil;
+import com.intellij.ui.tree.TreeVisitor;
+import com.intellij.util.Consumer;
+import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.containers.SmartHashSet;
+import com.intellij.util.ui.tree.AbstractTreeModel;
+import com.intellij.util.ui.tree.TreeModelAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.concurrency.AsyncPromise;
+import org.jetbrains.concurrency.Obsolescent;
+import org.jetbrains.concurrency.Promise;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreePath;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.jetbrains.concurrency.Promises.rejectedPromise;
+
+/**
+ * Fork of JetBrain's intellij-community AsyncTreeModel allowing us to use a custom Invoker.
+ * The only changes to this from original version are removal of deprecated constructors, and changing of imports
+ */
+public final class AsyncTreeModel extends AbstractTreeModel implements Identifiable, Searchable, Navigatable, TreeVisitor.Acceptor {
+  private static final Logger LOG = Logger.getInstance(AsyncTreeModel.class);
+  private final Command.Processor processor;
+  private final Tree tree = new Tree();
+  private final TreeModel model;
+  private final boolean showLoadingNode;
+  private final TreeModelListener listener = new TreeModelAdapter() {
+    @Override
+    protected void process(@NotNull TreeModelEvent event, @NotNull EventType type) {
+      TreePath path = event.getTreePath();
+      if (path == null) {
+        // request a new root from model according to the specification
+        processor.process(new CmdGetRoot("Reload root", null));
+        return;
+      }
+      Object object = path.getLastPathComponent();
+      if (object == null) {
+        LOG.warn("unsupported path: " + path);
+        return;
+      }
+      if (path.getParentPath() == null && type == EventType.StructureChanged) {
+        // set a new root object according to the specification
+        processor.process(new CmdGetRoot("Update root", object));
+        return;
+      }
+      onValidThread(() -> {
+        Node node = tree.map.get(object);
+        if (node == null) {
+          LOG.debug("ignore updating of nonexistent node: ", object);
+        }
+        else if (type == EventType.NodesChanged) {
+          // the object is already updated, so we should not start additional command to update
+          AsyncTreeModel.this.treeNodesChanged(event.getTreePath(), event.getChildIndices(), event.getChildren());
+        }
+        else if (node.isLoadingRequired()) {
+          // update the object presentation only, if its children are not requested yet
+          AsyncTreeModel.this.treeNodesChanged(event.getTreePath(), null, null);
+        }
+        else if (type == EventType.NodesInserted) {
+          processor.process(new CmdGetChildren("Insert children", node, false));
+        }
+        else if (type == EventType.NodesRemoved) {
+          processor.process(new CmdGetChildren("Remove children", node, false));
+        }
+        else {
+          processor.process(new CmdGetChildren("Update children", node, true));
+        }
+      });
+    }
+  };
+
+  public AsyncTreeModel(@NotNull TreeModel model, boolean showLoadingNode, @NotNull Disposable parent) {
+    if (model instanceof Disposable) {
+      Disposer.register(this, (Disposable)model);
+    }
+    Invoker foreground = new Invoker.EDT(this);
+    Invoker background = foreground;
+    if (model instanceof InvokerSupplier) {
+      InvokerSupplier supplier = (InvokerSupplier)model;
+      background = supplier.getInvoker();
+    }
+    this.processor = new Command.Processor(foreground, background);
+    this.model = model;
+    this.model.addTreeModelListener(listener);
+    this.showLoadingNode = showLoadingNode;
+    Disposer.register(parent, this);
+  }
+
+  @Override
+  public void dispose() {
+    super.dispose();
+    model.removeTreeModelListener(listener);
+  }
+
+  @Override
+  public Object getUniqueID(@NotNull TreePath path) {
+    return model instanceof Identifiable ? ((Identifiable)model).getUniqueID(path) : null;
+  }
+
+  @NotNull
+  @Override
+  public Promise<TreePath> getTreePath(Object object) {
+    if (disposed) return rejectedPromise();
+    return resolve(model instanceof Searchable ? ((Searchable)model).getTreePath(object) : null);
+  }
+
+  @NotNull
+  @Override
+  public Promise<TreePath> nextTreePath(@NotNull TreePath path, Object object) {
+    if (disposed) return rejectedPromise();
+    return resolve(model instanceof Navigatable ? ((Navigatable)model).nextTreePath(path, object) : null);
+  }
+
+  @NotNull
+  @Override
+  public Promise<TreePath> prevTreePath(@NotNull TreePath path, Object object) {
+    if (disposed) return rejectedPromise();
+    return resolve(model instanceof Navigatable ? ((Navigatable)model).prevTreePath(path, object) : null);
+  }
+
+  @NotNull
+  public Promise<TreePath> resolve(TreePath path) {
+    AsyncPromise<TreePath> async = new AsyncPromise<>();
+    onValidThread(() -> resolve(async, path));
+    return async;
+  }
+
+  @NotNull
+  private Promise<TreePath> resolve(Promise<? extends TreePath> promise) {
+    if (promise == null && isValidThread()) {
+      return rejectedPromise();
+    }
+    AsyncPromise<TreePath> async = new AsyncPromise<>();
+    if (promise == null) {
+      onValidThread(() -> async.setError("rejected"));
+    }
+    else {
+      promise.onError(onValidThread(async::setError));
+      promise.onSuccess(onValidThread(path -> resolve(async, path)));
+    }
+    return async;
+  }
+
+  private void resolve(@NotNull AsyncPromise<? super TreePath> async, TreePath path) {
+    LOG.debug("resolve path: ", path);
+    if (path == null) {
+      async.setError("path is null");
+      return;
+    }
+    Object object = path.getLastPathComponent();
+    if (object == null) {
+      async.setError("path is wrong");
+      return;
+    }
+    accept(new TreeVisitor.ByTreePath<>(path, o -> o))
+            .onProcessed(result -> {
+              if (result == null) {
+                async.setError("path not found");
+                return;
+              }
+              async.setResult(result);
+            });
+  }
+
+  @Override
+  public Object getRoot() {
+    if (disposed) return null;
+    onValidThread(this::promiseRootEntry);
+    Node node = tree.root;
+    return node == null ? null : node.object;
+  }
+
+  @Override
+  public Object getChild(Object object, int index) {
+    List<Node> children = getEntryChildren(object);
+    return 0 <= index && index < children.size() ? children.get(index).object : null;
+  }
+
+  @Override
+  public int getChildCount(Object object) {
+    return getEntryChildren(object).size();
+  }
+
+  @Override
+  public boolean isLeaf(Object object) {
+    Node node = getEntry(object);
+    if (node == null) return true;
+    if (node.leafState == LeafState.ALWAYS) return true;
+    if (node.leafState == LeafState.NEVER) return false;
+    List<Node> children = node.children;
+    // leaf only if no children were loaded
+    return children != null && children.isEmpty();
+  }
+
+  @Override
+  public void valueForPathChanged(@NotNull TreePath path, Object value) {
+    processor.background.runOrInvokeLater(() -> model.valueForPathChanged(path, value));
+  }
+
+  @Override
+  public int getIndexOfChild(Object object, Object child) {
+    if (child != null) {
+      List<Node> children = getEntryChildren(object);
+      for (int i = 0; i < children.size(); i++) {
+        if (child.equals(children.get(i).object)) return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Starts visiting the tree structure with loading all needed children.
+   *
+   * @param visitor an object that controls visiting a tree structure
+   * @return a promise that will be resolved when visiting is finished
+   */
+  @Override
+  @NotNull
+  public Promise<TreePath> accept(@NotNull TreeVisitor visitor) {
+    return accept(visitor, true);
+  }
+
+  /**
+   * Starts visiting the tree structure.
+   *
+   * @param visitor      an object that controls visiting a tree structure
+   * @param allowLoading load all needed children if {@code true}
+   * @return a promise that will be resolved when visiting is finished
+   */
+  @NotNull
+  public Promise<TreePath> accept(@NotNull TreeVisitor visitor, boolean allowLoading) {
+    AbstractTreeWalker<Node> walker = new AbstractTreeWalker<Node>(visitor, node -> node.object) {
+      @Override
+      protected Collection<Node> getChildren(@NotNull Node node) {
+        if (node.leafState == LeafState.ALWAYS || !allowLoading) return node.getChildren();
+        promiseChildren(node)
+                .onSuccess(parent -> setChildren(parent.getChildren()))
+                .onError(this::setError);
+        return null;
+      }
+    };
+    if (allowLoading) {
+      // start visiting on the background thread to ensure that root node is already invalidated
+      processor.background.invokeLater(() -> onValidThread(() -> promiseRootEntry().onSuccess(walker::start).onError(walker::setError)));
+    }
+    else {
+      onValidThread(() -> walker.start(tree.root));
+    }
+    return walker.promise();
+  }
+
+  /**
+   * @return {@code true} if this model is updating its structure
+   */
+  public boolean isProcessing() {
+    if (processor.getTaskCount() > 0) return true;
+    ObsolescentCommand command = tree.queue.get();
+    return command != null && command.isPending();
+  }
+
+  private boolean isValidThread() {
+    if (processor.foreground.isValidThread()) return true;
+    LOG.warn(new IllegalStateException("AsyncTreeModel is used from unexpected thread"));
+    return false;
+  }
+
+  public void onValidThread(@NotNull Runnable runnable) {
+    processor.foreground.runOrInvokeLater(runnable);
+  }
+
+  @NotNull
+  private <T> java.util.function.Consumer<T> onValidThread(@NotNull Consumer<? super T> consumer) {
+    return value -> onValidThread(() -> consumer.consume(value));
+  }
+
+  @NotNull
+  private Promise<Node> promiseRootEntry() {
+    if (disposed) return rejectedPromise();
+    return tree.queue.promise(processor, () -> new CmdGetRoot("Load root", null));
+  }
+
+  @NotNull
+  private Promise<Node> promiseChildren(@NotNull Node node) {
+    if (disposed) return rejectedPromise();
+    return node.queue.promise(processor, () -> {
+      node.setLoading(!showLoadingNode ? null : new Node(new LoadingNode(), LeafState.ALWAYS));
+      return new CmdGetChildren("Load children", node, false);
+    });
+  }
+
+  private Node getEntry(Object object) {
+    return disposed || object == null || !isValidThread() ? null : tree.map.get(object);
+  }
+
+  @NotNull
+  private List<Node> getEntryChildren(Object object) {
+    Node node = getEntry(object);
+    if (node == null) return emptyList();
+    if (node.isLoadingRequired()) promiseChildren(node);
+    return node.getChildren();
+  }
+
+  @NotNull
+  private TreeModelEvent createEvent(@NotNull TreePath path, Map<Object, Integer> map) {
+    if (map == null || map.isEmpty()) return new TreeModelEvent(this, path, null, null);
+    int i = 0;
+    int size = map.size();
+    int[] indices = new int[size];
+    Object[] children = new Object[size];
+    for (Entry<Object, Integer> entry : map.entrySet()) {
+      indices[i] = entry.getValue();
+      children[i] = entry.getKey();
+      i++;
+    }
+    return new TreeModelEvent(this, path, indices, children);
+  }
+
+  private void treeNodesChanged(@NotNull Node node, Map<Object, Integer> map) {
+    if (!listeners.isEmpty()) {
+      for (TreePath path : node.paths) {
+        listeners.treeNodesChanged(createEvent(path, map));
+      }
+    }
+  }
+
+  private void treeNodesInserted(@NotNull Node node, Map<Object, Integer> map) {
+    if (!listeners.isEmpty()) {
+      for (TreePath path : node.paths) {
+        listeners.treeNodesInserted(createEvent(path, map));
+      }
+    }
+  }
+
+  private void treeNodesRemoved(@NotNull Node node, Map<Object, Integer> map) {
+    if (!listeners.isEmpty()) {
+      for (TreePath path : node.paths) {
+        listeners.treeNodesRemoved(createEvent(path, map));
+      }
+    }
+  }
+
+  @NotNull
+  private static LinkedHashMap<Object, Integer> getIndices(@NotNull List<Node> children, @Nullable ToIntFunction<? super Node> function) {
+    LinkedHashMap<Object, Integer> map = new LinkedHashMap<>();
+    for (int i = 0; i < children.size(); i++) {
+      Node child = children.get(i);
+      if (map.containsKey(child.object)) {
+        LOG.warn("ignore duplicated " + (function == null ? "old" : "new") + " child at " + i);
+      }
+      else {
+        map.put(child.object, function == null ? i : function.applyAsInt(child));
+      }
+    }
+    return map;
+  }
+
+  private static int getIntersectionCount(@NotNull Map<Object, Integer> indices, @NotNull Iterable<Object> objects) {
+    int count = 0;
+    int last = -1;
+    for (Object object : objects) {
+      Integer index = indices.get(object);
+      if (index != null && last < index.intValue()) {
+        last = index;
+        count++;
+      }
+    }
+    return count;
+  }
+
+  @NotNull
+  private static List<Object> getIntersection(@NotNull Map<Object, Integer> indices, @NotNull Iterable<Object> objects) {
+    List<Object> list = new ArrayList<>(indices.size());
+    int last = -1;
+    for (Object object : objects) {
+      Integer index = indices.get(object);
+      if (index != null && last < index.intValue()) {
+        last = index;
+        list.add(object);
+      }
+    }
+    return list;
+  }
+
+  @NotNull
+  private static List<Object> getIntersection(@NotNull Map<Object, Integer> removed, @NotNull Map<Object, Integer> inserted) {
+    if (removed.isEmpty() || inserted.isEmpty()) return emptyList();
+    int countOne = getIntersectionCount(removed, inserted.keySet());
+    int countTwo = getIntersectionCount(inserted, removed.keySet());
+    if (countOne > countTwo) return getIntersection(removed, inserted.keySet());
+    if (countTwo > 0) return getIntersection(inserted, removed.keySet());
+    return emptyList();
+  }
+
+  @NotNull
+  private LeafState getLeafState(Object object) {
+    LOG.assertTrue(processor.background.isValidThread());
+    if (object instanceof LeafState.Supplier) {
+      LeafState.Supplier supplier = (LeafState.Supplier)object;
+      LeafState leafState = supplier.getLeafState();
+      if (LeafState.DEFAULT != leafState) return leafState;
+    }
+    return model.isLeaf(object) ? LeafState.ALWAYS : LeafState.NEVER;
+  }
+
+  private abstract static class ObsolescentCommand implements Obsolescent, Command<Node> {
+    final AsyncPromise<Node> promise = new AsyncPromise<>();
+    final String name;
+    final Object object;
+    volatile boolean started;
+
+    ObsolescentCommand(@NotNull String name, Object object) {
+      this.name = name;
+      this.object = object;
+      LOG.debug("create command: ", this);
+    }
+
+    abstract Node getNode(Object object);
+
+    abstract void setNode(Node node);
+
+    boolean isPending() {
+      return Promise.State.PENDING == promise.getState();
+    }
+
+    @Override
+    public String toString() {
+      return object == null ? name : name + ": " + object;
+    }
+
+    @Override
+    public Node get() {
+      started = true;
+      if (isObsolete()) {
+        LOG.debug("obsolete command: ", this);
+        return null;
+      }
+      else {
+        LOG.debug("background command: ", this);
+        return getNode(object);
+      }
+    }
+
+    @Override
+    public void accept(Node node) {
+      if (isObsolete()) {
+        LOG.debug("obsolete command: ", this);
+      }
+      else {
+        LOG.debug("foreground command: ", this);
+        setNode(node);
+      }
+    }
+  }
+
+  private final class CmdGetRoot extends ObsolescentCommand {
+    private CmdGetRoot(@NotNull String name, Object object) {
+      super(name, object);
+      tree.queue.add(this, old -> old.started || old.object != object);
+    }
+
+    @Override
+    public boolean isObsolete() {
+      return disposed || this != tree.queue.get();
+    }
+
+    @Override
+    Node getNode(Object object) {
+      if (object == null) object = model.getRoot();
+      if (object == null || isObsolete()) return null;
+      return new Node(object, getLeafState(object));
+    }
+
+    @Override
+    void setNode(Node loaded) {
+      Node root = tree.root;
+      if (root == null && loaded == null) {
+        LOG.debug("no root");
+        tree.queue.done(this, null);
+        return;
+      }
+
+      if (root != null && loaded != null && root.object.equals(loaded.object)) {
+        tree.fixEqualButNotSame(root, loaded.object);
+        LOG.debug("same root: ", root.object);
+        if (!root.isLoadingRequired()) processor.process(new CmdGetChildren("Update root children", root, true));
+        tree.queue.done(this, root);
+        return;
+      }
+
+      if (root != null) {
+        root.removeMapping(null, tree);
+      }
+      if (!tree.map.isEmpty()) {
+        tree.map.values().forEach(node -> {
+          node.queue.close();
+          LOG.warn("remove staled node: " + node.object);
+        });
+        tree.map.clear();
+      }
+
+      tree.root = loaded;
+      if (loaded != null) {
+        tree.map.put(loaded.object, loaded);
+        TreePath path = new TreePath(loaded.object);
+        loaded.insertPath(path);
+        treeStructureChanged(path, null, null);
+        LOG.debug("new root: ", loaded.object);
+        tree.queue.done(this, loaded);
+      }
+      else {
+        treeStructureChanged(null, null, null);
+        LOG.debug("root removed");
+        tree.queue.done(this, null);
+      }
+    }
+  }
+
+  private final class CmdGetChildren extends ObsolescentCommand {
+    private final Node node;
+    private volatile boolean deep;
+
+    CmdGetChildren(@NotNull String name, @NotNull Node node, boolean deep) {
+      super(name, node.object);
+      this.node = node;
+      if (deep) this.deep = true;
+      node.queue.add(this, old -> {
+        if (!deep && old.deep && old.isPending()) this.deep = true;
+        return true;
+      });
+    }
+
+    @Override
+    public boolean isObsolete() {
+      return disposed || this != node.queue.get();
+    }
+
+    @Override
+    Node getNode(Object object) {
+      Node loaded = new Node(object, getLeafState(object));
+      if (loaded.leafState == LeafState.ALWAYS || isObsolete()) return loaded;
+
+      if (model instanceof ChildrenProvider) {
+        //noinspection unchecked
+        ChildrenProvider<Object> provider = (ChildrenProvider)model;
+        List<?> children = provider.getChildren(object);
+        if (children == null) throw new ProcessCanceledException(); // cancel this command
+        loaded.children = load(children.size(), index -> children.get(index));
+      }
+      else {
+        loaded.children = load(model.getChildCount(object), index -> model.getChild(object, index));
+      }
+      return loaded;
+    }
+
+    @Nullable
+    private List<Node> load(int count, @NotNull IntFunction function) {
+      if (count < 0) LOG.warn("illegal child count: " + count);
+      if (count <= 0) return emptyList();
+
+      SmartHashSet<Object> set = new SmartHashSet<>(count);
+      List<Node> children = new ArrayList<>(count);
+      for (int i = 0; i < count; i++) {
+        if (isObsolete()) return null;
+        Object child = function.apply(i);
+        if (child == null) {
+          LOG.warn("ignore null child at " + i);
+        }
+        else if (!set.add(child)) {
+          LOG.warn("ignore duplicated child at " + i + ": " + child);
+        }
+        else {
+          if (isObsolete()) return null;
+          children.add(new Node(child, getLeafState(child)));
+        }
+      }
+      return children;
+    }
+
+    @Override
+    void setNode(Node loaded) {
+      if (loaded == null || loaded.isLoadingRequired()) {
+        LOG.debug("cancelled command: ", this);
+        return;
+      }
+      if (node != tree.map.get(loaded.object)) {
+        node.queue.close();
+        LOG.warn("ignore removed node: " + node.object);
+        return;
+      }
+      List<Node> oldChildren = node.getChildren();
+      List<Node> newChildren = loaded.getChildren();
+      if (oldChildren.isEmpty() && newChildren.isEmpty()) {
+        node.setLeafState(loaded.leafState);
+        treeNodesChanged(node, null);
+        LOG.debug("no children: ", node.object);
+        node.queue.done(this, node);
+        return;
+      }
+
+      LinkedHashMap<Object, Integer> removed = getIndices(oldChildren, null);
+      if (newChildren.isEmpty()) {
+        oldChildren.forEach(child -> child.removeMapping(node, tree));
+        node.setLeafState(loaded.leafState);
+        treeNodesRemoved(node, removed);
+        LOG.debug("children removed: ", node.object);
+        node.queue.done(this, node);
+        return;
+      }
+
+      // remove duplicated nodes during indices calculation
+      ArrayList<Node> list = new ArrayList<>(newChildren.size());
+      SmartHashSet<Object> reload = new SmartHashSet<>();
+      LinkedHashMap<Object, Integer> inserted = getIndices(newChildren, child -> {
+        Node found = tree.map.get(child.object);
+        if (found == null) {
+          tree.map.put(child.object, child);
+          list.add(child);
+        }
+        else {
+          tree.fixEqualButNotSame(found, child.object);
+          list.add(found);
+          if (found.leafState == LeafState.ALWAYS) {
+            if (child.leafState != LeafState.ALWAYS) {
+              found.setLeafState(child.leafState); // mark existing leaf node as not a leaf
+              reload.add(found.object); // and request to load its children
+            }
+          }
+          else if (child.leafState == LeafState.ALWAYS || !found.isLoadingRequired() && (deep || !removed.containsKey(found.object))) {
+            reload.add(found.object); // request to load children of existing node
+          }
+        }
+        return list.size() - 1;
+      });
+      newChildren = list;
+
+      if (oldChildren.isEmpty()) {
+        newChildren.forEach(child -> child.insertMapping(node));
+        node.setChildren(newChildren);
+        treeNodesInserted(node, inserted);
+        LOG.debug("children inserted: ", node.object);
+        node.queue.done(this, node);
+        return;
+      }
+
+      LinkedHashMap<Object, Integer> contained = new LinkedHashMap<>();
+      for (Object object : getIntersection(removed, inserted)) {
+        Integer oldIndex = removed.remove(object);
+        if (oldIndex == null) {
+          LOG.warn("intersection failed");
+        }
+        Integer newIndex = inserted.remove(object);
+        if (newIndex == null) {
+          LOG.warn("intersection failed");
+        }
+        else {
+          contained.put(object, newIndex);
+        }
+      }
+
+      for (Node child : newChildren) {
+        if (!removed.containsKey(child.object) && inserted.containsKey(child.object)) {
+          child.insertMapping(node);
+        }
+      }
+
+      for (Node child : oldChildren) {
+        if (removed.containsKey(child.object) && !inserted.containsKey(child.object)) {
+          child.removeMapping(node, tree);
+        }
+      }
+
+      node.setChildren(newChildren);
+      if (!removed.isEmpty()) treeNodesRemoved(node, removed);
+      if (!inserted.isEmpty()) treeNodesInserted(node, inserted);
+      if (!contained.isEmpty()) treeNodesChanged(node, contained);
+      if (removed.isEmpty() && inserted.isEmpty()) treeNodesChanged(node, null);
+      LOG.debug("children changed: ", node.object);
+
+      if (!reload.isEmpty()) {
+        for (Node child : newChildren) {
+          if (reload.contains(child.object)) {
+            processor.process(new CmdGetChildren("Update children recursively", child, true));
+          }
+        }
+      }
+      node.queue.done(this, node);
+    }
+  }
+
+  private static final class CommandQueue<T extends ObsolescentCommand> {
+    private final Deque<T> deque = new ArrayDeque<>();
+    private volatile boolean closed;
+
+    T get() {
+      synchronized (deque) {
+        return deque.peekFirst();
+      }
+    }
+
+    @NotNull
+    Promise<Node> promise(@NotNull Command.Processor processor, @NotNull Supplier<? extends T> supplier) {
+      T command;
+      synchronized (deque) {
+        command = deque.peekFirst();
+        if (command != null) return command.promise;
+        command = supplier.get();
+      }
+      processor.process(command);
+      return command.promise;
+    }
+
+    void add(@NotNull T command, @NotNull Predicate<? super T> predicate) {
+      synchronized (deque) {
+        if (closed) return;
+        T old = deque.peekFirst();
+        boolean add = old == null || predicate.test(old);
+        if (add) deque.addFirst(command);
+      }
+    }
+
+    void done(@NotNull T command, Node node) {
+      Iterable<AsyncPromise<Node>> promises;
+      synchronized (deque) {
+        if (closed) return;
+        if (!deque.contains(command)) return;
+        promises = getPromises(command);
+        if (deque.isEmpty()) deque.addLast(command);
+      }
+      promises.forEach(promise -> promise.setResult(node));
+    }
+
+    void close() {
+      Iterable<AsyncPromise<Node>> promises;
+      synchronized (deque) {
+        if (closed) return;
+        closed = true;
+        if (deque.isEmpty()) return;
+        promises = getPromises(null);
+      }
+      promises.forEach(promise -> promise.setError("cancel loading"));
+    }
+
+    @NotNull
+    private Iterable<AsyncPromise<Node>> getPromises(T command) {
+      ArrayList<AsyncPromise<Node>> list = new ArrayList<>();
+      while (true) {
+        T last = deque.pollLast();
+        if (last == null) break;
+        if (last.isPending()) list.add(last.promise);
+        if (last.equals(command)) break;
+      }
+      return list;
+    }
+  }
+
+  private static final class Tree {
+    private final CommandQueue<CmdGetRoot> queue = new CommandQueue<>();
+    private final Map<Object, Node> map = new HashMap<>();
+    private volatile Node root;
+
+    private void removeEmpty(@NotNull Node child) {
+      child.forEachChildExceptLoading(this::removeEmpty);
+      if (child.paths.isEmpty()) {
+        child.queue.close();
+        Node node = map.remove(child.object);
+        if (node != child) {
+          LOG.warn("invalid node: " + child.object);
+          if (node != null) map.put(node.object, node);
+        }
+      }
+    }
+
+    private void fixEqualButNotSame(@NotNull Node node, @NotNull Object object) {
+      if (object == node.object) return;
+      // always use new instance of user's object, because
+      // some trees provide equal nodes with different behavior
+      map.remove(node.object);
+      node.updatePaths(node.object, object);
+      node.object = object;
+      map.put(object, node); // update key
+    }
+  }
+
+  private static final class Node {
+    private final CommandQueue<CmdGetChildren> queue = new CommandQueue<>();
+    private final Set<TreePath> paths = new SmartHashSet<>();
+    private volatile Object object;
+    private volatile LeafState leafState;
+    @Nullable
+    private volatile List<Node> children;
+    private volatile Node loading;
+
+    private Node(@NotNull Object object, @NotNull LeafState leafState) {
+      this.object = object;
+      this.leafState = leafState;
+    }
+
+    private void setLeafState(@NotNull LeafState leafState) {
+      this.leafState = leafState;
+      this.children = leafState == LeafState.ALWAYS ? null : emptyList();
+      this.loading = null;
+    }
+
+    private void setChildren(@NotNull List<Node> children) {
+      this.leafState = LeafState.NEVER;
+      this.children = children;
+      this.loading = null;
+    }
+
+    private void setLoading(Node loading) {
+      this.leafState = LeafState.NEVER;
+      this.children = loading != null ? singletonList(loading) : emptyList();
+      this.loading = loading;
+    }
+
+    private boolean isLoadingRequired() {
+      return leafState != LeafState.ALWAYS && children == null;
+    }
+
+    @NotNull
+    private List<Node> getChildren() {
+      List<Node> list = children;
+      return list != null ? list : emptyList();
+    }
+
+    private void forEachChildExceptLoading(Consumer<? super Node> consumer) {
+      for (Node node : getChildren()) {
+        if (node != loading) consumer.consume(node);
+      }
+    }
+
+    private void insertPath(@NotNull TreePath path) {
+      if (!paths.add(path)) {
+        LOG.warn("node is already attached to " + path);
+      }
+      forEachChildExceptLoading(child -> child.insertPath(path.pathByAddingChild(child.object)));
+    }
+
+    private void insertMapping(Node parent) {
+      if (parent == null) {
+        insertPath(new TreePath(object));
+      }
+      else if (parent.loading == this) {
+        LOG.warn("insert loading node unexpectedly");
+      }
+      else if (parent.paths.isEmpty()) {
+        LOG.warn("insert to invalid parent");
+      }
+      else {
+        parent.paths.forEach(path -> insertPath(path.pathByAddingChild(object)));
+      }
+    }
+
+    private void removePath(@NotNull TreePath path) {
+      if (!paths.remove(path)) {
+        LOG.warn("node is not attached to " + path);
+      }
+      forEachChildExceptLoading(child -> child.removePath(path.pathByAddingChild(child.object)));
+    }
+
+    private void removeMapping(Node parent, @NotNull Tree tree) {
+      if (parent == null) {
+        removePath(new TreePath(object));
+        tree.removeEmpty(this);
+      }
+      else if (parent.loading == this) {
+        parent.loading = null;
+      }
+      else if (parent.paths.isEmpty()) {
+        LOG.warn("remove from invalid parent");
+      }
+      else {
+        parent.paths.forEach(path -> removePath(path.pathByAddingChild(object)));
+        tree.removeEmpty(this);
+      }
+    }
+
+    private void updatePaths(@NotNull Object oldObject, @NotNull Object newObject) {
+      if (paths.stream().anyMatch(path -> contains(path, oldObject))) {
+        // replace instance of user's object in all internal maps to avoid memory leaks
+        List<TreePath> updated = ContainerUtil.map(paths, path -> update(path, oldObject, newObject));
+        paths.clear();
+        paths.addAll(updated);
+        forEachChildExceptLoading(child -> child.updatePaths(oldObject, newObject));
+      }
+    }
+
+    @NotNull
+    private static TreePath update(@NotNull TreePath path, @NotNull Object oldObject, @NotNull Object newObject) {
+      if (!contains(path, oldObject)) return path;
+      LOG.debug("update path: ", path);
+      Object[] objects = TreePathUtil.convertTreePathToArray(path);
+      for (int i = 0; i < objects.length; i++) {
+        if (oldObject == objects[i]) objects[i] = newObject;
+      }
+      return TreePathUtil.convertArrayToTreePath(objects);
+    }
+
+    private static boolean contains(@NotNull TreePath path, @NotNull Object object) {
+      while (object != path.getLastPathComponent()) {
+        path = path.getParentPath();
+        if (path == null) return false;
+      }
+      return true;
+    }
+  }
+
+  @Override
+  protected void treeStructureChanged(TreePath path, int[] indices, Object[] children) {
+    try {
+      super.treeStructureChanged(path, indices, children);
+    }
+    catch (Throwable throwable) {
+      LOG.error("custom model: " + model, throwable);
+    }
+  }
+
+  @Override
+  protected void treeNodesChanged(TreePath path, int[] indices, Object[] children) {
+    try {
+      super.treeNodesChanged(path, indices, children);
+    }
+    catch (Throwable throwable) {
+      LOG.error("custom model: " + model, throwable);
+    }
+  }
+
+  @Override
+  protected void treeNodesInserted(TreePath path, int[] indices, Object[] children) {
+    try {
+      super.treeNodesInserted(path, indices, children);
+    }
+    catch (Throwable throwable) {
+      LOG.error("custom model: " + model, throwable);
+    }
+  }
+
+  @Override
+  protected void treeNodesRemoved(TreePath path, int[] indices, Object[] children) {
+    try {
+      super.treeNodesRemoved(path, indices, children);
+    }
+    catch (Throwable throwable) {
+      LOG.error("custom model: " + model, throwable);
+    }
+  }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/Command.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/Command.java
@@ -1,0 +1,77 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.aws.toolkits.jetbrains.ui.tree;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Coped over from JetBrains intellij-community to make the imports and casts align correctly
+ */
+public interface Command<T> extends Supplier<T>, Consumer<T> {
+  final class Processor {
+    public final Invoker foreground;
+    public final Invoker background;
+
+    public Processor(@NotNull Invoker foreground, @NotNull Invoker background) {
+      this.foreground = foreground;
+      this.background = background;
+    }
+
+    /**
+     * Lets the specified consumer to accept the given value on the foreground thread.
+     */
+    public <T> void consume(Consumer<? super T> consumer, T value) {
+      if (consumer != null) foreground.runOrInvokeLater(() -> consumer.accept(value));
+    }
+
+    /**
+     * Lets the specified command to produce a value on the background thread
+     * and to accept this value on the foreground thread.
+     */
+    public <T> void process(Command<T> command) {
+      if (command != null) background.runOrInvokeLater(() -> consume(command, command.get()));
+    }
+
+    /**
+     * Lets the specified supplier to produce a value on the background thread
+     * and the specified consumer to accept this value on the foreground thread.
+     */
+    public <T> void process(Supplier<? extends T> supplier, Consumer<? super T> consumer) {
+      if (supplier != null) {
+        background.runOrInvokeLater(() -> consume(consumer, supplier.get()));
+      }
+      else {
+        consume(consumer, null);
+      }
+    }
+
+    /**
+     * Returns a workload of both task queues.
+     *
+     * @return amount of tasks, which are executing or waiting for execution
+     */
+    public int getTaskCount() {
+      if (foreground == background) return background.getTaskCount();
+      return foreground.getTaskCount() + background.getTaskCount();
+    }
+  }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/Invoker.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/Invoker.java
@@ -1,0 +1,323 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package software.aws.toolkits.jetbrains.ui.tree;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.util.ProgressIndicatorBase;
+import com.intellij.openapi.project.IndexNotReadyException;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import com.intellij.util.concurrency.EdtExecutorService;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.concurrency.AsyncPromise;
+import org.jetbrains.concurrency.CancellablePromise;
+import org.jetbrains.concurrency.Obsolescent;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.intellij.openapi.util.Disposer.register;
+import static java.awt.EventQueue.isDispatchThread;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Fork of JB's Invoker that eliminates the read action in the invokeSafely method. We should migrate back if/when
+ * they remove that limitation
+ */
+public abstract class Invoker implements Disposable {
+  private static final int THRESHOLD = Integer.MAX_VALUE;
+  private static final Logger LOG = Logger.getInstance(Invoker.class);
+  private static final AtomicInteger UID = new AtomicInteger();
+  private final ConcurrentHashMap<AsyncPromise<?>, ProgressIndicatorBase> indicators = new ConcurrentHashMap<>();
+  private final AtomicInteger count = new AtomicInteger();
+  private final String description;
+  private volatile boolean disposed;
+
+  private Invoker(@NotNull String prefix, @NotNull Disposable parent) {
+    description = UID.getAndIncrement() + ".Invoker." + prefix + ": " + parent;
+    register(parent, this);
+  }
+
+  @Override
+  public String toString() {
+    return description;
+  }
+
+  @Override
+  public void dispose() {
+    disposed = true;
+    while (!indicators.isEmpty()) {
+      indicators.keySet().forEach(AsyncPromise::cancel);
+    }
+  }
+
+  /**
+   * Returns {@code true} if the current thread allows to process a task.
+   *
+   * @return {@code true} if the current thread is valid, or {@code false} otherwise
+   */
+  public abstract boolean isValidThread();
+
+  /**
+   * Invokes the specified task asynchronously on the valid thread.
+   * Even if this method is called from the valid thread
+   * the specified task will still be deferred
+   * until all pending events have been processed.
+   *
+   * @param task a task to execute asynchronously on the valid thread
+   * @return an object to control task processing
+   */
+  @NotNull
+  public final CancellablePromise<?> invokeLater(@NotNull Runnable task) {
+    return invokeLater(task, 0);
+  }
+
+  /**
+   * Invokes the specified task on the valid thread after the specified delay.
+   *
+   * @param task  a task to execute asynchronously on the valid thread
+   * @param delay milliseconds for the initial delay
+   * @return an object to control task processing
+   */
+  @NotNull
+  public final CancellablePromise<?> invokeLater(@NotNull Runnable task, int delay) {
+    if (delay < 0) throw new IllegalArgumentException("delay must be non-negative: " + delay);
+    AsyncPromise<?> promise = new AsyncPromise<>();
+    if (canInvoke(task, promise)) {
+      count.incrementAndGet();
+      offer(() -> invokeSafely(task, promise, 0), delay);
+    }
+    return promise;
+  }
+
+  /**
+   * Invokes the specified task immediately if the current thread is valid,
+   * or asynchronously after all pending tasks have been processed.
+   *
+   * @param task a task to execute on the valid thread
+   * @return an object to control task processing
+   */
+  @NotNull
+  public final CancellablePromise<?> runOrInvokeLater(@NotNull Runnable task) {
+    if (isValidThread()) {
+      count.incrementAndGet();
+      AsyncPromise<?> promise = new AsyncPromise<>();
+      invokeSafely(task, promise, 0);
+      return promise;
+    }
+    return invokeLater(task);
+  }
+
+  /**
+   * @deprecated use {@link #runOrInvokeLater(Runnable)}
+   */
+  @Deprecated
+  public final void invokeLaterIfNeeded(@NotNull Runnable task) {
+    runOrInvokeLater(task);
+  }
+
+  /**
+   * Returns a workload of the task queue.
+   *
+   * @return amount of tasks, which are executing or waiting for execution
+   */
+  public final int getTaskCount() {
+    return disposed ? 0 : count.get();
+  }
+
+  abstract void offer(@NotNull Runnable runnable, int delay);
+
+  /**
+   * @param task    a task to execute on the valid thread
+   * @param promise an object to control task processing
+   * @param attempt an attempt to run the specified task
+   */
+  private void invokeSafely(@NotNull Runnable task, @NotNull AsyncPromise<?> promise, int attempt) {
+
+    // NOTE: This is the spot where we differ from JetBrains!!!!
+    // Original code: https://github.com/JetBrains/intellij-community/blob/351994570e5f6e5d8cc57e8febe217d933a13a09/platform/platform-impl/src/com/intellij/util/concurrency/Invoker.java#L138
+
+    try {
+      if (canInvoke(task, promise)) {
+        ProgressManager.getInstance().runProcess(task, indicator(promise));
+        promise.setResult(null);
+      }
+    }
+    catch (ProcessCanceledException | IndexNotReadyException exception) {
+      if (canRestart(task, promise, attempt)) {
+        count.incrementAndGet();
+        int nextAttempt = attempt + 1;
+        offer(() -> invokeSafely(task, promise, nextAttempt), 10);
+        LOG.debug("Task is restarted");
+      }
+    }
+    catch (Throwable throwable) {
+      try {
+        LOG.error(throwable);
+      }
+      finally {
+        promise.setError(throwable);
+      }
+    }
+    finally {
+      count.decrementAndGet();
+    }
+  }
+
+  /**
+   * @param task    a task to execute on the valid thread
+   * @param promise an object to control task processing
+   * @param attempt an attempt to run the specified task
+   * @return {@code false} if too many attempts to run the task,
+   * or if the given promise is already done or cancelled,
+   * or if the current invoker is disposed,
+   * or if the specified task is obsolete
+   */
+  private boolean canRestart(@NotNull Runnable task, @NotNull AsyncPromise<?> promise, int attempt) {
+    LOG.debug("Task is canceled");
+    if (attempt < THRESHOLD) return canInvoke(task, promise);
+    LOG.warn("Task is always canceled: " + task);
+    promise.setError("timeout");
+    return false;
+  }
+
+  /**
+   * @param task    a task to execute on the valid thread
+   * @param promise an object to control task processing
+   * @return {@code false} if the given promise is already done or cancelled,
+   * or if the current invoker is disposed,
+   * or if the specified task is obsolete
+   */
+  private boolean canInvoke(@NotNull Runnable task, @NotNull AsyncPromise<?> promise) {
+    if (promise.isDone()) {
+      LOG.debug("Promise is cancelled: ", promise.isCancelled());
+      return false;
+    }
+    if (disposed) {
+      LOG.debug("Invoker is disposed");
+      promise.setError("disposed");
+      return false;
+    }
+    if (task instanceof Obsolescent) {
+      Obsolescent obsolescent = (Obsolescent)task;
+      if (obsolescent.isObsolete()) {
+        LOG.debug("Task is obsolete");
+        promise.setError("obsolete");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @NotNull
+  private ProgressIndicatorBase indicator(@NotNull AsyncPromise<?> promise) {
+    ProgressIndicatorBase indicator = indicators.get(promise);
+    if (indicator == null) {
+      indicator = new ProgressIndicatorBase(true);
+      ProgressIndicatorBase old = indicators.put(promise, indicator);
+      if (old != null) LOG.error("the same task is running in parallel");
+      promise.onProcessed(done -> indicators.remove(promise).cancel());
+    }
+    return indicator;
+  }
+
+  /**
+   * This class is the {@code Invoker} in the Event Dispatch Thread,
+   * which is the only one valid thread for this invoker.
+   */
+  public static final class EDT extends Invoker {
+    public EDT(@NotNull Disposable parent) {
+      super("EDT", parent);
+    }
+
+    @Override
+    public boolean isValidThread() {
+      return isDispatchThread();
+    }
+
+    @Override
+    void offer(@NotNull Runnable runnable, int delay) {
+      if (delay > 0) {
+        EdtExecutorService.getScheduledExecutorInstance().schedule(runnable, delay, MILLISECONDS);
+      }
+      else {
+        EdtExecutorService.getInstance().execute(runnable);
+      }
+    }
+  }
+
+  /**
+   * This class is the {@code Invoker} in a background thread pool.
+   * Every thread is valid for this invoker except the EDT.
+   * It allows to run background tasks in parallel,
+   * but requires a good synchronization.
+   */
+  public static final class BackgroundPool extends Invoker {
+    public BackgroundPool(@NotNull Disposable parent) {
+      super("Background.Pool", parent);
+    }
+
+    @Override
+    public boolean isValidThread() {
+      return !isDispatchThread();
+    }
+
+    @Override
+    void offer(@NotNull Runnable runnable, int delay) {
+      schedule(AppExecutorUtil.getAppScheduledExecutorService(), runnable, delay);
+    }
+  }
+
+  /**
+   * This class is the {@code Invoker} in a single background thread.
+   * This invoker does not need additional synchronization.
+   */
+  public static final class BackgroundThread extends Invoker {
+    private final ScheduledExecutorService executor;
+    private volatile Thread thread;
+
+    public BackgroundThread(@NotNull Disposable parent) {
+      super("Background.Thread", parent);
+      executor = AppExecutorUtil.createBoundedScheduledExecutorService(toString(), 1);
+    }
+
+    @Override
+    public void dispose() {
+      super.dispose();
+      executor.shutdown();
+    }
+
+    @Override
+    public boolean isValidThread() {
+      return thread == Thread.currentThread();
+    }
+
+    @Override
+    void offer(@NotNull Runnable runnable, int delay) {
+      schedule(executor, () -> {
+        if (thread != null) LOG.error("unexpected thread: " + thread);
+        try {
+          thread = Thread.currentThread();
+          runnable.run(); // may throw an assertion error
+        }
+        finally {
+          thread = null;
+        }
+      }, delay);
+    }
+  }
+
+  private static void schedule(ScheduledExecutorService executor, Runnable runnable, int delay) {
+    if (delay > 0) {
+      executor.schedule(runnable, delay, MILLISECONDS);
+    }
+    else {
+      executor.execute(runnable);
+    }
+  }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/InvokerSupplier.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/InvokerSupplier.java
@@ -1,0 +1,32 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.aws.toolkits.jetbrains.ui.tree;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Coped over from JetBrains intellij-community to make the imports and casts align correctly
+ */
+public interface InvokerSupplier {
+  /**
+   * @return preferable invoker to be used to access the supplier
+   */
+  @NotNull
+  Invoker getInvoker();
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/Reference.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/Reference.java
@@ -1,0 +1,43 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.aws.toolkits.jetbrains.ui.tree;
+
+final class Reference<T> {
+  private volatile boolean valid;
+  private volatile T value;
+
+  boolean isValid() {
+    return valid;
+  }
+
+  void invalidate() {
+    valid = false;
+  }
+
+  T set(T value) {
+    T old = this.value;
+    this.value = value;
+    valid = true;
+    return old;
+  }
+
+  T get() {
+    return value;
+  }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/StructureTreeModel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/StructureTreeModel.java
@@ -1,0 +1,624 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package software.aws.toolkits.jetbrains.ui.tree;
+
+import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.ide.util.treeView.AbstractTreeStructure;
+import com.intellij.ide.util.treeView.NodeDescriptor;
+import com.intellij.ide.util.treeView.ValidateableNode;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.tree.ChildrenProvider;
+import com.intellij.ui.tree.LeafState;
+import com.intellij.ui.tree.TreePathUtil;
+import com.intellij.ui.tree.TreeVisitor;
+import com.intellij.util.ui.tree.AbstractTreeModel;
+import com.intellij.util.ui.tree.TreeUtil;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.concurrency.AsyncPromise;
+import org.jetbrains.concurrency.Promise;
+import software.aws.toolkits.jetbrains.core.explorer.AwsExplorerTreeStructure;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javax.swing.JTree;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.MutableTreeNode;
+import javax.swing.tree.TreeNode;
+import javax.swing.tree.TreePath;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.enumeration;
+import static java.util.Collections.unmodifiableList;
+import static org.jetbrains.concurrency.Promises.rejectedPromise;
+
+/**
+ * @author Sergey.Malenkov
+ */
+public class StructureTreeModel
+  extends AbstractTreeModel implements Disposable, InvokerSupplier, ChildrenProvider<TreeNode> {
+
+  private static final TreePath ROOT_INVALIDATED = new TreePath(new DefaultMutableTreeNode());
+  private static final Logger LOG = Logger.getInstance(StructureTreeModel.class);
+  private final Reference<Node> root = new Reference<>();
+  private final String description;
+  private final Invoker invoker;
+  private final AwsExplorerTreeStructure structure;
+  private volatile Comparator<? super Node> comparator;
+
+  private StructureTreeModel(@NotNull AwsExplorerTreeStructure structure, boolean background, @NotNull Disposable parentDisposable) {
+    this.structure = structure;
+    description = format(structure.toString());
+    invoker = background
+              ? new Invoker.BackgroundThread(this)
+              : new Invoker.EDT(this);
+    Disposer.register(parentDisposable, this);
+  }
+
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "2019.3")
+  public StructureTreeModel(@NotNull AwsExplorerTreeStructure structure) {
+    this(structure, Disposer.newDisposable());
+  }
+
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "2019.3")
+  public StructureTreeModel(@NotNull AwsExplorerTreeStructure structure,
+                            @NotNull Comparator<? super NodeDescriptor> comparator) {
+    this(structure, comparator, Disposer.newDisposable());
+  }
+
+  public StructureTreeModel(@NotNull AwsExplorerTreeStructure structure, @NotNull Disposable parentDisposable) {
+    this(structure, true, parentDisposable);
+  }
+
+  public StructureTreeModel(@NotNull AwsExplorerTreeStructure structure,
+                            @NotNull Comparator<? super NodeDescriptor> comparator,
+                            @NotNull Disposable parentDisposable) {
+    this(structure, parentDisposable);
+    this.comparator = wrapToNodeComparator(comparator);
+  }
+
+  @NotNull
+  private static Comparator<? super Node> wrapToNodeComparator(@NotNull Comparator<? super NodeDescriptor> comparator) {
+    return (node1, node2) -> comparator.compare(node1.getDescriptor(), node2.getDescriptor());
+  }
+
+  /**
+   * @param comparator a comparator to sort tree nodes or {@code null} to disable sorting
+   */
+  public final void setComparator(@Nullable Comparator<? super NodeDescriptor> comparator) {
+    if (disposed) return;
+    if (comparator != null) {
+      this.comparator = wrapToNodeComparator(comparator);
+      invalidate();
+    }
+    else if (this.comparator != null) {
+      this.comparator = null;
+      invalidate();
+    }
+  }
+
+  @Override
+  public void dispose() {
+    comparator = null;
+    Node node = root.set(null);
+    if (node != null) node.dispose();
+    // notify tree to clean up inner structures
+    treeStructureChanged(null, null, null);
+    super.dispose(); // remove listeners after notification
+  }
+
+  @NotNull
+  @Override
+  public final Invoker getInvoker() {
+    return invoker;
+  }
+
+  private boolean isValidThread() {
+    if (invoker.isValidThread()) return true;
+    LOG.warn(new IllegalStateException("StructureTreeModel is used from unexpected thread"));
+    return false;
+  }
+
+  /**
+   * @param function a function to process current structure on a valid thread
+   * @return a promise that will be succeed if the specified function returns non-null value
+   */
+  @NotNull
+  private <Result> Promise<Result> onValidThread(@NotNull Function<? super AwsExplorerTreeStructure, ? extends Result> function) {
+    AsyncPromise<Result> promise = new AsyncPromise<>();
+    invoker.runOrInvokeLater(() -> {
+      if (!disposed) {
+        Result result = function.apply(structure);
+        if (result != null) promise.setResult(result);
+      }
+      if (!promise.isDone()) promise.cancel();
+    }).onError(promise::setError);
+    return promise;
+  }
+
+  /**
+   * @param path     a path to the node
+   * @param function a function to process corresponding node on a valid thread
+   * @return a promise that will be succeed if the specified function returns non-null value
+   */
+  @NotNull
+  private <Result> Promise<Result> onValidThread(@NotNull TreePath path, @NotNull Function<? super Node, ? extends Result> function) {
+    Object component = path.getLastPathComponent();
+    if (component instanceof Node) {
+      Node node = (Node)component;
+      return onValidThread(structure -> disposed || isNodeRemoved(node) ? null : function.apply(node));
+    }
+    return rejectedPromise("unexpected node: " + component);
+  }
+
+  /**
+   * @param element  an element of the internal tree structure
+   * @param function a function to process corresponding node on a valid thread
+   * @return a promise that will be succeed if the specified function returns non-null value
+   */
+  @NotNull
+  private <Result> Promise<Result> onValidThread(@NotNull Object element, @NotNull Function<? super Node, ? extends Result> function) {
+    return onValidThread(structure -> {
+      Node node = root.get();
+      if (node == null) return null;
+      if (node.matches(element)) return function.apply(node);
+      ArrayDeque<Object> stack = new ArrayDeque<>();
+      for (Object e = element; e != null; e = structure.getParentElement(e)) stack.push(e);
+      if (!node.matches(stack.pop())) return null;
+      while (!stack.isEmpty()) {
+        node = node.findChild(stack.pop());
+        if (node == null) return null;
+      }
+      return function.apply(node);
+    });
+  }
+
+  /**
+   * Invalidates all nodes and notifies Swing model that a whole tree hierarchy is changed.
+   */
+  @NotNull
+  public final Promise<?> invalidate() {
+    return onValidThread(structure -> invalidateInternal(null, true));
+  }
+
+  /**
+   * Invalidates specified nodes and notifies Swing model that these nodes are changed.
+   *
+   * @param path      a path to the node to invalidate
+   * @param structure {@code true} means that all child nodes must be invalidated;
+   *                  {@code false} means that only the node specified by {@code path} must be updated
+   * @return a promise that will be succeed if path to invalidate is found
+   * @see #invalidate(Object, boolean)
+   */
+  @NotNull
+  public final Promise<TreePath> invalidate(@NotNull TreePath path, boolean structure) {
+    return onValidThread(path, node -> invalidateInternal(node, structure));
+  }
+
+  /**
+   * Invalidates specified nodes and notifies Swing model that these nodes are changed.
+   * This method does not bother Swing model if the corresponding nodes have not yet been loaded.
+   *
+   * @param element   an element of the internal tree structure
+   * @param structure {@code true} means that all child nodes must be invalidated;
+   *                  {@code false} means that only the node specified by {@code path} must be updated
+   * @return a promise that will be succeed if path to invalidate is found
+   * @see #invalidate(TreePath, boolean)
+   */
+  @NotNull
+  public final Promise<TreePath> invalidate(@NotNull Object element, boolean structure) {
+    return onValidThread(element, node -> invalidateInternal(node, structure));
+  }
+
+  @Nullable
+  private TreePath invalidateInternal(@Nullable Node node, boolean structure) {
+    assert invoker.isValidThread();
+    while (node != null && !isValid(node)) {
+      LOG.debug("invalid element cannot be updated: ", node);
+      node = (Node)node.getParent();
+      structure = true;
+    }
+    if (node == null) {
+      node = root.get();
+      if (node != null) node.invalidate();
+      root.invalidate();
+      LOG.debug("root invalidated: ", node);
+      treeStructureChanged(null, null, null);
+      return ROOT_INVALIDATED;
+    }
+    boolean updated = node.update();
+    if (structure) {
+      node.invalidate();
+      TreePath path = TreePathUtil.pathToTreeNode(node);
+      treeStructureChanged(path, null, null);
+      return path;
+    }
+    if (updated) {
+      TreePath path = TreePathUtil.pathToTreeNode(node);
+      treeNodesChanged(path, null, null);
+      return path;
+    }
+    return null;
+  }
+
+  /**
+   * Expands a node in the specified tree.
+   *
+   * @param element  an element of the internal tree structure
+   * @param tree     a tree, which nodes should be expanded
+   * @param consumer a path consumer called on EDT if path is found and expanded
+   */
+  public final void expand(@NotNull Object element, @NotNull JTree tree, @NotNull Consumer<? super TreePath> consumer) {
+    promiseVisitor(element).onSuccess(visitor -> TreeUtil.expand(tree, visitor, consumer));
+  }
+
+  /**
+   * Makes visible a node in the specified tree.
+   *
+   * @param element  an element of the internal tree structure
+   * @param tree     a tree, which nodes should be made visible
+   * @param consumer a path consumer called on EDT if path is found and made visible
+   */
+  public final void makeVisible(@NotNull Object element, @NotNull JTree tree, @NotNull Consumer<? super TreePath> consumer) {
+    promiseVisitor(element).onSuccess(visitor -> TreeUtil.makeVisible(tree, visitor, consumer));
+  }
+
+  /**
+   * Selects a node in the specified tree.
+   *
+   * @param element  an element of the internal tree structure
+   * @param tree     a tree, which nodes should be selected
+   * @param consumer a path consumer called on EDT if path is found and selected
+   */
+  public final void select(@NotNull Object element, @NotNull JTree tree, @NotNull Consumer<? super TreePath> consumer) {
+    promiseVisitor(element).onSuccess(visitor -> TreeUtil.select(tree, visitor, consumer));
+  }
+
+  /**
+   * Promises to create default visitor to find the specified element.
+   *
+   * @param element an element of the internal tree structure
+   * @return a promise that will be succeed if visitor is created
+   * @see TreeUtil#promiseExpand(JTree, TreeVisitor)
+   * @see TreeUtil#promiseSelect(JTree, TreeVisitor)
+   */
+  @NotNull
+  public final Promise<TreeVisitor> promiseVisitor(@NotNull Object element) {
+    return onValidThread(structure -> new TreeVisitor.ByTreePath<>(
+      TreePathUtil.pathToCustomNode(element, structure::getParentElement),
+      node -> node instanceof Node ? ((Node)node).getElement() : null));
+  }
+
+  @Override
+  public final TreeNode getRoot() {
+    if (disposed || !isValidThread()) return null;
+    if (!root.isValid()) {
+      Node newRoot = getValidRoot();
+      root.set(newRoot);
+      LOG.debug("root updated: ", newRoot);
+    }
+    return root.get();
+  }
+
+  private Node getNode(Object object, boolean validateChildren) {
+    if (disposed || !(object instanceof Node) || !isValidThread()) return null;
+    Node node = (Node)object;
+    if (isNodeRemoved(node)) return null;
+    if (validateChildren) validateChildren(node);
+    return node;
+  }
+
+  private void validateChildren(@NotNull Node node) {
+    if (!node.children.isValid()) {
+      List<Node> newChildren = getValidChildren(node);
+      List<Node> oldChildren = node.children.set(newChildren);
+      if (oldChildren != null) oldChildren.forEach(child -> child.setParent(null));
+      if (newChildren != null) newChildren.forEach(child -> child.setParent(node));
+      LOG.debug("children updated: ", node);
+    }
+  }
+
+  private boolean isNodeRemoved(@NotNull Node node) {
+    return !node.isNodeAncestor(root.get());
+  }
+
+  @Override
+  public final List<TreeNode> getChildren(Object object) {
+    Node node = getNode(object, true);
+    List<Node> list = node == null ? null : node.children.get();
+    if (list == null || list.isEmpty()) return emptyList();
+    list.forEach(Node::update);
+    return unmodifiableList(list);
+  }
+
+  @Override
+  public final int getChildCount(Object object) {
+    Node node = getNode(object, true);
+    return node == null ? 0 : node.getChildCount();
+  }
+
+  @Override
+  public final TreeNode getChild(Object object, int index) {
+    Node node = getNode(object, true);
+    return node == null ? null : node.getChildAt(index);
+  }
+
+  @Override
+  public final boolean isLeaf(Object object) {
+    Node node = getNode(object, false);
+    return node == null || node.isLeaf(this::validateChildren);
+  }
+
+  @Override
+  public final int getIndexOfChild(Object object, Object child) {
+    return object instanceof Node && child instanceof Node ? ((Node)object).getIndex((TreeNode)child) : -1;
+  }
+
+  private boolean isValid(@NotNull Node node) {
+    return isValid(structure, node.getElement());
+  }
+
+  private static boolean isValid(@NotNull AbstractTreeStructure structure, Object element) {
+    if (element == null) return false;
+    if (element instanceof AbstractTreeNode) {
+      AbstractTreeNode node = (AbstractTreeNode)element;
+      if (null == node.getValue()) return false;
+    }
+    if (element instanceof ValidateableNode) {
+      ValidateableNode node = (ValidateableNode)element;
+      if (!node.isValid()) return false;
+    }
+    return structure.isValid(element);
+  }
+
+  @Nullable
+  private Node getValidRoot() {
+    Object element = structure.getRootElement();
+    if (!isValid(structure, element)) return null;
+
+    Node newNode = new Node(structure, element, null); // an exception may be thrown while getting a root
+    Node oldNode = root.get();
+    if (oldNode != null && oldNode.canReuse(newNode, element)) {
+      return oldNode; // reuse old node with possible children
+    }
+    return newNode;
+  }
+
+  @Nullable
+  private List<Node> getValidChildren(@NotNull Node node) {
+    NodeDescriptor descriptor = node.getDescriptor();
+    if (descriptor == null) return null;
+
+    Object parent = descriptor.getElement();
+    if (!isValid(structure, parent)) return null;
+
+    Object[] elements = structure.getChildElements(parent);
+    if (elements.length == 0) return null;
+
+    List<Node> list = new ArrayList<>(elements.length);
+    for (Object element : elements) {
+      if (isValid(structure, element)) {
+        list.add(new Node(structure, element, descriptor)); // an exception may be thrown while getting children
+      }
+    }
+    Comparator<? super Node> comparator = this.comparator;
+    if (comparator != null) {
+      try {
+        list.sort(comparator); // an exception may be thrown while sorting children
+      }
+      catch (IllegalArgumentException exception) {
+        StringBuilder sb = new StringBuilder("unexpected sorting failed in ");
+        sb.append(this);
+        for (Node next : list) sb.append('\n').append(next);
+        LOG.error(sb.toString(), exception);
+      }
+    }
+    HashMap<Object, Node> map = new HashMap<>();
+    node.getChildren().forEach(child -> {
+      Object element = child.getElement();
+      if (element != null) map.put(element, child);
+    });
+    for (int i = 0; i < list.size(); i++) {
+      Node newNode = list.get(i);
+      Node oldNode = map.get(newNode.getElement());
+      if (oldNode != null && oldNode.canReuse(newNode, null)) {
+        list.set(i, oldNode); // reuse old node with possible children
+      }
+    }
+    return list;
+  }
+
+  private static final class Node extends DefaultMutableTreeNode implements LeafState.Supplier {
+    private final Reference<List<Node>> children = new Reference<>();
+    private final LeafState leafState;
+    private final int hashCode;
+
+    private Node(@NotNull AwsExplorerTreeStructure structure, @NotNull Object element, NodeDescriptor parent) {
+      this(structure.createDescriptor(element, parent), structure.getLeafState(element), element.hashCode());
+    }
+
+    private Node(@NotNull NodeDescriptor descriptor, @NotNull LeafState leafState, int hashCode) {
+      super(descriptor, leafState != LeafState.ALWAYS);
+      this.leafState = leafState;
+      this.hashCode = hashCode;
+      if (leafState == LeafState.ALWAYS) children.set(null); // validate children for leaf node
+      update(); // an exception may be thrown while updating
+    }
+
+    private void dispose() {
+      setParent(null);
+      List<Node> list = children.set(null);
+      if (list != null) list.forEach(Node::dispose);
+    }
+
+    private boolean canReuse(@NotNull Node node, Object element) {
+      if (leafState != node.leafState || hashCode != node.hashCode) return false;
+      if (element != null && !matches(element)) return false;
+      userObject = node.userObject; // replace old descriptor
+      return true;
+    }
+
+    private boolean update() {
+      NodeDescriptor descriptor = getDescriptor();
+      return descriptor != null && descriptor.update();
+    }
+
+    private void invalidate() {
+      if (leafState != LeafState.ALWAYS) {
+        children.invalidate();
+        LOG.debug("node invalidated: ", this);
+        getChildren().forEach(Node::invalidate);
+      }
+    }
+
+    private boolean matches(@NotNull Object element) {
+      return matches(element, element.hashCode());
+    }
+
+    private boolean matches(@NotNull Object element, int hashCode) {
+      return this.hashCode == hashCode && element.equals(getElement());
+    }
+
+    private Node findChild(@NotNull Object element) {
+      List<Node> list = children.get();
+      if (list != null) {
+        if (!list.isEmpty()) {
+          int hashCode = element.hashCode();
+          Optional<Node> result = list.stream().filter(node -> node.matches(element, hashCode)).findFirst();
+          if (result.isPresent()) return result.get(); // found child node that matches given element
+        }
+        if (LOG.isTraceEnabled()) LOG.debug("node '", getElement(), "' have no child: ", element);
+      }
+      else {
+        if (LOG.isTraceEnabled()) LOG.debug("node '", getElement(), "' have no loaded children");
+      }
+      return null;
+    }
+
+    @NotNull
+    private List<Node> getChildren() {
+      List<Node> list = children.get();
+      return list != null ? list : emptyList();
+    }
+
+    private NodeDescriptor getDescriptor() {
+      Object object = getUserObject();
+      return object instanceof NodeDescriptor ? (NodeDescriptor)object : null;
+    }
+
+    private Object getElement() {
+      NodeDescriptor descriptor = getDescriptor();
+      return descriptor == null ? null : descriptor.getElement();
+    }
+
+    @Override
+    public void setUserObject(Object object) {
+      throw new UnsupportedOperationException("cannot modify node");
+    }
+
+    @Override
+    public void setAllowsChildren(boolean value) {
+      throw new UnsupportedOperationException("cannot modify node");
+    }
+
+    @Override
+    public Object clone() {
+      throw new UnsupportedOperationException("cannot clone node");
+    }
+
+    @Override
+    public void insert(MutableTreeNode child, int index) {
+      throw new UnsupportedOperationException("cannot insert node");
+    }
+
+    @Override
+    public void remove(int index) {
+      throw new UnsupportedOperationException("cannot remove node");
+    }
+
+    @Override
+    public Enumeration children() {
+      return enumeration(getChildren());
+    }
+
+    @Override
+    public TreeNode getChildAt(int index) {
+      List<Node> list = getChildren();
+      return 0 <= index && index < list.size() ? list.get(index) : null;
+    }
+
+    @Override
+    public int getChildCount() {
+      return getChildren().size();
+    }
+
+    @Override
+    public boolean isLeaf() {
+      return isLeaf(null);
+    }
+
+    private boolean isLeaf(@Nullable Consumer<? super Node> validator) {
+      // root node should not be a leaf node when it is not visible in a tree
+      // javax.swing.tree.VariableHeightLayoutCache.TreeStateNode.expand(boolean)
+      if (null == getParent()) return false;
+      if (leafState == LeafState.ALWAYS) return true;
+      if (leafState == LeafState.NEVER) return false;
+      if (leafState == LeafState.DEFAULT && validator != null) validator.accept(this);
+      return children.isValid() && super.isLeaf();
+    }
+
+    @Override
+    public int getIndex(@NotNull TreeNode child) {
+      return child instanceof Node && isNodeChild(child) ? getChildren().indexOf(child) : -1;
+    }
+
+    @NotNull
+    @Override
+    public LeafState getLeafState() {
+      return leafState;
+    }
+  }
+
+  /**
+   * @deprecated do not use
+   */
+  @Deprecated
+  public final TreeNode getRootImmediately() {
+    if (!root.isValid()) {
+      root.set(getValidRoot());
+    }
+    return root.get();
+  }
+
+  /**
+   * @return a descriptive name for the instance to help a tree identification
+   */
+  @Override
+  public String toString() {
+    return description;
+  }
+
+  @NotNull
+  private static String format(@NotNull String prefix) {
+    for (StackTraceElement element : new Exception().getStackTrace()) {
+      if (!StructureTreeModel.class.getName().equals(element.getClassName())) {
+        return prefix + " @ " + element.getFileName() + " : " + element.getLineNumber();
+      }
+    }
+    return prefix;
+  }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/StructureTreeModel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/tree/StructureTreeModel.java
@@ -593,6 +593,7 @@ public class StructureTreeModel
     }
   }
 
+
   /**
    * @deprecated do not use
    */
@@ -620,5 +621,10 @@ public class StructureTreeModel
       }
     }
     return prefix;
+  }
+
+  @Override
+  public void valueForPathChanged(TreePath path, Object value) {
+    throw new UnsupportedOperationException("editable tree have to implement TreeModel#valueForPathChanged");
   }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/tree/AsyncTreeModelTest.java
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/tree/AsyncTreeModelTest.java
@@ -1,0 +1,899 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package software.aws.toolkits.jetbrains.ui.tree;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.tree.TreePathUtil;
+import com.intellij.ui.tree.TreeVisitor;
+import com.intellij.util.ArrayUtilRt;
+import com.intellij.util.concurrency.Invoker;
+import com.intellij.util.concurrency.InvokerSupplier;
+import com.intellij.util.ui.tree.AbstractTreeModel;
+import com.intellij.util.ui.tree.TreeModelAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.concurrency.AsyncPromise;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.MutableTreeNode;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreeNode;
+import javax.swing.tree.TreePath;
+
+import static com.intellij.diagnostic.ThreadDumper.dumpThreadsToString;
+import static com.intellij.util.ui.tree.TreeUtil.expandAll;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class AsyncTreeModelTest {
+  /**
+   * A bigger threshold increases a probability of restarting current task.
+   */
+  private static final double THRESHOLD = .001;
+  /**
+   * Set to true to print some debugging information.
+   */
+  private static final boolean PRINT = false;
+
+  @Test
+  public void testAggressiveUpdating() {
+    testBackgroundThread(() -> null, test -> test.updateModelAndWait(model -> {
+      for (int i = 0; i < 10000; i++) ((DefaultTreeModel)model).setRoot(createRoot());
+    }, test::done), false, 0);
+  }
+
+  @Test
+  public void testProcessingNPE() {
+    Disposable disposable = Disposer.newDisposable();
+    AsyncTreeModel model = new AsyncTreeModel(new DefaultTreeModel(new DefaultMutableTreeNode()), true, disposable);
+    try {
+      assert !model.isProcessing() : "created model should not update content";
+    }
+    finally {
+      Disposer.dispose(disposable);
+    }
+  }
+
+  @Test
+  public void testNullRoot() {
+    testAsync(() -> null, test
+      -> testPathState0(test.tree, ()
+      -> test.updateModelAndWait(model -> ((DefaultTreeModel)model).setRoot(createRoot()), ()
+      -> testPathState1(test.tree, test::done))));
+  }
+
+  @Test
+  public void testRootOnly() {
+    testAsync(AsyncTreeModelTest::createRoot, test
+      -> testPathState1(test.tree, ()
+      -> test.updateModelAndWait(model -> ((DefaultTreeModel)model).setRoot(null), ()
+      -> testPathState0(test.tree, test::done))));
+  }
+
+  @Test
+  public void testRootOnlyUpdate() {
+    testRootOnlyUpdate(false);
+    testRootOnlyUpdate(true);
+  }
+
+  private static void testRootOnlyUpdate(boolean mutable) {
+    TreeNode first = new Node("root", mutable);
+    TreeNode second = new Node("root", mutable);
+    assert mutable == first.equals(second);
+    assert first != second : "both nodes should not be the same";
+    testAsync(() -> first, test
+      -> testPathState1(test.tree, ()
+      -> testRootOnlyUpdate(test, first, ()
+      -> test.updateModelAndWait(model -> ((DefaultTreeModel)model).setRoot(second), ()
+      -> testPathState1(test.tree, ()
+      -> testRootOnlyUpdate(test, second, test::done))))));
+  }
+
+  private static void testRootOnlyUpdate(@NotNull ModelTest test, @NotNull TreeNode expected, @NotNull Runnable task) {
+    Object actual = test.tree.getModel().getRoot();
+    assert expected.equals(actual) : "expected node should be equal to the tree root";
+    assert expected == actual : "expected node should be the same";
+    task.run();
+  }
+
+  @Test
+  public void testChildrenUpdate() {
+    ArrayList<TreePath> list = new ArrayList<>();
+    testAsync(AsyncTreeModelTest::createMutableRoot, test
+      -> expandAll(test.tree, ()
+      -> testPathState(test.tree, "   +'root'\n" + MUTABLE_CHILDREN, ()
+      -> collectTreePaths(test.tree, list, ()
+      -> test.updateModelAndWait(model -> ((DefaultTreeModel)model).setRoot(createMutableRoot()), ()
+      -> testPathState(test.tree, "   +'root'\n" + MUTABLE_CHILDREN, ()
+      -> checkTreePaths(test.tree, list, test::done)))))));
+  }
+
+  private static void collectTreePaths(@NotNull JTree tree, @NotNull ArrayList<TreePath> list, @NotNull Runnable task) {
+    list.clear();
+    forEachRow(tree, list::add);
+    task.run();
+  }
+
+  private static void checkTreePaths(@NotNull JTree tree, @NotNull ArrayList<TreePath> list, @NotNull Runnable task) {
+    Iterator<TreePath> iterator = list.iterator();
+    forEachRow(tree, path -> {
+      assertTrue(iterator.hasNext());
+      assertTreePath(path, iterator.next());
+    });
+    assertFalse(iterator.hasNext());
+    task.run();
+  }
+
+  private static void assertTreePath(@NotNull TreePath expected, @NotNull TreePath actual) {
+    assertEquals("expected path should be equal to the actual path", expected, actual);
+    // do no validate root node, because it is not updated in Swing's viewable row list
+    if (expected.getParentPath() == null && actual.getParentPath() == null) return;
+    assertComponent(expected.getLastPathComponent(), actual.getLastPathComponent());
+    assertTreePath(expected.getParentPath(), actual.getParentPath());
+  }
+
+  private static void assertComponent(@NotNull Object expected, @NotNull Object actual) {
+    assertEquals("expected node should be equal to the actual node", expected, actual);
+    assertNotSame(expected, actual);
+  }
+
+  @NotNull
+  private static TreeNode createMutableRoot() {
+    return new Node(true, "root",
+                    new Node(true, "color", "red", "green", "blue"),
+                    new Node(true, "greek", "alpha", "beta", "gamma"));
+  }
+
+  private static final String MUTABLE_CHILDREN
+    = "     +'color'\n" +
+      "        'red'\n" +
+      "        'green'\n" +
+      "        'blue'\n" +
+      "     +'greek'\n" +
+      "        'alpha'\n" +
+      "        'beta'\n" +
+      "        'gamma'\n";
+
+  @Test
+  public void testChildren() {
+    TreeNode color = createColorNode();
+    TreeNode digit = createDigitNode();
+    TreeNode greek = createGreekNode();
+    TreeNode root = new Node("root", color, digit, greek);
+    TreePath path = new TreePath(root);
+    testAsync(() -> root, test
+      -> testPathState(test.tree, "   +'root'\n" + CHILDREN, ()
+      -> test.collapse(path, ()
+      -> testPathState1(test.tree, ()
+      -> test.setRootVisible(false, ()
+      -> testPathState0(test.tree, ()
+      -> test.expand(path, ()
+      -> testPathState(test.tree, CHILDREN, ()
+      -> test.expand(path.pathByAddingChild(color), ()
+      -> testPathState(test.tree, CHILDREN_COLOR, ()
+      -> test.expand(path.pathByAddingChild(greek), ()
+      -> testPathState(test.tree, CHILDREN_COLOR_GREEK, ()
+      -> test.collapse(path, ()
+      -> testPathState0(test.tree, ()
+      -> test.setRootVisible(true, ()
+      -> testPathState1(test.tree, ()
+      -> test.expand(path, ()
+      -> testPathState(test.tree, "   +'root'\n" + CHILDREN_COLOR_GREEK, test::done))))))))))))))))));
+  }
+
+  private static final String CHILDREN
+    = "      'color'\n" +
+      "      'digit'\n" +
+      "      'greek'\n";
+  private static final String CHILDREN_COLOR
+    = "     +'color'\n" +
+      "        'red'\n" +
+      "        'green'\n" +
+      "        'blue'\n" +
+      "      'digit'\n" +
+      "      'greek'\n";
+  private static final String CHILDREN_COLOR_GREEK
+    = "     +'color'\n" +
+      "        'red'\n" +
+      "        'green'\n" +
+      "        'blue'\n" +
+      "      'digit'\n" +
+      "     +'greek'\n" +
+      "        'alpha'\n" +
+      "        'beta'\n" +
+      "        'gamma'\n" +
+      "        'delta'\n" +
+      "        'epsilon'\n";
+
+  @Test
+  public void testChildrenResolve() {
+    Node node = new Node("node");
+    Node root = new Node("root", new Node("upper", new Node("middle", new Node("lower", node))));
+    TreePath tp = TreePathUtil.convertArrayToTreePath(node.getPath());
+    testAsync(() -> root, test
+      -> testPathState(test.tree, "   +'root'\n      'upper'\n", ()
+      -> test.resolve(tp, path
+      -> test.expand(path.getParentPath(), () // expand parent path because leaf nodes are ignored
+      -> testPathState(test.tree, "   +'root'\n     +'upper'\n       +'middle'\n         +'lower'\n            'node'\n", test::done)))));
+  }
+
+  @Test
+  public void testChildrenVisit() {
+    Node node = new Node("node");
+    Node root = new Node("root", new Node("upper", new Node("middle", new Node("lower", node))));
+    TreePath tp = TreePathUtil.convertArrayToTreePath(node.getPath(), Object::toString);
+    testAsync(() -> root, test
+      -> testPathState(test.tree, "   +'root'\n      'upper'\n", ()
+      -> test.visit(new TreeVisitor.ByTreePath<>(tp, Object::toString), true, path
+      -> test.expand(path.getParentPath(), () // expand parent path because leaf nodes are ignored
+      -> testPathState(test.tree, "   +'root'\n     +'upper'\n       +'middle'\n         +'lower'\n            'node'\n", test::done)))));
+  }
+
+  @Test
+  public void testChildrenVisitWithoutLoading() {
+    Node node = new Node("node");
+    Node root = new Node("root", new Node("upper", new Node("middle", new Node("lower", node))));
+    TreePath tp = TreePathUtil.convertArrayToTreePath(node.getPath(), Object::toString);
+    testAsync(() -> root, test
+      -> testPathState(test.tree, "   +'root'\n      'upper'\n", ()
+      -> test.visit(new TreeVisitor.ByTreePath<>(tp, Object::toString), false, path -> {
+      assertNull(path);
+      test.done();
+    })));
+  }
+
+  @Test
+  public void testCollapsedNodeUpdateIfChildrenNotLoaded() {
+    TreeNode color = createColorNode();
+    TreeNode digit = createDigitNode();
+    TreeNode greek = createGreekNode();
+    TreeNode root = new Node("root", color, digit, greek);
+    TreePath path = new TreePath(root).pathByAddingChild(greek);
+    testAsync(() -> root, test
+      -> testPathState(test.tree, "   +'root'\n" + CHILDREN, ()
+      -> test.fireStructureChanged(path)));
+  }
+
+  @Test
+  public void testCollapsedNodeUpdateIfChildrenLoaded() {
+    TreeNode color = createColorNode();
+    TreeNode digit = createDigitNode();
+    TreeNode greek = createGreekNode();
+    TreeNode root = new Node("root", color, digit, greek);
+    TreePath path = new TreePath(root);
+    testAsync(() -> root, test
+      -> testPathState(test.tree, "   +'root'\n" + CHILDREN, ()
+      -> test.collapse(path, ()
+      -> testPathState1(test.tree, ()
+      -> test.fireStructureChanged(path)))));
+  }
+
+  @Test
+  public void testExpandedNodeUpdateIfChildrenLoaded() {
+    TreeNode color = createColorNode();
+    TreeNode digit = createDigitNode();
+    TreeNode greek = createGreekNode();
+    TreeNode root = new Node("root", color, digit, greek);
+    TreePath path = new TreePath(root);
+    testAsync(() -> root, test
+      -> testPathState(test.tree, "   +'root'\n" + CHILDREN, ()
+      -> test.fireStructureChanged(path)));
+  }
+
+  @NotNull
+  private static TreeNode createRoot() {
+    return new Node("root");
+  }
+
+  @NotNull
+  private static TreeNode createColorNode() {
+    return new Node("color", "red", "green", "blue");
+  }
+
+  @NotNull
+  private static TreeNode createDigitNode() {
+    return new Node("digit", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine");
+  }
+
+  @NotNull
+  private static TreeNode createGreekNode() {
+    return new Node("greek", "alpha", "beta", "gamma", "delta", "epsilon");
+  }
+
+  private static void testPathState(@NotNull JTree tree, @NotNull String state, @NotNull Runnable task) {
+    assertEquals("unexpected tree state", state, getPathState(tree));
+    task.run();
+  }
+
+  private static void testPathState0(@NotNull JTree tree, @NotNull Runnable task) {
+    assert 0 == tree.getRowCount() : "tree should have no nodes";
+    testPathState(tree, "", task);
+  }
+
+  private static void testPathState1(@NotNull JTree tree, @NotNull Runnable task) {
+    assert 1 == tree.getRowCount() : "tree should have only one node";
+    testPathState(tree, "    'root'\n", task);
+  }
+
+  private static void forEachRow(JTree tree, Consumer<TreePath> consumer) {
+    int count = tree.getRowCount();
+    for (int row = 0; row < count; row++) {
+      consumer.accept(tree.getPathForRow(row));
+    }
+  }
+
+  @NotNull
+  private static String getPathState(JTree tree) {
+    StringBuilder sb = new StringBuilder();
+    forEachRow(tree, path -> addState(sb, tree, path));
+    return sb.toString();
+  }
+
+  private static void addState(StringBuilder sb, JTree tree, TreePath path) {
+    boolean expanded = tree.isExpanded(path);
+    boolean selected = tree.isPathSelected(path);
+    sb.append(selected ? '[' : ' ');
+    int count = path.getPathCount();
+    while (0 < count--) sb.append("  ");
+    sb.append(expanded ? '+' : ' ');
+    sb.append(path.getLastPathComponent());
+    if (selected) sb.append(']');
+    sb.append("\n");
+  }
+
+  private static void testAsync(Supplier<TreeNode> root, @NotNull Consumer<ModelTest> consumer) {
+    testAsync(root, consumer, false);
+    testAsync(root, consumer, true);
+  }
+
+  private static void testAsync(Supplier<TreeNode> root, @NotNull Consumer<ModelTest> consumer, boolean showLoadingNode) {
+    testEventDispatchThread(root, consumer, showLoadingNode);
+    testBackgroundThread(root, consumer, showLoadingNode);
+    testBackgroundPool(root, consumer, showLoadingNode);
+  }
+
+  private static void testEventDispatchThread(Supplier<TreeNode> root, Consumer<ModelTest> consumer, boolean showLoadingNode) {
+    testEventDispatchThread(root, consumer, showLoadingNode, TreeTest.FAST);
+    testEventDispatchThread(root, consumer, showLoadingNode, TreeTest.SLOW);
+  }
+
+  private static void testEventDispatchThread(Supplier<TreeNode> root, Consumer<ModelTest> consumer, boolean showLoadingNode, int delay) {
+    new AsyncTest(showLoadingNode, new EventDispatchThreadModel(delay, root)).start(consumer, getSecondsToWait(delay));
+  }
+
+  private static void testBackgroundThread(Supplier<TreeNode> root, Consumer<ModelTest> consumer, boolean showLoadingNode) {
+    testBackgroundThread(root, consumer, showLoadingNode, TreeTest.FAST);
+    testBackgroundThread(root, consumer, showLoadingNode, TreeTest.SLOW);
+  }
+
+  private static void testBackgroundThread(Supplier<TreeNode> root, Consumer<ModelTest> consumer, boolean showLoadingNode, int delay) {
+    if (consumer != null) new AsyncTest(showLoadingNode, new BackgroundThreadModel(delay, root)).start(consumer, getSecondsToWait(delay));
+  }
+
+  private static void testBackgroundPool(Supplier<TreeNode> root, Consumer<ModelTest> consumer, boolean showLoadingNode) {
+    testBackgroundPool(root, consumer, showLoadingNode, TreeTest.FAST);
+    testBackgroundPool(root, consumer, showLoadingNode, TreeTest.SLOW);
+  }
+
+  private static void testBackgroundPool(Supplier<TreeNode> root, Consumer<ModelTest> consumer, boolean showLoadingNode, int delay) {
+    if (consumer != null) new AsyncTest(showLoadingNode, new BackgroundPoolModel(delay, root)).start(consumer, getSecondsToWait(delay));
+  }
+
+  private static void printTime(String prefix, long time) {
+    time = System.currentTimeMillis() - time;
+    if (PRINT) System.out.println(prefix + time + " ms");
+  }
+
+  private static void invokeWhenProcessingDone(@NotNull Runnable task, @NotNull AsyncTreeModel model, long time, int count) {
+    //noinspection SSBasedInspection
+    SwingUtilities.invokeLater(() -> {
+      if (model.isProcessing()) {
+        invokeWhenProcessingDone(task, model, time, 0);
+      }
+      else if (count < 2) {
+        invokeWhenProcessingDone(task, model, time, count + 1);
+      }
+      else {
+        printTime("wait for ", time);
+        task.run();
+      }
+    });
+  }
+
+  /**
+   * @param delay a delay used to create a slow tree model
+   * @return a maximal time in seconds allowed for the test
+   */
+  private static int getSecondsToWait(int delay) {
+    return delay + 20;
+  }
+
+  private static class ModelTest {
+    private final AsyncPromise<String> promise = new AsyncPromise<>();
+    private final TreeModel model;
+    private volatile JTree tree;
+
+    private ModelTest(long delay, Supplier<TreeNode> root) {
+      this(new SlowModel(delay, root));
+    }
+
+    private ModelTest(TreeModel model) {
+      this.model = model;
+    }
+
+    protected TreeModel createModelForTree(TreeModel model, Disposable disposable) {
+      return model;
+    }
+
+    void start(@NotNull Consumer<ModelTest> consumer, int seconds) {
+      if (PRINT) System.out.println("start " + toString());
+      assert !SwingUtilities.isEventDispatchThread() : "test should be started on the main thread";
+      long time = System.currentTimeMillis();
+      Disposable disposable = Disposer.newDisposable();
+
+      runOnSwingThread(() -> {
+        tree = new JTree(createModelForTree(model, disposable));
+        runOnSwingThreadWhenProcessingDone(() -> consumer.accept(this));
+      });
+      try {
+        promise.blockingGet(seconds, SECONDS);
+      }
+      catch (Exception exception) {
+        //noinspection InstanceofCatchParameter because of Kotlin
+        if (exception instanceof TimeoutException) {
+          System.err.println(dumpThreadsToString());
+          fail(seconds + " seconds is not enough for " + toString());
+        }
+        throw exception;
+      }
+      finally {
+        Disposer.dispose(disposable);
+        printTime("done in ", time);
+        if (PRINT) System.out.println();
+      }
+    }
+
+    void done() {
+      promise.setResult(null);
+    }
+
+    @NotNull
+    private Runnable wrap(@NotNull Runnable task) {
+      return () -> {
+        try {
+          task.run();
+        }
+        catch (Throwable throwable) {
+          promise.setError(throwable);
+        }
+      };
+    }
+
+    private void setRootVisible(boolean visible, @NotNull Runnable task) {
+      tree.setRootVisible(visible);
+      runOnSwingThreadWhenProcessingDone(task);
+    }
+
+    private void expand(@NotNull TreePath path, @NotNull Runnable task) {
+      tree.expandPath(path);
+      runOnSwingThreadWhenProcessingDone(task);
+    }
+
+    private void collapse(@NotNull TreePath path, @NotNull Runnable task) {
+      tree.collapsePath(path);
+      runOnSwingThreadWhenProcessingDone(task);
+    }
+
+    private void fireStructureChanged(@NotNull TreePath path) {
+      runOnSwingThread(() -> {
+        tree.getModel().addTreeModelListener(new TreeModelAdapter() {
+          @Override
+          protected void process(@NotNull TreeModelEvent event, @NotNull EventType type) {
+            assertEquals("unexpected tree path", path, event.getTreePath());
+            //noinspection SSBasedInspection
+            SwingUtilities.invokeLater(ModelTest.this::done);
+          }
+        });
+        runOnModelThread(() -> {
+          TreeModelEvent event = new TreeModelEvent(model, path);
+          TreeModelListener[] listeners = ((DefaultTreeModel)model).getTreeModelListeners();
+          for (TreeModelListener listener : listeners) listener.treeStructureChanged(event);
+        });
+      });
+    }
+
+    private void updateModelAndWait(Consumer<TreeModel> consumer, @NotNull Runnable task) {
+      runOnModelThread(() -> {
+        consumer.accept(model);
+        runOnSwingThreadWhenProcessingDone(task);
+      });
+    }
+
+    private void runOnModelThread(@NotNull Runnable task) {
+      if (model instanceof InvokerSupplier) {
+        InvokerSupplier supplier = (InvokerSupplier)model;
+        supplier.getInvoker().runOrInvokeLater(wrap(task));
+      }
+      else {
+        runOnSwingThread(task);
+      }
+    }
+
+    private void runOnSwingThread(@NotNull Runnable task) {
+      if (SwingUtilities.isEventDispatchThread()) {
+        wrap(task).run();
+      }
+      else {
+        //noinspection SSBasedInspection
+        SwingUtilities.invokeLater(wrap(task));
+      }
+    }
+
+    private void runOnSwingThreadWhenProcessingDone(@NotNull Runnable task) {
+      TreeModel model = tree.getModel();
+      if (model instanceof AsyncTreeModel) {
+        invokeWhenProcessingDone(wrap(task), (AsyncTreeModel)model, System.currentTimeMillis(), 0);
+      }
+      else {
+        runOnSwingThread(task);
+      }
+    }
+
+    private void resolve(@NotNull TreePath path, @NotNull Consumer<TreePath> consumer) {
+      AsyncTreeModel model = (AsyncTreeModel)tree.getModel();
+      model.resolve(path).onError(promise::setError).onSuccess(consumer);
+    }
+
+    private void visit(@NotNull TreeVisitor visitor, boolean allowLoading, @NotNull Consumer<TreePath> consumer) {
+      AsyncTreeModel model = (AsyncTreeModel)tree.getModel();
+      model.accept(visitor, allowLoading).onError(promise::setError).onSuccess(consumer);
+    }
+
+    @Override
+    public String toString() {
+      return model.toString();
+    }
+  }
+
+  private static class AsyncTest extends ModelTest {
+    private final boolean showLoadingNode;
+
+    private AsyncTest(boolean showLoadingNode, TreeModel model) {
+      super(model);
+      this.showLoadingNode = showLoadingNode;
+    }
+
+    @Override
+    protected TreeModel createModelForTree(TreeModel model, Disposable disposable) {
+      return new AsyncTreeModel(model, showLoadingNode, disposable);
+    }
+
+    @Override
+    public String toString() {
+      String string = super.toString();
+      if (showLoadingNode) string = "show loading node " + string;
+      return string;
+    }
+  }
+
+  private static class SlowModel extends DefaultTreeModel implements Disposable {
+    private final long delay;
+
+    private SlowModel(long delay, Supplier<TreeNode> root) {
+      super(root == null ? null : root.get());
+      this.delay = delay;
+    }
+
+    private void pause() {
+      if (this instanceof InvokerSupplier && THRESHOLD > Math.random()) {
+        // sometimes throw an exception to cancel current operation
+        if (PRINT) System.out.println("interrupt access to model:" + toString());
+        throw new ProcessCanceledException();
+      }
+      if (delay > 0) {
+        try {
+          Thread.sleep(delay);
+        }
+        catch (InterruptedException ignored) {
+        }
+      }
+    }
+
+    @Override
+    public final Object getRoot() {
+      pause();
+      return super.getRoot();
+    }
+
+    @Override
+    public final Object getChild(Object parent, int index) {
+      if (index == 0) pause(); // do not pause for every child
+      return super.getChild(parent, index);
+    }
+
+    @Override
+    public final int getChildCount(Object parent) {
+      pause();
+      return super.getChildCount(parent);
+    }
+
+    @Override
+    public final boolean isLeaf(Object node) {
+      pause();
+      return super.isLeaf(node);
+    }
+
+    @Override
+    public final int getIndexOfChild(Object parent, Object child) {
+      pause();
+      return super.getIndexOfChild(parent, child);
+    }
+
+    @Override
+    public final void dispose() {
+    }
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName() + "+" + delay + "ms";
+    }
+  }
+
+  private static final class EventDispatchThreadModel extends SlowModel implements InvokerSupplier {
+    private final Invoker invoker = new Invoker.EDT(this);
+
+    private EventDispatchThreadModel(long delay, Supplier<TreeNode> root) {
+      super(delay, root);
+    }
+
+    @NotNull
+    @Override
+    public Invoker getInvoker() {
+      return invoker;
+    }
+  }
+
+  private static final class BackgroundThreadModel extends SlowModel implements InvokerSupplier {
+    private final Invoker invoker = new Invoker.BackgroundThread(this);
+
+    private BackgroundThreadModel(long delay, Supplier<TreeNode> root) {
+      super(delay, root);
+    }
+
+    @NotNull
+    @Override
+    public Invoker getInvoker() {
+      return invoker;
+    }
+  }
+
+  private static final class BackgroundPoolModel extends SlowModel implements InvokerSupplier {
+    private final Invoker invoker = new Invoker.BackgroundPool(this);
+
+    private BackgroundPoolModel(long delay, Supplier<TreeNode> root) {
+      super(delay, root);
+    }
+
+    @NotNull
+    @Override
+    public Invoker getInvoker() {
+      return invoker;
+    }
+  }
+
+  private static class Node extends DefaultMutableTreeNode {
+    private final boolean mutable;
+
+    private Node(String content, boolean mutable) {
+      this(mutable, content, ArrayUtilRt.EMPTY_OBJECT_ARRAY);
+    }
+
+    private Node(String content, Object... children) {
+      this(false, content, children);
+    }
+
+    private Node(boolean mutable, Object content, Object... children) {
+      super(content);
+      this.mutable = mutable;
+      for (Object child : children) {
+        add(child instanceof MutableTreeNode
+            ? (MutableTreeNode)child
+            : new Node(mutable, child, ArrayUtilRt.EMPTY_OBJECT_ARRAY));
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      if (!mutable) return super.hashCode();
+      Object content = getUserObject();
+      return content == null ? 0 : content.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+      if (!mutable) return super.equals(object);
+      if (object instanceof Node) {
+        Node node = (Node)object;
+        if (node.mutable) return Objects.equals(getUserObject(), node.getUserObject());
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      Object content = getUserObject();
+      if (content == null) return "null";
+      return "'" + content + "'";
+    }
+  }
+
+
+  @Test
+  public void testNodePreservingOnEventDispatchThread() {
+    testNodePreservingOnEventDispatchThread(false);
+    testNodePreservingOnEventDispatchThread(true);
+  }
+
+  private static void testNodePreservingOnEventDispatchThread(boolean showLoadingNode) {
+    testNodePreserving(showLoadingNode, new GroupModel() {
+      private final Invoker invoker = new Invoker.EDT(this);
+
+      @NotNull
+      @Override
+      public Invoker getInvoker() {
+        return invoker;
+      }
+    });
+  }
+
+  @Test
+  public void testNodePreservingOnBackgroundThread() {
+    testNodePreservingOnBackgroundThread(false);
+    testNodePreservingOnBackgroundThread(true);
+  }
+
+  private static void testNodePreservingOnBackgroundThread(boolean showLoadingNode) {
+    testNodePreserving(showLoadingNode, new GroupModel() {
+      private final Invoker invoker = new Invoker.BackgroundThread(this);
+
+      @NotNull
+      @Override
+      public Invoker getInvoker() {
+        return invoker;
+      }
+    });
+  }
+
+  @Test
+  public void testNodePreservingOnBackgroundPool() {
+    testNodePreservingOnBackgroundPool(false);
+    testNodePreservingOnBackgroundPool(true);
+  }
+
+  private static void testNodePreservingOnBackgroundPool(boolean showLoadingNode) {
+    testNodePreserving(showLoadingNode, new GroupModel() {
+      private final Invoker invoker = new Invoker.BackgroundPool(this);
+
+      @NotNull
+      @Override
+      public Invoker getInvoker() {
+        return invoker;
+      }
+    });
+  }
+
+  private static void testNodePreserving(boolean showLoadingNode, @NotNull GroupModel model) {
+    new AsyncTest(showLoadingNode, model).start(test -> testPathState(test.tree, "   +root\n      node\n", ()
+      -> testNodePreserving(test, model, "first", ()
+      -> testNodePreserving(test, model, "second", ()
+      -> testNodePreserving(test, model, null, ()
+      -> testNodePreserving(test, model, "third", test::done))))), 10);
+  }
+
+  private static void testNodePreserving(@NotNull ModelTest test, @NotNull GroupModel model, Object group, @NotNull Runnable task) {
+    model.setGroup(group, () -> test.runOnSwingThreadWhenProcessingDone(() -> test.visit(path -> {
+      test.tree.makeVisible(path);
+      return TreeVisitor.Action.CONTINUE;
+    }, true, done -> testPathState(test.tree, group != null
+                                              ? "   +root\n     +" + group + "\n       +node\n          leaf\n"
+                                              : "   +root\n     +node\n        leaf\n", task))));
+  }
+
+  static abstract class GroupModel extends AbstractTreeModel implements InvokerSupplier {
+    private final Object myRoot = new StringBuilder("root");
+    private final Object myNode = new StringBuilder("node");
+    private final Object myLeaf = new StringBuilder("leaf");
+    private volatile Object myGroup;
+
+    @Override
+    public void valueForPathChanged(TreePath path, Object newValue) {
+      throw new UnsupportedOperationException();
+    }
+
+    public void setGroup(Object group, @NotNull Runnable task) {
+      getInvoker().runOrInvokeLater(() -> {
+        myGroup = group;
+        treeStructureChanged(null, null, null);
+        task.run();
+      });
+    }
+
+    @Override
+    public final Object getRoot() {
+      return myRoot;
+    }
+
+    @Override
+    public final Object getChild(Object parent, int index) {
+      if (index == 0) {
+        Object group = myGroup;
+        if (group == null) {
+          if (myRoot.equals(parent)) return myNode;
+        }
+        else {
+          if (myRoot.equals(parent)) return group;
+          if (group.equals(parent)) return myNode;
+        }
+        if (myNode.equals(parent)) return myLeaf;
+      }
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public final int getChildCount(Object parent) {
+      Object group = myGroup;
+      if (myRoot.equals(parent) || group != null && group.equals(parent)) return 1;
+      if (myNode.equals(parent)) return 1;
+      if (myLeaf.equals(parent)) return 0;
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public final boolean isLeaf(Object node) {
+      Object group = myGroup;
+      if (myRoot.equals(node) || group != null && group.equals(node)) return false;
+      if (myNode.equals(node)) return false;
+      if (myLeaf.equals(node)) return true;
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public final int getIndexOfChild(Object parent, Object child) {
+      Object group = myGroup;
+      if (group == null) {
+        if (myRoot.equals(parent) && myNode.equals(child)) return 0;
+      }
+      else {
+        if (myRoot.equals(parent) && group.equals(child)) return 0;
+        if (group.equals(parent) && myNode.equals(child)) return 0;
+      }
+      if (myNode.equals(parent) && myLeaf.equals(child)) return 0;
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public String toString() {
+      return getClass().getName();
+    }
+  }
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/tree/TreeTest.java
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/tree/TreeTest.java
@@ -1,0 +1,254 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package software.aws.toolkits.jetbrains.ui.tree;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.util.concurrency.Invoker;
+import com.intellij.util.concurrency.InvokerSupplier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.concurrency.AsyncPromise;
+import org.junit.Assert;
+
+import javax.swing.JTree;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreeNode;
+import javax.swing.tree.TreePath;
+import java.awt.EventQueue;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class TreeTest implements Disposable {
+  public static final int FAST = 0;
+  public static final int SLOW = 10;
+
+  private final AsyncPromise<Throwable> promise = new AsyncPromise<>();
+  private JTree tree;
+
+  public TreeTest(int minutes, Consumer<TreeTest> consumer, Function<Disposable, TreeModel> function) {
+    assert !EventQueue.isDispatchThread() : "main thread is expected";
+    invokeLater(() -> {
+      tree = new JTree(function.apply(this));
+      invokeAfterProcessing(() -> {
+        tree.collapseRow(0); // because root node is expanded by default
+        consumer.accept(this);
+      });
+    });
+    try {
+      Throwable throwable = promise.blockingGet(minutes, MINUTES);
+      if (throwable != null) throw new IllegalStateException("test failed", throwable);
+    }
+    finally {
+      Disposer.dispose(this);
+    }
+  }
+
+  @Override
+  public void dispose() {
+  }
+
+  public void invokeAfterProcessing(@NotNull Runnable runnable) {
+    if (TreeTestUtil.isProcessing(tree)) {
+      invokeLater(() -> invokeAfterProcessing(runnable));
+    }
+    else {
+      invokeSafely(runnable);
+    }
+  }
+
+  public void invokeLater(@NotNull Runnable runnable) {
+    EventQueue.invokeLater(() -> invokeSafely(runnable));
+  }
+
+  public void invokeSafely(@NotNull Runnable runnable) {
+    try {
+      runnable.run();
+    }
+    catch (Throwable throwable) {
+      promise.setResult(throwable);
+    }
+  }
+
+  public void assertTree(@NotNull String expected, @NotNull Runnable runnable) {
+    assertTree(expected, false, runnable);
+  }
+
+  public void assertTree(@NotNull String expected, boolean showSelection, @NotNull Runnable runnable) {
+    invokeSafely(() -> {
+      Assert.assertEquals(expected, TreeTestUtil.toString(getTree(), showSelection));
+      runnable.run();
+    });
+  }
+
+  public void addSelection(TreePath path, @NotNull Runnable runnable) {
+    invokeSafely(() -> {
+      Assert.assertNotNull(path);
+      Assert.assertTrue(getTree().isVisible(path));
+      getTree().addSelectionPath(path);
+      runnable.run();
+    });
+  }
+
+  public void done() {
+    promise.setResult(null);
+  }
+
+  @NotNull
+  public JTree getTree() {
+    return tree;
+  }
+
+  public static void test(Supplier<TreeNode> supplier, Consumer<TreeTest> consumer) {
+    test(2, supplier, consumer);
+  }
+
+  public static void test(int minutes, Supplier<TreeNode> supplier, Consumer<TreeTest> consumer) {
+    new TreeTest(minutes, consumer, parent -> model(supplier, FAST, false, null));
+    new TreeTest(minutes, consumer, parent -> model(supplier, SLOW, false, null));
+    new TreeTest(minutes, consumer, parent -> model(supplier, FAST, true, new Invoker.EDT(parent)));
+    new TreeTest(minutes, consumer, parent -> model(supplier, FAST, false, new Invoker.EDT(parent)));
+    new TreeTest(minutes, consumer, parent -> model(supplier, SLOW, true, new Invoker.EDT(parent)));
+    new TreeTest(minutes, consumer, parent -> model(supplier, SLOW, false, new Invoker.EDT(parent)));
+    new TreeTest(minutes, consumer, parent -> model(supplier, FAST, true, new Invoker.BackgroundThread(parent)));
+    new TreeTest(minutes, consumer, parent -> model(supplier, FAST, false, new Invoker.BackgroundThread(parent)));
+    new TreeTest(minutes, consumer, parent -> model(supplier, SLOW, true, new Invoker.BackgroundThread(parent)));
+    new TreeTest(minutes, consumer, parent -> model(supplier, SLOW, false, new Invoker.BackgroundThread(parent)));
+  }
+
+  private static TreeModel model(Supplier<TreeNode> supplier, long delay, boolean showLoadingNode, Invoker invoker) {
+    TreeModel model = new DefaultTreeModel(supplier.get());
+    if (delay > 0) {
+      model = new Wrapper.WithDelay(model, delay);
+    }
+    if (invoker != null) {
+      model = new Wrapper.WithInvoker(model, invoker);
+      model = new AsyncTreeModel(model, showLoadingNode, invoker);
+    }
+    return model;
+  }
+
+  private static class Wrapper implements TreeModel {
+    private final TreeModel model;
+
+    Wrapper(@NotNull TreeModel model) {
+      this.model = model;
+    }
+
+    @Override
+    public Object getRoot() {
+      return model.getRoot();
+    }
+
+    @Override
+    public Object getChild(Object parent, int index) {
+      return model.getChild(parent, index);
+    }
+
+    @Override
+    public int getChildCount(Object parent) {
+      return model.getChildCount(parent);
+    }
+
+    @Override
+    public int getIndexOfChild(Object parent, Object child) {
+      return model.getIndexOfChild(parent, child);
+    }
+
+    @Override
+    public boolean isLeaf(Object child) {
+      return model.isLeaf(child);
+    }
+
+    @Override
+    public void valueForPathChanged(TreePath path, Object value) {
+      model.valueForPathChanged(path, value);
+    }
+
+    @Override
+    public void addTreeModelListener(TreeModelListener listener) {
+      model.addTreeModelListener(listener);
+    }
+
+    @Override
+    public void removeTreeModelListener(TreeModelListener listener) {
+      model.removeTreeModelListener(listener);
+    }
+
+    private static class WithDelay extends Wrapper {
+      private final long delay;
+
+      WithDelay(@NotNull TreeModel model, long delay) {
+        super(model);
+        this.delay = delay;
+      }
+
+      void pause() {
+        if (delay > 0) {
+          try {
+            Thread.sleep(delay);
+          }
+          catch (InterruptedException ignored) {
+          }
+        }
+      }
+
+      @Override
+      public Object getRoot() {
+        pause();
+        return super.getRoot();
+      }
+
+      @Override
+      public Object getChild(Object parent, int index) {
+        if (index == 0) pause(); // do not pause for every child
+        return super.getChild(parent, index);
+      }
+
+      @Override
+      public int getChildCount(Object parent) {
+        pause();
+        return super.getChildCount(parent);
+      }
+
+      @Override
+      public int getIndexOfChild(Object parent, Object child) {
+        pause();
+        return super.getIndexOfChild(parent, child);
+      }
+
+      @Override
+      public boolean isLeaf(Object child) {
+        pause();
+        return super.isLeaf(child);
+      }
+
+      @Override
+      public void valueForPathChanged(TreePath path, Object value) {
+        pause();
+        super.valueForPathChanged(path, value);
+      }
+    }
+
+    private static class WithInvoker extends Wrapper implements InvokerSupplier {
+      private final Invoker invoker;
+
+      WithInvoker(@NotNull TreeModel model, @NotNull Invoker invoker) {
+        super(model);
+        this.invoker = invoker;
+      }
+
+      @NotNull
+      @Override
+      public Invoker getInvoker() {
+        return invoker;
+      }
+    }
+  }
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/tree/TreeTestUtil.java
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/tree/TreeTestUtil.java
@@ -1,0 +1,101 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2000-2017 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package software.aws.toolkits.jetbrains.ui.tree;
+
+import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.openapi.ui.Queryable;
+import com.intellij.ui.tree.TreeVisitor;
+import com.intellij.util.ArrayUtil;
+import com.intellij.util.ui.tree.TreeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import javax.swing.JTree;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreeNode;
+import javax.swing.tree.TreePath;
+
+public class TreeTestUtil {
+  public static final TreeVisitor VISIT_ALL = path -> TreeVisitor.Action.CONTINUE;
+  public static final Predicate<TreePath> APPEND_ALL = path -> true;
+  public static final Function<Object, String> TO_STRING = getToString(null);
+
+  @NotNull
+  public static Function<Object, String> getToString(@Nullable Queryable.PrintInfo info) {
+    return object -> {
+      if (object instanceof AbstractTreeNode) {
+        AbstractTreeNode node = (AbstractTreeNode)object;
+        return node.toTestString(info);
+      }
+      return String.valueOf(object);
+    };
+  }
+
+  @NotNull
+  public static String toString(@NotNull JTree tree) {
+    return toString(tree, VISIT_ALL, APPEND_ALL, false, TO_STRING);
+  }
+
+  @NotNull
+  public static String toString(@NotNull JTree tree, boolean showSelection) {
+    return toString(tree, VISIT_ALL, APPEND_ALL, showSelection, TO_STRING);
+  }
+
+  @NotNull
+  public static String toString(@NotNull JTree tree, @NotNull Predicate<? super TreePath> append, boolean showSelection) {
+    return toString(tree, VISIT_ALL, append, showSelection, TO_STRING);
+  }
+
+  @NotNull
+  public static String toString(@NotNull JTree tree, boolean showSelection, @NotNull Function<Object, String> toString) {
+    return toString(tree, VISIT_ALL, APPEND_ALL, showSelection, toString);
+  }
+
+  @NotNull
+  public static String toString(@NotNull JTree tree,
+                                @NotNull TreeVisitor visitor,
+                                @NotNull Predicate<? super TreePath> append,
+                                boolean showSelection,
+                                @NotNull Function<Object, String> toString) {
+    StringBuilder sb = new StringBuilder();
+    TreeUtil.visitVisibleRows(tree, path -> {
+      TreeVisitor.Action action = visitor.visit(path);
+      if (append.test(path)) {
+        int count = path.getPathCount();
+        for (int i = 1; i < count; i++) sb.append(' ');
+        Object component = path.getLastPathComponent();
+        if (!tree.getModel().isLeaf(component)) sb.append(tree.isExpanded(path) ? '-' : '+');
+        boolean selected = showSelection && tree.isPathSelected(path);
+        if (selected) sb.append('[');
+        sb.append(toString.apply(TreeUtil.getUserObject(component)));
+        if (selected) sb.append(']');
+        sb.append('\n');
+      }
+      return action;
+    });
+    return sb.toString();
+  }
+
+  public static boolean isProcessing(@NotNull JTree tree) {
+    TreeModel model = tree.getModel();
+    if (model instanceof AsyncTreeModel) {
+      AsyncTreeModel async = (AsyncTreeModel)model;
+      return async.isProcessing();
+    }
+    return false;
+  }
+
+  @NotNull
+  public static DefaultMutableTreeNode node(@NotNull Object object, Object... children) {
+    if (object instanceof DefaultMutableTreeNode && ArrayUtil.isEmpty(children)) return (DefaultMutableTreeNode)object;
+    if (object instanceof TreeNode) throw new IllegalArgumentException("do not use a tree node as a node content");
+    DefaultMutableTreeNode node = new DefaultMutableTreeNode(object);
+    for (Object child : children) node.add(node(child));
+    return node;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* JetBrain's Invoker is forced to run under a read action, fork the Invoker and AsyncTreeModel (and supporting classes) to remove that requirement

Changes include:
* Changed imports to align
* The invokeSafely method in Inoker

## Motivation and Context
Will be used in the explorer tree changes

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
