### PR TITLE
Update Rider tests to reuse test solution when possible

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ publishChannel=
 
 # Common dependencies
 ideProfileName=2019.2
-kotlinVersion=1.3.61
+kotlinVersion=1.3.70
 awsSdkVersion=2.10.60
 ideaPluginVersion=0.4.16
 ktlintVersion=0.36.0

--- a/intellijJVersions.gradle
+++ b/intellijJVersions.gradle
@@ -112,8 +112,8 @@ static def ideProfiles() {
                 ],
                 "RD": [
                     sdkVersion: "RD-2020.1-SNAPSHOT",
-                    rdGenVersion: "0.201.65",
-                    nugetVersion: "2020.1.0-eap01",
+                    rdGenVersion: "0.201.69",
+                    nugetVersion: "2020.1.0-eap05",
                     plugins: [
                         "yaml"
                     ]

--- a/jetbrains-rider/build.gradle
+++ b/jetbrains-rider/build.gradle
@@ -69,20 +69,17 @@ tasks.withType(prepareSandbox.class).all {
 
 compileKotlin.dependsOn(generateModel)
 
-tasks.findByName("compileTestKotlin").onlyIf { resolveIdeProfileName() != "2019.2" /* Tests require 2019.3 to build and run */ }
+tasks.findByName("compileTestKotlin").onlyIf { resolveIdeProfileName() != "2019.2" /* Tests require 2019.3 or higher to build and run */ }
 test {
     systemProperty("log.dir", "${org.jetbrains.intellij.Utils.systemDir(intellij.sandboxDirectory, true)}/logs")
-
     useTestNG()
-
     environment("LOCAL_ENV_RUN", localEnv)
-}.onlyIf { resolveIdeProfileName() != "2019.2" /* Tests require 2019.3 to build and run */ }
+}.onlyIf { resolveIdeProfileName() != "2019.2" /* Tests require 2019.3 or higher to build and run */ }
 
 tasks.integrationTest {
     useTestNG()
-
     environment("LOCAL_ENV_RUN", localEnv)
-}.onlyIf { resolveIdeProfileName() != "2019.2" /* Tests require 2019.3 to build and run */ }
+}.onlyIf { resolveIdeProfileName() != "2019.2" /* Tests require 2019.3 or higher to build and run */ }
 
 runIde {
     systemProperty("aws.toolkits.enableTelemetry", false)

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/clouddebug/DotNetDebuggerSupport.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/clouddebug/DotNetDebuggerSupport.kt
@@ -222,7 +222,7 @@ class DotNetDebuggerSupport : DebuggerSupport() {
             ?: throw RuntimeConfigurationError(
                 message("cloud_debug.run_configuration.dotnet.start_command.miss_assembly_path", START_COMMAND_ASSEMBLY_PLACEHOLDER))
 
-        if (!path.contains(File.separatorChar))
+        if (!path.contains('/'))
             throw RuntimeConfigurationError(message("cloud_debug.run_configuration.dotnet.start_command.assembly_path_not_valid", path))
 
         // Start command should follow the pattern 'dotnet <remote_path_to_assembly>'. Take a remote assembly path.

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/clouddebug/DotNetStartupCommand.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/clouddebug/DotNetStartupCommand.kt
@@ -86,7 +86,7 @@ class DotNetStartupCommand : CloudDebugStartupCommand(CloudDebuggingPlatform.DOT
                     }
 
                     // Path is generated from <remote_path> + <relative_assembly_path_with_basename>
-                    val command = "dotnet ${remoteBaseFile.resolve(relativeAssemblyPath)}"
+                    val command = "dotnet ${remoteBaseFile.resolve(relativeAssemblyPath).invariantSeparatorsPath}"
                     logger.info { "Generate a CloudDebug startup command: '$command'." }
                     onCommandGet(command)
                 }

--- a/jetbrains-rider/tst/base/AwsMarkupBaseTest.kt
+++ b/jetbrains-rider/tst/base/AwsMarkupBaseTest.kt
@@ -5,7 +5,6 @@ package base
 
 import com.intellij.openapi.util.SystemInfo
 import com.jetbrains.rider.test.base.BaseTestWithMarkup
-import com.jetbrains.rider.test.base.PrepareTestEnvironment
 import com.jetbrains.rider.test.scriptingApi.setUpCustomToolset
 import com.jetbrains.rider.test.scriptingApi.setUpDotNetCoreCliPath
 import org.testng.annotations.BeforeClass
@@ -24,8 +23,8 @@ open class AwsMarkupBaseTest : BaseTestWithMarkup() {
     @BeforeClass
     fun setUpBuildToolPath() {
         if (SystemInfo.isWindows) {
-            PrepareTestEnvironment.dotnetCoreCliPath = "C:\\Program Files\\dotnet\\dotnet.exe"
-            setUpDotNetCoreCliPath(PrepareTestEnvironment.dotnetCoreCliPath)
+            dotnetCoreCliPath = "C:\\Program Files\\dotnet\\dotnet.exe"
+            setUpDotNetCoreCliPath(dotnetCoreCliPath)
             setUpCustomToolset("C:\\Program Files\\dotnet\\sdk\\2.2.104\\MSBuild.dll")
         }
     }

--- a/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
+++ b/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
@@ -5,10 +5,7 @@ package base
 
 import com.intellij.ide.GeneralSettings
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.SystemInfo
 import com.jetbrains.rider.test.base.BaseTestWithSolutionBase
-import com.jetbrains.rider.test.scriptingApi.setUpCustomToolset
-import com.jetbrains.rider.test.scriptingApi.setUpDotNetCoreCliPath
 import com.jetbrains.rider.test.scriptingApi.useCachedTemplates
 import org.testng.annotations.AfterClass
 import org.testng.annotations.BeforeClass
@@ -17,12 +14,6 @@ import java.io.File
 /**
  * Base test class that uses the same solution per test class.
  * Solution re-open logic takes time. We can avoid this by using the same solution instance per every test in a class
- *
- * When running with LOCAL_ENV_RUN flag set to true (for running tests outside of internal IntelliJ networks),
- * Rider will auto-detect and use Rider's bundled MSBuild that might be incompatible with full .NET framework installed
- * on Windows agent to open an empty solution. This cause the MSBuild error when loading a test project.
- *
- * To avoid such errors we need to explicitly set toolset and MSBuild to be selected on an instance.
  */
 abstract class AwsReuseSolutionTestBase : BaseTestWithSolutionBase() {
 
@@ -48,15 +39,6 @@ abstract class AwsReuseSolutionTestBase : BaseTestWithSolutionBase() {
     @BeforeClass(alwaysRun = true)
     fun setUpClassSolution() {
         openSolution(getSolutionDirectoryName())
-    }
-
-    @BeforeClass(alwaysRun = true)
-    fun setUpBuildToolPath() {
-        if (SystemInfo.isWindows) {
-            dotnetCoreCliPath = "C:\\Program Files\\dotnet\\dotnet.exe"
-            setUpDotNetCoreCliPath(dotnetCoreCliPath)
-            setUpCustomToolset("C:\\Program Files\\dotnet\\sdk\\2.2.104\\MSBuild.dll")
-        }
     }
 
     @AfterClass(alwaysRun = true)

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaHandlerResolverTest.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaHandlerResolverTest.kt
@@ -3,8 +3,8 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.dotnet
 
+import base.AwsReuseSolutionTestBase
 import com.jetbrains.rider.test.asserts.shouldBe
-import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.framework.frameworkLogger
 import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
@@ -14,7 +14,7 @@ import software.aws.toolkits.jetbrains.services.lambda.Lambda
 /**
  * Tests to verify R# backend PSI element based on handler string
  */
-class DotNetLambdaHandlerResolverTest : BaseTestWithSolution() {
+class DotNetLambdaHandlerResolverTest : AwsReuseSolutionTestBase() {
 
     override fun getSolutionDirectoryName(): String = "SamHelloWorldApp"
 

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LambdaRunConfigurationTestBase.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LambdaRunConfigurationTestBase.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
-import com.jetbrains.rider.test.base.BaseTestWithSolution
+import base.AwsReuseSolutionTestBase
 import org.testng.annotations.AfterMethod
 import org.testng.annotations.BeforeMethod
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommonTestUtils
 
-abstract class LambdaRunConfigurationTestBase : BaseTestWithSolution() {
+abstract class LambdaRunConfigurationTestBase : AwsReuseSolutionTestBase() {
 
     companion object {
         protected const val HANDLER_EVALUATE_TIMEOUT_MS = 20000
@@ -24,7 +24,7 @@ abstract class LambdaRunConfigurationTestBase : BaseTestWithSolution() {
     protected val defaultHandler = "HelloWorld::HelloWorld.Function::FunctionHandler"
     protected val defaultInput = "inputText"
 
-    protected var validSam: String = ""
+    protected var validSam = ""
 
     @BeforeMethod
     fun setUpCredentialsManager() {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Update Rider tests to re-use the same solution when possible.

## Motivation and Context
Rider tests are running against a test solution that is set up as a test environment. Most of the time in Rider tests is spent on setup a solution and close it. There is an option to reuse a solution for similar tests and save time on opening/closing it for every single test. This commit use this logic for test classes when possible.

## Related Issue(s)
None.

## Testing
Re-run Rider tests.
The local runs saves over 2min on local box.

## Screenshots (if appropriate)
None.

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
