### PR TITLE
build: improve ALTERNATIVE_IDE message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,10 @@ allprojects {
                 if(file(System.env.ALTERNATIVE_IDE).exists()) {
                     alternativeIdePath = System.env.ALTERNATIVE_IDE
                 } else {
-                    throw new GradleException("ALTERNATIVE_IDE path ${System.env.ALTERNATIVE_IDE} not found")
+                    throw new GradleException("ALTERNATIVE_IDE path not found"
+                      + (System.env.ALTERNATIVE_IDE ==~ /.*[\/\\] *$/
+                        ? " (HINT: remove trailing slash '/')"
+                        : ": ${System.env.ALTERNATIVE_IDE}"))
                 }
             }
         }


### PR DESCRIPTION
## Types of changes

Small improvement to build script.

## Description

Problem: If path has a trailing slash, the "does not exist" message is confusing.

Solution: show a hint if the path has a trailing slash.

## Testing

Tested with (1) valid path, (2) valid path with trailing slash, (3) invalid path.


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
