### PR TITLE
Ripped out Guava cache implementation to avoid AssertionError

### DIFF
--- a/.changes/next-release/bugfix-4ae48455-7ae7-434a-a8c9-67ec4414d828.json
+++ b/.changes/next-release/bugfix-4ae48455-7ae7-434a-a8c9-67ec4414d828.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fixing random AssertionError exception caused by Guava cache."
+}


### PR DESCRIPTION
Replaced with `ConcurrentHashMap` which is periodically pruned to ensure memory remains managable.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Removed Guava cache implementation. New implementation is a basic Java `ConcurrentHashMap` with a periodically scheduled job that prunes entries once the map exceeds a certain number of (configurable) entries - currently set to 1000. Entries are sorted by expiration with those closest to expiry being removed.

Entries are given a weighting (rather than just a straight number) in an attempt to size them, collection based entries use the size of the collection as the weight, all others are 1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Guava cache implementation randomly throws `AssertionError` exceptions on some cache accesses (as part of the cache eviction process) when using `asMap()`

See https://github.com/google/guava/issues/3464

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit tests added.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
