### PR TITLE
Fix the bug that PyCharm errors when selecting pipenv but the locatio…

### DIFF
--- a/.changes/next-release/bugfix-116ff706-b5ff-4375-bb88-374a38ad8c71.json
+++ b/.changes/next-release/bugfix-116ff706-b5ff-4375-bb88-374a38ad8c71.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix the bug that PyCharm pipenv doesn't create the project location folder"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/PyCharmSdkSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/PyCharmSdkSelectionPanel.kt
@@ -7,6 +7,7 @@ import com.intellij.ide.util.projectWizard.AbstractNewProjectStep
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil
 import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.ui.DocumentAdapter
 import com.intellij.util.ui.UIUtil
 import com.jetbrains.python.newProject.PyNewProjectSettings
@@ -19,6 +20,7 @@ import icons.AwsIcons
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedSdkSettings
 import software.aws.toolkits.jetbrains.services.lambda.SdkSettings
 import software.aws.toolkits.resources.message
+import java.io.File
 import javax.swing.Icon
 import javax.swing.JLabel
 import javax.swing.JPanel
@@ -89,6 +91,7 @@ class PyCharmSdkSelectionPanel(val step: SamProjectRuntimeSelectionStep) : SdkSe
         when (val panel = sdkSelectionPanel.selectedPanel) {
             // this list should be exhaustive
             is PyAddNewEnvironmentPanel -> {
+                FileUtil.createDirectory(File(step.getLocationField().text.trim()))
                 panel.getOrCreateSdk()?.also {
                     SdkConfigurationUtil.addSdk(it)
                 }


### PR DESCRIPTION
…n file doesn't exist

<!--- Provide a general summary of your changes in the Title above -->
Fix the bug that when creating a new serverless application in PyCharm, IDE throws error dialog when choosing to use pipenv and the project location specified is not a valid a folder.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#1159 

## Testing
Tested manually in PyCharm.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
