### PR TITLE
Fixing issue with debugger attaching in 2019.3

### DIFF
--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamDebugSupport.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamDebugSupport.kt
@@ -21,6 +21,7 @@ import org.jetbrains.io.LocalFileFinder
 import software.aws.toolkits.jetbrains.services.lambda.execution.PathMapping
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamDebugSupport
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamRunningState
+import software.aws.toolkits.jetbrains.utils.CompatibilityUtils.createRemoteDebuggingFileFinder
 import java.net.InetSocketAddress
 
 class NodeJsSamDebugSupport : SamDebugSupport {
@@ -31,7 +32,9 @@ class NodeJsSamDebugSupport : SamDebugSupport {
     ): XDebugProcessStarter? = object : XDebugProcessStarter() {
         override fun start(session: XDebugSession): XDebugProcess {
             val mappings = createBiMapMappings(state.builtLambda.mappings)
-            val fileFinder = RemoteDebuggingFileFinder(mappings, LocalFileSystemFileFinder(false))
+            val fileFinder =
+                createRemoteDebuggingFileFinder<RemoteDebuggingFileFinder>(mappings, LocalFileSystemFileFinder(false))
+
             val connection = WipLocalVmConnection()
             val executionResult = state.execute(environment.executor, environment.runner)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

Fixing class cast exception when invoking the node debugger in 2019.3-EAP

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested in WebStorm 2019.2 and 2019.3-EAP

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
