### PR TITLE
Push resolveCredentials and resolveRegion up to AwsConnectionSettingsEditor

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfigurationBase.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfigurationBase.kt
@@ -14,9 +14,6 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.util.xmlb.annotations.Property
 import org.jdom.Element
-import software.aws.toolkits.core.credentials.CredentialProviderNotFound
-import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
-import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.ui.connection.AwsConnectionsRunConfigurationBase
 import software.aws.toolkits.jetbrains.ui.connection.BaseAwsConnectionOptions
 import software.aws.toolkits.resources.message
@@ -87,25 +84,6 @@ abstract class LambdaRunConfigurationBase<T : BaseLambdaOptions>(
             it
         }
     } ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_input_specified"))
-
-    protected fun resolveCredentials() = credentialProviderId()?.let {
-        try {
-            CredentialManager.getInstance().getCredentialProvider(it)
-        } catch (e: CredentialProviderNotFound) {
-            throw RuntimeConfigurationError(message("lambda.run_configuration.credential_not_found_error", it))
-        } catch (e: Exception) {
-            throw RuntimeConfigurationError(
-                message(
-                    "lambda.run_configuration.credential_error",
-                    e.message ?: "Unknown"
-                )
-            )
-        }
-    } ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_credentials_specified"))
-
-    protected fun resolveRegion() = regionId()?.let {
-        AwsRegionProvider.getInstance().regions()[it]
-    } ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_region_specified"))
 }
 
 open class BaseLambdaOptions : BaseAwsConnectionOptions() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- resolveCredentials and resolveRegion are reusable in other run configs and make sense in AwsConnectionSettingsEditor
- Make AwsConnectionsRunConfigurationBase take a `String?` like its base class
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
