### PR TITLE
Fix integration tests failing

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -15,13 +15,13 @@ phases:
       - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay&
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
       - apt-get update
-      - apt-get install -y jq python2.7 python3.6 python3.7 msbuild
+      - apt-get install -y jq python2.7 python-pip python3.6 python3.7 msbuild
       - aws sts assume-role --role-arn $ASSUME_ROLE_ARN --role-session-name integ-test > creds.json
       - export KEY_ID=`jq -r '.Credentials.AccessKeyId' creds.json`
       - export SECRET=`jq -r '.Credentials.SecretAccessKey' creds.json`
       - export TOKEN=`jq -r '.Credentials.SessionToken' creds.json`
-      - pip install --user aws-sam-cli
-      - pip install --upgrade awscli
+      - pip3 install --user aws-sam-cli
+      - pip3 install --upgrade awscli
 
   build:
     commands:


### PR DESCRIPTION
* Install SAM using pip3 so we force it to run on python3
* Fix test failing due to python2.7 did not have pip

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
