### PR TITLE
Fix 2019.3 unit tests

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
@@ -50,6 +50,7 @@ interface ExecutableManager {
 
 inline fun <reified T : ExecutableType<*>> ExecutableManager.getExecutable() = getExecutable(ExecutableType.getInstance<T>())
 inline fun <reified T : ExecutableType<*>> ExecutableManager.getExecutableIfPresent() = getExecutableIfPresent(ExecutableType.getInstance<T>())
+inline fun <reified T : ExecutableType<*>> ExecutableManager.setExecutablePath(path: Path) = setExecutablePath(ExecutableType.getInstance<T>(), path)
 
 @State(name = "executables", storages = [Storage("aws.xml")])
 class DefaultExecutableManager : PersistentStateComponent<ExecutableStateList>, ExecutableManager {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/CreateRunConfiguration.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/CreateRunConfiguration.kt
@@ -8,11 +8,15 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
+import software.aws.toolkits.jetbrains.core.executables.setExecutablePath
 import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfigurationType
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamVersionCache
 import software.aws.toolkits.jetbrains.services.lambda.validation.LambdaHandlerValidator
+import java.nio.file.Paths
 import java.security.InvalidParameterException
 
 private const val TEST_EVALUATE_BLOCKING_TIMEOUT_MS = 2000
@@ -107,6 +111,7 @@ fun samRunConfiguration(project: Project): LocalLambdaRunConfiguration {
 fun preWarmSamVersionCache(path: String?, timeoutMs: Int = TEST_EVALUATE_BLOCKING_TIMEOUT_MS) {
     path ?: throw InvalidParameterException("Test SAM CLI executable path is not set")
     SamVersionCache.evaluateBlocking(path, timeoutMs)
+    ExecutableManager.getInstance().setExecutablePath<SamExecutable>(Paths.get(path))
 }
 
 fun preWarmLambdaHandlerValidation(project: Project, runtime: Runtime, handler: String, timeoutMs: Int = TEST_EVALUATE_BLOCKING_TIMEOUT_MS) {


### PR DESCRIPTION
## Description
2019.3 unit tests were broken due to not setting the SAM executable
See the beta account for a successful test run

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
