### PR TITLE
Fix double right click performing actions in S3 browser

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeTable.kt
@@ -87,7 +87,7 @@ class S3TreeTable(
     }
 
     private fun handleOpeningFile(row: Int, e: MouseEvent) {
-        if (e.clickCount < 2) {
+        if (e.clickCount < 2 || e.button != MouseEvent.BUTTON1) {
             return
         }
         val objectNode = (tree.getPathForRow(row).lastPathComponent as? DefaultMutableTreeNode)?.userObject as? S3TreeObjectNode ?: return
@@ -120,7 +120,7 @@ class S3TreeTable(
     }
 
     private fun handleLoadingMore(row: Int, e: MouseEvent) {
-        if (e.clickCount < 2) {
+        if (e.clickCount < 2 || e.button != MouseEvent.BUTTON1) {
             return
         }
         val continuationNode = (tree.getPathForRow(row).lastPathComponent as? DefaultMutableTreeNode)?.userObject as? S3TreeContinuationNode ?: return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Double right click was able to open files and load more in the S3 Browser. Instead, check for left click only

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
