### PR TITLE
Enable CodeBuild local cache for linux integ tests

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -1,5 +1,10 @@
 version: 0.2
 
+cache:
+  paths:
+    - '/root/.gradle/caches/**/*'
+    - '/root/.gradle/wrapper/**/*'
+
 env:
   variables:
     CI: true


### PR DESCRIPTION


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
