### PR TITLE
Do not include Kotlin into the distribution of the plugin to fix Clas…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,11 @@ allprojects {
             }
         }
     }
+
+    configurations {
+        runtimeClasspath.exclude group: "org.jetbrains.kotlin"
+        runtimeClasspath.exclude group: "org.jetbrains.kotlinx"
+    }
 }
 
 // Kotlin plugin seems to be bugging out when there are no kotlin sources


### PR DESCRIPTION
…sCastExceptions

## Motivation
Should fix:
```
Caused by: java.lang.ClassCastException: class kotlinx.coroutines.scheduling.DefaultScheduler cannot be cast to class kotlin.coroutines.CoroutineContext (kotlinx.coroutines.scheduling.DefaultScheduler is in unnamed module of loader com.intellij.util.lang.UrlClassLoader @490ab905; kotlin.coroutines.CoroutineContext is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @1cb74099)
	at software.aws.toolkits.jetbrains.core.credentials.DefaultProjectAccountSettingsManager.loadState(DefaultProjectAccountSettingsManager.kt:46)
	at software.aws.toolkits.jetbrains.core.credentials.DefaultProjectAccountSettingsManager.loadState(DefaultProjectAccountSettingsManager.kt:25)
	at com.intellij.configurationStore.ComponentStoreImpl.doInitComponent(ComponentStoreImpl.kt:405)
	at com.intellij.configurationStore.ComponentStoreImpl.initComponent(ComponentStoreImpl.kt:355)
	at com.intellij.configurationStore.ComponentStoreImpl.initPersistenceStateComponent(ComponentStoreImpl.kt:122)
	at com.intellij.configurationStore.ComponentStoreImpl.initComponent(ComponentStoreImpl.kt:97)
	... 81 more
```

so that coroutines and stdlib are in sync and compatible

## Testing
Fixed 192-201 to make sure each started correctly

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
