### PR TITLE
Fix service constructor initialization issues

### DIFF
--- a/.changes/next-release/bugfix-cc879f64-2620-4120-8ca5-bb98f01b701f.json
+++ b/.changes/next-release/bugfix-cc879f64-2620-4120-8ca5-bb98f01b701f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Resolve initialization errors on 2019.3 EAP"
+}

--- a/core/src/software/aws/toolkits/core/telemetry/TelemetryBatcher.kt
+++ b/core/src/software/aws/toolkits/core/telemetry/TelemetryBatcher.kt
@@ -18,6 +18,11 @@ interface TelemetryBatcher {
 
     fun flush(retry: Boolean)
 
+    /**
+     * Immediately shutdown the current batcher and delegate remaining events to a new batcher
+     */
+    fun shutdownAndFlush(batcher: TelemetryBatcher)
+
     fun onTelemetryEnabledChanged(newValue: Boolean)
 
     fun shutdown()
@@ -74,6 +79,13 @@ open class DefaultTelemetryBatcher(
 
     override fun flush(retry: Boolean) {
         flush(retry, isTelemetryEnabled.get())
+    }
+
+    @Synchronized
+    override fun shutdownAndFlush(batcher: TelemetryBatcher) {
+        executor.shutdown()
+        batcher.onTelemetryEnabledChanged(isTelemetryEnabled.get())
+        batcher.enqueue(eventQueue.toList())
     }
 
     // TODO: This should flush to disk instead of network on shutdown. User should not have to wait for network calls to exit. Also consider handling clock drift

--- a/core/src/software/aws/toolkits/core/telemetry/TelemetryBatcher.kt
+++ b/core/src/software/aws/toolkits/core/telemetry/TelemetryBatcher.kt
@@ -21,7 +21,7 @@ interface TelemetryBatcher {
     /**
      * Immediately shutdown the current batcher and delegate remaining events to a new batcher
      */
-    fun shutdownAndFlush(batcher: TelemetryBatcher)
+    fun setBatcher(batcher: TelemetryBatcher)
 
     fun onTelemetryEnabledChanged(newValue: Boolean)
 
@@ -82,7 +82,7 @@ open class DefaultTelemetryBatcher(
     }
 
     @Synchronized
-    override fun shutdownAndFlush(batcher: TelemetryBatcher) {
+    override fun setBatcher(batcher: TelemetryBatcher) {
         executor.shutdown()
         batcher.onTelemetryEnabledChanged(isTelemetryEnabled.get())
         batcher.enqueue(eventQueue.toList())

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/RemoteResourceResolverProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/RemoteResourceResolverProvider.kt
@@ -23,12 +23,10 @@ interface RemoteResourceResolverProvider {
     }
 }
 
-class DefaultRemoteResourceResolverProvider @JvmOverloads constructor(private val resolver: RemoteResourceResolver = RESOLVER_INSTANCE) :
-    RemoteResourceResolverProvider {
-    override fun get() = resolver
+class DefaultRemoteResourceResolverProvider : RemoteResourceResolverProvider {
+    override fun get() = RESOLVER_INSTANCE
 
     companion object {
-
         private val RESOLVER_INSTANCE by lazy {
             val cachePath = Paths.get(PathManager.getSystemPath(), "aws-static-resources").createDirectories()
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
@@ -80,7 +80,7 @@ class DefaultTelemetryService(settings: AwsSettings) :
     TelemetryService, TelemetryEnabledChangedNotifier {
     var batcher: TelemetryBatcher = DefaultTelemetryBatcher(DefaultTelemetryPublisher())
         set(value) {
-            batcher.shutdownAndFlush(value)
+            batcher.setBatcher(value)
             field = value
         }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
@@ -76,13 +76,16 @@ interface TelemetryEnabledChangedNotifier {
     fun notify(isTelemetryEnabled: Boolean)
 }
 
-class DefaultTelemetryService(settings: AwsSettings, private val batcher: TelemetryBatcher = DefaultTelemetryBatcher(DefaultTelemetryPublisher())) :
+class DefaultTelemetryService(settings: AwsSettings) :
     TelemetryService, TelemetryEnabledChangedNotifier {
+    var batcher: TelemetryBatcher = DefaultTelemetryBatcher(DefaultTelemetryPublisher())
+        set(value) {
+            batcher.shutdownAndFlush(value)
+            field = value
+        }
+
     private val isDisposing: AtomicBoolean = AtomicBoolean(false)
     private val startTime: Instant
-
-    @Suppress("unused")
-    constructor(settings: AwsSettings) : this(settings, DefaultTelemetryBatcher(DefaultTelemetryPublisher()))
 
     init {
         TelemetryService.subscribe(this)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* JetBrains started throwing errors in the latest EAP if a service constructor takes a parameter that can't be auto-injected. They provide a new annotation `@NonInjectable`, but that is not available unless you pull in the EAP SDK, so instead fix by removing those constructors.

## Testing
Look no error
![image](https://user-images.githubusercontent.com/742829/67723852-797c9b80-f99a-11e9-9a1c-bb8373294386.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
