### PR TITLE
Allow OS X builds to fail, and don't wait on them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ env:
     - LOCAL_ENV_RUN=true
 
 matrix:
+  fast_finish: true
+  allow_failures:
+    - os: osx
   include:
     - os: linux
       dist: xenial


### PR DESCRIPTION
Allow OS X to fail since they never start on time, and don't make it wait for it

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
