### PR TITLE
Fix build failures

### DIFF
--- a/jetbrains-rider/build.gradle
+++ b/jetbrains-rider/build.gradle
@@ -1,16 +1,16 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-def ideProfileName = resolveIdeProfileName()
-
 buildscript {
-    if(ideProfileName == "2019.2") {
+    if(resolveIdeProfileName() == "2019.2") {
         ext.rd_version = "0.192.36"
-    } else if(ideProfileName == "2019.3") {
+    } else if(resolveIdeProfileName() == "2019.3") {
         ext.rd_version = "0.193.51"
     } else {
-        throw new IllegalStateException("rdgen version not set for $ideProfileName")
+        throw new IllegalStateException("rdgen version not set for $resolveIdeProfileName()")
     }
+
+    println("Using rd-gen: $rd_version")
 
     repositories {
         maven { url 'https://www.myget.org/F/rd-snapshots/maven/' }

--- a/jetbrains-rider/protocol.gradle
+++ b/jetbrains-rider/protocol.gradle
@@ -11,6 +11,8 @@ ext.csAwsSettingGeneratedOutput = new File(resharperPluginPath, "src/AWS.Setting
 ext.ktGeneratedOutput = new File(projectDir, "src/software/aws/toolkits/jetbrains/protocol")
 
 ext.modelDir = new File(projectDir, "protocol/model")
+ext.rdgenDir = file("${project.buildDir}/rdgen/")
+rdgenDir.mkdirs()
 
 task generateDaemonModel(type: tasks.getByName("rdgen").class) {
     def daemonModelSource = new File(modelDir, "daemon").canonicalPath
@@ -19,7 +21,7 @@ task generateDaemonModel(type: tasks.getByName("rdgen").class) {
     // intellij SDK, which is extracted in afterEvaluate
     params {
         verbose = true
-        hashFolder = "build/rdgen"
+        hashFolder = rdgenDir
 
         logger.info("Configuring rdgen params")
         classpath {
@@ -57,7 +59,7 @@ task generatePsiModel(type: tasks.getByName("rdgen").class) {
     // intellij SDK, which is extracted in afterEvaluate
     params {
         verbose = true
-        hashFolder = "build/rdgen"
+        hashFolder = rdgenDir
 
         logger.info("Configuring rdgen params")
         classpath {
@@ -95,7 +97,7 @@ task generateAwsSettingModel(type: tasks.getByName("rdgen").class) {
     // intellij SDK, which is extracted in afterEvaluate
     params {
         verbose = true
-        hashFolder = "build/rdgen"
+        hashFolder = rdgenDir
 
         logger.info("Configuring rdgen params")
         classpath {


### PR DESCRIPTION
## Description
* Make sure we create the rdgen folder before we invoke tasks, else it sometimes fails due to FileNotFoundException
* Change how we pick the rd-gen version since the variable was getting shadowed/silently overridden by gradle property

## Testing
```
LTERNATIVE_IDE_PROFILE_NAME=2019.3 ./gradlew :buildPlugin

> Configure project :jetbrains-rider
Using rd-gen: 0.193.51
Not running in JetBrains' network

> Task :jetbrains-rider:generateAwsSettingModel
Reading hash from /Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/build/rdgen/.rdgen
Hashes are different at key 'file: /Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/ReSharper.AWS/src/AWS.Psi/Protocol/LambdaPsiModel.Generated.cs', oldHash: 2019-11-09_14:37:28.647, newHash:
Temporary folder created: /var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/rdgen-10560344962301153051
Searching for Kotlin compiler
Compiling sources from '/Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/protocol/model/setting' to '/var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/rdgen-10560344962301153051'
User classpath: '/Users/alfredbr/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.rider/riderRD/2019.3-SNAPSHOT/cd595b50978d615424151b26795756d31f492c0f/riderRD-2019.3-SNAPSHOT/lib/rd/rider-model.jar'
Rdgen default classpath: '/Users/alfredbr/.gradle/caches/modules-2/files-2.1/com.jetbrains.rd/rd-gen/0.193.51/a27ad2ec7baa9c9d8aaa541146d240e2a025f5fc/rd-gen-0.193.51.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.3.21/d0634d54452abc421db494ad32dd215e6591c49f/kotlin-stdlib-jdk8-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.21/d207ce2c9bcf17dc8e51bab4dbfdac4d013e7138/kotlin-stdlib-jdk7-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.10/dd02865be0351707554b16a896b766b2396cdafa/kotlin-reflect-1.3.10.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.21/4bcc2012b84840e19e1e28074284cac908be0295/kotlin-stdlib-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.3.21/f30e4a9897913e53d778f564110bafa1fef46643/kotlin-stdlib-common-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.3.21/677cc9553b8964c895abc76da9b6a0faea8f671d/kotlin-compiler-embeddable-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.21/d0d5ff2ac2ebd8a42697af41e20fc225a23c5d3b/kotlin-reflect-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/1.3.21/510f640ddab3074a890450f870e65630cf5e0055/kotlin-scripting-compiler-embeddable-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-script-runtime/1.3.21/29363d474ee6fda354900636320a177c7286def9/kotlin-script-runtime-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.3.50/bf65725d4ae2cf00010d84e945fcbc201f590e11/kotlin-stdlib-jdk8-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler/1.3.50/ec5559072cc613b67b47ae33c4936fe00a6e356f/kotlin-compiler-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.50/b499f22fd7c3e9c2e5b6c4005221fa47fc7f9a7a/kotlin-reflect-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.50/50ad05ea1c2595fb31b800e76db464d08d599af3/kotlin-stdlib-jdk7-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.50/b529d1738c7e98bbfa36a4134039528f2ce78ebf/kotlin-stdlib-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.3.50/3d9cd3e1bc7b92e95f43d45be3bfbcf38e36ab87/kotlin-stdlib-common-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-script-runtime/1.3.50/59492b8dfb92522ba0ddb5dd1c4d0ef0a4fca1af/kotlin-script-runtime-1.3.50.jar'
Resulting kotlinc classpath: '/Users/alfredbr/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.rider/riderRD/2019.3-SNAPSHOT/cd595b50978d615424151b26795756d31f492c0f/riderRD-2019.3-SNAPSHOT/lib/rd/rider-model.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/com.jetbrains.rd/rd-gen/0.193.51/a27ad2ec7baa9c9d8aaa541146d240e2a025f5fc/rd-gen-0.193.51.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.3.21/d0634d54452abc421db494ad32dd215e6591c49f/kotlin-stdlib-jdk8-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.21/d207ce2c9bcf17dc8e51bab4dbfdac4d013e7138/kotlin-stdlib-jdk7-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.10/dd02865be0351707554b16a896b766b2396cdafa/kotlin-reflect-1.3.10.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.21/4bcc2012b84840e19e1e28074284cac908be0295/kotlin-stdlib-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.3.21/f30e4a9897913e53d778f564110bafa1fef46643/kotlin-stdlib-common-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.3.21/677cc9553b8964c895abc76da9b6a0faea8f671d/kotlin-compiler-embeddable-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.21/d0d5ff2ac2ebd8a42697af41e20fc225a23c5d3b/kotlin-reflect-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/1.3.21/510f640ddab3074a890450f870e65630cf5e0055/kotlin-scripting-compiler-embeddable-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-script-runtime/1.3.21/29363d474ee6fda354900636320a177c7286def9/kotlin-script-runtime-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.3.50/bf65725d4ae2cf00010d84e945fcbc201f590e11/kotlin-stdlib-jdk8-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler/1.3.50/ec5559072cc613b67b47ae33c4936fe00a6e356f/kotlin-compiler-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.50/b499f22fd7c3e9c2e5b6c4005221fa47fc7f9a7a/kotlin-reflect-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.50/50ad05ea1c2595fb31b800e76db464d08d599af3/kotlin-stdlib-jdk7-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.50/b529d1738c7e98bbfa36a4134039528f2ce78ebf/kotlin-stdlib-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.3.50/3d9cd3e1bc7b92e95f43d45be3bfbcf38e36ab87/kotlin-stdlib-common-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-script-runtime/1.3.50/59492b8dfb92522ba0ddb5dd1c4d0ef0a4fca1af/kotlin-script-runtime-1.3.50.jar'
kotlinc -cp /Users/alfredbr/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.rider/riderRD/2019.3-SNAPSHOT/cd595b50978d615424151b26795756d31f492c0f/riderRD-2019.3-SNAPSHOT/lib/rd/rider-model.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/com.jetbrains.rd/rd-gen/0.193.51/a27ad2ec7baa9c9d8aaa541146d240e2a025f5fc/rd-gen-0.193.51.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.3.21/d0634d54452abc421db494ad32dd215e6591c49f/kotlin-stdlib-jdk8-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.21/d207ce2c9bcf17dc8e51bab4dbfdac4d013e7138/kotlin-stdlib-jdk7-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.10/dd02865be0351707554b16a896b766b2396cdafa/kotlin-reflect-1.3.10.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.21/4bcc2012b84840e19e1e28074284cac908be0295/kotlin-stdlib-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.3.21/f30e4a9897913e53d778f564110bafa1fef46643/kotlin-stdlib-common-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.3.21/677cc9553b8964c895abc76da9b6a0faea8f671d/kotlin-compiler-embeddable-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.21/d0d5ff2ac2ebd8a42697af41e20fc225a23c5d3b/kotlin-reflect-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/1.3.21/510f640ddab3074a890450f870e65630cf5e0055/kotlin-scripting-compiler-embeddable-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-script-runtime/1.3.21/29363d474ee6fda354900636320a177c7286def9/kotlin-script-runtime-1.3.21.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.3.50/bf65725d4ae2cf00010d84e945fcbc201f590e11/kotlin-stdlib-jdk8-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler/1.3.50/ec5559072cc613b67b47ae33c4936fe00a6e356f/kotlin-compiler-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.50/b499f22fd7c3e9c2e5b6c4005221fa47fc7f9a7a/kotlin-reflect-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.50/50ad05ea1c2595fb31b800e76db464d08d599af3/kotlin-stdlib-jdk7-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.50/b529d1738c7e98bbfa36a4134039528f2ce78ebf/kotlin-stdlib-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.3.50/3d9cd3e1bc7b92e95f43d45be3bfbcf38e36ab87/kotlin-stdlib-common-1.3.50.jar:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-script-runtime/1.3.50/59492b8dfb92522ba0ddb5dd1c4d0ef0a4fca1af/kotlin-script-runtime-1.3.50.jar -d /var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/rdgen-10560344962301153051 -jvm-target 1.8 /Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/protocol/model/setting
warning: unable to find kotlin-stdlib.jar in the Kotlin home directory. Pass either '-no-stdlib' to prevent adding it to the classpath, or the correct '-kotlin-home'
warning: unable to find kotlin-script-runtime.jar in the Kotlin home directory. Pass either '-no-stdlib' to prevent adding it to the classpath, or the correct '-kotlin-home'
warning: unable to find kotlin-reflect.jar in the Kotlin home directory. Pass either '-no-reflect' or '-no-stdlib' to prevent adding it to the classpath, or the correct '-kotlin-home'
Compilation finished in 354 ms
Loading compiled classes from 'file:/var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/rdgen-10560344962301153051/, file:/Users/alfredbr/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.rider/riderRD/2019.3-SNAPSHOT/cd595b50978d615424151b26795756d31f492c0f/riderRD-2019.3-SNAPSHOT/lib/rd/rider-model.jar'

RdGen model generator started
Searching classes with namespace prefixes: 'protocol.model.setting'
Regex for filtering generators: '.*'
Found 2 gradle generators
1 classes found
1 toplevel class found

Toplevels to generate:
  singleton `AwsSettingModel` :> concrete_class `Solution` :> singleton `SolutionModel` :> root `IdeRoot`

Collecting generators (filtering generator's `javaClass.simpleName` by regex '.*'):
  0 hardcoded generator(s) -- specified directly in 'Root' constructor
  2 gradle generator(s)    -- specified in gradle's rdgen plugin 'rdgen { generator { ...} }' sections
  0 external generator(s)  -- specified by extending kotlin object from class GenerationUnit

++  MATCHED TO  ++ 'root `IdeRoot`' + Kotlin11(AsIs, "com.jetbrains.rider.model", '/Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/protocol')
++  MATCHED TO  ++ 'root `IdeRoot`' + CSharp50(Reversed, "JetBrains.Rider.Model", '/Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/ReSharper.AWS/src/AWS.Settings/Protocol')

After filtering 2 generator(s) to run
Invoke CSharp50(Reversed, "JetBrains.Rider.Model", '/Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/ReSharper.AWS/src/AWS.Settings/Protocol') on root `IdeRoot`, clearFolder=false
Invoke Kotlin11(AsIs, "com.jetbrains.rider.model", '/Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/protocol') on root `IdeRoot`, clearFolder=false
Generation finished in 629 ms
Storing hash into '/Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/build/rdgen/.rdgen'

> Task :jetbrains-rider:generateDaemonModel
Reading hash from /Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/build/rdgen/.rdgen
Hashes are different at key 'file: /Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/protocol/model/setting/AwsSettingModel.kt', oldHash: 2019-11-09_13:38:22.220, newHash:
Temporary folder created: /var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/rdgen-11101463920668567004
Searching for Kotlin compiler
Compiling sources from '/Users/alfredbr/aws-intellij-toolkit/jetbrains-rider/protocol/model/daemon' to '/var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/rdgen-11101463920668567004'
User classpath: '/Users/alfredbr/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.rider/riderRD/2019.3-SNAPSHOT/cd595b50978d615424151b26795756d31f492c0f/riderRD-2019.3-SNAPSHOT/lib/rd/rider-model.jar'
```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
