### PR TITLE
CI: use codebuild dotnet instead of choco

### DIFF
--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -15,8 +15,8 @@ phases:
   install:
     commands:
       - choco install -y --no-progress codecov
-      - choco install -y --no-progress dotnetcore-sdk --version 2.2.104
-      - choco install -y --no-progress netfx-4.6.1-devpack
+    runtime-versions:
+      dotnet: 2.2
 
   build:
     commands:


### PR DESCRIPTION
Attempt to avoid choco.

- codebuild provides dotnet 2.2: https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#runtime-versions-buildspec-file
- Windows build succeeds without `netfx-4.6.1-devpack`. Did the tests silently skip?

Also, [this](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html) says:

>  The base image of the Windows Server Core 2016 contains the following runtimes. 
> ...
> dotnet | 2.2

For reference, https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script provides `dotnet-install.ps1` but that's for dotnet core, which the image already includes. We apparently need .NET framework plus whatever the "devpack" includes?

- powershell alternative to choco (get URL from [here](https://docs.microsoft.com/en-us/dotnet/framework/deployment/deployment-guide-for-developers)): 
  ```
  Invoke-WebRequest -Uri "http://go.microsoft.com/fwlink/?LinkId=863262" -OutFile installer.exe
  .\installer.exe /norestart /quiet
  ```
- other alternative: https://scoop.sh/
  - comparison to choco: https://github.com/lukesampson/scoop/wiki/Chocolatey-Comparison


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
