### PR TITLE
Raise resource cache default timeout from 5s to 30s

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
@@ -120,7 +120,9 @@ interface AwsResourceCache {
         @JvmStatic
         fun getInstance(project: Project): AwsResourceCache = ServiceManager.getService(project, AwsResourceCache::class.java)
 
-        private val DEFAULT_TIMEOUT = Duration.ofSeconds(5)
+        // Getting resources can take a long time on a slow connection or if there are a lot of resources. This call should
+        // always be done in an async context so it should be OK to take multiple seconds.
+        private val DEFAULT_TIMEOUT = Duration.ofSeconds(30)
         private fun <T> wait(timeout: Duration, call: () -> CompletionStage<T>) = try {
             call().toCompletableFuture().get(timeout.toMillis(), TimeUnit.MILLISECONDS)
         } catch (e: ExecutionException) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Getting resources can take a long time on a slow connection or if there are a lot of resources, 30 seconds is a much better timeout for a slow connection but not too long so as to seem like the IDE is broken.

## Related Issue(s)
#1414

## Testing
Paused the resource cache call in `getCachedResource` to simulate a large amount of resources then resumed before and after 30 seconds of waiting.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
