### PR TITLE
A few S3 browser UI and UX fixes

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ColumnInfo.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ColumnInfo.kt
@@ -29,7 +29,7 @@ open class S3ColumnInfo(columnTitle: String, val valueGetter: (S3VirtualFile) ->
 }
 
 class S3KeyColumnInfo(valueGetter: (S3VirtualFile) -> String?) :
-    S3ColumnInfo("Key", valueGetter) {
+    S3ColumnInfo("Name", valueGetter) {
 
     override fun valueOf(obj: Any): String? {
         val file = super.getVirtualFileFromNode(obj)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3KeyNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3KeyNode.kt
@@ -72,7 +72,7 @@ class S3KeyNode(val virtualFile: VirtualFile) : SimpleNode() {
         /**
          * Page Limits
          */
-        const val UPDATE_LIMIT = 30
+        const val UPDATE_LIMIT = 300
         const val START_SIZE = 0
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ViewerPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ViewerPanel.form
@@ -8,24 +8,6 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="b5a3f" binding="bucketName" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children>
-          <component id="eef6d" class="javax.swing.JLabel" binding="name">
-            <constraints>
-              <grid row="0" column="0" row-span="2" col-span="4" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value=""/>
-            </properties>
-          </component>
-        </children>
-      </grid>
       <component id="af06" class="javax.swing.JLabel" binding="creationDate">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -81,14 +63,6 @@
           </grid>
         </children>
       </grid>
-      <component id="a463c" class="javax.swing.JLabel" binding="bucketArn">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="bucketArn"/>
-        </properties>
-      </component>
       <component id="96459" class="javax.swing.JTextField" binding="arnText">
         <constraints>
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
@@ -97,6 +71,22 @@
         </constraints>
         <properties>
           <text value="arnText"/>
+        </properties>
+      </component>
+      <component id="a463c" class="javax.swing.JLabel" binding="bucketArn">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="bucketArn"/>
+        </properties>
+      </component>
+      <component id="eef6d" class="javax.swing.JLabel" binding="name">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="bucketName"/>
         </properties>
       </component>
     </children>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ViewerPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ViewerPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.s3.bucketEditor.S3ViewerPanel">
-  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -8,17 +8,9 @@
     <properties/>
     <border type="none"/>
     <children>
-      <component id="af06" class="javax.swing.JLabel" binding="creationDate">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Date Created"/>
-        </properties>
-      </component>
       <component id="862dc" class="javax.swing.JTextField" binding="date">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -26,7 +18,7 @@
       </component>
       <grid id="9bf03" binding="mainPanel" layout-manager="BorderLayout" hgap="0" vgap="0">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -65,7 +57,7 @@
       </grid>
       <component id="96459" class="javax.swing.JTextField" binding="arnText">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -73,22 +65,54 @@
           <text value="arnText"/>
         </properties>
       </component>
-      <component id="a463c" class="javax.swing.JLabel" binding="bucketArn">
+      <component id="eef6d" class="javax.swing.JTextField" binding="name">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="bucketArn"/>
-        </properties>
-      </component>
-      <component id="eef6d" class="javax.swing.JLabel" binding="name">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="bucketName"/>
         </properties>
       </component>
+      <component id="b3ec1" class="javax.swing.JLabel" binding="bucketName">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="bucketName"/>
+        </properties>
+      </component>
+      <component id="a463c" class="javax.swing.JLabel" binding="bucketArn">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="bucketArn"/>
+        </properties>
+      </component>
+      <component id="af06" class="javax.swing.JLabel" binding="creationDate">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Date Created"/>
+        </properties>
+      </component>
+      <hspacer id="b2ad3">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="5" height="-1"/>
+            <maximum-size width="5" height="-1"/>
+          </grid>
+        </constraints>
+      </hspacer>
+      <vspacer id="2ea96">
+        <constraints>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+            <preferred-size width="-1" height="2"/>
+            <maximum-size width="-1" height="2"/>
+          </grid>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ViewerPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ViewerPanel.java
@@ -31,7 +31,6 @@ import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.RowFilter;
 import javax.swing.SwingConstants;
-import javax.swing.border.TitledBorder;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
@@ -49,7 +48,7 @@ import software.aws.toolkits.jetbrains.ui.tree.StructureTreeModel;
 public class S3ViewerPanel {
     private final int SCROLLPANE_SIZE = 11;
     private JPanel content;
-    private JLabel name;
+    private JTextField name;
     private JLabel creationDate;
     private JTextField date;
     private JPanel mainPanel;
@@ -59,6 +58,7 @@ public class S3ViewerPanel {
     private JPanel paginationPanel;
     private JButton searchButton;
     private JTextField searchTextField;
+    private JLabel bucketName;
     private S3VirtualBucket bucketVirtual;
     private S3TreeTable treeTable;
     private AnActionButton uploadObjectButton;
@@ -77,10 +77,12 @@ public class S3ViewerPanel {
         this.searchTextField.setText("");
 
         this.arnText.setText("arn:aws:s3:::" + bucketVirtual.getVirtualBucketName());
-        this.bucketArn.setText("Bucket Arn:");
+        this.bucketArn.setText("Bucket ARN:");
+        this.bucketName.setText("Bucket Name:");
         this.creationDate.setText("Creation Date:");
         this.date.setEditable(false);
         this.arnText.setEditable(false);
+        this.name.setEditable(false);
         JPopupMenu menu = new JPopupMenu();
         Action copyAction = new AbstractAction("Copy") {
             @Override
@@ -103,11 +105,7 @@ public class S3ViewerPanel {
             ColumnInfo modified = new S3ColumnInfo("Last-Modified",
                                                    virtualFile -> virtualFile.formatDate(virtualFile.getFile().getLastModified()));
 
-            ColumnInfo eTag = new S3ColumnInfo("Etag",
-                                               virtualFile -> virtualFile.getFile().getETag().replace("\"", ""));
-
-
-            final ColumnInfo[] COLUMNS = new ColumnInfo[] {key, size, modified, eTag};
+            final ColumnInfo[] COLUMNS = new ColumnInfo[] {key, size, modified};
             createTreeTable(COLUMNS);
 
             DefaultActionGroup actionGroup = new DefaultActionGroup();
@@ -189,7 +187,7 @@ public class S3ViewerPanel {
         return content;
     }
 
-    public JLabel getName() {
+    public JTextField getName() {
         return name;
     }
 
@@ -207,23 +205,24 @@ public class S3ViewerPanel {
     private void searchAndSortTable() {
         TableRowSorter<TableModel> sorter = new TableRowSorter<TableModel>(treeTable.getModel());
         treeTable.setRowSorter(sorter);
-        searchButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                String text = searchTextField.getText();
-                if (text.isEmpty()) {
-                    s3Node.setPrev(S3KeyNode.START_SIZE);
-                    s3Node.setNext(Math.min(S3KeyNode.UPDATE_LIMIT, s3Node.getCurrSize()));
-                    sorter.setRowFilter(null);
-                } else {
-                    ApplicationManager.getApplication().executeOnPooledThread(() -> {
-                        s3Node.resetLimitsForSearch();
-                    });
-                    sorter.setRowFilter(RowFilter.regexFilter("(?i)" + text));
-                }
-                sorter.setSortKeys(null);
-                treeTable.refresh();
-            }
-        });
+        searchButton.addActionListener(e -> search(sorter));
+        searchTextField.addActionListener(e -> search(sorter));
+    }
+
+    private void search(TableRowSorter<TableModel> sorter) {
+        String text = searchTextField.getText();
+        if (text.isEmpty()) {
+            s3Node.setPrev(S3KeyNode.START_SIZE);
+            s3Node.setNext(Math.min(S3KeyNode.UPDATE_LIMIT, s3Node.getCurrSize()));
+            sorter.setRowFilter(null);
+        } else {
+            ApplicationManager.getApplication().executeOnPooledThread(() -> {
+                s3Node.resetLimitsForSearch();
+            });
+            sorter.setRowFilter(RowFilter.regexFilter("(?i)" + text));
+        }
+        sorter.setSortKeys(null);
+        treeTable.refresh();
     }
 
     private void clearSelectionOnWhiteSpace() {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ViewerPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketEditor/S3ViewerPanel.java
@@ -49,7 +49,6 @@ import software.aws.toolkits.jetbrains.ui.tree.StructureTreeModel;
 public class S3ViewerPanel {
     private final int SCROLLPANE_SIZE = 11;
     private JPanel content;
-    private JPanel bucketName;
     private JLabel name;
     private JLabel creationDate;
     private JTextField date;
@@ -70,10 +69,6 @@ public class S3ViewerPanel {
     private S3TreeTableModel model;
 
     public S3ViewerPanel(S3VirtualBucket bucketVirtual) {
-        TitledBorder border = new TitledBorder("Bucket Details");
-        border.setTitleJustification(TitledBorder.CENTER);
-        border.setTitlePosition(TitledBorder.TOP);
-        this.content.setBorder(border);
         this.bucketVirtual = bucketVirtual;
         this.name.setText(bucketVirtual.getVirtualBucketName());
         this.date.setText(bucketVirtual.formatDate(bucketVirtual.getS3Bucket().creationDate()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Make enter on the search box search (previously, the search button needed to be pressed)
- Make the UI more consistent. Remove title, make bucketName box the same as the others, add spacing around it
- Increase default number of objects in bucket to 300 to match the console
- Update "Key" to "Name" to match the console

## Screenshots (if appropriate)
![Screen Shot 2019-12-04 at 10 20 57 AM](https://user-images.githubusercontent.com/11964782/70169509-d47f6d80-167f-11ea-9d37-519b3e6db223.png)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
