### PR TITLE
CloudWatchLogWindow: show a hint if no logs were found

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogWindow.kt
@@ -24,8 +24,11 @@ class CloudWatchLogWindow(private val project: Project) {
         runInEdt {
             toolWindow.addTab(displayName, console.component, activate = true, id = id)
         }
-        client.getLogEventsPaginator { it.logGroupName(logGroup).logStreamName(logStream).startFromHead(fromHead) }.events().forEach {
-            console.print("${it.message()}\n", ConsoleViewContentType.NORMAL_OUTPUT)
+        val events = client.getLogEventsPaginator { it.logGroupName(logGroup).logStreamName(logStream).startFromHead(fromHead) }.events()
+        if (events.none()) {
+            console.print(message("ecs.service.logs.empty", "$logGroup/$logStream\n"), ConsoleViewContentType.NORMAL_OUTPUT)
+        } else {
+            events.forEach { console.print("${it.message()}\n", ConsoleViewContentType.NORMAL_OUTPUT) }
         }
     }
 

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -448,6 +448,7 @@ ecs.service.logs.cannot_determine_log_stream=Cannot determine log streams for se
 ecs.service.logs.cannot_find_container_log_stream=Cannot determine log stream for container {0}.
 ecs.service.logs.no_running_tasks=Service has no running tasks.
 ecs.service.logs.action_label=Show logs
+ecs.service.logs.empty=No events found in log stream: {0}
 ecs.container_actions_group.label=Containers
 ecs.task_definition.json_schema_name=AWS ECS Task Definition
 cloudwatch.log.toolwindow=CloudWatch Logs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description

After user invokes "Show logs" on an ECS node, show a hint if no logs were found.

## Motivation and Context

If only an empty window is shown, user may wonder if the action completed/failed/etc.




## Screenshots (if appropriate)

![Screen Shot 2019-11-25 at 6 43 50 PM](https://user-images.githubusercontent.com/55561878/69595864-931efc00-0fb5-11ea-9305-7cd5bad7a807.png)



## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
