### PR TITLE
Fix an exception thrown when using ExecutableManager

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
@@ -126,12 +126,17 @@ class DefaultExecutableManager : PersistentStateComponent<List<ExecutableState>>
         val message = message("aws.settings.executables.executable_invalid", type.displayName, e.asString)
         LOG.warn(e) { message }
 
-        ExecutableInstance.InvalidExecutable(path,
+        ExecutableInstance.InvalidExecutable(
+            path,
             null,
             autoResolved,
             message
         )
-    }.also { updateInternalState(type, it) }
+    }.also {
+        when (it) {
+            is ExecutableInstance.Executable -> updateInternalState(type, it)
+        }
+    }
 
     private fun determineVersion(type: ExecutableType<*>, path: Path, autoResolved: Boolean): ExecutableInstance = try {
         ExecutableInstance.Executable(path, type.version(path).toString(), autoResolved)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
@@ -85,7 +85,6 @@ class DefaultExecutableManager : PersistentStateComponent<List<ExecutableState>>
         val future = CompletableFuture<ExecutableInstance>()
         ApplicationManager.getApplication().executeOnPooledThread {
             val executable = validate(type, path, false)
-            updateInternalState(type, executable)
             future.complete(executable)
         }
         return future
@@ -106,7 +105,12 @@ class DefaultExecutableManager : PersistentStateComponent<List<ExecutableState>>
             resolved?.executablePath?.toString(),
             resolved?.autoResolved,
             resolved?.executablePath?.lastModifiedOrNull()?.toMillis())
-        internalState[type.id] = Triple(newPersistedState, instance, resolved?.executablePath?.lastModified())
+        val lastModified = try {
+            resolved?.executablePath?.lastModified()
+        } catch (e: Exception) {
+            null
+        }
+        internalState[type.id] = Triple(newPersistedState, instance, lastModified)
     }
 
     private fun resolve(type: ExecutableType<*>): ExecutableInstance = try {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/executables/ExecutableManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/executables/ExecutableManagerTest.kt
@@ -14,6 +14,7 @@ import software.aws.toolkits.jetbrains.utils.isInstanceOf
 import software.aws.toolkits.jetbrains.utils.value
 import software.aws.toolkits.jetbrains.utils.wait
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicInteger
 
 class ExecutableManagerTest {
@@ -160,6 +161,21 @@ class ExecutableManagerTest {
         assertThat(sut.getExecutableIfPresent(type)).isInstanceOfSatisfying(ExecutableInstance.Executable::class.java) {
             assertThat(it.executablePath).isEqualTo(executable.toPath())
         }
+    }
+
+    @Test
+    fun setExecutablePathFailsWhenValidateFails() {
+        val type = object : DummyExecutableType("dummy"), AutoResolvable, Validatable {
+            override fun resolve(): Path? = null
+            override fun validate(path: Path) {
+                throw RuntimeException("ow")
+            }
+        }
+        val executable = "/fake/path////////////        "
+
+        sut.setExecutablePath(type, Paths.get(executable)).value
+
+        assertThat(sut.getExecutable(type).value).isInstanceOf(ExecutableInstance.UnresolvedExecutable::class.java)
     }
 
     private fun modifyFile(executable: Path) {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/executables/ExecutableManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/executables/ExecutableManagerTest.kt
@@ -171,7 +171,7 @@ class ExecutableManagerTest {
                 throw RuntimeException("ow")
             }
         }
-        val executable = "/fake/path////////////        "
+        val executable = "/fake/path////////////"
 
         sut.setExecutablePath(type, Paths.get(executable)).value
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- ```resolved?.executablePath?.lastModified()``` was throwing when executablePath existed but was not valid.
- Additionally, ```updateInternalState``` was being called twice because ```validate``` already calls ```updateInternalState``` with an ```also```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
