### PR TITLE
Align the S3 viewer's table UX with other IDE trees

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3ViewerPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3ViewerPanel.java
@@ -9,20 +9,17 @@ import com.intellij.openapi.actionSystem.ActionPlaces;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.Separator;
 import com.intellij.openapi.project.Project;
-import com.intellij.ui.ClickListener;
 import com.intellij.ui.PopupHandler;
 import com.intellij.ui.ScrollPaneFactory;
 import com.intellij.ui.treeStructure.SimpleTreeStructure;
 import com.intellij.util.ui.ColumnInfo;
 import java.awt.BorderLayout;
-import java.awt.event.MouseEvent;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableCellRenderer;
-import org.jetbrains.annotations.NotNull;
 import software.aws.toolkits.jetbrains.services.s3.objectActions.CopyPathAction;
 import software.aws.toolkits.jetbrains.services.s3.objectActions.DeleteObjectAction;
 import software.aws.toolkits.jetbrains.services.s3.objectActions.DownloadObjectAction;
@@ -85,8 +82,6 @@ public class S3ViewerPanel {
         treeTable.getColumnModel().getColumn(1).setMaxWidth(120);
 
         mainPanel.add(ScrollPaneFactory.createScrollPane(treeTable), BorderLayout.CENTER);
-
-        clearSelectionOnWhiteSpace();
     }
 
     private void createUIComponents() {
@@ -121,21 +116,5 @@ public class S3ViewerPanel {
         actionGroup.add(new Separator());
         actionGroup.add(new DeleteObjectAction(project, treeTable));
         PopupHandler.installPopupHandler(treeTable, actionGroup, ActionPlaces.EDITOR_POPUP, ActionManager.getInstance());
-    }
-
-    private void clearSelectionOnWhiteSpace() {
-        new ClickListener() {
-            @Override
-            public boolean onClick(@NotNull MouseEvent e, int clickCount) {
-                if (clickCount != 1) {
-                    return false;
-                }
-                if (treeTable.rowAtPoint(e.getPoint()) < 0) {
-                    treeTable.clearSelection();
-                    return true;
-                }
-                return false;
-            }
-        }.installOn(treeTable);
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/NewFolderAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/NewFolderAction.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeDirectoryNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeTable
 import software.aws.toolkits.jetbrains.services.s3.editor.getDirectoryKey
@@ -28,6 +27,4 @@ class NewFolderAction(private val project: Project, treeTable: S3TreeTable) : Si
             }
         }
     }
-
-    override fun enabled(node: S3TreeNode): Boolean = node is S3TreeDirectoryNode
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/S3ObjectAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/S3ObjectAction.kt
@@ -22,7 +22,7 @@ abstract class S3ObjectAction(protected val treeTable: S3TreeTable, title: Strin
 
     override fun actionPerformed(e: AnActionEvent) = performAction(selected().filter { it !is S3TreeContinuationNode })
 
-    private fun selected() = treeTable.getSelectedNodes().takeIf { it.isNotEmpty() } ?: listOf(treeTable.getRootNode())
+    private fun selected(): List<S3TreeNode> = treeTable.getSelectedNodes().takeIf { it.isNotEmpty() } ?: listOf(treeTable.getRootNode())
 }
 
 abstract class SingleS3ObjectAction(treeTable: S3TreeTable, title: String, icon: Icon? = null) : S3ObjectAction(treeTable, title, icon) {


### PR DESCRIPTION
* Don't allow selection to clear, no other tree does
* Allow new folder to work anywhere, parent of the key is used if not a directory. This matches the Project Tree

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
