### PR TITLE
Fix CloudDebug stack never able to update.

### DIFF
--- a/jetbrains-core/it-resources/cloudDebugTestCluster.yaml
+++ b/jetbrains-core/it-resources/cloudDebugTestCluster.yaml
@@ -134,7 +134,7 @@ Resources:
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupName: "Internet Group"
+      GroupName: "Full Internet Group"
       GroupDescription: "All traffic IN/OUT."
       VpcId: !Ref VPC
       SecurityGroupIngress:


### PR DESCRIPTION
The description is a replacement...so change the name so that the replacement can execute

```
GroupDescription
    A description for the security group. **This is informational only.**

    Constraints: Up to 255 characters in length
    Constraints for EC2-Classic: ASCII characters
    Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*

    Required: Yes

    Type: String

    Update requires: **Replacement**
```
<!--- Provide a general summary of your changes in the Title above -->

## Testing
Was able to update the stack in personal account

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
