### PR TITLE
Revert to the old way of opening the Settings page in UI tests

### DIFF
--- a/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/fixtures/WelcomeFrameUtils.kt
+++ b/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/fixtures/WelcomeFrameUtils.kt
@@ -1,0 +1,15 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.fixtures
+
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.testGuiFramework.fixtures.WelcomeFrameFixture
+import com.intellij.testGuiFramework.impl.actionLink
+import com.intellij.testGuiFramework.impl.popupMenu
+
+fun WelcomeFrameFixture.openSettingsDialog() {
+    actionLink("Configure").click()
+    val prefName = if (SystemInfo.isMac) "Preferences" else "Settings"
+    popupMenu(prefName).clickSearchedItem()
+}

--- a/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/settings/SetSamCli.kt
+++ b/jetbrains-core-gui/tst/software/aws/toolkits/jetbrains/settings/SetSamCli.kt
@@ -10,12 +10,10 @@ import com.intellij.testGuiFramework.impl.button
 import com.intellij.testGuiFramework.impl.findComponentWithTimeout
 import com.intellij.testGuiFramework.impl.jTree
 import com.intellij.testGuiFramework.impl.textfield
-import com.intellij.testGuiFramework.util.Key
-import com.intellij.testGuiFramework.util.Modifier
-import com.intellij.testGuiFramework.util.plus
 import com.intellij.testGuiFramework.util.step
 import com.intellij.ui.SearchTextField
 import org.junit.Test
+import software.aws.toolkits.jetbrains.fixtures.openSettingsDialog
 
 class SetSamCli : GuiTestCase() {
     @Test
@@ -23,7 +21,7 @@ class SetSamCli : GuiTestCase() {
         val samPath = System.getenv("SAM_CLI_EXEC") ?: SamExecutableDetector().detect() ?: "sam"
         welcomeFrame {
             step("Open preferences page") {
-                shortcut(Modifier.CONTROL + Modifier.ALT + Key.S, Modifier.META + Key.COMMA)
+                openSettingsDialog()
 
                 dialog(defaultSettingsTitle) {
                     // Search for AWS because sometimes it is off the screen


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
