### PR TITLE
Fix not able to compile rider on linux

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -20,7 +20,7 @@ phases:
       - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay&
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
       - apt-get update
-      - apt-get install -y jq python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils msbuild
+      - apt-get install -y jq python2.7 python-pip python3.6 python3.7 python3.8 python3-pip python3-distutils mono-complete
       - aws sts assume-role --role-arn $ASSUME_ROLE_ARN --role-session-name integ-test > creds.json
       - export KEY_ID=`jq -r '.Credentials.AccessKeyId' creds.json`
       - export SECRET=`jq -r '.Credentials.SecretAccessKey' creds.json`

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -18,7 +18,7 @@ phases:
 
     commands:
       - apt update
-      - apt install -y msbuild
+      - apt install -y mono-complete
 
   build:
     commands:

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -20,7 +20,7 @@ phases:
 
     commands:
       - apt-get update
-      - apt-get install -y xvfb icewm procps ffmpeg libswt-gtk-3-java msbuild
+      - apt-get install -y xvfb icewm procps ffmpeg libswt-gtk-3-java mono-complete
       - mkdir -p /tmp/.aws
       - aws sts assume-role --role-arn $ASSUME_ROLE_ARN --role-session-name ui-test > /tmp/.aws/creds.json
       - |


### PR DESCRIPTION
Fix:
```
MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.
System.BadImageFormatException: Could not resolve field token 0x04000383, due to: Could not load type of field 'Microsoft.Build.Execution.BuildManager:_workQueue' (33) due to: Could not load file or assembly 'System.Threading.Tasks.Dataflow, Version=4.6.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. assembly:/usr/lib/mono/msbuild/Current/bin/Microsoft.Build.dll type:BuildManager member:(null)
```


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
