### PR TITLE
Clean up the last usages of `when`

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -100,7 +100,7 @@ class AwsResourceCacheTest {
 
     @Test
     fun exceptionsAreBubbledWhenNoEntry() {
-        doAnswer { throw Throwable("Bang!") }.`when`(mockResource).fetch(any(), any(), any())
+        doAnswer { throw Throwable("Bang!") }.whenever(mockResource).fetch(any(), any(), any())
         assertThat(sut.getResource(mockResource)).hasException.withFailMessage("Bang!")
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/Mocks.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/Mocks.kt
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.aws.toolkits.jetbrains.services.cloudformation.stack
 
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert
 import org.mockito.Mockito
-import org.mockito.Mockito.`when`
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.amazon.awssdk.services.cloudformation.model.DescribeStackEventsRequest
 import software.amazon.awssdk.services.cloudformation.model.DescribeStackEventsResponse
@@ -58,7 +58,7 @@ internal fun MockClientManagerRule.createMock(
     events: MockEventsGenerator,
     postprocess: (CloudFormationClient) -> Unit = { }
 ) = create<CloudFormationClient>().apply {
-    `when`(describeStackEvents(Mockito.any<DescribeStackEventsRequest>())).then { invocation ->
+    whenever(describeStackEvents(Mockito.any<DescribeStackEventsRequest>())).then { invocation ->
         events.getEvents((invocation.arguments[0] as DescribeStackEventsRequest))
     }
     postprocess(this)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/UpdaterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/UpdaterTest.kt
@@ -5,11 +5,11 @@ package software.aws.toolkits.jetbrains.services.cloudformation.stack
 import com.intellij.testFramework.ProjectRule
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.atLeast
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourcesRequest
@@ -49,7 +49,7 @@ class UpdaterTest {
 
     @Before
     fun setUp() {
-        arrayOf(treeView, tableView).forEach { `when`(it.component).thenReturn(JLabel()) }
+        arrayOf(treeView, tableView).forEach { whenever(it.component).thenReturn(JLabel()) }
     }
 
     @Test
@@ -57,9 +57,9 @@ class UpdaterTest {
         val setStackStatus = createSemaphore()
         val fillResources = createSemaphore()
         val insertEvents = createSemaphore()
-        `when`(treeView.fillResources(any())).then { fillResources.release() }
-        `when`(treeView.setStackStatus(StackStatus.CREATE_COMPLETE)).then { setStackStatus.release() }
-        `when`(tableView.insertEvents(any(), any())).then { insertEvents.release() }
+        whenever(treeView.fillResources(any())).then { fillResources.release() }
+        whenever(treeView.setStackStatus(StackStatus.CREATE_COMPLETE)).then { setStackStatus.release() }
+        whenever(tableView.insertEvents(any(), any())).then { insertEvents.release() }
 
         val mockEventsGenerator = MockEventsGenerator()
 
@@ -79,10 +79,10 @@ class UpdaterTest {
         var availablePages = emptySet<Page>()
         SwingUtilities.invokeLater {
             val client = mockClientManagerRule.createMock(mockEventsGenerator) { mock ->
-                `when`(mock.describeStacks(any<DescribeStacksRequest>()))
+                whenever(mock.describeStacks(any<DescribeStacksRequest>()))
                     .thenReturn(StackStatus.CREATE_IN_PROGRESS.asResponse)
                     .thenReturn(StackStatus.CREATE_COMPLETE.asResponse)
-                `when`(mock.describeStackResources(any<DescribeStackResourcesRequest>()))
+                whenever(mock.describeStackResources(any<DescribeStackResourcesRequest>()))
                     .thenReturn(DescribeStackResourcesResponse.builder().stackResources(resources).build())
             }
             Updater(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
While writing tests for CloudWatch logs I noticed we still had some usages of the literal \`when\` vs `whenever` that comes from MockitoKotlin, cleaned up the last instances of this.

## Types of changes
- [x] Code cleanup

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
