### PR TITLE
Remove the extra --debug-port that is added for dotnet debugging

### DIFF
--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
@@ -135,7 +135,6 @@ class DotNetSamDebugSupport : SamDebugSupport {
             .withParameters(debuggerBinDirectory.path)
             .withParameters("--debug-args")
             .withParameters(debugArgs)
-            .withParameters("--debug-port").withParameters(frontendPort.toString())
 
         super.patchCommandLine(debugPorts, commandLine)
     }


### PR DESCRIPTION
* The super method handles adding it, it should not be added in the overriden one

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
