### PR TITLE
Fix S3 actions being usable

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyPathAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyPathAction.kt
@@ -25,6 +25,9 @@ class CopyPathAction(private val treeTable: S3TreeTable) : AnActionButton(messag
         }
     }
 
+    override fun isDumbAware(): Boolean = true
+    override fun updateButton(e: AnActionEvent) {}
+
     companion object {
         private const val TELEMETRY_NAME = "s3_copypath"
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/DeleteObjectAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/DeleteObjectAction.kt
@@ -24,6 +24,8 @@ class DeleteObjectAction(private val treeTable: S3TreeTable) : AnActionButton(me
         deleteSelectedObjects(e.getRequiredData(LangDataKeys.PROJECT), treeTable)
     }
 
+    override fun isDumbAware(): Boolean = true
+    override fun updateButton(e: AnActionEvent) {}
     override fun isEnabled(): Boolean = (!(treeTable.isEmpty || (treeTable.selectedRow < 0) || (treeTable.getValueAt(treeTable.selectedRow, 1) == "")))
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/DownloadObjectAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/DownloadObjectAction.kt
@@ -73,6 +73,8 @@ class DownloadObjectAction(
         }
     }
 
+    override fun isDumbAware(): Boolean = true
+    override fun updateButton(e: AnActionEvent) {}
     override fun isEnabled(): Boolean = !(treeTable.isEmpty || (treeTable.selectedRow < 0) || (treeTable.getValueAt(treeTable.selectedRow, 1) == ""))
 
     companion object {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/NewFolderAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/NewFolderAction.kt
@@ -15,6 +15,8 @@ import software.aws.toolkits.resources.message
 
 class NewFolderAction(private val treeTable: S3TreeTable) : AnActionButton(message("s3.new.folder"), null, null) {
 
+    override fun isDumbAware(): Boolean = true
+    override fun updateButton(e: AnActionEvent) {}
     override fun isEnabled(): Boolean = treeTable.selectedRows.size <= 1
 
     override fun actionPerformed(e: AnActionEvent) {
@@ -32,9 +34,5 @@ class NewFolderAction(private val treeTable: S3TreeTable) : AnActionButton(messa
                 }
             }
         }
-    }
-
-    companion object {
-        private const val TELEMETRY_NAME = "s3_newfolder"
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/RenameObjectAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/RenameObjectAction.kt
@@ -53,6 +53,8 @@ class RenameObjectAction(private val treeTable: S3TreeTable) :
         }
     }
 
+    override fun isDumbAware(): Boolean = true
+    override fun updateButton(e: AnActionEvent) {}
     override fun isEnabled(): Boolean = !(treeTable.isEmpty || (treeTable.selectedRow < 0) ||
         (treeTable.getValueAt(treeTable.selectedRow, 1) == "") || (treeTable.selectedRows.size > 1))
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectAction.kt
@@ -55,6 +55,8 @@ class UploadObjectAction(
         }
     }
 
+    override fun isDumbAware(): Boolean = true
+    override fun updateButton(e: AnActionEvent) {}
     override fun isEnabled(): Boolean =
         (treeTable.isEmpty || treeTable.selectedRows.size <= 1) && !treeTable.getSelectedNodes().any { it is S3TreeContinuationNode }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Actions were not selectable due to a field they needed to override not being overwritten, so they were always disabled

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
