### PR TITLE
Always disable telemetry from every JavaExec call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ allprojects {
     apply plugin: "com.adarshr.test-logger"
     apply plugin: 'jacoco'
 
+    tasks.withType(JavaExec) {
+        systemProperty("aws.toolkits.enableTelemetry", false)
+    }
+
     tasks.withType(org.jetbrains.intellij.tasks.RunIdeTask) {
         systemProperty("aws.toolkits.enableTelemetry", false)
         intellij {


### PR DESCRIPTION
## Testing
`./gradlew :buildSearchableOptions --info` -> ` -Dapple.laf.useScreenMenuBar=true -Daws.toolkits.enableTelemetry=false -Didea.classpath.index.enabled=false`

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
