### PR TITLE
Stress project account settings manager

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
@@ -156,6 +156,28 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
+    fun stressTest() {
+        val region = AwsRegionProvider.getInstance().defaultRegion()
+        changeRegion(region)
+
+        assertThat(manager.recentlyUsedCredentials()).isEmpty()
+
+        val credentialsList = List(100) {
+            val credentials = mockCredentialManager.addCredentials("Mock$it")
+            markConnectionSettingsAsValid(credentials, region)
+            credentials
+        }
+
+        credentialsList.forEach {
+            manager.changeCredentialProvider(it)
+        }
+
+        waitForTerminalConnectionState()
+
+        assertThat(manager.connectionSettings()?.credentials?.id).isEqualTo(credentialsList.last().id)
+    }
+
+    @Test
     fun testSavingActiveRegion() {
         manager.changeRegion(AwsRegion.GLOBAL)
         val element = Element("AccountState")


### PR DESCRIPTION
New stress test broke due to bad concurrency, switching to the actor with conflated queue will always process the latest event in the queue after it finishes processing the current request.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
