### PR TITLE
Add support for loading any AWS partition

### DIFF
--- a/core/src/software/aws/toolkits/core/region/AwsPartition.kt
+++ b/core/src/software/aws/toolkits/core/region/AwsPartition.kt
@@ -1,0 +1,6 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.core.region
+
+data class AwsPartition(val id: String, val description: String, val regions: Collection<AwsRegion>)

--- a/core/src/software/aws/toolkits/core/region/AwsRegion.kt
+++ b/core/src/software/aws/toolkits/core/region/AwsRegion.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.core.region
 
 import software.amazon.awssdk.regions.Region
 
-data class AwsRegion(val id: String, val name: String) {
+data class AwsRegion(val id: String, val name: String, val partitionId: String) {
     val category: String? = when {
         id.startsWith("us") -> "North America"
         id.startsWith("ca") -> "North America"
@@ -30,7 +30,7 @@ data class AwsRegion(val id: String, val name: String) {
     )
 
     companion object {
-        val GLOBAL = AwsRegion(Region.AWS_GLOBAL.id(), "Global")
+        val GLOBAL = AwsRegion(Region.AWS_GLOBAL.id(), "Global", "Global")
         private fun String.trimPrefixAndRemoveBrackets(prefix: String) = this.removePrefix(prefix).replace("(", "").replace(")", "").trim()
     }
 }

--- a/core/src/software/aws/toolkits/core/region/Partitions.kt
+++ b/core/src/software/aws/toolkits/core/region/Partitions.kt
@@ -21,6 +21,7 @@ data class Partitions(val partitions: List<Partition>) {
 
 data class Partition(
     val partition: String,
+    val partitionName: String,
     val regions: Map<String, PartitionRegion>,
     val services: Map<String, Service>
 )

--- a/core/src/software/aws/toolkits/core/region/ToolkitRegionProvider.kt
+++ b/core/src/software/aws/toolkits/core/region/ToolkitRegionProvider.kt
@@ -44,7 +44,6 @@ abstract class ToolkitRegionProvider {
     }
 
     companion object {
-        private const val DEFAULT_REGION = "us-east-1"
         private const val DEFAULT_PARTITION = "aws"
     }
 }

--- a/core/src/software/aws/toolkits/core/region/ToolkitRegionProvider.kt
+++ b/core/src/software/aws/toolkits/core/region/ToolkitRegionProvider.kt
@@ -37,7 +37,7 @@ abstract class ToolkitRegionProvider {
     @Deprecated("This loads the default region if specified region doesn't exist which does not make sense")
     fun lookupRegionById(regionId: String?): AwsRegion = regions()[regionId] ?: defaultRegion()
 
-    fun isServiceSupported(region: AwsRegion, serviceName: String): Boolean {
+    open fun isServiceSupported(region: AwsRegion, serviceName: String): Boolean {
         val currentPartition = partitionData()[region.partitionId] ?: return false
         val service = currentPartition.services[serviceName] ?: return false
         return service.isGlobal || service.endpoints.containsKey(region.id)

--- a/core/src/software/aws/toolkits/core/region/ToolkitRegionProvider.kt
+++ b/core/src/software/aws/toolkits/core/region/ToolkitRegionProvider.kt
@@ -6,14 +6,45 @@ package software.aws.toolkits.core.region
 /**
  * An SPI to provide regions supported by this toolkit
  */
-interface ToolkitRegionProvider {
+abstract class ToolkitRegionProvider {
+    protected data class PartitionData(val description: String, val services: Map<String, Service>, val regions: Map<String, AwsRegion>)
+
+    protected abstract fun partitionData(): Map<String, PartitionData>
+
     /**
      * Returns a map of region ID([AwsRegion.id]) to [AwsRegion]
      */
-    fun regions(): Map<String, AwsRegion>
-    fun defaultRegion(): AwsRegion
+    @Deprecated("Not partition aware")
+    fun regions(): Map<String, AwsRegion> = partitionData()[DEFAULT_PARTITION]?.regions?.asSequence()?.associate { it.key to it.value } ?: emptyMap()
 
+    /**
+     * Returns a map of region ID([AwsRegion.id]) to [AwsRegion] for the specified partition
+     */
+    fun regions(partitionId: String): Map<String, AwsRegion> = partitionData()[partitionId]?.regions
+        ?: throw IllegalArgumentException("Unknown partition $partitionId")
+
+    /**
+     * Returns a map of partition ID([AwsPartition.id]) to [AwsPartition]
+     */
+    fun partitions(): Map<String, AwsPartition> = partitionData().asSequence()
+        .associate { it.key to AwsPartition(it.key, it.value.description, it.value.regions.values) }
+
+    /**
+     * Returns the default region to use based on the environment
+     */
+    abstract fun defaultRegion(): AwsRegion
+
+    @Deprecated("This loads the default region if specified region doesn't exist which does not make sense")
     fun lookupRegionById(regionId: String?): AwsRegion = regions()[regionId] ?: defaultRegion()
 
-    fun isServiceSupported(region: AwsRegion, serviceName: String): Boolean
+    fun isServiceSupported(region: AwsRegion, serviceName: String): Boolean {
+        val currentPartition = partitionData()[region.partitionId] ?: return false
+        val service = currentPartition.services[serviceName] ?: return false
+        return service.isGlobal || service.endpoints.containsKey(region.id)
+    }
+
+    companion object {
+        private const val DEFAULT_REGION = "us-east-1"
+        private const val DEFAULT_PARTITION = "aws"
+    }
 }

--- a/core/tst/software/aws/toolkits/core/region/AwsRegionTest.kt
+++ b/core/tst/software/aws/toolkits/core/region/AwsRegionTest.kt
@@ -16,15 +16,15 @@ class AwsRegionTest(private val region: AwsRegion, private val expectedCategory:
         @JvmStatic
         @Parameterized.Parameters(name = "{2}")
         fun data(): Collection<Array<Any>> = listOf(
-            arrayOf(AwsRegion("ap-northeast-1", "Asia Pacific (Tokyo)"), "Asia Pacific", "Tokyo (ap-northeast-1)"),
-            arrayOf(AwsRegion("ca-central-1", "Canada (Central)"), "North America", "Canada Central (ca-central-1)"),
-            arrayOf(AwsRegion("eu-central-1", "EU (Frankfurt)"), "Europe", "Frankfurt (eu-central-1)"),
-            arrayOf(AwsRegion("sa-east-1", "South America (Sao Paulo)"), "South America", "Sao Paulo (sa-east-1)"),
-            arrayOf(AwsRegion("us-east-1", "US East (N. Virginia)"), "North America", "N. Virginia (us-east-1)"),
-            arrayOf(AwsRegion("us-west-1", "US West (N. California)"), "North America", "N. California (us-west-1)"),
-            arrayOf(AwsRegion("cn-north-1", "China (Beijing)"), "China", "Beijing (cn-north-1)"),
-            arrayOf(AwsRegion("us-gov-west-1", "AWS GovCloud (US)"), "North America", "AWS GovCloud US (us-gov-west-1)"),
-            arrayOf(AwsRegion("me-south-1", "Middle East (Bahrain)"), "Middle East", "Bahrain (me-south-1)")
+            arrayOf(AwsRegion("ap-northeast-1", "Asia Pacific (Tokyo)", "aws"), "Asia Pacific", "Tokyo (ap-northeast-1)"),
+            arrayOf(AwsRegion("ca-central-1", "Canada (Central)", "aws"), "North America", "Canada Central (ca-central-1)"),
+            arrayOf(AwsRegion("eu-central-1", "EU (Frankfurt)", "aws"), "Europe", "Frankfurt (eu-central-1)"),
+            arrayOf(AwsRegion("sa-east-1", "South America (Sao Paulo)", "aws"), "South America", "Sao Paulo (sa-east-1)"),
+            arrayOf(AwsRegion("us-east-1", "US East (N. Virginia)", "aws"), "North America", "N. Virginia (us-east-1)"),
+            arrayOf(AwsRegion("us-west-1", "US West (N. California)", "aws"), "North America", "N. California (us-west-1)"),
+            arrayOf(AwsRegion("cn-north-1", "China (Beijing)", "aws"), "China", "Beijing (cn-north-1)"),
+            arrayOf(AwsRegion("us-gov-west-1", "AWS GovCloud (US)", "aws"), "North America", "AWS GovCloud US (us-gov-west-1)"),
+            arrayOf(AwsRegion("me-south-1", "Middle East (Bahrain)", "aws"), "Middle East", "Bahrain (me-south-1)")
         )
     }
 

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTestCase.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTestCase.kt
@@ -54,7 +54,7 @@ abstract class CloudDebugTestCase(private val taskDefName: String) {
     @Before
     open fun setUp() {
         // does not validate that a SSM session is successfully created
-        val region = AwsRegion("us-west-2", "US West 2")
+        val region = AwsRegion("us-west-2", "US West 2", "aws")
         MockRegionProvider.getInstance().addRegion(region)
         ProjectAccountSettingsManager.getInstance(getProject()).changeRegion(region)
         instrumentationRole = cfnRule.outputs["TaskRole"] ?: throw RuntimeException("Could not find instrumentation role in CloudFormation outputs")

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployTest.kt
@@ -48,7 +48,7 @@ class SamDeployTest {
     @Before
     fun setUp() {
         SamSettings.getInstance().savedExecutablePath = System.getenv().getOrDefault("SAM_CLI_EXEC", "sam")
-        MockProjectAccountSettingsManager.getInstance(projectRule.project).changeRegion(AwsRegion(Region.US_WEST_2.id(), "us-west-2"))
+        MockProjectAccountSettingsManager.getInstance(projectRule.project).changeRegion(AwsRegion(Region.US_WEST_2.id(), "us-west-2", "aws"))
     }
 
     @Test

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/region/AwsRegionProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/region/AwsRegionProvider.kt
@@ -8,7 +8,6 @@ import software.amazon.awssdk.regions.providers.AwsProfileRegionProvider
 import software.amazon.awssdk.regions.providers.AwsRegionProviderChain
 import software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider
 import software.aws.toolkits.core.region.AwsRegion
-import software.aws.toolkits.core.region.Partition
 import software.aws.toolkits.core.region.PartitionParser
 import software.aws.toolkits.core.region.ServiceEndpointResource
 import software.aws.toolkits.core.region.ToolkitRegionProvider
@@ -17,42 +16,38 @@ import software.aws.toolkits.core.utils.inputStream
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.RemoteResourceResolverProvider
 
-class AwsRegionProvider constructor(remoteResourceResolverProvider: RemoteResourceResolverProvider) : ToolkitRegionProvider {
-    private val regions: Map<String, AwsRegion>
-    private val partition: Partition?
-
-    init {
+class AwsRegionProvider constructor(remoteResourceResolverProvider: RemoteResourceResolverProvider) : ToolkitRegionProvider() {
+    private val partitions: Map<String, PartitionData> by lazy {
         val inputStream = remoteResourceResolverProvider.get().resolve(ServiceEndpointResource).toCompletableFuture().get()?.inputStream()
-        // TODO: handle non-standard AWS partitions based on account type
-        partition = inputStream?.let { PartitionParser.parse(it) }?.getPartition("aws")
-        regions = partition?.regions?.map { (key, region) ->
-            key to AwsRegion(key, region.description)
-        }?.toMap() ?: emptyMap()
+        val partitions = inputStream?.use { PartitionParser.parse(it) }?.partitions ?: return@lazy emptyMap<String, PartitionData>()
+
+        partitions.asSequence().associateBy { it.partition }.mapValues {
+            PartitionData(
+                it.value.partitionName,
+                it.value.services,
+                it.value.regions.asSequence().associate { region -> region.key to AwsRegion(region.key, region.value.description, it.key) }
+            )
+        }
     }
 
-    override fun regions() = regions
+    override fun partitionData(): Map<String, PartitionData> = partitions
 
     override fun defaultRegion(): AwsRegion = try {
         // Querying the instance metadata is expensive due to high timeouts and retries
         val regionProviderChange = AwsRegionProviderChain(SystemSettingsRegionProvider(), AwsProfileRegionProvider())
-        regionProviderChange.region.id().let { regions[it] } ?: fallbackRegion()
+        regionProviderChange.region.id().let { regions(DEFAULT_PARTITION)[it] } ?: fallbackRegion()
     } catch (e: Exception) {
         LOG.warn(e) { "Failed to find default region" }
         fallbackRegion()
     }
 
-    private fun fallbackRegion(): AwsRegion = regions.getOrElse(DEFAULT_REGION) {
-        throw IllegalStateException("Region provider data is missing default region")
-    }
-
-    override fun isServiceSupported(region: AwsRegion, serviceName: String): Boolean {
-        val currentPartition = partition ?: return false
-        val service = currentPartition.services[serviceName] ?: return false
-        return service.isGlobal || service.endpoints.containsKey(region.id)
+    private fun fallbackRegion(): AwsRegion = regions(DEFAULT_PARTITION).getOrElse(DEFAULT_REGION) {
+        throw IllegalStateException("Region provider data is missing default data")
     }
 
     companion object {
         private const val DEFAULT_REGION = "us-east-1"
+        private const val DEFAULT_PARTITION = "aws"
         private val LOG = getLogger<AwsRegionProvider>()
 
         @JvmStatic

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -142,7 +142,7 @@ class AwsClientManagerTest {
         val first = sut.getClient<DummyServiceClient>()
 
         val testSettings = ProjectAccountSettingsManager.getInstance(projectRule.project)
-        testSettings.changeRegion(AwsRegion("us-west-2", "us-west-2"))
+        testSettings.changeRegion(AwsRegion("us-west-2", "us-west-2", "aws"))
 
         val afterRegionUpdate = sut.getClient<DummyServiceClient>()
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -423,8 +423,8 @@ class AwsResourceCacheTest {
     companion object {
         private val CRED1 = DummyToolkitCredentialsProvider("cred1")
         private val CRED2 = DummyToolkitCredentialsProvider("cred2")
-        private val US_WEST_1 = AwsRegion("us-west-1", "USW1")
-        private val US_WEST_2 = AwsRegion("us-west-2", "USW2")
+        private val US_WEST_1 = AwsRegion("us-west-1", "USW1", "aws")
+        private val US_WEST_2 = AwsRegion("us-west-2", "USW2", "aws")
 
         private val DEFAULT_EXPIRY = Duration.ofMinutes(10)
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
@@ -100,8 +100,8 @@ class DefaultProjectAccountSettingsManagerTest {
     @Test
     fun testMakingRegionActive() {
         val mockRegionProvider = MockRegionProvider.getInstance()
-        val mockRegion1 = mockRegionProvider.addRegion(AwsRegion("MockRegion-1", "MockRegion-1"))
-        val mockRegion2 = mockRegionProvider.addRegion(AwsRegion("MockRegion-2", "MockRegion-2"))
+        val mockRegion1 = mockRegionProvider.addRegion(AwsRegion("MockRegion-1", "MockRegion-1", "aws"))
+        val mockRegion2 = mockRegionProvider.addRegion(AwsRegion("MockRegion-2", "MockRegion-2", "aws"))
 
         assertThat(manager.recentlyUsedRegions()).isEmpty()
 
@@ -130,7 +130,7 @@ class DefaultProjectAccountSettingsManagerTest {
             }
         })
 
-        changeRegion(mockRegionManager.lookupRegionById("MockRegion-1"))
+        changeRegion(AwsRegionProvider.getInstance().defaultRegion())
 
         assertThat(gotNotification).isTrue()
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.components.ServiceManager
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.region.ToolkitRegionProvider
 
-class MockRegionProvider : ToolkitRegionProvider {
+class MockRegionProvider : ToolkitRegionProvider() {
     private val overrideRegions: MutableMap<String, AwsRegion> = mutableMapOf()
 
     fun addRegion(region: AwsRegion): AwsRegion {
@@ -19,14 +19,22 @@ class MockRegionProvider : ToolkitRegionProvider {
         overrideRegions.clear()
     }
 
+    override fun partitionData(): Map<String, PartitionData> {
+        val combinedRegions = regions + overrideRegions
+        return combinedRegions.asSequence()
+            .associate {
+                it.value.partitionId to PartitionData(
+                    "MockPartition",
+                    emptyMap(),
+                    combinedRegions.filterValues { regions -> regions.partitionId == it.value.partitionId }
+                )
+            }
+    }
+
     override fun defaultRegion(): AwsRegion = US_EAST_1
 
-    override fun regions(): Map<String, AwsRegion> = regions + overrideRegions
-
-    override fun isServiceSupported(region: AwsRegion, serviceName: String): Boolean = true
-
     companion object {
-        private val US_EAST_1 = AwsRegion("us-east-1", "US East (N. Virginia)")
+        private val US_EAST_1 = AwsRegion("us-east-1", "US East (N. Virginia)", "aws")
         private val regions = mapOf(US_EAST_1.id to US_EAST_1)
         fun getInstance(): MockRegionProvider = ServiceManager.getService(ToolkitRegionProvider::class.java) as MockRegionProvider
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -31,6 +31,8 @@ class MockRegionProvider : ToolkitRegionProvider() {
             }
     }
 
+    override fun isServiceSupported(region: AwsRegion, serviceName: String): Boolean = true
+
     override fun defaultRegion(): AwsRegion = US_EAST_1
 
     companion object {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationProducerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationProducerTest.kt
@@ -27,7 +27,7 @@ class RemoteLambdaRunConfigurationProducerTest {
     @Test
     fun validRunConfigurationIsCreated() {
         val functionName = "SomeFunction"
-        val region = AwsRegion("us-east-1", "us-east-1")
+        val region = AwsRegion("us-east-1", "us-east-1", "aws")
         val credentialProviderId = "SomeCredProvider"
 
         val lambdaLocation = LambdaFunction(

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialogTest.kt
@@ -52,7 +52,7 @@ class EditFunctionDialogTest {
     fun setup() {
         s3Client = mockClientManager.create()
         iamClient = mockClientManager.create()
-        mockSettingsManager.changeRegion(AwsRegion("us-west-1", "US West 1"))
+        mockSettingsManager.changeRegion(AwsRegion("us-west-1", "US West 1", "aws"))
 
         val sdk = IdeaTestUtil.getMockJdk18()
         runInEdtAndWait {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
@@ -15,7 +15,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.telemetry.DefaultMetricEvent.Companion.METADATA_NA
 import software.aws.toolkits.core.telemetry.DefaultMetricEvent.Companion.METADATA_NOT_SET
@@ -130,10 +129,10 @@ class TelemetryServiceTest {
         MockResourceCache.getInstance(projectRule.project).addValidAwsCredential(accountSettings.activeRegion.id, "profile:admin", "111111111111")
 
         accountSettings.changeCredentialProvider(
-            MockCredentialsManager.getInstance().addCredentials("profile:admin", AwsBasicCredentials.create("Access", "Secret"))
+            MockCredentialsManager.getInstance().addCredentials("profile:admin")
         )
 
-        val mockRegion = AwsRegion("foo-region", "foo-region")
+        val mockRegion = AwsRegion("foo-region", "foo-region", "aws")
         MockRegionProvider.getInstance().addRegion(mockRegion)
         accountSettings.changeRegion(mockRegion)
 
@@ -161,10 +160,10 @@ class TelemetryServiceTest {
         MockResourceCache.getInstance(projectRule.project).addValidAwsCredential(accountSettings.activeRegion.id, "profile:admin", "111111111111")
 
         accountSettings.changeCredentialProvider(
-            MockCredentialsManager.getInstance().addCredentials("profile:admin", AwsBasicCredentials.create("Access", "Secret"))
+            MockCredentialsManager.getInstance().addCredentials("profile:admin")
         )
 
-        val mockRegion = AwsRegion("foo-region", "foo-region")
+        val mockRegion = AwsRegion("foo-region", "foo-region", "aws")
         MockRegionProvider.getInstance().addRegion(mockRegion)
         accountSettings.changeRegion(mockRegion)
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/ResourceSelectorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/ResourceSelectorTest.kt
@@ -163,7 +163,7 @@ class ResourceSelectorTest {
         mockResourceCache.addEntry(mockResource, "region1", "credential1", listOf("foo"))
         val comboBox = ResourceSelector.builder(projectRule.project)
             .resource(mockResource)
-            .awsConnection(AwsRegion("region1", "") to mockCred("credential1"))
+            .awsConnection(AwsRegion("region1", "", "aws") to mockCred("credential1"))
             .build()
 
         retryableAssert {


### PR DESCRIPTION
* Move common code up into ToolkitRegionProvider so mock is more accurate
* It is not possible to switch to a region outside of AWS Standard yet

## Motivation and Context
This refactor is in prep for allowing to switch to CN and GovCloud

## Related Issue(s)
#1405 #816 #699 

## Testing
Tests pass, backwards compat test added

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
