### PR TITLE
Make Rider run configs made through gutter icon temp and active

### DIFF
--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/LambdaDaemonHost.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/LambdaDaemonHost.kt
@@ -115,8 +115,11 @@ class LambdaDaemonHost(project: Project) : LifetimedProjectComponent(project) {
             val configurationToAdd = factory.createConfiguration("[Local] $methodName", configuration)
             settings = runManager.createConfiguration(configurationToAdd, factory)
 
-            runManager.addConfiguration(settings)
+            runManager.setTemporaryConfiguration(settings)
+            runManager.addConfiguration(settings, isShared = false) // Match platform default of not saving run configs by default
         }
+
+        runManager.selectedConfiguration = settings
 
         ProgramRunnerUtil.executeConfiguration(settings, executor)
     }


### PR DESCRIPTION
* Mark run configurations that are created through gutter icons be temporary since that is standard
* Make the run config active when executed
* https://youtrack.jetbrains.com/issue/RIDER-34229

## Screenshots (if appropriate)

![Screen Shot 2019-11-12 at 5 07 49 PM](https://user-images.githubusercontent.com/8992246/68723942-fe58df00-056e-11ea-98b6-f76da811f9e0.png)


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
