### PR TITLE
Use JDK 11 on Windows, change how we install dotnet

### DIFF
--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -7,12 +7,15 @@ env:
 
 phases:
   install:
+    runtime-versions:
+      java: openjdk11
+      dotnet: 2.2
+
     commands:
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             choco install -y --no-progress codecov
         }
-      - choco install -y --no-progress dotnetcore-sdk --version 2.2.104
       - choco install -y --no-progress netfx-4.6.1-devpack
 
   build:


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
