### PR TITLE
Fix `gradlew runIde` starting multiple IDEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ check.dependsOn coverageReport
 // community edition
 if (gradle.startParameter.taskNames.contains("runIde")) {
     // Only disable this if running from root project
-    if (gradle.startParameter.projectDir == project.rootProject.rootDir
+    if (project.projectDir == project.rootProject.rootDir
         || System.properties.containsKey("idea.gui.tests.gradle.runner")) {
         println("Top level runIde selected, excluding sub-projects' runIde")
         gradle.taskGraph.whenReady { graph ->
@@ -271,9 +271,7 @@ if (gradle.startParameter.taskNames.contains("runIde")) {
                         it.enabled = false
                     }
                 } else {
-                    if (it.name == "runIde" &&
-                        it.project != project(':jetbrains-core') &&
-                        it.project != project(':jetbrains-rider')) {
+                    if (it.name == "runIde" && it.project != project(':jetbrains-core')) {
                         it.enabled = false
                     }
                 }


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
