### PR TITLE
Fix registering the deploy action twice in rider

### DIFF
--- a/jetbrains-core/resources/META-INF/ext-rider.xml
+++ b/jetbrains-core/resources/META-INF/ext-rider.xml
@@ -29,15 +29,10 @@
         <sam.projectWizard runtimeGroup="DOTNET" implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetSamProjectWizard"/>
     </extensions>
 
-    <!-- This is copied here because in non-rider SolutionExplorerPopupMenu isn't a group so it gets added to the default group -->
     <actions>
-        <group id="aws.toolkit.serverless.template">
+        <group>
             <add-to-group group-id="SolutionExplorerPopupMenu" anchor="last"/>
-
-            <separator/>
-            <action id="serverless.application.deploy"
-                    class="software.aws.toolkits.jetbrains.services.lambda.actions.DeployServerlessApplicationAction"/>
-            <separator/>
+            <reference ref="aws.toolkit.serverless.template"/>
         </group>
     </actions>
 


### PR DESCRIPTION
## Description
Use an anonymous group and a reference to add the sam deploy action group to be added to the solution menu

## Related Issue(s)
#1338

## Testing
Action shows in the solution menu, and no longer reports error of duplicate action ID

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
