### PR TITLE
Add a basic sort to CredentialManager#getCredentialIdentifiers

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
@@ -35,7 +35,8 @@ abstract class CredentialManager : SimpleModificationTracker() {
     fun getAwsCredentialProvider(providerId: ToolkitCredentialsIdentifier, region: AwsRegion): ToolkitCredentialsProvider =
         ToolkitCredentialsProvider(providerId, AwsCredentialProviderProxy(providerId, region))
 
-    fun getCredentialIdentifiers(): List<ToolkitCredentialsIdentifier> = providerIds.values.toList()
+    fun getCredentialIdentifiers(): List<ToolkitCredentialsIdentifier> = providerIds.values
+        .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.displayName })
 
     fun getCredentialIdentifierById(id: String): ToolkitCredentialsIdentifier? = providerIds[id]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Gives some stability to the credential selection menu

Cheap sort that isn't perfect (cred-101 is considered higher than cred-1009), but naming your credentials from 1 to 2000 is probably an anti-pattern.

## Testing
![Screen Shot 2020-02-18 at 4 10 56 PM](https://user-images.githubusercontent.com/8992246/74790667-18d8dd80-526d-11ea-9510-ae45a3212123.png)
to
![Screen Shot 2020-02-18 at 4 38 43 PM](https://user-images.githubusercontent.com/8992246/74790683-2e4e0780-526d-11ea-87ce-b2907a556b00.png)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
