### PR TITLE
Fix line markers throwing exception if no active credentials and not …

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
@@ -21,6 +21,7 @@ import com.intellij.psi.SmartPointerManager
 import icons.AwsIcons
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.core.AwsResourceCache
+import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplateIndex.Companion.listFunctions
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
@@ -97,6 +98,10 @@ class LambdaLineMarker : LineMarkerProviderDescriptor() {
 
     // Handler defined in remote Lambda with the same runtime group is valid
     private fun handlerInRemote(psiFile: PsiFile, handler: String, runtimeGroup: RuntimeGroup): Boolean {
+        if (!ProjectAccountSettingsManager.getInstance(psiFile.project).hasActiveCredentials()) {
+            return false
+        }
+
         val cache = AwsResourceCache.getInstance(psiFile.project)
 
         return when (val functions = cache.getResourceIfPresent(LambdaResources.LIST_FUNCTIONS)) {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaLineMarkerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaLineMarkerTest.kt
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.lambda.model.FunctionConfiguration
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.amazon.awssdk.services.lambda.model.TracingMode
 import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.credentials.MockProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.services.lambda.resources.LambdaResources
 import software.aws.toolkits.jetbrains.services.lambda.upload.LambdaLineMarker
 import software.aws.toolkits.jetbrains.settings.LambdaSettings
@@ -480,6 +481,31 @@ Resources:
 
         findAndAssertMarks(fixture) { marks ->
             assertLineMarkerIs(marks, "ConcreteHandler")
+        }
+    }
+
+    @Test
+    fun noCredentialsLeadsToNoMarkerIfNoOtherCriteriaPasses() {
+        LambdaSettings.getInstance(projectRule.project).showAllHandlerGutterIcons = false
+        MockProjectAccountSettingsManager.getInstance(projectRule.project).changeCredentialProvider(null)
+
+        val fixture = projectRule.fixture
+
+        fixture.openClass(
+            """
+             package com.example;
+
+             public class UsefulUtils {
+
+                 public String upperCase(String input) {
+                     return input.toUpperCase();
+                 }
+             }
+             """
+        )
+
+        findAndAssertMarks(fixture) { marks ->
+            assertThat(marks).isEmpty()
         }
     }
 


### PR DESCRIPTION
…in template

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes
```
During querying provider AWS Lambda (class software.aws.toolkits.jetbrains.services.lambda.upload.LambdaLineMarker)

software.aws.toolkits.core.credentials.CredentialProviderNotFound: No active credential provider configured
	at software.aws.toolkits.jetbrains.core.credentials.DefaultProjectAccountSettingsManager.getActiveCredentialProvider(ProjectAccountSettingsManager.kt:154)
	at software.aws.toolkits.jetbrains.core.DefaultAwsResourceCache.getResourceIfPresent(AwsResourceCache.kt:285)
	at software.aws.toolkits.jetbrains.core.AwsResourceCache$DefaultImpls.getResourceIfPresent$default(AwsResourceCache.kt:94)
	at software.aws.toolkits.jetbrains.services.lambda.upload.LambdaLineMarker.handlerInRemote(LambdaLineMarker.kt:102)
	at software.aws.toolkits.jetbrains.services.lambda.upload.LambdaLineMarker.shouldShowLineMarker(LambdaLineMarker.kt:89)
	at software.aws.toolkits.jetbrains.services.lambda.upload.LambdaLineMarker.getLineMarkerInfo(LambdaLineMarker.kt:51)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.queryProviders(LineMarkersPass.java:171)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.lambda$doCollectInformation$3(LineMarkersPass.java:96)
	at com.intellij.codeInsight.daemon.impl.Divider.divideInsideAndOutsideInOneRoot(Divider.java:79)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.doCollectInformation(LineMarkersPass.java:91)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:69)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$null$1(PassExecutorService.java:430)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1166)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:423)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:586)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:532)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:86)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:422)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:398)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:164)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:218)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:396)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:174)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
