### PR TITLE
Fix Rider compilation in 2020.1

### DIFF
--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/clouddebug/DotNetDebuggerSupport.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/clouddebug/DotNetDebuggerSupport.kt
@@ -80,7 +80,7 @@ class DotNetDebuggerSupport : DebuggerSupport() {
         val useDotnetCoreRuntime
             get() = Registry.`is`(USE_DOTNET_CORE_RUNTIME_FLAG_NAME) && isRider20193OrLater
 
-        val isRider20193OrLater = ApplicationInfo.getInstance().build >= BuildNumber.fromString("193.0")
+        val isRider20193OrLater = BuildNumber.fromString("193.0")?.let { ApplicationInfo.getInstance().build >= it } == true
     }
 
     private var exeRemotePath: String = ""


### PR DESCRIPTION
`@NotNull` was being compared with `@Nullable`

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
