### PR TITLE
Record telemetry if S3 upload objects is cancelled

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectAction.kt
@@ -10,6 +10,8 @@ import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeDirectoryNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeTable
 import software.aws.toolkits.resources.message
+import software.aws.toolkits.telemetry.Result
+import software.aws.toolkits.telemetry.S3Telemetry
 
 class UploadObjectAction(private val project: Project, treeTable: S3TreeTable) :
     SingleS3ObjectAction(treeTable, message("s3.upload.object.action"), AllIcons.Actions.Upload) {
@@ -18,6 +20,12 @@ class UploadObjectAction(private val project: Project, treeTable: S3TreeTable) :
             FileChooserDescriptorFactory.createAllButJarContentsDescriptor().withDescription(message("s3.upload.object.action", treeTable.bucket.name))
         val chooserDialog = FileChooserFactory.getInstance().createFileChooser(descriptor, project, null)
         val filesChosen = chooserDialog.choose(project, null).toList()
+
+        // If there are no files chosen, the user has cancelled upload
+        if (filesChosen.isEmpty()) {
+            S3Telemetry.uploadObjects(project, Result.CANCELLED)
+            return
+        }
 
         treeTable.uploadAndRefresh(filesChosen, node)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is a quick follow up to #1584 which should have had this as part of it. No file selected to upload is a cancel so record it as such.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
