### PR TITLE
Install msbuild instead of mono-complete

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -14,9 +14,8 @@ phases:
     commands:
       - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay&
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
-      - echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list
       - apt-get update
-      - apt-get install -y jq python2.7 python3.6 python3.7 mono-complete
+      - apt-get install -y jq python2.7 python3.6 python3.7 msbuild
       - aws sts assume-role --role-arn $ASSUME_ROLE_ARN --role-session-name integ-test > creds.json
       - export KEY_ID=`jq -r '.Credentials.AccessKeyId' creds.json`
       - export SECRET=`jq -r '.Credentials.SecretAccessKey' creds.json`

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -17,12 +17,8 @@ phases:
       dotnet: 2.2
 
     commands:
-      - echo "Install Mono"
-      - apt install -y gnupg ca-certificates
-      - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-      - echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list
       - apt update
-      - apt install -y mono-complete
+      - apt install -y msbuild
 
   build:
     commands:

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -15,11 +15,11 @@ phases:
   install:
     runtime-versions:
       java: openjdk8
+      dotnet: 2.2
 
     commands:
-      - echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list
       - apt-get update
-      - apt-get install -y xvfb icewm procps ffmpeg libswt-gtk-3-java mono-complete
+      - apt-get install -y xvfb icewm procps ffmpeg libswt-gtk-3-java msbuild
       - pip install --user aws-sam-cli
 
   build:


### PR DESCRIPTION
CodeBuild images already pull in mono-devel; use that instead of installing mono-complete which takes forever

https://github.com/aws/aws-codebuild-docker-images/blob/b012b0110081a077bbd3d54a6ba92100e9585a79/ubuntu/standard/2.0/Dockerfile#L71

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
