### PR TITLE
[WIP] Enable windows gradle cache in CodeBuild

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,11 +184,6 @@ def removeTask(tasks, taskName) {
     }
 }
 
-wrapper {
-    distributionType = Wrapper.DistributionType.ALL
-    gradleVersion '5.4.1'
-}
-
 apply plugin: 'org.jetbrains.intellij'
 apply plugin: ChangeLogPlugin
 

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -1,9 +1,15 @@
 version: 0.2
 
+cache:
+  paths:
+    - 'build-cache/caches/'
+    - 'build-cache/wrapper/'
+
 env:
   variables:
     CI: true
     LOCAL_ENV_RUN: true
+    GRADLE_CACHE_LOCATION: build-cache
 
 phases:
   install:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -20,7 +20,7 @@ phases:
 
   build:
     commands:
-      - ./gradlew check coverageReport --info --full-stacktrace --console plain
+      - ./gradlew check coverageReport --info --full-stacktrace --console plain --gradle-user-home $Env:GRADLE_CACHE_LOCATION
 
   post_build:
     commands:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ include 'jetbrains-rider'
 if (System.getenv("GRADLE_CACHE_LOCATION") != null) {
     buildCache {
         local {
-            directory = System.getenv("GRADLE_CACHE_LOCATION")
+            directory = file(System.getenv("GRADLE_CACHE_LOCATION"))
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,3 +10,11 @@ include 'jetbrains-core'
 include 'jetbrains-core-gui'
 include 'jetbrains-ultimate'
 include 'jetbrains-rider'
+
+if (System.getenv("GRADLE_CACHE_LOCATION") != null) {
+    buildCache {
+        local {
+            directory = System.getenv("GRADLE_CACHE_LOCATION")
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,11 +10,3 @@ include 'jetbrains-core'
 include 'jetbrains-core-gui'
 include 'jetbrains-ultimate'
 include 'jetbrains-rider'
-
-if (System.getenv("GRADLE_CACHE_LOCATION") != null) {
-    buildCache {
-        local {
-            directory = file(System.getenv("GRADLE_CACHE_LOCATION"))
-        }
-    }
-}


### PR DESCRIPTION
Attempting to speed up Windows CodeBuild by using the local cache.
It seems we can't cache an absolute dir correctly, so move the cache into a sub-dir controlled by env var

```
[Container] 2019/10/18 20:07:30 MkdirAll: C:\codebuild\local-cache\custom\0f900cd21c87cb6898a6b8520848dc92dbac027d229b5cfbe23d1cef0de28788\C:\Users\ContainerAdministrator\.gradle\caches 
[Container] 2019/10/18 20:07:30 Error mounting C:\Users\ContainerAdministrator\.gradle\caches: mkdir C:\codebuild\local-cache\custom\0f900cd21c87cb6898a6b8520848dc92dbac027d229b5cfbe23d1cef0de28788\C:: The filename, directory name, or volume label syntax is incorrect. 
[Container] 2019/10/18 20:07:30 MkdirAll: C:\codebuild\local-cache\custom\201a15a76c7cd6c5e6ad715bb76d03383bcba83ff2be7472dad28c40931a9a64\C:\Users\ContainerAdministrator\.gradle\wrapper 
[Container] 2019/10/18 20:07:30 Error mounting C:\Users\ContainerAdministrator\.gradle\wrapper: mkdir C:\codebuild\local-cache\custom\201a15a76c7cd6c5e6ad715bb76d03383bcba83ff2be7472dad28c40931a9a64\C:: The filename, directory name, or volume label syntax is incorrect. 
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
