### PR TITLE
Downgrade Coroutines version

### DIFF
--- a/jetbrains-core/build.gradle
+++ b/jetbrains-core/build.gradle
@@ -54,8 +54,8 @@ dependencies {
     compile(project(":core")) {
         exclude group: 'org.slf4j'
     }
-    compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3")
-    compile("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.3.3")
+    compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1")
+    compile("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.2.1")
     compile("software.amazon.awssdk:s3:$awsSdkVersion") {
         exclude group: 'org.slf4j'
     }


### PR DESCRIPTION
* The newer version changed the method name of the scheduler method, so the ThreadTracker in IntelliJ test framework things the thread leaked. We can't upgrade until JB fixes their thread tracker code for coroutines

## Motivation and Context
Commit they changed it:
https://github.com/Kotlin/kotlinx.coroutines/commit/f27d176e7a6add3b92f268c413b0ea4d27de35aa#diff-a17845c69f019970b8d901ad0d53f95aL802 

Leads to this check failing:
https://github.com/JetBrains/intellij-community/blob/master/platform/testFramework/src/com/intellij/testFramework/ThreadTracker.java#L277

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
