### PR TITLE
doc: clarify when ALTERNATIVE_IDE is needed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,30 +81,31 @@ To test your changes locally, you can run the project from IntelliJ or gradle.
   The `runIde` task automatically downloads the correct version of IntelliJ
   Community Edition, builds and installs the plugin, and starts a _new_
   instance of IntelliJ with the built extension.
-- If you need to run the plugin in a specific JetBrains IDE (and you have it installed) you can do so by specifying the `ALTERNATIVE_IDE` environment variable. For example run:
+- To run **Rider or "Ultimate"**, specify the respective gradle target:
   ```
-  ALTERNATIVE_IDE=$(PATH_TO_ALTERNATIVE_IDE) ./gradlew runIde
+  ./gradlew jetbrains-ultimate:runIde
+  ./gradlew jetbrains-rider:runIde
   ```
-  (see `alternativeIdePath` in the Gradle IntelliJ Plugin [documentation](https://github.com/JetBrains/gradle-intellij-plugin) for more details)
-  - For WebStorm, use the `jetbrains-ultimate:runIde` target:
-    ```
-    ALTERNATIVE_IDE="…" ./gradlew jetbrains-ultimate:runIde
-    ```
-  - For Rider, use the `jetbrains-rider:runIde` target:
-    ```
-    ALTERNATIVE_IDE="…" ./gradlew jetbrains-rider:runIde
-    ```
-- If you wish to run the integration tests, they require valid AWS credentials to run. Take care, as it will respect any credentials currently defined in your environmental variables, and fallback to your default AWS profile otherwise.
-You will also need to have SAM CLI available in your path.
+  - These targets download the required IDE for testing.
+  - Do not specify `ALTERNATIVE_IDE`.
+- To run the plugin in a **specific JetBrains IDE** (and you have it installed), specify the `ALTERNATIVE_IDE` environment variable:
+  ```
+  ALTERNATIVE_IDE=/path/to/ide ./gradlew :runIde
+  ```
+  - This is needed to run PyCharm and WebStorm.
+  - Notice that the top-level `:runIde` target is always used with `ALTERNATIVE_IDE`.
+  - See also `alternativeIdePath` in the Gradle IntelliJ Plugin [documentation](https://github.com/JetBrains/gradle-intellij-plugin).
+- To run **integration tests**:
   ```
   ./gradlew integrationTest
   ```
-
-- Run GUI tests:
+  - Requires valid AWS credentials (take care: it will respect any credentials currently defined in your environmental variables, and fallback to your default AWS profile otherwise).
+  - Requires `sam` CLI to be on your `$PATH`.
+- To run **GUI tests**:
   ```
   ./gradlew guiTest
   ```
-  - To debug GUI tests, 
+  - To debug GUI tests,
     1. Set `runIde.debugOptions.enabled=true` in the gradle file.
     2. When prompted, attach your (IntelliJ) debugger to port 5005.
 


### PR DESCRIPTION
## Types of changes

Documentation

## Description

Clarify some confusing parts of the build system.

## Motivation and Context

It was not clear when `ALTERNATIVE_IDE` is needed or not.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
