### PR TITLE
Remove slf4j from runtime classpath globally, cleanup excludes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ allprojects {
     }
 
     configurations {
+        runtimeClasspath.exclude group: "org.slf4j"
         runtimeClasspath.exclude group: "org.jetbrains.kotlin"
         runtimeClasspath.exclude group: "org.jetbrains.kotlinx"
     }
@@ -288,9 +289,9 @@ task guiTest(type: Test) {
 }
 
 dependencies {
-    compile project(':jetbrains-ultimate')
+    implementation project(':jetbrains-ultimate')
     project.findProject(':jetbrains-rider')?.collect {
-        compile it
+        implementation it
     }
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"

--- a/jetbrains-core/build.gradle
+++ b/jetbrains-core/build.gradle
@@ -73,38 +73,20 @@ artifacts {
 }
 
 dependencies {
-    compile(project(":core")) {
-        exclude group: 'org.slf4j'
-    }
-    compile("software.amazon.awssdk:s3:$awsSdkVersion") {
-        exclude group: 'org.slf4j'
-    }
-    compile("software.amazon.awssdk:lambda:$awsSdkVersion") {
-        exclude group: 'org.slf4j'
-    }
-    compile("software.amazon.awssdk:iam:$awsSdkVersion") {
-        exclude group: 'org.slf4j'
-    }
-    compile("software.amazon.awssdk:ecs:$awsSdkVersion") {
-        exclude group: 'org.slf4j'
-    }
-    compile("software.amazon.awssdk:cloudformation:$awsSdkVersion") {
-        exclude group: 'org.slf4j'
-    }
-    compile("software.amazon.awssdk:schemas:$awsSdkVersion") {
-        exclude group: 'org.slf4j'
-    }
-    compile("software.amazon.awssdk:cloudwatchlogs:$awsSdkVersion") {
-        exclude group: 'org.slf4j'
-    }
-    compile("software.amazon.awssdk:apache-client:$awsSdkVersion") {
-        exclude group: 'org.slf4j'
-    }
-    compile("software.amazon.awssdk:resourcegroupstaggingapi:$awsSdkVersion") {
-        exclude group: 'org.slf4j'
-    }
+    api(project(":core"))
+    api("software.amazon.awssdk:s3:$awsSdkVersion")
+    api("software.amazon.awssdk:lambda:$awsSdkVersion")
+    api("software.amazon.awssdk:iam:$awsSdkVersion")
+    api("software.amazon.awssdk:ecs:$awsSdkVersion")
+    api("software.amazon.awssdk:cloudformation:$awsSdkVersion")
+    api("software.amazon.awssdk:schemas:$awsSdkVersion")
+    api("software.amazon.awssdk:cloudwatchlogs:$awsSdkVersion")
+    api("software.amazon.awssdk:apache-client:$awsSdkVersion")
+    api("software.amazon.awssdk:resourcegroupstaggingapi:$awsSdkVersion")
+
     testImplementation project(path: ":core", configuration: 'testArtifacts')
     testImplementation('com.github.tomakehurst:wiremock-jre8:2.26.0')
+
     integrationTestImplementation('org.eclipse.jetty:jetty-servlet:9.4.15.v20190215')
     integrationTestImplementation('org.eclipse.jetty:jetty-proxy:9.4.15.v20190215')
 }


### PR DESCRIPTION
## Testing
Check passes, not in zip

```
jar tf build/distributions/aws-jetbrains-toolkit-1.12-SNAPSHOT-192.zip | grep slf | wc -l
       0
```
## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
