### PR TITLE
Allow plugin to be built without Rider by simply commenting it out of…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ reported the issue. Please try to include as much information as you can. Detail
 
 * [Java 8](https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html)
 * [Git](https://git-scm.com/)
+* Dotnet Framework if on Windows / Mono if on Linux/Mac
+  * Note: You can skip this if you do not want to build Rider support by adding `-PskipRider` to any Gradle command 
 
 #### Instructions
 

--- a/build.gradle
+++ b/build.gradle
@@ -199,9 +199,11 @@ intellij {
 }
 
 prepareSandbox {
-    from(tasks.getByPath(":jetbrains-rider:buildReSharperPlugin"), {
-        into("${intellij.pluginName}/dotnet")
-    })
+    tasks.findByPath(":jetbrains-rider:buildReSharperPlugin")?.collect {
+        from(it, {
+            into("${intellij.pluginName}/dotnet")
+        })
+    }
 }
 
 publishPlugin {
@@ -285,7 +287,9 @@ task guiTest(type: Test) {
 
 dependencies {
     compile project(':jetbrains-ultimate')
-    compile project(':jetbrains-rider')
+    project.findProject(':jetbrains-rider')?.collect {
+        compile it
+    }
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"
     ktlint project(":ktlint-rules")

--- a/jetbrains-core-gui/build.gradle
+++ b/jetbrains-core-gui/build.gradle
@@ -54,7 +54,11 @@ task classesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.output
     from project(':jetbrains-core').sourceSets.main.output
     from project(':jetbrains-ultimate').sourceSets.main.output
-    from project(':jetbrains-rider').sourceSets.main.output
+
+    project.findProject(':jetbrains-rider')?.collect {
+        from it.sourceSets.main.output
+    }
+
     from project(':core').sourceSets.test.output
     exclude 'META-INF/plugin.xml'
     exclude 'testData/*'

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,6 @@ include 'core'
 include 'jetbrains-core'
 include 'jetbrains-core-gui'
 include 'jetbrains-ultimate'
-include 'jetbrains-rider'
+if (!startParameter.properties.containsKey("skipRider")) {
+    include 'jetbrains-rider'
+}


### PR DESCRIPTION
… settings.gradle

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
