### PR TITLE
Fix Rider test testHandler_ValidHandler failing due to not waiting fo…

### DIFF
--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/DotNetLocalLambdaRunConfigurationTest.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/DotNetLocalLambdaRunConfigurationTest.kt
@@ -15,6 +15,8 @@ class DotNetLocalLambdaRunConfigurationTest : LambdaRunConfigurationTestBase() {
 
     override fun getSolutionDirectoryName(): String = "SamHelloWorldApp"
 
+    override val waitForCaches = true
+
     @Test
     fun testHandler_ValidHandler() {
         preWarmSamVersionCache(SamSettings.getInstance().executablePath)


### PR DESCRIPTION
…r the caches to be ready

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
