### PR TITLE
Change Solution name to default names when switching between templates

### DIFF
--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/ui/wizard/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/ui/wizard/DotNetSamProjectGenerator.kt
@@ -30,6 +30,8 @@ import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.jetbrains.utils.DotNetRuntimeUtils
 import software.aws.toolkits.resources.message
 import java.awt.Dimension
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
 import java.io.File
 import javax.swing.JScrollPane
 import javax.swing.JTabbedPane
@@ -70,7 +72,6 @@ class DotNetSamProjectGenerator(
     }
 
     init {
-        solutionNameField.text = getPossibleName(SAM_HELLO_WORLD_PROJECT_NAME)
         title.labels = arrayOf(group, categoryName)
         initProjectTextField()
         initSamPanel()
@@ -89,6 +90,9 @@ class DotNetSamProjectGenerator(
         updateInfo()
         super.initialize()
         super.layout()
+
+        // Call this init method after super.initialize() to make sure solutionNameField override a base listener
+        initSolutionTextField()
 
         addAdditionPane(samPanel.mainPanel)
         addAdditionPane(projectStructurePanel)
@@ -191,8 +195,23 @@ class DotNetSamProjectGenerator(
 
     override fun refreshUI() {
         super.refreshUI()
+        // This restore project name when user change a solution name and switch between templates
+        projectNameField.text = SAM_HELLO_WORLD_PROJECT_NAME
         validationError.set(null)
         validateData()
+    }
+
+    private fun initSolutionTextField() {
+        solutionNameField.text = getPossibleName(SAM_HELLO_WORLD_PROJECT_NAME)
+
+        // "ReSharperTemplateGeneratorBase" base class has a logic that synchronize solution and project names.
+        // Project name has a constant value for SAM template. This is a workaround to persist project name unchanged.
+        // Please use "changeProjectName" flags when switch to 193 min version FIX_WHEN_MIN_IS_193
+        solutionNameField.addKeyListener(object : KeyAdapter() {
+            override fun keyReleased(e: KeyEvent?) {
+                projectNameField.text = SAM_HELLO_WORLD_PROJECT_NAME
+            }
+        })
     }
 
     /**
@@ -202,9 +221,6 @@ class DotNetSamProjectGenerator(
     private fun initProjectTextField() {
         projectNameField.text = SAM_HELLO_WORLD_PROJECT_NAME
         projectNameField.isEnabled = false
-
-        solutionNameSetByUser = true
-        projectNameSetByUser = true
 
         sameDirectoryCheckBox.isEnabled = false
     }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Fix the issue with solution name persist a "HelloWorld" name when switching to AWS template. Remove flags to set solution and and project name by user that block using default solution names.

## Motivation and Context
Solution name should use a default template names unless name is set by user. The behavior should persists for each project type. It was broken after switching to AWS template.

## Related Issue(s)
None.

## Testing
Verified default template solution name persists if user does not change a name.
Verified value persists when changing by user.

## Screenshots (if appropriate)
None.

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
