### PR TITLE
Clean up CloudWatch group UI

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogWindow.kt
@@ -32,7 +32,7 @@ class CloudWatchLogWindow(private val project: Project) : CoroutineScope by Appl
         val group = CloudWatchLogGroup(project, logGroup)
         val title = message("cloudwatch.logs.log_group_title", logGroup.split("/").last())
         withContext(edtContext) {
-            toolWindow.addTab(title, group.content, activate = true, id = logGroup, disposable = group)
+            toolWindow.addTab(title, group.panel, activate = true, id = logGroup, disposable = group)
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogWindow.kt
@@ -32,7 +32,7 @@ class CloudWatchLogWindow(private val project: Project) : CoroutineScope by Appl
         val group = CloudWatchLogGroup(project, logGroup)
         val title = message("cloudwatch.logs.log_group_title", logGroup.split("/").last())
         withContext(edtContext) {
-            toolWindow.addTab(title, group.panel, activate = true, id = logGroup, disposable = group)
+            toolWindow.addTab(title, group.content, activate = true, id = logGroup, disposable = group)
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.form
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.CloudWatchLogGroup">
-  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="514" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <component id="c43d5" class="javax.swing.JLabel" binding="locationInformation">
+      <component id="c43d5" class="com.intellij.ui.components.JBLabel" binding="locationInformation">
         <constraints>
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -19,17 +19,10 @@
       <hspacer id="e40b2">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="10" height="-1"/>
+            <preferred-size width="5" height="-1"/>
           </grid>
         </constraints>
       </hspacer>
-      <vspacer id="8dc57">
-        <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="1" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="-1" height="10"/>
-          </grid>
-        </constraints>
-      </vspacer>
       <component id="99ed7" class="com.intellij.ui.components.JBTextField" binding="filterField">
         <constraints>
           <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
@@ -54,6 +47,13 @@
         </constraints>
         <properties/>
       </component>
+      <vspacer id="d75c6">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+            <preferred-size width="-1" height="5"/>
+          </grid>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.CloudWatchLogGroup">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="514" height="400"/>
@@ -8,24 +8,15 @@
     <properties/>
     <border type="none"/>
     <children>
-      <component id="c43d5" class="com.intellij.ui.components.JBLabel" binding="locationInformation">
+      <component id="c43d5" class="com.intellij.ui.components.breadcrumbs.Breadcrumbs" binding="locationInformation">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
-        <properties>
-          <text value="This text should be overwitten, if it's not file an issue"/>
-        </properties>
+        <properties/>
       </component>
-      <hspacer id="e40b2">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="5" height="-1"/>
-          </grid>
-        </constraints>
-      </hspacer>
       <component id="99ed7" class="com.intellij.ui.components.JBTextField" binding="filterField">
         <constraints>
-          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="27"/>
           </grid>
         </constraints>
@@ -33,7 +24,7 @@
       </component>
       <component id="afa20" class="javax.swing.JButton" binding="refreshButton">
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>
@@ -41,7 +32,7 @@
       </component>
       <component id="baa18" class="javax.swing.JScrollPane" binding="tableScroll" custom-create="true">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="4" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="50"/>
           </grid>
         </constraints>
@@ -49,7 +40,7 @@
       </component>
       <vspacer id="d75c6">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="5"/>
           </grid>
         </constraints>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.form
@@ -1,50 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.CloudWatchLogGroup">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-    <margin top="0" left="0" bottom="0" right="0"/>
+  <grid id="27dc6" binding="content" layout-manager="BorderLayout" hgap="0" vgap="0">
     <constraints>
       <xy x="20" y="20" width="514" height="400"/>
     </constraints>
     <properties/>
-    <border type="none"/>
+    <border type="none">
+      <color color="-16777216"/>
+    </border>
     <children>
       <component id="c43d5" class="com.intellij.ui.components.breadcrumbs.Breadcrumbs" binding="locationInformation">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
+        <constraints border-constraint="North"/>
         <properties/>
       </component>
-      <component id="99ed7" class="com.intellij.ui.components.JBTextField" binding="filterField">
-        <constraints>
-          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="27"/>
-          </grid>
-        </constraints>
+      <component id="baa18" class="com.intellij.openapi.ui.SimpleToolWindowPanel" binding="tablePanel" custom-create="true">
+        <constraints border-constraint="Center"/>
         <properties/>
       </component>
-      <component id="afa20" class="javax.swing.JButton" binding="refreshButton">
-        <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value=""/>
-        </properties>
-      </component>
-      <component id="baa18" class="javax.swing.JScrollPane" binding="tableScroll" custom-create="true">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="50"/>
-          </grid>
-        </constraints>
-        <properties/>
-      </component>
-      <vspacer id="d75c6">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
-            <preferred-size width="-1" height="5"/>
-          </grid>
-        </constraints>
-      </vspacer>
     </children>
   </grid>
 </form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
@@ -14,14 +14,14 @@ import com.intellij.openapi.application.impl.runUnlessDisposed
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.ui.DoubleClickListener
-import com.intellij.ui.JBColor
+import com.intellij.ui.IdeBorderFactory
 import com.intellij.ui.PopupHandler
 import com.intellij.ui.ScrollPaneFactory
+import com.intellij.ui.SideBorder
 import com.intellij.ui.TableSpeedSearch
 import com.intellij.ui.components.breadcrumbs.Breadcrumbs
 import com.intellij.ui.table.JBTable
 import com.intellij.ui.table.TableView
-import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.ListTableModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -79,7 +79,7 @@ class CloudWatchLogGroup(
     init {
         val locationCrumbs = LocationCrumbs(project, logGroup)
         locationInformation.crumbs = locationCrumbs.crumbs
-        locationInformation.border = JBUI.Borders.customLine(JBColor.border(), 0, 0, 1, 0)
+        locationInformation.border = IdeBorderFactory.createBorder(SideBorder.BOTTOM)
 
         addActions()
         addToolbar()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
@@ -7,14 +7,16 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.application.impl.runUnlessDisposed
 import com.intellij.openapi.project.Project
-import com.intellij.ui.DocumentAdapter
+import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.ui.DoubleClickListener
+import com.intellij.ui.JBColor
 import com.intellij.ui.PopupHandler
 import com.intellij.ui.ScrollPaneFactory
-import com.intellij.ui.components.JBTextField
 import com.intellij.ui.components.breadcrumbs.Breadcrumbs
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
@@ -35,22 +37,16 @@ import software.aws.toolkits.jetbrains.utils.getCoroutineUiContext
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
 import java.awt.event.MouseEvent
-import javax.swing.JButton
 import javax.swing.JPanel
-import javax.swing.JScrollPane
-import javax.swing.RowFilter
 import javax.swing.SortOrder
-import javax.swing.event.DocumentEvent
 
 class CloudWatchLogGroup(
     private val project: Project,
     private val logGroup: String
 ) : CoroutineScope by ApplicationThreadPoolScope("CloudWatchLogsGroup"), Disposable {
-    lateinit var panel: JPanel
+    lateinit var content: JPanel
 
-    private lateinit var refreshButton: JButton
-    private lateinit var filterField: JBTextField
-    private lateinit var tableScroll: JScrollPane
+    private lateinit var tablePanel: SimpleToolWindowPanel
     private lateinit var groupTable: JBTable
     private lateinit var tableModel: ListTableModel<LogStream>
     private lateinit var locationInformation: Breadcrumbs
@@ -74,33 +70,25 @@ class CloudWatchLogGroup(
             tableHeader.reorderingAllowed = false
         }
         groupTable.rowSorter = LogGroupTableSorter(tableModel)
+        // TODO fix resizing
+        groupTable.columnModel.getColumn(1).preferredWidth = 150
+        groupTable.columnModel.getColumn(1).maxWidth = 150
 
         addTableMouseListener(groupTable)
-        tableScroll = ScrollPaneFactory.createScrollPane(groupTable)
+        val scroll = ScrollPaneFactory.createScrollPane(groupTable)
+        tablePanel = SimpleToolWindowPanel(false, true)
+        tablePanel.setContent(scroll)
     }
 
     init {
         val locationCrumbs = LocationCrumbs(project, logGroup)
         locationInformation.crumbs = locationCrumbs.crumbs
-        filterField.emptyText.text = message("cloudwatch.logs.filter_log_streams")
-        filterField.document.addDocumentListener(buildStreamSearchListener(groupTable))
+        locationInformation.border = JBUI.Borders.customLine(JBColor.border(), 0, 0, 1, 0)
 
-        setUpRefreshButton()
         addActions()
+        addToolbar()
 
         launch { refreshLogStreams() }
-    }
-
-    private fun buildStreamSearchListener(table: JBTable) = object : DocumentAdapter() {
-        override fun textChanged(e: DocumentEvent) {
-            val text = filterField.text
-            val sorter = (table.rowSorter as LogGroupTableSorter)
-            if (text.isNullOrBlank()) {
-                sorter.rowFilter = null
-            } else {
-                sorter.rowFilter = RowFilter.regexFilter(text)
-            }
-        }
     }
 
     private fun addTableMouseListener(table: JBTable) {
@@ -114,16 +102,6 @@ class CloudWatchLogGroup(
                 return true
             }
         }.installOn(table)
-    }
-
-    private fun setUpRefreshButton() {
-        refreshButton.background = null
-        refreshButton.border = null
-        refreshButton.isBorderPainted = false
-        refreshButton.margin = JBUI.emptyInsets()
-        refreshButton.isContentAreaFilled = false
-        refreshButton.icon = AllIcons.Actions.Refresh
-        refreshButton.addActionListener { launch { refreshLogStreams() } }
     }
 
     private suspend fun refreshLogStreams() {
@@ -146,6 +124,16 @@ class CloudWatchLogGroup(
             ActionPlaces.EDITOR_POPUP,
             ActionManager.getInstance()
         )
+    }
+
+    private fun addToolbar() {
+        val actionGroup = DefaultActionGroup()
+        actionGroup.addAction(object : AnAction(message("explorer.refresh.title"), null, AllIcons.Actions.Refresh) {
+            override fun actionPerformed(e: AnActionEvent) {
+                launch { refreshLogStreams() }
+            }
+        })
+        tablePanel.toolbar = ActionManager.getInstance().createActionToolbar("CloudWatchLogStream", actionGroup, false).component
     }
 
     private suspend fun populateModel() = runUnlessDisposed(this) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
@@ -7,13 +7,17 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.application.impl.runUnlessDisposed
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.ui.DocumentAdapter
 import com.intellij.ui.DoubleClickListener
 import com.intellij.ui.PopupHandler
 import com.intellij.ui.ScrollPaneFactory
+import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.ListTableModel
@@ -36,7 +40,6 @@ import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
 import java.awt.event.MouseEvent
 import javax.swing.JButton
-import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JScrollPane
 import javax.swing.RowFilter
@@ -47,10 +50,10 @@ class CloudWatchLogGroup(
     private val project: Project,
     private val logGroup: String
 ) : CoroutineScope by ApplicationThreadPoolScope("CloudWatchLogsGroup"), Disposable {
-    lateinit var content: JPanel
+    lateinit var panel: JPanel
 
     private lateinit var refreshButton: JButton
-    private lateinit var locationInformation: JLabel
+    private lateinit var locationInformation: JBLabel
     private lateinit var filterField: JBTextField
     private lateinit var tableScroll: JScrollPane
     private lateinit var groupTable: JBTable
@@ -81,7 +84,8 @@ class CloudWatchLogGroup(
     }
 
     init {
-        locationInformation.text = "${project.activeCredentialProvider().displayName} => ${project.activeRegion().displayName} => $logGroup"
+        locationInformation.text = "${project.activeCredentialProvider().displayName} > ${project.activeRegion().displayName} > $logGroup"
+        locationInformation.background = null
         filterField.emptyText.text = message("cloudwatch.logs.filter_log_streams")
         filterField.document.addDocumentListener(buildStreamSearchListener(groupTable))
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.withContext
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsRequest
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogStream
-import software.amazon.awssdk.services.cloudwatchlogs.model.OutputLogEvent
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.core.awsClient
@@ -41,7 +40,6 @@ import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
 import java.awt.event.MouseEvent
 import javax.swing.JPanel
-import javax.swing.SortOrder
 
 class CloudWatchLogGroup(
     private val project: Project,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
@@ -17,6 +17,7 @@ import com.intellij.ui.DoubleClickListener
 import com.intellij.ui.JBColor
 import com.intellij.ui.PopupHandler
 import com.intellij.ui.ScrollPaneFactory
+import com.intellij.ui.TableSpeedSearch
 import com.intellij.ui.components.breadcrumbs.Breadcrumbs
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
@@ -73,6 +74,7 @@ class CloudWatchLogGroup(
         // TODO fix resizing
         groupTable.columnModel.getColumn(1).preferredWidth = 150
         groupTable.columnModel.getColumn(1).maxWidth = 150
+        TableSpeedSearch(groupTable)
 
         addTableMouseListener(groupTable)
         val scroll = ScrollPaneFactory.createScrollPane(groupTable)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LocationCrumbs.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LocationCrumbs.kt
@@ -1,0 +1,19 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor
+
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.breadcrumbs.Crumb
+import software.aws.toolkits.jetbrains.core.credentials.activeCredentialProvider
+import software.aws.toolkits.jetbrains.core.credentials.activeRegion
+
+// TODO add actions
+class LocationCrumbs(project: Project, logGroup: String, logStream: String? = null) {
+    val crumbs: List<Crumb> = listOfNotNull(
+        Crumb.Impl(null, project.activeCredentialProvider().displayName, null, null),
+        Crumb.Impl(null, project.activeRegion().displayName, null, null),
+        Crumb.Impl(null, logGroup, null, null),
+        logStream?.let { Crumb.Impl(null, it, null, null) }
+    )
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Breadcrumbs for where we are, later this will have actions to open group from string
- Remove search bar and replace with `SpeedSearch`
- Put refresh in the newly added idiomatic `Toolbar`. This will have an export action added to it later
- Fix sorting of the log streams + re-enable user sort + fix the width of last log stream time

## Screenshots (if appropriate)
![Kapture 2020-03-20 at 12 51 49](https://user-images.githubusercontent.com/11964782/77201445-b6604080-6aa9-11ea-809f-a5732d80871d.gif)


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
