### PR TITLE
Allow the CloudDebug tests to not clobber each other by making the CF…

### DIFF
--- a/jetbrains-core/it-resources/cloudDebugTestCluster.yaml
+++ b/jetbrains-core/it-resources/cloudDebugTestCluster.yaml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: An ECS cluster for running integration tests for Cloud Debug
 
-Parameters:
-  ContainerImageParameter:
-    Type: 'String'
-
 Resources:
   Cluster:
     Type: AWS::ECS::Cluster
@@ -25,7 +21,36 @@ Resources:
       TaskRoleArn: !Ref TaskRole
       ContainerDefinitions:
         - Name: 'ContainerName'
-          Image: !Ref ContainerImageParameter
+          Image: "amazoncorretto"
+          Command:
+            - 'tail -f /dev/null'
+          EntryPoint:
+            - 'sh'
+            - '-c'
+          PortMappings:
+            - ContainerPort: 80
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: ecs
+  TaskDefinitionWithNode:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn: LogGroup
+    Properties:
+      Family: !Join ['', [!Ref Cluster, TaskDefinitionWithNode]]
+      # awsvpc is required for Fargate
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 1024
+      Memory: 2GB
+      ExecutionRoleArn: !Ref ExecutionRole
+      TaskRoleArn: !Ref TaskRole
+      ContainerDefinitions:
+        - Name: 'ContainerName'
+          Image: "node"
           Command:
             - 'tail -f /dev/null'
           EntryPoint:
@@ -42,7 +67,7 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Join ['', [/ecs/, !Ref Cluster, TaskDefinitionWithJava]]
+      LogGroupName: !Join ['', [/ecs/, !Ref Cluster]]
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -110,7 +135,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: "Internet Group"
-      GroupDescription: "All traffic IN/OUT. This needs to include at least the LoadBalancer and health check port"
+      GroupDescription: "All traffic IN/OUT."
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: -1

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTestCase.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTestCase.kt
@@ -12,7 +12,6 @@ import org.junit.Rule
 import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
-import software.amazon.awssdk.services.cloudformation.model.Parameter
 import software.amazon.awssdk.services.ecs.EcsClient
 import software.amazon.awssdk.services.ecs.model.AssignPublicIp
 import software.amazon.awssdk.services.ecs.model.LaunchType
@@ -34,21 +33,19 @@ import software.aws.toolkits.jetbrains.utils.rules.CloudFormationLazyInitRule
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-abstract class CloudDebugTestCase(containerImage: String = "amazoncorretto") {
-    lateinit var service: Service
-    lateinit var instrumentationRole: String
-    lateinit var instrumentedService: Service
+abstract class CloudDebugTestCase(private val taskDefName: String) {
+    protected lateinit var service: Service
+    private lateinit var instrumentationRole: String
+    private lateinit var instrumentedService: Service
 
-    val cfnRule = CloudFormationLazyInitRule(
+    private val cfnRule = CloudFormationLazyInitRule(
         "CloudDebugTestCluster",
         CloudDebugTestCase::class.java.getResource("/cloudDebugTestCluster.yaml").readText(),
-        listOf(Parameter.builder().parameterKey("ContainerImageParameter").parameterValue(containerImage).build()),
+        emptyList(),
         cloudFormationClient
     )
 
-    val ecsRule = ECSTemporaryServiceRule(
-        ecsClient
-    )
+    private val ecsRule = ECSTemporaryServiceRule(ecsClient)
 
     @Rule
     @JvmField
@@ -91,11 +88,11 @@ abstract class CloudDebugTestCase(containerImage: String = "amazoncorretto") {
         }
     }
 
-    fun createService(): Service {
+    private fun createService(): Service {
         val cfnOutputs = cfnRule.outputs
         val service = ecsRule.createService {
             it.desiredCount(1)
-            it.taskDefinition("CloudDebugTestECSClusterTaskDefinitionWithJava")
+            it.taskDefinition(taskDefName)
             it.cluster("CloudDebugTestECSCluster")
             it.launchType(LaunchType.FARGATE)
             it.networkConfiguration { networkConfig ->

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/java/JavaDebugEndToEndTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/java/JavaDebugEndToEndTest.kt
@@ -36,7 +36,7 @@ import software.aws.toolkits.jetbrains.utils.setUpGradleProject
 import java.nio.file.Paths
 import java.util.concurrent.CompletableFuture
 
-class JavaDebugEndToEndTest : CloudDebugTestCase() {
+class JavaDebugEndToEndTest : CloudDebugTestCase("CloudDebugTestECSClusterTaskDefinitionWithJava") {
     @JvmField
     @Rule
     val projectRule = HeavyJavaCodeInsightTestFixtureRule()

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/python/PythonDebugEndToEndTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/python/PythonDebugEndToEndTest.kt
@@ -27,7 +27,8 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CountDownLatch
 
-class PythonDebugEndToEndTest : CloudDebugTestCase() {
+// We use the corretto image for Python too, that is why we use the Java Task Def
+class PythonDebugEndToEndTest : CloudDebugTestCase("CloudDebugTestECSClusterTaskDefinitionWithJava") {
     @JvmField
     @Rule
     val projectRule = PythonCodeInsightTestFixtureRule()

--- a/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/clouddebug/nodejs/NodeJsDebugEndToEndTest.kt
+++ b/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/clouddebug/nodejs/NodeJsDebugEndToEndTest.kt
@@ -29,7 +29,7 @@ import software.aws.toolkits.jetbrains.utils.checkBreakPointHit
 import software.aws.toolkits.jetbrains.utils.executeRunConfiguration
 import software.aws.toolkits.jetbrains.utils.rules.HeavyNodeJsCodeInsightTestFixtureRule
 
-class NodeJsDebugEndToEndTest : CloudDebugTestCase("node") {
+class NodeJsDebugEndToEndTest : CloudDebugTestCase("CloudDebugTestECSClusterTaskDefinitionWithNode") {
     @Rule
     @JvmField
     val projectRule = HeavyNodeJsCodeInsightTestFixtureRule()


### PR DESCRIPTION
…N stack immutable

Attempt to stabilize the tests by making the CFN stack not be mutated.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
