### PR TITLE
Disable S3 Browser in preperation for merging the S3 browser branch

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -276,7 +276,7 @@
                     class="software.aws.toolkits.jetbrains.services.cloudformation.DeleteCloudFormationStackAction"/>
         </group>
 
-        <group id="aws.toolkit.explorer.s3" popup="false" compact="false">
+        <!--group id="aws.toolkit.explorer.s3" popup="false" compact="false">
         <action id="s3.create.bucket"
                 class="software.aws.toolkits.jetbrains.services.s3.CreateBucketAction"/>
         </group>
@@ -289,7 +289,7 @@
                     class="software.aws.toolkits.jetbrains.services.s3.bucketActions.OpenBucketViewerAction"/>
             <action id="s3.copy.bucketname.check"
                     class="software.aws.toolkits.jetbrains.services.s3.bucketActions.CopyBucketNameAction"/>
-        </group>
+        </group-->
 
         <group id="aws.toolkit.explorer.schemas" popup="true" compact="false">
             <action id="schemas.search"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerService.kt
@@ -13,7 +13,6 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceRoo
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationServiceNode
 import software.aws.toolkits.jetbrains.services.ecs.EcsParentNode
 import software.aws.toolkits.jetbrains.services.lambda.LambdaServiceNode
-import software.aws.toolkits.jetbrains.services.s3.S3ServiceNode
 import software.aws.toolkits.jetbrains.services.schemas.SchemasServiceNode
 import software.aws.toolkits.resources.message
 
@@ -23,10 +22,10 @@ enum class AwsExplorerService(val serviceId: String, val displayName: String) {
     },
     LAMBDA(LambdaClient.SERVICE_NAME, message("explorer.node.lambda")) {
         override fun buildServiceRootNode(project: Project) = LambdaServiceNode(project)
-    },
+    },/*
     S3(S3Client.SERVICE_NAME, message("explorer.node.s3")) {
         override fun buildServiceRootNode(project: Project) = S3ServiceNode(project)
-    },
+    },*/
     ECS(EcsClient.SERVICE_NAME, message("explorer.node.ecs")) {
         override fun buildServiceRootNode(project: Project) = EcsParentNode(project)
     },

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/S3ExplorerNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/S3ExplorerNode.kt
@@ -9,17 +9,12 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import icons.AwsIcons
 import software.amazon.awssdk.services.s3.S3Client
-import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.amazon.awssdk.services.s3.model.Bucket
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
-import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
-import software.aws.toolkits.jetbrains.core.explorer.AwsExplorerService
-import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
+import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
-import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceRootNode
-import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 
+/*
 class S3ServiceNode(project: Project) : AwsExplorerServiceRootNode(project, AwsExplorerService.S3) {
     private val activeRegionId = ProjectAccountSettingsManager.getInstance(nodeProject).activeRegion.id
 
@@ -29,6 +24,7 @@ class S3ServiceNode(project: Project) : AwsExplorerServiceRootNode(project, AwsE
         .map { S3BucketNode(nodeProject, it) }
         .toList()
 }
+*/
 
 class S3BucketNode(project: Project, val bucket: Bucket) :
     AwsExplorerResourceNode<String>(project, S3Client.SERVICE_NAME, bucket.name(), AwsIcons.Resources.S3_BUCKET) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- We had a discussion about how we wanted to merge back, and it seems the most reasonable thing to do right now is delete the feature branch and develop out of master with the feature disabled by default.
- Comment out the S3 browser extension points

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
