### PR TITLE
Deprecate "namespace" in telemetry calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,9 +136,6 @@ subprojects {
         tasks.withType(JavaCompile).all {
             options.compilerArgs << "-Werror"
         }
-        tasks.withType(KotlinCompile).all {
-            kotlinOptions.allWarningsAsErrors = true
-        }
     }
 
     task integrationTest(type: Test) {

--- a/core/src/software/aws/toolkits/core/telemetry/TelemetryNamespace.kt
+++ b/core/src/software/aws/toolkits/core/telemetry/TelemetryNamespace.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.core.telemetry
 
+@Deprecated("TelemetryNamespace should not be used")
 interface TelemetryNamespace {
     fun getNamespace(): String = javaClass.simpleName
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
@@ -28,9 +28,13 @@ interface TelemetryService : Disposable {
         val awsRegion: String = METADATA_NA
     )
 
-    // TODO consider using DataProvider for the metricEventMetadata.
-    fun record(namespace: String, metricEventMetadata: MetricEventMetadata, buildEvent: MetricEvent.Builder.() -> kotlin.Unit = {}): MetricEvent
+    fun record(metricEventMetadata: MetricEventMetadata, buildEvent: MetricEvent.Builder.() -> kotlin.Unit = {}) = record(null, metricEventMetadata, buildEvent)
 
+    // TODO consider using DataProvider for the metricEventMetadata.
+    @Deprecated("Record should not be called with a namespace")
+    fun record(namespace: String?, metricEventMetadata: MetricEventMetadata, buildEvent: MetricEvent.Builder.() -> kotlin.Unit = {}): MetricEvent
+
+    @Deprecated("Record should not be called with a namespace")
     fun record(project: Project?, namespace: String, buildEvent: MetricEvent.Builder.() -> kotlin.Unit = {}): CompletableFuture<MetricEvent> {
         val metricEvent = CompletableFuture<MetricEvent>()
         ApplicationManager.getApplication().executeOnPooledThread {
@@ -98,7 +102,7 @@ class DefaultTelemetryService(
     }
 
     override fun record(
-        namespace: String,
+        namespace: String?,
         metricEventMetadata: TelemetryService.MetricEventMetadata,
         buildEvent: MetricEvent.Builder.() -> kotlin.Unit
     ): MetricEvent {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/DefaultTelemetryPublisherTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/DefaultTelemetryPublisherTest.kt
@@ -18,14 +18,13 @@ import software.aws.toolkits.core.telemetry.DefaultMetricEvent
 import software.aws.toolkits.jetbrains.utils.delegateMock
 
 class DefaultTelemetryPublisherTest {
-
     @Rule
     @JvmField
     val projectRule = ProjectRule()
 
     @Test
-    fun testPublish() {
-        val mockPostMetircsRequestCaptor = argumentCaptor<PostMetricsRequest>()
+    fun testPublish_withNamespace() {
+        val mockPostMetricsRequestCaptor = argumentCaptor<PostMetricsRequest>()
 
         val mockTelemetryClient = delegateMock<ToolkitTelemetryClient>()
         val publisher = DefaultTelemetryPublisher(
@@ -39,16 +38,21 @@ class DefaultTelemetryPublisherTest {
             osVersion = "1.0"
         )
 
-        val metricEvent = DefaultMetricEvent.builder("Foo")
-            .awsAccount("111111111111")
-            .awsRegion("us-west-2")
-            .datum("Bar") { this.count() }
-            .build()
+        publisher.publish(listOf(
+            DefaultMetricEvent.builder("Foo")
+                .awsAccount("111111111111")
+                .awsRegion("us-west-2")
+                .datum("foobar") { this.count() }
+                .build(),
+            DefaultMetricEvent.builder("Bar")
+                .awsAccount("111111111111")
+                .awsRegion("us-west-2")
+                .datum("spam") { this.count() }
+                .build()
+        ))
 
-        publisher.publish(listOf(metricEvent))
-
-        verify(mockTelemetryClient, times(1)).postMetrics(mockPostMetircsRequestCaptor.capture())
-        val postMetricsRequest = mockPostMetircsRequestCaptor.firstValue
+        verify(mockTelemetryClient, times(1)).postMetrics(mockPostMetricsRequestCaptor.capture())
+        val postMetricsRequest = mockPostMetricsRequestCaptor.firstValue
 
         assertThat(postMetricsRequest.awsProduct()).isEqualTo(AWSProduct.AWS_TOOLKIT_FOR_JET_BRAINS)
         assertThat(postMetricsRequest.awsProductVersion()).isEqualTo("1.0")
@@ -57,19 +61,171 @@ class DefaultTelemetryPublisherTest {
         assertThat(postMetricsRequest.parentProductVersion()).isEqualTo("191")
         assertThat(postMetricsRequest.os()).isEqualTo("mac")
         assertThat(postMetricsRequest.osVersion()).isEqualTo("1.0")
-        assertThat(postMetricsRequest.metricData()).hasSize(1)
+        assertThat(postMetricsRequest.metricData()).hasSize(2)
 
-        val metricDatum = postMetricsRequest.metricData()[0]
-        assertThat(metricDatum.metricName()).isEqualTo("Foo.Bar")
-        assertThat(metricDatum.metadata()).contains(
-            MetadataEntry.builder()
-                .key("awsAccount")
-                .value("111111111111")
-                .build(),
-            MetadataEntry.builder()
-                .key("awsRegion")
-                .value("us-west-2")
-                .build()
+        postMetricsRequest.metricData()[0].let {
+            assertThat(it.metricName()).isEqualTo("Foo.foobar")
+            assertThat(it.metadata()).contains(
+                MetadataEntry.builder()
+                    .key("awsAccount")
+                    .value("111111111111")
+                    .build(),
+                MetadataEntry.builder()
+                    .key("awsRegion")
+                    .value("us-west-2")
+                    .build()
+            )
+        }
+
+        postMetricsRequest.metricData()[1].let {
+            assertThat(it.metricName()).isEqualTo("Bar.spam")
+            assertThat(it.metadata()).contains(
+                MetadataEntry.builder()
+                    .key("awsAccount")
+                    .value("111111111111")
+                    .build(),
+                MetadataEntry.builder()
+                    .key("awsRegion")
+                    .value("us-west-2")
+                    .build()
+            )
+        }
+    }
+
+    @Test
+    fun testPublish_withNamespace_withoutDatum() {
+        val mockPostMetricsRequestCaptor = argumentCaptor<PostMetricsRequest>()
+
+        val mockTelemetryClient = delegateMock<ToolkitTelemetryClient>()
+        val publisher = DefaultTelemetryPublisher(
+            productName = AWSProduct.AWS_TOOLKIT_FOR_JET_BRAINS,
+            productVersion = "1.0",
+            clientId = "foo",
+            parentProduct = "JetBrains",
+            parentProductVersion = "191",
+            client = mockTelemetryClient,
+            os = "mac",
+            osVersion = "1.0"
         )
+
+        publisher.publish(listOf(
+            DefaultMetricEvent.builder("Foo")
+                .awsAccount("111111111111")
+                .awsRegion("us-west-2")
+                .build(),
+            DefaultMetricEvent.builder("Bar")
+                .awsAccount("111111111111")
+                .awsRegion("us-west-2")
+                .build()
+        ))
+
+        verify(mockTelemetryClient, times(1)).postMetrics(mockPostMetricsRequestCaptor.capture())
+        val postMetricsRequest = mockPostMetricsRequestCaptor.firstValue
+
+        assertThat(postMetricsRequest.awsProduct()).isEqualTo(AWSProduct.AWS_TOOLKIT_FOR_JET_BRAINS)
+        assertThat(postMetricsRequest.awsProductVersion()).isEqualTo("1.0")
+        assertThat(postMetricsRequest.clientID()).isEqualTo("foo")
+        assertThat(postMetricsRequest.parentProduct()).isEqualTo("JetBrains")
+        assertThat(postMetricsRequest.parentProductVersion()).isEqualTo("191")
+        assertThat(postMetricsRequest.os()).isEqualTo("mac")
+        assertThat(postMetricsRequest.osVersion()).isEqualTo("1.0")
+        assertThat(postMetricsRequest.metricData()).hasSize(2)
+
+        postMetricsRequest.metricData()[0].let {
+            assertThat(it.metricName()).isEqualTo("Foo")
+            assertThat(it.metadata()).contains(
+                MetadataEntry.builder()
+                    .key("awsAccount")
+                    .value("111111111111")
+                    .build(),
+                MetadataEntry.builder()
+                    .key("awsRegion")
+                    .value("us-west-2")
+                    .build()
+            )        }
+
+        postMetricsRequest.metricData()[1].let {
+            assertThat(it.metricName()).isEqualTo("Bar")
+            assertThat(it.metadata()).contains(
+                MetadataEntry.builder()
+                    .key("awsAccount")
+                    .value("111111111111")
+                    .build(),
+                MetadataEntry.builder()
+                    .key("awsRegion")
+                    .value("us-west-2")
+                    .build()
+            )
+        }
+    }
+
+    @Test
+    fun testPublish_withoutNamespace() {
+        val mockPostMetricsRequestCaptor = argumentCaptor<PostMetricsRequest>()
+
+        val mockTelemetryClient = delegateMock<ToolkitTelemetryClient>()
+        val publisher = DefaultTelemetryPublisher(
+            productName = AWSProduct.AWS_TOOLKIT_FOR_JET_BRAINS,
+            productVersion = "1.0",
+            clientId = "foo",
+            parentProduct = "JetBrains",
+            parentProductVersion = "191",
+            client = mockTelemetryClient,
+            os = "mac",
+            osVersion = "1.0"
+        )
+
+        publisher.publish(listOf(
+            DefaultMetricEvent.builder()
+                .awsAccount("111111111111")
+                .awsRegion("us-west-2")
+                .datum("foobar") { this.count() }
+                .build(),
+            DefaultMetricEvent.builder()
+                .awsAccount("111111111111")
+                .awsRegion("us-west-2")
+                .datum("spam") { this.count() }
+                .build()
+        ))
+
+        verify(mockTelemetryClient, times(1)).postMetrics(mockPostMetricsRequestCaptor.capture())
+        val postMetricsRequest = mockPostMetricsRequestCaptor.firstValue
+
+        assertThat(postMetricsRequest.awsProduct()).isEqualTo(AWSProduct.AWS_TOOLKIT_FOR_JET_BRAINS)
+        assertThat(postMetricsRequest.awsProductVersion()).isEqualTo("1.0")
+        assertThat(postMetricsRequest.clientID()).isEqualTo("foo")
+        assertThat(postMetricsRequest.parentProduct()).isEqualTo("JetBrains")
+        assertThat(postMetricsRequest.parentProductVersion()).isEqualTo("191")
+        assertThat(postMetricsRequest.os()).isEqualTo("mac")
+        assertThat(postMetricsRequest.osVersion()).isEqualTo("1.0")
+        assertThat(postMetricsRequest.metricData()).hasSize(2)
+
+        postMetricsRequest.metricData()[0].let {
+            assertThat(it.metricName()).isEqualTo("foobar")
+            assertThat(it.metadata()).contains(
+                MetadataEntry.builder()
+                    .key("awsAccount")
+                    .value("111111111111")
+                    .build(),
+                MetadataEntry.builder()
+                    .key("awsRegion")
+                    .value("us-west-2")
+                    .build()
+            )
+        }
+
+        postMetricsRequest.metricData()[1].let {
+            assertThat(it.metricName()).isEqualTo("spam")
+            assertThat(it.metadata()).contains(
+                MetadataEntry.builder()
+                    .key("awsAccount")
+                    .value("111111111111")
+                    .build(),
+                MetadataEntry.builder()
+                    .key("awsRegion")
+                    .value("us-west-2")
+                    .build()
+            )
+        }
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/DefaultTelemetryPublisherTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/DefaultTelemetryPublisherTest.kt
@@ -142,7 +142,8 @@ class DefaultTelemetryPublisherTest {
                     .key("awsRegion")
                     .value("us-west-2")
                     .build()
-            )        }
+            )
+        }
 
         postMetricsRequest.metricData()[1].let {
             assertThat(it.metricName()).isEqualTo("Bar")

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/MockTelemetryService.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/MockTelemetryService.kt
@@ -8,9 +8,9 @@ import software.aws.toolkits.core.telemetry.MetricEvent
 
 class MockTelemetryService : TelemetryService {
     override fun record(
-        namespace: String,
+        namespace: String?,
         metricEventMetadata: TelemetryService.MetricEventMetadata,
-        buildEvent: MetricEvent.Builder.() -> kotlin.Unit
+        buildEvent: MetricEvent.Builder.() -> Unit
     ): MetricEvent {
         val builder = DefaultMetricEvent.builder(namespace)
         buildEvent(builder)


### PR DESCRIPTION
"Namespace" as a concept doesn't mesh well with our team's new naming strategy for telemetry events. This change marks all references to "namespace" as deprecated and allows building telemetry events that are not tied to a top-level "namespace".

In the future, we should:
* have all of our metric names in a schematized format that can be shared across our products.
* remove the `ActionWrappers` and `LoggingDialogWrapper` system
* migrate the existing telemetry names into the new format

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
