### PR TITLE
Strip trailing version number from generated changelog entries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
 apply from: 'intellijJVersions.gradle'
 
 group 'software.aws.toolkits'
+// please check changelog generation logic if this format is changed
 version toolkitVersion + "-" + shortenVersion(resolveIdeProfileName())
 
 repositories {

--- a/buildSrc/src/Tasks.kt
+++ b/buildSrc/src/Tasks.kt
@@ -149,7 +149,7 @@ open class CreateRelease : ChangeLogTask() {
     var releaseDate: String = DateTimeFormatter.ISO_DATE.format(LocalDate.now())
 
     @Input
-    var releaseVersion: String = project.version as String
+    var releaseVersion: String = (project.version as String).substringBeforeLast('-')
 
     @OutputFile
     fun releaseEntry(): File = File(changesDirectory, "$releaseVersion.json")


### PR DESCRIPTION
Our change logs should say "1.8" instead of "1.8-192"

## Testing
Resulting CHANGELOG.md and changelogs.xml after running on commit "1.8~1" both say "1.8"

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
