### PR TITLE
Don't retry 400 errors when publishing to telemetry.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,6 +4,7 @@
 dependencies {
     compile(project(":resources"))
     compile(project(":telemetry-client"))
+    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
     compile("software.amazon.awssdk:cognitoidentity:$awsSdkVersion")
@@ -13,6 +14,7 @@ dependencies {
 }
 
 configurations {
+    testRuntimeClasspath.extendsFrom(compileOnly)
     testArtifacts
 }
 

--- a/core/src/software/aws/toolkits/core/telemetry/TelemetryPublisher.kt
+++ b/core/src/software/aws/toolkits/core/telemetry/TelemetryPublisher.kt
@@ -1,8 +1,8 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.core.telemetry
 
 interface TelemetryPublisher {
-    fun publish(metricEvents: Collection<MetricEvent>): Boolean
+    suspend fun publish(metricEvents: Collection<MetricEvent>)
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/DefaultTelemetryPublisherTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/DefaultTelemetryPublisherTest.kt
@@ -7,6 +7,7 @@ import com.intellij.testFramework.ProjectRule
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -38,18 +39,20 @@ class DefaultTelemetryPublisherTest {
             osVersion = "1.0"
         )
 
-        publisher.publish(listOf(
-            DefaultMetricEvent.builder()
-                .awsAccount("111111111111")
-                .awsRegion("us-west-2")
-                .datum("foobar") { this.count() }
-                .build(),
-            DefaultMetricEvent.builder()
-                .awsAccount("111111111111")
-                .awsRegion("us-west-2")
-                .datum("spam") { this.count() }
-                .build()
-        ))
+        runBlocking {
+            publisher.publish(listOf(
+                DefaultMetricEvent.builder()
+                    .awsAccount("111111111111")
+                    .awsRegion("us-west-2")
+                    .datum("foobar") { this.count() }
+                    .build(),
+                DefaultMetricEvent.builder()
+                    .awsAccount("111111111111")
+                    .awsRegion("us-west-2")
+                    .datum("spam") { this.count() }
+                    .build()
+            ))
+        }
 
         verify(mockTelemetryClient, times(1)).postMetrics(mockPostMetricsRequestCaptor.capture())
         val postMetricsRequest = mockPostMetricsRequestCaptor.firstValue
@@ -108,18 +111,20 @@ class DefaultTelemetryPublisherTest {
             osVersion = "1.0"
         )
 
-        publisher.publish(listOf(
-            DefaultMetricEvent.builder()
-                .awsAccount("111111111111")
-                .awsRegion("us-west-2")
-                .datum("foobar") { this.count() }
-                .build(),
-            DefaultMetricEvent.builder()
-                .awsAccount("111111111111")
-                .awsRegion("us-west-2")
-                .datum("spam") { this.count() }
-                .build()
-        ))
+        runBlocking {
+            publisher.publish(listOf(
+                DefaultMetricEvent.builder()
+                    .awsAccount("111111111111")
+                    .awsRegion("us-west-2")
+                    .datum("foobar") { this.count() }
+                    .build(),
+                DefaultMetricEvent.builder()
+                    .awsAccount("111111111111")
+                    .awsRegion("us-west-2")
+                    .datum("spam") { this.count() }
+                    .build()
+            ))
+        }
 
         verify(mockTelemetryClient, times(1)).postMetrics(mockPostMetricsRequestCaptor.capture())
         val postMetricsRequest = mockPostMetricsRequestCaptor.firstValue


### PR DESCRIPTION
Also moving TelemetryPublisher to use co-routines.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
