### PR TITLE
Fix windows tests failing on 2020.1 due to too long of paths causing …

### DIFF
--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -1,15 +1,9 @@
 version: 0.2
 
-cache:
-  paths:
-    - 'build-cache/caches/'
-    - 'build-cache/wrapper/'
-
 env:
   variables:
     CI: true
     LOCAL_ENV_RUN: true
-    GRADLE_CACHE_LOCATION: build-cache
 
 phases:
   install:
@@ -23,7 +17,7 @@ phases:
 
   build:
     commands:
-      - ./gradlew check coverageReport --info --full-stacktrace --console plain --gradle-user-home $Env:GRADLE_CACHE_LOCATION
+      - ./gradlew check coverageReport --info --full-stacktrace --console plain
 
   post_build:
     commands:


### PR DESCRIPTION
…bytebuddy to fail to start

* Move Gradle cache back to default location
* Local cache disabled until we can figure out how to fix it

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
