### PR TITLE
Don't create a hash map of the credential identifiers, there already …

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
@@ -183,9 +183,8 @@ abstract class ProjectAccountSettingsManager(private val project: Project) : Sim
      * Returns the list of recently used [ToolkitCredentialsIdentifier]
      */
     fun recentlyUsedCredentials(): List<ToolkitCredentialsIdentifier> {
-        val credentialsProvider = CredentialManager.getInstance()
-        val providerIds = credentialsProvider.getCredentialIdentifiers().map { it.id to it }.toMap()
-        return recentlyUsedProfiles.elements().mapNotNull { providerIds[it] }
+        val credentialManager = CredentialManager.getInstance()
+        return recentlyUsedProfiles.elements().mapNotNull { credentialManager.getCredentialIdentifierById(it) }
     }
 
     /**


### PR DESCRIPTION
…is one in the CredentialManager

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
The code was re-creating the exact hash map that is inside of CredentialManager, so instead just query that map to see if the ID still exists

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
