### PR TITLE
Upgrade Kotlin to 1.3.61

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ publishChannel=
 
 # Common dependencies
 ideProfileName=2019.2
-kotlinVersion=1.3.21
+kotlinVersion=1.3.61
 awsSdkVersion=2.10.30
 ideaPluginVersion=0.4.13
 ktlintVersion=0.32.0

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/iam/CreateIamRoleDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/iam/CreateIamRoleDialog.kt
@@ -108,12 +108,12 @@ class CreateIamRoleDialog(
     }
 
     @TestOnly
-    fun createIamRoleForTesting() {
+    internal fun createIamRoleForTesting() {
         createIamRole(roleName(), policyDocument(), assumeRolePolicy())
     }
 
     @TestOnly
-    fun getViewForTesting(): CreateRolePanel = view
+    internal fun getViewForTesting(): CreateRolePanel = view
 
     private companion object {
         val LOG = getLogger<CreateIamRoleDialog>()


### PR DESCRIPTION
This version has fixed the "friend" task system so now we can use internal keyword and access it from tests even with instrumentation enabled

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
