### PR TITLE
Fix loading of region in AWS Connection tab

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/connection/AwsConnectionSettingsEditor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/connection/AwsConnectionSettingsEditor.kt
@@ -46,7 +46,7 @@ class AwsConnectionSettingsEditor<T : AwsConnectionsRunConfigurationBase<*>>(
     override fun createEditor(): JComponent = view.panel
 
     override fun resetEditorFrom(settings: T) {
-        view.region.selectedRegion = settings.regionId()?.let { regionProvider.lookupRegionById(it) }
+        settings.regionId()?.let { view.region.selectedRegion = regionProvider.lookupRegionById(it) }
 
         settings.credentialProviderId()?.let { credentialProviderId ->
             try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Region was getting overwritten by null after being set, this fixes this issue.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
