### PR TITLE
Fix project templates validation and logic

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/completion/HandlerCompletionProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/completion/HandlerCompletionProvider.kt
@@ -11,6 +11,7 @@ import com.intellij.util.textCompletion.TextCompletionProvider
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
+import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 
 class HandlerCompletionProvider(private val project: Project, runtime: Runtime?) : TextCompletionProvider {
@@ -18,7 +19,7 @@ class HandlerCompletionProvider(private val project: Project, runtime: Runtime?)
     private val logger = getLogger<HandlerCompletionProvider>()
 
     private val handlerCompletion: HandlerCompletion? by lazy {
-        val runtimeGroup = runtime?.runtimeGroup ?: return@lazy null
+        val runtimeGroup = runtime?.runtimeGroup ?: RuntimeGroup.determineRuntime(project)?.runtimeGroup ?: return@lazy null
 
         return@lazy HandlerCompletion.getInstance(runtimeGroup) ?: let {
             logger.info { "Lambda handler completion provider is not registered for runtime: ${runtimeGroup.name}. Completion is not supported." }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Predefine Solution name in Project wizard
* Fix project template validation logic to be initialized when wizard is opened
* Fix disabled completion in Rider

## Motivation and Context
- Fix completion in Rider;
- Add predefined solution name to project template wizard and initiate wizard dialog validation when wizard is opened.

## Related Issue(s)
None.

## Testing
- Verified completion in Rider and Serverless App template logic;
- Verified all tests passed.

## Screenshots (if appropriate)
None.

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
