### PR TITLE
Bump SAM Version default timeout to 5000ms from 500ms

### DIFF
--- a/.changes/next-release/bugfix-080010ad-e643-4f27-b1c3-3767717e4d10.json
+++ b/.changes/next-release/bugfix-080010ad-e643-4f27-b1c3-3767717e4d10.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix getting SAM version timing out in some circumstances which caused SAM related commands to fail"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
@@ -96,7 +96,8 @@ class SamCommon {
             return try {
                 getInvalidVersionMessage(
                     SamVersionCache.evaluateBlocking(
-                        sanitizedPath
+                        sanitizedPath,
+                        SamVersionCache.DEFAULT_TIMEOUT_MS
                     ).result
                 )
             } catch (e: Exception) {
@@ -112,7 +113,7 @@ class SamCommon {
                 ?: return "UNKNOWN"
 
             return try {
-                SamVersionCache.evaluateBlocking(sanitizedPath).result.rawVersion
+                SamVersionCache.evaluateBlocking(sanitizedPath, SamVersionCache.DEFAULT_TIMEOUT_MS).result.rawVersion
             } catch (e: Exception) {
                 logger.error(e) { "Error while getting SAM executable version." }
                 return "UNKNOWN"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCache.kt
@@ -30,4 +30,6 @@ object SamVersionCache : FileInfoCache<SemVer>() {
                 ?: throw IllegalStateException(message("sam.executable.version_parse_error", version))
         }
     }
+
+    val DEFAULT_TIMEOUT_MS = 5000
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCache.kt
@@ -31,5 +31,8 @@ object SamVersionCache : FileInfoCache<SemVer>() {
         }
     }
 
+    // This is the timeout to evaluate SAM version. On slow computers, or computers that have security scanners,
+    // this can take longer than the default 500ms timeout of FileInfoCache. Since this is run in the background,
+    // we can afford to bump it much higher.
     val DEFAULT_TIMEOUT_MS = 5000
 }


### PR DESCRIPTION
* In reasonable circumstances this call can time out (like if there is a security scanner or a slow computer), so bump the timeout when it is called

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->
#1261

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
