### PR TITLE
Enhancements to the resource cache

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
@@ -8,16 +8,21 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import software.amazon.awssdk.core.SdkClient
+import software.aws.toolkits.core.credentials.ToolkitCredentialsChangeListener
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
+import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
+import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
 /**
@@ -51,6 +56,45 @@ interface AwsResourceCache {
     ): CompletionStage<T>
 
     /**
+     * Blocking version of [getResource]
+     *
+     * @param[useStale] if an exception occurs attempting to refresh the resource return a cached version if it exists (even if it's expired). Default: true
+     * @param[forceFetch] force the resource to refresh (and update cache) even if a valid cache version exists. Default: false
+     */
+    fun <T> getResourceNow(resource: Resource<T>, timeout: Duration = DEFAULT_TIMEOUT, useStale: Boolean = true, forceFetch: Boolean = false): T =
+        wait(timeout) { getResource(resource, useStale, forceFetch) }
+
+    /**
+     * Blocking version of [getResource]
+     *
+     * @param[region] the specific [AwsRegion] to use for this resource
+     * @param[credentialProvider] the specific [ToolkitCredentialsProvider] to use for this resource
+     */
+    fun <T> getResourceNow(
+        resource: Resource<T>,
+        region: AwsRegion,
+        credentialProvider: ToolkitCredentialsProvider,
+        timeout: Duration = DEFAULT_TIMEOUT,
+        useStale: Boolean = true,
+        forceFetch: Boolean = false
+    ): T = wait(timeout) { getResource(resource, region, credentialProvider, useStale, forceFetch) }
+
+    /**
+     * Gets the [resource] if it exists in the cache.
+     *
+     * @param[useStale] return a cached version if it exists (even if it's expired). Default: true
+     */
+    fun <T> getResourceIfPresent(resource: Resource<T>, useStale: Boolean = true): T?
+
+    /**
+     * Gets the [resource] if it exists in the cache.
+     *
+     * @param[region] the specific [AwsRegion] to use for this resource
+     * @param[credentialProvider] the specific [ToolkitCredentialsProvider] to use for this resource
+     */
+    fun <T> getResourceIfPresent(resource: Resource<T>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider, useStale: Boolean = true): T?
+
+    /**
      * Clears the contents of the cache across all regions, credentials and resource types.
      */
     fun clear()
@@ -68,6 +112,13 @@ interface AwsResourceCache {
     companion object {
         @JvmStatic
         fun getInstance(project: Project): AwsResourceCache = ServiceManager.getService(project, AwsResourceCache::class.java)
+
+        private val DEFAULT_TIMEOUT = Duration.ofSeconds(5)
+        private fun <T> wait(timeout: Duration, call: () -> CompletionStage<T>) = try {
+            call().toCompletableFuture().get(timeout.toMillis(), TimeUnit.MILLISECONDS)
+        } catch (e: ExecutionException) {
+            throw e.cause ?: e
+        }
     }
 }
 
@@ -82,6 +133,7 @@ sealed class Resource<T> {
     abstract class Cached<T> : Resource<T>() {
         abstract fun fetch(project: Project, region: AwsRegion, credentials: ToolkitCredentialsProvider): T
         open fun expiry(): Duration = DEFAULT_EXPIRY
+        abstract val id: String
 
         companion object {
             private val DEFAULT_EXPIRY = Duration.ofMinutes(10)
@@ -101,6 +153,7 @@ sealed class Resource<T> {
 
 class ClientBackedCachedResource<ReturnType, ClientType : SdkClient>(
     private val sdkClientClass: KClass<ClientType>,
+    override val id: String,
     private val fetchCall: ClientType.() -> ReturnType
 ) : Resource.Cached<ReturnType>() {
     override fun fetch(project: Project, region: AwsRegion, credentials: ToolkitCredentialsProvider): ReturnType {
@@ -109,12 +162,17 @@ class ClientBackedCachedResource<ReturnType, ClientType : SdkClient>(
     }
 }
 
-class DefaultAwsResourceCache(private val project: Project, private val clock: Clock, maximumCacheEntries: Long) : AwsResourceCache {
+class DefaultAwsResourceCache(private val project: Project, private val clock: Clock, maximumCacheEntries: Long) :
+    AwsResourceCache, ToolkitCredentialsChangeListener {
 
     @Suppress("unused")
     constructor(project: Project) : this(project, Clock.systemDefaultZone(), MAXIMUM_CACHE_ENTRIES)
 
-    private val cache = CacheBuilder.newBuilder().maximumSize(maximumCacheEntries).build<Key<*>, Entry<*>>().asMap()
+    init {
+        ApplicationManager.getApplication().messageBus.connect().subscribe(CredentialManager.CREDENTIALS_CHANGED, this)
+    }
+
+    private val cache = CacheBuilder.newBuilder().maximumSize(maximumCacheEntries).build<CacheKey, Entry<*>>().asMap()
     private val accountSettings = ProjectAccountSettingsManager.getInstance(project)
 
     override fun <T> getResource(resource: Resource<T>, useStale: Boolean, forceFetch: Boolean) =
@@ -127,14 +185,17 @@ class DefaultAwsResourceCache(private val project: Project, private val clock: C
         useStale: Boolean,
         forceFetch: Boolean
     ): CompletionStage<T> = when (resource) {
-        is Resource.View<*, T> -> getResource(resource.underlying, region, credentialProvider, useStale, forceFetch).thenApply { resource.doMap(it as Any) }
+        is Resource.View<*, T> ->
+            getResource(resource.underlying, region, credentialProvider, useStale, forceFetch).thenApply { resource.doMap(it as Any) }
         is Resource.Cached<T> -> {
             val future = CompletableFuture<T>()
-            val key = Key(resource, region, credentialProvider)
+            val context = Context(resource, region, credentialProvider, useStale, forceFetch)
             ApplicationManager.getApplication().executeOnPooledThread {
                 try {
                     @Suppress("UNCHECKED_CAST")
-                    val result = cache.compute(key) { _, value -> fetchIfNeeded(key, value as Entry<T>?, useStale, forceFetch) } as Entry<T>
+                    val result = cache.compute(context.cacheKey) { _, value ->
+                        fetchIfNeeded(context, value as Entry<T>?)
+                    } as Entry<T>
                     future.complete(result.value)
                 } catch (e: Exception) {
                     future.completeExceptionally(e)
@@ -144,13 +205,28 @@ class DefaultAwsResourceCache(private val project: Project, private val clock: C
         }
     }
 
+    override fun <T> getResourceIfPresent(resource: Resource<T>, useStale: Boolean): T? =
+        getResourceIfPresent(resource, accountSettings.activeRegion, accountSettings.activeCredentialProvider, useStale)
+
+    override fun <T> getResourceIfPresent(resource: Resource<T>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider, useStale: Boolean): T? =
+        when (resource) {
+            is Resource.Cached<T> -> {
+                val entry = cache.getTyped<T>(CacheKey(resource.id, region.id, credentialProvider.id))
+                when {
+                    entry != null && (useStale || entry.notExpired) -> entry.value
+                    else -> null
+                }
+            }
+            is Resource.View<*, T> -> getResourceIfPresent(resource.underlying, region, credentialProvider, useStale)?.let { resource.doMap(it) }
+        }
+
     override fun clear(resource: Resource<*>) {
         clear(resource, accountSettings.activeRegion, accountSettings.activeCredentialProvider)
     }
 
     override fun clear(resource: Resource<*>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider) {
         when (resource) {
-            is Resource.Cached<*> -> cache.remove(Key(resource, region, credentialProvider))
+            is Resource.Cached<*> -> cache.remove(CacheKey(resource.id, region.id, credentialProvider.id))
             is Resource.View<*, *> -> clear(resource.underlying, region, credentialProvider)
         }
     }
@@ -159,28 +235,56 @@ class DefaultAwsResourceCache(private val project: Project, private val clock: C
         cache.clear()
     }
 
-    private fun <T> fetchIfNeeded(key: Key<T>, currentEntry: Entry<T>?, useStale: Boolean, forceFetch: Boolean) = when {
-        currentEntry == null -> fetch(key)
-        clock.instant().isBefore(currentEntry.expiry) && !forceFetch -> currentEntry
-        !useStale -> fetch(key)
-        else -> try {
-            fetch(key)
-        } catch (e: Exception) {
-            LOG.warn(e) { "Failed to fetch resource using $key, falling back to expired entry" }
-            currentEntry
-        } as Entry<T>
+    override fun providerRemoved(providerId: String) = clearByCredential(providerId)
+
+    override fun providerModified(provider: ToolkitCredentialsProvider) = clearByCredential(provider.id)
+
+    private fun clearByCredential(providerId: String) {
+        cache.keys.removeIf { it.credentialsId == providerId }
     }
 
-    private fun <T> fetch(key: Key<T>): Entry<T> {
-        val value = key.resource.fetch(project, key.region, key.credentials)
-        return Entry(clock.instant().plus(key.resource.expiry()), value)
+    private fun <T> fetchIfNeeded(context: Context<T>, currentEntry: Entry<T>?) = when {
+        currentEntry == null -> fetch(context)
+        currentEntry.notExpired && !context.forceFetch -> currentEntry
+        context.useStale -> fetchWithFallback(context, currentEntry)
+        else -> fetch(context)
     }
+
+    private fun <T> fetchWithFallback(context: Context<T>, currentEntry: Entry<T>) = try {
+        fetch(context)
+    } catch (e: Exception) {
+        LOG.warn(e) { "Failed to fetch resource using ${context.cacheKey}, falling back to expired entry" }
+        currentEntry
+    }
+
+    private fun <T> fetch(context: Context<T>): Entry<T> {
+        val value = context.resource.fetch(project, context.region, context.credentials)
+        return Entry(clock.instant().plus(context.resource.expiry()), value)
+    }
+
+    private val Entry<*>.notExpired get() = clock.instant().isBefore(expiry)
 
     companion object {
         private val LOG = getLogger<DefaultAwsResourceCache>()
         private const val MAXIMUM_CACHE_ENTRIES = 100L
 
-        private data class Key<T>(val resource: Resource.Cached<T>, val region: AwsRegion, val credentials: ToolkitCredentialsProvider)
+        private data class CacheKey(val resourceId: String, val regionId: String, val credentialsId: String)
+
+        private class Context<T>(
+            val resource: Resource.Cached<T>,
+            val region: AwsRegion,
+            val credentials: ToolkitCredentialsProvider,
+            val useStale: Boolean,
+            val forceFetch: Boolean
+        ) {
+            val cacheKey = CacheKey(resource.id, region.id, credentials.id)
+        }
+
         private class Entry<T>(val expiry: Instant, val value: T)
+
+        private fun <T> ConcurrentMap<CacheKey, Entry<*>>.getTyped(key: CacheKey) = this[key]?.let {
+            @Suppress("UNCHECKED_CAST")
+            it as Entry<T>
+        }
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/resources/LambdaResources.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/resources/LambdaResources.kt
@@ -7,5 +7,7 @@ import software.amazon.awssdk.services.lambda.LambdaClient
 import software.aws.toolkits.jetbrains.core.ClientBackedCachedResource
 
 object LambdaResources {
-    val LIST_FUNCTIONS = ClientBackedCachedResource(LambdaClient::class) { listFunctionsPaginator().functions().toList() }
+    val LIST_FUNCTIONS = ClientBackedCachedResource(LambdaClient::class, "lambda.list_functions") {
+        listFunctionsPaginator().functions().toList()
+    }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -3,8 +3,11 @@
 
 package software.aws.toolkits.jetbrains.core
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
 import com.intellij.testFramework.ProjectRule
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
@@ -13,6 +16,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.CompletableFutureAssert
 import org.junit.Before
 import org.junit.Rule
@@ -20,6 +24,7 @@ import org.junit.Test
 import software.amazon.awssdk.auth.credentials.AwsCredentials
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -27,6 +32,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 
 class AwsResourceCacheTest {
@@ -44,6 +50,7 @@ class AwsResourceCacheTest {
         sut.clear()
         reset(mockClock, mockResource)
         whenever(mockResource.expiry()).thenReturn(DEFAULT_EXPIRY)
+        whenever(mockResource.id).thenReturn("mock")
         whenever(mockClock.instant()).thenReturn(Instant.now())
     }
 
@@ -198,10 +205,14 @@ class AwsResourceCacheTest {
         try {
             val futures = (1 until concurrency).map {
                 val future = CompletableFuture<String>()
-                executor.submit { sut.getResource(mockResource).whenComplete { result, error -> when {
-                    result != null -> future.complete(result)
-                    error != null -> future.completeExceptionally(error)
-                } } }
+                executor.submit {
+                    sut.getResource(mockResource).whenComplete { result, error ->
+                        when {
+                            result != null -> future.complete(result)
+                            error != null -> future.completeExceptionally(error)
+                        }
+                    }
+                }
                 future
             }.toTypedArray()
             CompletableFuture.allOf(*futures).value
@@ -210,6 +221,123 @@ class AwsResourceCacheTest {
         }
 
         verifyResourceCalled(times = 1)
+    }
+
+    @Test
+    fun cachingShouldBeBasedOnId() {
+        val first = DummyCachedResource("first")
+        val anotherFirst = DummyCachedResource("first")
+
+        sut.getResource(first).value
+        sut.getResource(anotherFirst).value
+        assertThat(first.callCount).hasValue(1)
+        assertThat(anotherFirst.callCount).hasValue(0)
+    }
+
+    @Test
+    fun whenACredentialIdIsRemovedItsEntriesAreRemovedFromTheCache() {
+        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        getAllRegionAndCredPermutations()
+
+        ApplicationManager.getApplication().messageBus.syncPublisher(CredentialManager.CREDENTIALS_CHANGED).providerRemoved(CRED1.id)
+
+        getAllRegionAndCredPermutations()
+
+        verify(mockResource, times(2)).fetch(projectRule.project, US_WEST_1, CRED1)
+        verify(mockResource, times(2)).fetch(projectRule.project, US_WEST_2, CRED1)
+        verify(mockResource, times(1)).fetch(projectRule.project, US_WEST_1, CRED2)
+        verify(mockResource, times(1)).fetch(projectRule.project, US_WEST_2, CRED2)
+    }
+
+    @Test
+    fun whenACredentialIdIsModifiedItsEntriesAreRemovedFromTheCache() {
+        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        getAllRegionAndCredPermutations()
+
+        ApplicationManager.getApplication().messageBus.syncPublisher(CredentialManager.CREDENTIALS_CHANGED).providerModified(CRED1)
+
+        getAllRegionAndCredPermutations()
+
+        verify(mockResource, times(2)).fetch(projectRule.project, US_WEST_1, CRED1)
+        verify(mockResource, times(2)).fetch(projectRule.project, US_WEST_2, CRED1)
+        verify(mockResource, times(1)).fetch(projectRule.project, US_WEST_1, CRED2)
+        verify(mockResource, times(1)).fetch(projectRule.project, US_WEST_2, CRED2)
+    }
+
+    @Test
+    fun cacheExposesBlockingApi() {
+        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        assertThat(sut.getResourceNow(mockResource)).isEqualTo("hello")
+    }
+
+    @Test
+    fun cacheExposesBlockingApiWithRegionAndCred() {
+        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        assertThat(sut.getResourceNow(mockResource, US_WEST_1, CRED1)).isEqualTo("hello")
+        verify(mockResource).fetch(projectRule.project, US_WEST_1, CRED1)
+    }
+
+    @Test
+    fun cacheExposesBlockingApiWhereExecutionExceptionIsUnwrapped() {
+        whenever(mockResource.fetch(any(), any(), any())).thenThrow(RuntimeException("boom"))
+        assertThatThrownBy { sut.getResourceNow(mockResource, timeout = Duration.ofMillis(5)) }
+            .isInstanceOf(RuntimeException::class.java)
+            .withFailMessage("boom")
+    }
+
+    @Test
+    fun cacheExposesBlockingApiWithTimeout() {
+        whenever(mockResource.fetch(any(), any(), any())).thenAnswer {
+            Thread.sleep(50)
+            "hello"
+        }
+        assertThatThrownBy { sut.getResourceNow(mockResource, timeout = Duration.ofMillis(5)) }.isInstanceOf(TimeoutException::class.java)
+    }
+
+    @Test
+    fun canConditionallyFetchOnlyIfAvailableInCache() {
+        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+
+        assertThat(sut.getResourceIfPresent(mockResource, US_WEST_1, CRED1)).isNull()
+        sut.getResource(mockResource, US_WEST_1, CRED1).value
+        assertThat(sut.getResourceIfPresent(mockResource, US_WEST_1, CRED1)).isEqualTo("hello")
+    }
+
+    @Test
+    fun canConditionallyFetchOnlyIfAvailableInCacheAndRespectExpiry() {
+        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+
+        val now = Instant.now()
+        whenever(mockClock.instant()).thenReturn(now)
+        sut.getResource(mockResource, US_WEST_1, CRED1).value
+
+        whenever(mockClock.instant()).thenReturn(now.plus(DEFAULT_EXPIRY).plusMillis(1))
+        assertThat(sut.getResourceIfPresent(mockResource, US_WEST_1, CRED1, useStale = false)).isNull()
+    }
+
+    @Test
+    fun canConditionallyFetchViewOnlyIfAvailableInCache() {
+        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        val viewResource = Resource.View(mockResource) { reversed() }
+
+        assertThat(sut.getResourceIfPresent(viewResource, US_WEST_1, CRED1)).isNull()
+        sut.getResource(viewResource, US_WEST_1, CRED1).value
+        assertThat(sut.getResourceIfPresent(viewResource, US_WEST_1, CRED1)).isEqualTo("olleh")
+    }
+
+    @Test
+    fun canConditionallyFetchOnlyIfAvailableWithoutExplicitCredentialsRegion() {
+        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        sut.getResource(mockResource).value
+
+        assertThat(sut.getResourceIfPresent(mockResource)).isEqualTo("hello")
+    }
+
+    private fun getAllRegionAndCredPermutations() {
+        sut.getResource(mockResource, US_WEST_1, CRED1).value
+        sut.getResource(mockResource, US_WEST_2, CRED1).value
+        sut.getResource(mockResource, US_WEST_1, CRED2).value
+        sut.getResource(mockResource, US_WEST_2, CRED2).value
     }
 
     private fun assertExpectedExpiryFunctions(expiryFunction: Instant.() -> Instant, shouldExpire: Boolean) {
@@ -232,6 +360,7 @@ class AwsResourceCacheTest {
     private fun verifyResourceCalled(times: Int, resource: Resource.Cached<*> = mockResource) {
         verify(resource, times(times)).fetch(any(), any(), any())
         verify(resource, times(times)).expiry()
+        verify(resource, atLeastOnce()).id
         verifyNoMoreInteractions(resource)
     }
 
@@ -265,6 +394,14 @@ class AwsResourceCacheTest {
 
             override fun resolveCredentials(): AwsCredentials {
                 TODO("not implemented")
+            }
+        }
+
+        private class DummyCachedResource(override val id: String) : Resource.Cached<String>() {
+            val callCount = AtomicInteger(0)
+            override fun fetch(project: Project, region: AwsRegion, credentials: ToolkitCredentialsProvider): String {
+                callCount.incrementAndGet()
+                return id
             }
         }
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
@@ -12,6 +12,13 @@ import java.util.concurrent.CompletionStage
 
 @Suppress("UNCHECKED_CAST")
 class MockResourceCache : AwsResourceCache {
+    override fun <T> getResourceIfPresent(resource: Resource<T>, useStale: Boolean): T? {
+        TODO("not implemented")
+    }
+
+    override fun <T> getResourceIfPresent(resource: Resource<T>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider, useStale: Boolean): T? {
+        TODO("not implemented")
+    }
 
     override fun <T> getResource(resource: Resource<T>, useStale: Boolean, forceFetch: Boolean) = resourceFuture as CompletionStage<T>
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/ResourceSelectorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/ResourceSelectorTest.kt
@@ -43,6 +43,7 @@ class ResourceSelectorTest {
     fun comboBoxPopulation_useDefaultSelectedWhenPreviouslySelectedIsNull() {
         val items = listOf("foo", "bar", "baz")
 
+        comboBox.model.selectedItem = null
         comboBox.populateValues(default = "bar", forceSelectDefault = false) { items }
 
         waitForPopulationComplete(comboBox, items.size)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Several enhancements to the resource cache:
* `Resource.Cache` keys now expose a `String` `id` field which is used as the cache-key - previously was using object identity.
* When a credential provider is updated or removed, its related cache entries are evicted
* Added two styles of blocking API: 
  * `getResourceNow` - a wrapper around the async API that will block until the resource is available
  * `getResourceIfPresent` - will return a value only if it exists in the cache (else `null`)

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
new unit tests added to cover functionality

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
