### PR TITLE
Fix Local Lambda gutter icons running on '.aws-sam' contents

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
@@ -57,10 +57,10 @@ object Lambda {
         }?.isHandlerValid(project, handler) == true
     }
 
-    fun findSamBuildContents(project: Project): Collection<VirtualFile> =
+    private fun findSamBuildContents(project: Project): Collection<VirtualFile> =
         ModuleManager.getInstance(project).modules.flatMap { findSamBuildContents(it) }
 
-    fun findSamBuildContents(module: Module): Collection<VirtualFile> =
+    private fun findSamBuildContents(module: Module): Collection<VirtualFile> =
         ModuleRootManager.getInstance(module).contentRoots.map {
             it.findChild(SamCommon.SAM_BUILD_DIR)
         }.filterNotNull()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
@@ -31,7 +31,6 @@ import software.aws.toolkits.jetbrains.services.lambda.LambdaLimits.MIN_MEMORY
 import software.aws.toolkits.jetbrains.services.lambda.LambdaLimits.MIN_TIMEOUT
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.jetbrains.ui.SliderPanel
-import java.lang.StringBuilder
 import java.util.concurrent.TimeUnit
 
 object Lambda {
@@ -69,15 +68,11 @@ object Lambda {
                 VfsUtil.collectChildrenRecursively(it)
             }
 
-    private fun logHandlerPsiElements(handler: String, elements: Array<NavigatablePsiElement>) {
-        val sb = StringBuilder()
-        sb.appendln("Found ${elements.size} PsiElements for Handler: $handler")
-
-        elements.forEach {
-            sb.appendln(it.containingFile.virtualFile.path)
-        }
-
-        LOG.debug { sb.toString() }
+    private fun logHandlerPsiElements(handler: String, elements: Array<NavigatablePsiElement>) = LOG.debug {
+        elements.joinToString(
+            prefix = "Found ${elements.size} PsiElements for Handler: $handler\n",
+            separator = "\n"
+        ) { it.containingFile.virtualFile.path }
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
@@ -68,11 +68,13 @@ object Lambda {
                 VfsUtil.collectChildrenRecursively(it)
             }
 
-    private fun logHandlerPsiElements(handler: String, elements: Array<NavigatablePsiElement>) = LOG.debug {
-        elements.joinToString(
-            prefix = "Found ${elements.size} PsiElements for Handler: $handler\n",
-            separator = "\n"
-        ) { it.containingFile.virtualFile.path }
+    private fun logHandlerPsiElements(handler: String, elements: Array<NavigatablePsiElement>) {
+        LOG.debug {
+            elements.joinToString(
+                prefix = "Found ${elements.size} PsiElements for Handler: $handler\n",
+                separator = "\n"
+            ) { it.containingFile.virtualFile.path }
+        }
     }
 }
 


### PR DESCRIPTION

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

This change skips the SAM Build folder(s) when looking for files that could contain Lambda Handlers.

It is a fix for the issue where the Lambda Handler gutter icons would try to build/invoke the files in the `.aws-sam` SAM Build folder.

This is more prevalent in scenarios where you open a folder that contains more than one SAM Application, located within child folders.

## Testing

Opened a folder containing several JS SAM Applications in WebStorm. Tried to locally run/debug JS Lambda Handlers from the various applications, both when the project root's `.aws-sam` folder was present and empty.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
