### PR TITLE
Fix hiding handler field when enable/disable "use template" checkbox in run config

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditorPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditorPanel.java
@@ -102,7 +102,7 @@ public final class LocalLambdaRunSettingsEditorPanel {
     private void updateComponents() {
         EditorTextField handler = handlerPanel.getHandler();
 
-        handlerPanel.setVisible(!useTemplate.isSelected());
+        handlerPanel.setEnabled(!useTemplate.isSelected());
         runtime.setEnabled(!useTemplate.isSelected());
         templateFile.setEnabled(useTemplate.isSelected());
         timeoutSlider.setEnabled(!useTemplate.isSelected());

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/HandlerPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/HandlerPanel.kt
@@ -36,6 +36,12 @@ class HandlerPanel(private val project: Project) : JPanel(MigLayout("novisualpad
         switchCompletion()
     }
 
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+        simpleHandler.isEnabled = enabled
+        handlerWithCompletion.isEnabled = enabled
+    }
+
     override fun setVisible(isVisible: Boolean) {
         super.setVisible(isVisible)
         if (!isVisible) {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Handler field disappear when selecting "Use Template" in run local lambda run configuration.
The fix disable the field instead of hiding it.

## Motivation and Context
Fix UI issue with handler field presentation in local lambda run configuration.

## Related Issue(s)
None.

## Testing
Verified selecting template and handler from the field in local lambda run configuration.
Verified all tests passed.

## Screenshots (if appropriate)
<img width="738" alt="HandlerDisappear" src="https://user-images.githubusercontent.com/6064345/67013598-0eaaa500-f0fc-11e9-83d9-295f0d0d35a8.png">

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
