### PR TITLE
Fix ult tests not running in 2019.3 for real

### DIFF
--- a/intellijJVersions.gradle
+++ b/intellijJVersions.gradle
@@ -55,6 +55,7 @@ static def ideProfiles() {
                     plugins: [
                         "Pythonid:193.5233.12",
                         "yaml",
+                        "stats-collector", // Transitive, used by JavaScriptLanguage
                         "JavaScriptLanguage",
                         "JavaScriptDebugger",
                         "CSS",


### PR DESCRIPTION
* The javascript plugin now depends on a new plugin in 193, we have to add that as a required plugin now

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
