### PR TITLE
Redo the ProfileWatcher

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialWriter.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialWriter.kt
@@ -18,7 +18,6 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.LocalFileSystem
 import org.jetbrains.annotations.TestOnly
 import software.amazon.awssdk.profiles.ProfileFileLocation
-import software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileCredentialProviderFactory
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.aws.toolkits.resources.message
 import java.io.File
@@ -74,8 +73,6 @@ class CreateOrUpdateCredentialProfilesAction @TestOnly constructor(
                 }
                 TelemetryService.recordSimpleTelemetry(project, "aws_config_edit", true)
             }
-
-            ProfileCredentialProviderFactory.profileWatcher.start()
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
@@ -21,6 +21,7 @@ class ProfileCredentialProviderFactory : CredentialProviderFactory {
     companion object {
         val profileWatcher = ProfileWatcher().also {
             it.start()
+            // TODO: Scope this better in the cred manager refactor
             Disposer.register(ApplicationManager.getApplication(), it)
         }
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileToolkitCredentialsProviderFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileToolkitCredentialsProviderFactory.kt
@@ -143,10 +143,6 @@ class ProfileToolkitCredentialsProviderFactory(
         }
     }
 
-    override fun shutDown() {
-        profileWatcher.removeListener(this)
-    }
-
     companion object {
         private val LOG = LoggerFactory.getLogger(ProfileToolkitCredentialsProviderFactory::class.java)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.core.credentials.profiles
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.AsyncFileListener
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtilCore
@@ -20,8 +21,8 @@ class ProfileWatcher : AsyncFileListener, Disposable {
     private val watchRoots = mutableSetOf<LocalFileSystem.WatchRequest>()
 
     private val watchLocationsStrings = setOf(
-        ProfileFileLocation.configurationFilePath().toAbsolutePath().toString(),
-        ProfileFileLocation.credentialsFilePath().toAbsolutePath().toString()
+        FileUtil.normalize(ProfileFileLocation.configurationFilePath().toAbsolutePath().toString()),
+        FileUtil.normalize(ProfileFileLocation.credentialsFilePath().toAbsolutePath().toString())
     )
 
     override fun prepareChange(events: MutableList<out VFileEvent>): AsyncFileListener.ChangeApplier? {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
@@ -25,11 +25,9 @@ class ProfileWatcher : AsyncFileListener, Disposable {
     )
 
     override fun prepareChange(events: MutableList<out VFileEvent>): AsyncFileListener.ChangeApplier? {
-        val relevantChanges = events.filter { VfsUtilCore.isUnder(it.path, watchLocationsStrings) }.toList()
+        val isRelevant = events.any { VfsUtilCore.isUnder(it.path, watchLocationsStrings) }
 
-        return if (relevantChanges.isEmpty()) {
-            null
-        } else {
+        return if (isRelevant) {
             object : AsyncFileListener.ChangeApplier {
                 override fun afterVfsChange() {
                     listeners.forEach {
@@ -39,6 +37,8 @@ class ProfileWatcher : AsyncFileListener, Disposable {
                     }
                 }
             }
+        } else {
+            null
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
@@ -4,148 +4,63 @@
 package software.aws.toolkits.jetbrains.core.credentials.profiles
 
 import com.intellij.openapi.Disposable
-import com.intellij.util.io.isFile
+import com.intellij.openapi.vfs.AsyncFileListener
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import software.amazon.awssdk.profiles.ProfileFileLocation
-import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
-import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.core.utils.tryOrNull
-import software.aws.toolkits.core.utils.warn
-import java.nio.file.FileSystems
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardWatchEventKinds
-import java.nio.file.WatchKey
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
-import java.util.concurrent.Future
 
-class ProfileWatcher : Disposable {
+@Suppress("MissingRecentApi") // 2019.2 is 192.5728.98 TODO: Remove warning FIX_WHEN_MIN_IS_193
+class ProfileWatcher : AsyncFileListener, Disposable {
     private val listeners = ConcurrentHashMap.newKeySet<ProfileChangeListener>()
-    private val watchService = FileSystems.getDefault().newWatchService()
-    private val watchKeys: MutableMap<WatchKey, Path> = mutableMapOf()
-    private val watchLocations = setOf(
-        ProfileFileLocation.configurationFilePath().toAbsolutePath(),
-        ProfileFileLocation.credentialsFilePath().toAbsolutePath()
+    private val watchRoots = mutableSetOf<LocalFileSystem.WatchRequest>()
+
+    private val watchLocationsStrings = setOf(
+        ProfileFileLocation.configurationFilePath().toAbsolutePath().toString(),
+        ProfileFileLocation.credentialsFilePath().toAbsolutePath().toString()
     )
-    private val executor = Executors.newSingleThreadExecutor {
-        Thread(it).also { newThread ->
-            newThread.name = "AWSProfileWatcher"
-            newThread.isDaemon = true
+
+    override fun prepareChange(events: MutableList<out VFileEvent>): AsyncFileListener.ChangeApplier? {
+        val relevantChanges = events.filter { VfsUtilCore.isUnder(it.path, watchLocationsStrings) }.toList()
+
+        return if (relevantChanges.isEmpty()) {
+            null
+        } else {
+            object : AsyncFileListener.ChangeApplier {
+                override fun afterVfsChange() {
+                    listeners.forEach {
+                        LOG.tryOrNull("Invoking ProfileChangeListener failed") {
+                            it.onProfilesChanged()
+                        }
+                    }
+                }
+            }
         }
     }
-
-    @Volatile
-    private var watchFuture: Future<*>? = null
 
     fun addListener(listener: ProfileChangeListener) {
         listeners.add(listener)
     }
 
-    fun removeListener(listener: ProfileChangeListener) {
-        listeners.remove(listener)
-    }
-
-    @Synchronized
     fun start() {
-        if (executor.isShutdown) {
-            throw IllegalStateException("ProfileWatcher was shutdown")
-        }
-
-        // Register watch locations if they exist, safe to be ran multiple times
-        watchLocations.filter {
-            if (Files.exists(it)) {
-                true
-            } else {
-                LOG.info { "$it does not exist, won't watch" }
-                false
-            }
-        }.map {
-            val watchLocation = if (it.isFile()) it.parent else it
-            watchLocation.register(
-                watchService,
-                StandardWatchEventKinds.ENTRY_CREATE,
-                StandardWatchEventKinds.ENTRY_DELETE,
-                StandardWatchEventKinds.ENTRY_MODIFY
-            ) to watchLocation
-        }.forEach {
-            LOG.info { "Watching ${it.second} for file changes" }
-            watchKeys[it.first] = it.second
-        }
-
-        // Only start if not already running
-        if (watchFuture == null || watchFuture?.isDone == true) {
-            watchFuture = executor.submit(this::watch)
-        }
-    }
-
-    private fun watch() {
-        while (true) {
-            val key = try {
-                watchService.take()
-            } catch (e: InterruptedException) {
-                return
-            }
-
-            var invokeListeners = false
-            key.pollEvents().forEach {
-                try {
-                    val kind = it.kind()
-                    when (kind) {
-                        StandardWatchEventKinds.OVERFLOW -> {
-                            LOG.debug { "ProfileWatcher got an OVERFLOW" }
-                        }
-                        else -> {
-                            // Context path is relative to base registered to WatchKey
-                            val context = it.context()
-                            if (context is Path) {
-                                val fullPath = watchKeys[key]?.resolve(context)
-                                LOG.debug { "$fullPath was changed" }
-                                if (watchLocations.contains(fullPath)) {
-                                    // In case of back to back events, de-dupe them
-                                    invokeListeners = true
-                                }
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    LOG.warn(e) { "ProfileWatcher got an exception" }
-                }
-            }
-
-            val isValid = key.reset()
-            if (!isValid) {
-                LOG.debug { "WatchKey $key is no longer valid" }
-                watchKeys.remove(key)
-            }
-
-            if (watchKeys.isEmpty()) {
-                LOG.debug { "All watch keys have been removed, terminating watcher." }
-                return
-            }
-
-            if (invokeListeners) {
-                listeners.forEach { listener ->
-                    LOG.tryOrNull("Failed to notify listeners") {
-                        listener.onProfilesChanged()
-                    }
-                }
-
-                invokeListeners = false
-            }
-        }
+        watchRoots.addAll(LocalFileSystem.getInstance().addRootsToWatch(watchLocationsStrings, false))
+        VirtualFileManager.getInstance().addAsyncFileListener(this, this)
     }
 
     override fun dispose() {
-        watchService.close()
-        executor.shutdown()
-    }
-
-    private companion object {
-        val LOG = getLogger<ProfileWatcher>()
+        listeners.clear()
+        LocalFileSystem.getInstance().removeWatchedRoots(watchRoots)
     }
 
     interface ProfileChangeListener {
         fun onProfilesChanged()
+    }
+
+    private companion object {
+        private val LOG = getLogger<ProfileWatcher>()
     }
 }


### PR DESCRIPTION
* Use the VFS listener system, it is simpler and faster on OSX.
* We no longer need to "restart" it when we create a config or credential file

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
