### PR TITLE
[WIP]: ECS Debug-enabled Containers as Target Environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,12 @@ buildscript {
 
 apply from: 'intellijJVersions.gradle'
 
+def ideVersion = shortenVersion(resolveIdeProfileName())
+
 group 'software.aws.toolkits'
 // please check changelog generation logic if this format is changed
-version toolkitVersion + "-" + shortenVersion(resolveIdeProfileName())
+version "$toolkitVersion-$ideVersion".toString()
+
 
 repositories {
     maven { url "https://www.jetbrains.com/intellij-repository/snapshots/" }
@@ -94,15 +97,15 @@ subprojects {
     }
 
     sourceSets {
-        main.java.srcDir 'src'
-        main.resources.srcDir 'resources'
-        test.java.srcDir 'tst'
-        test.resources.srcDir 'tst-resources'
+        main.java.srcDirs = ['src', "src-$ideVersion"]
+        main.resources.srcDirs = ['resources', "resources-$ideVersion"]
+        test.java.srcDirs = ['tst', "tst-$ideVersion"]
+        test.resources.srcDirs = ['tst-resources', "tst-resources-$ideVersion"]
         integrationTest {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + test.output
-            java.srcDir 'it'
-            resources.srcDir 'it-resources'
+            java.srcDirs = ['it', "it-$ideVersion"]
+            resources.srcDirs = ['it-resources', "it-resources-$ideVersion"]
         }
     }
 
@@ -142,11 +145,18 @@ subprojects {
 
     idea {
         module {
+            sourceDirs += file("src-$ideVersion")
+            resourceDirs += file("resources-$ideVersion")
+            testSourceDirs += file("tst-$ideVersion")
+            testResourceDirs += file("tst-resources-$ideVersion")
+
             sourceDirs -= file("it")
             testSourceDirs += file("it")
+            testSourceDirs += file("it-$ideVersion")
 
             resourceDirs -= file("it-resources")
             testResourceDirs += file("it-resources")
+            testResourceDirs += file("it-resources-$ideVersion")
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ publishToken=
 publishChannel=
 
 # Common dependencies
-ideProfileName=2019.2
+ideProfileName=2020.1
 kotlinVersion=1.3.61
 awsSdkVersion=2.10.60
 ideaPluginVersion=0.4.16

--- a/intellijJVersions.gradle
+++ b/intellijJVersions.gradle
@@ -84,24 +84,24 @@ static def ideProfiles() {
             "untilVersion": "201.*",
             "products": [
                 "IC": [
-                    sdkVersion: "IC-201.5985.32-EAP-SNAPSHOT",
+                    sdkVersion: "IC-201.6487.11-EAP-SNAPSHOT",
                     plugins: [
                         "terminal",
                         "yaml",
-                        "PythonCore:201.5985.32",
+                        "PythonCore:201.6487.11",
                         "java",
                         "gradle",
                         "maven",
                         "properties", // Used by Maven
-                        "Docker:201.5985.25"
+                        "Docker:201.6487.11"
                     ]
                 ],
                 "IU": [
-                    sdkVersion: "IU-201.5985.32-EAP-SNAPSHOT",
+                    sdkVersion: "IU-201.6487.11-EAP-SNAPSHOT",
                     plugins: [
                         "terminal",
                         "platform-images", // Used by a bunch of plugins
-                        "Pythonid:201.5985.32",
+                        "Pythonid:201.6487.11",
                         "yaml",
                         "stats-collector", // Transitive, used by JavaScriptLanguage
                         "JavaScriptLanguage",

--- a/jetbrains-core/resources-201/META-INF/plugin-extra.xml
+++ b/jetbrains-core/resources-201/META-INF/plugin-extra.xml
@@ -1,0 +1,8 @@
+<!-- Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <extensions defaultExtensionNs="com.intellij">
+        <executionTargetType implementation="software.aws.toolkits.jetbrains.services.clouddebug.CloudDebugTargetEnvironmentType"/>
+    </extensions>
+</idea-plugin>

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -88,6 +88,10 @@
         <xi:fallback/>
     </xi:include>
 
+    <xi:include href="/META-INF/plugin-extra.xml" xpointer="xpointer(/idea-plugin/*)">
+        <xi:fallback/>
+    </xi:include>
+
     <application-components>
         <component>
             <interface-class>software.aws.toolkits.jetbrains.components.telemetry.TelemetryComponent</interface-class>
@@ -220,7 +224,6 @@
 
         <webHelpProvider implementation="software.aws.toolkits.jetbrains.core.help.HelpIdTranslator"/>
         <fileEditorProvider implementation="software.aws.toolkits.jetbrains.services.s3.S3ViewerEditorProvider"/>
-        <executionTargetType implementation="software.aws.toolkits.jetbrains.services.clouddebug.CloudDebugTargetEnvironmentType"/>
     </extensions>
 
     <extensions defaultExtensionNs="JavaScript.JsonSchema">

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -220,6 +220,7 @@
 
         <webHelpProvider implementation="software.aws.toolkits.jetbrains.core.help.HelpIdTranslator"/>
         <fileEditorProvider implementation="software.aws.toolkits.jetbrains.services.s3.S3ViewerEditorProvider"/>
+        <executionTargetType implementation="software.aws.toolkits.jetbrains.services.clouddebug.CloudDebugTargetEnvironmentType"/>
     </extensions>
 
     <extensions defaultExtensionNs="JavaScript.JsonSchema">

--- a/jetbrains-core/src-201/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTargetEnvironmentType.kt
+++ b/jetbrains-core/src-201/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTargetEnvironmentType.kt
@@ -93,7 +93,7 @@ class CloudDebugTargetEnvironmentConfiguration : TargetEnvironmentConfiguration(
         this.state = state
     }
 
-    fun workingDirectory(): String = state.workingDirectory ?: "/tmp/wsp" //throw IllegalStateException("Missing 'workingDirectory'")
+    fun workingDirectory(): String = state.workingDirectory ?: "/tmp/wsp" // throw IllegalStateException("Missing 'workingDirectory'")
 
     fun cluster(): String = state.cluster ?: throw IllegalStateException("Missing 'cluster'")
 
@@ -120,7 +120,6 @@ class CloudDebugTargetConfigurable(private val project: Project, config: CloudDe
     override fun apply() {
         // dun do nothing
     }
-
 }
 
 class CloudDebugTargetEnvironmentFactory(private val project: Project, private val config: CloudDebugTargetEnvironmentConfiguration) :
@@ -183,9 +182,8 @@ class CloudDebugTargetEnvironmentFactory(private val project: Project, private v
         override fun getTargetPlatform(): TargetPlatform = this@CloudDebugTargetEnvironmentFactory.targetPlatform
 
         fun cancel() {
-            //TODO unwind port mappings
+            // TODO unwind port mappings
         }
-
     }
 }
 
@@ -210,7 +208,7 @@ class PathValue(
     init {
         val remotePath = "$remoteWorkingDirectory/${UUID.randomUUID()}"
 
-        val createPath =  buildBaseCmdLine(project, executable).withParameters("exec")
+        val createPath = buildBaseCmdLine(project, executable).withParameters("exec")
             .withParameters("--target")
             .withParameters(target)
             /* TODO remove this when the cli conforms to the contract */
@@ -227,10 +225,10 @@ class PathValue(
             .withParameters("remote://$target://$container://$remotePath")
 
         val future = CompletableFuture<Nothing>()
-        runCommand(createPath, {future.completeExceptionally(RuntimeException(it))}) {
-            runCommand(copyCommand, {future.completeExceptionally(RuntimeException(it))}) {
+        runCommand(createPath, { future.completeExceptionally(RuntimeException(it)) }) {
+            runCommand(copyCommand, { future.completeExceptionally(RuntimeException(it)) }) {
                 val resolvedLocalPath = Paths.get(localPath)
-                val resolvedPath = "$remotePath/${localPath.substringAfterLast("/")}" //if (resolvedLocalPath.isDirectory()) { remotePath } else {  }
+                val resolvedPath = "$remotePath/${localPath.substringAfterLast("/")}"
                 resolve(resolvedPath)
                 future.complete(null)
             }

--- a/jetbrains-core/src-201/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTargetEnvironmentType.kt
+++ b/jetbrains-core/src-201/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTargetEnvironmentType.kt
@@ -31,9 +31,7 @@ import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
-import com.intellij.util.io.isDirectory
 import icons.AwsIcons
-import io.netty.util.concurrent.CompleteFuture
 import org.jetbrains.concurrency.AsyncPromise
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
@@ -54,7 +52,6 @@ import software.aws.toolkits.resources.message
 import java.nio.file.Paths
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.swing.Icon
 import javax.swing.JComponent

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTargetEnvironmentType.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTargetEnvironmentType.kt
@@ -1,0 +1,222 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@file:Suppress("MissingRecentApi")
+
+package software.aws.toolkits.jetbrains.services.clouddebug
+
+import com.intellij.execution.Platform
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.target.TargetEnvironment
+import com.intellij.execution.target.TargetEnvironmentConfiguration
+import com.intellij.execution.target.TargetEnvironmentFactory
+import com.intellij.execution.target.TargetEnvironmentRequest
+import com.intellij.execution.target.TargetEnvironmentType
+import com.intellij.execution.target.TargetPlatform
+import com.intellij.execution.target.TargetedCommandLine
+import com.intellij.execution.target.value.DeferredLocalTargetValue
+import com.intellij.execution.target.value.TargetValue
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import icons.AwsIcons
+import software.aws.toolkits.jetbrains.core.credentials.activeCredentialProvider
+import software.aws.toolkits.jetbrains.core.credentials.activeRegion
+import software.aws.toolkits.jetbrains.core.credentials.toEnvironmentVariables
+import software.aws.toolkits.jetbrains.core.executables.CloudDebugExecutable
+import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
+import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
+import software.aws.toolkits.jetbrains.core.executables.getExecutableIfPresent
+import software.aws.toolkits.jetbrains.services.clouddebug.CloudDebugTargetEnvironmentFactory.CloudDebugTargetEnvironmentRequest
+import software.aws.toolkits.jetbrains.services.clouddebug.resources.CloudDebuggingResources
+import software.aws.toolkits.jetbrains.services.ecs.EcsUtils
+import software.aws.toolkits.jetbrains.utils.notifyError
+import software.aws.toolkits.resources.message
+import javax.swing.Icon
+import javax.swing.JComponent
+import javax.swing.JLabel
+
+class CloudDebugTargetEnvironmentType : TargetEnvironmentType<CloudDebugTargetEnvironmentConfiguration>("clouddebug") {
+    override val displayName: String = "ECS Target"
+
+    override val icon: Icon = AwsIcons.Resources.Ecs.ECS_SERVICE
+
+    override fun createConfigurable(project: Project, config: CloudDebugTargetEnvironmentConfiguration) = CloudDebugTargetConfigurable(project, config)
+
+    override fun createDefaultConfig(): CloudDebugTargetEnvironmentConfiguration = CloudDebugTargetEnvironmentConfiguration()
+
+    override fun createEnvironmentFactory(project: Project, config: CloudDebugTargetEnvironmentConfiguration) = CloudDebugTargetEnvironmentFactory(
+        project,
+        config
+    )
+
+    override fun createSerializer(config: CloudDebugTargetEnvironmentConfiguration): PersistentStateComponent<*> = config
+}
+
+@State(name = "ecs-targets", storages = [Storage("aws.xml")])
+class CloudDebugTargetEnvironmentConfiguration : TargetEnvironmentConfiguration("clouddebug"),
+    PersistentStateComponent<CloudDebugTargetEnvironmentConfiguration.PersistentState> {
+
+    private var state = PersistentState()
+
+    data class PersistentState(
+        var cluster: String? = "default",
+        var service: String? = "cloud-debug-custom-service",
+        var containerName: String? = "custom",
+        var workingDirectory: String? = null
+    )
+
+    override fun getState(): PersistentState? = state
+
+    override fun loadState(state: PersistentState) {
+        this.state = state
+    }
+
+    fun workingDirectory(): String = state.workingDirectory ?: throw IllegalStateException("Missing 'workingDirectory'")
+
+    fun cluster(): String = state.cluster ?: throw IllegalStateException("Missing 'cluster'")
+
+    fun service(): String = state.service ?: throw IllegalStateException("Missing 'service'")
+
+    fun containerName(): String = state.containerName ?: throw IllegalStateException("Missing 'containerName'")
+
+    fun commandLineBase() {
+        when (val executable = ExecutableManager.getInstance().getExecutableIfPresent<CloudDebugExecutable>()) {
+            is ExecutableInstance.Executable -> executable.getCommandLine()
+        }
+    }
+}
+
+class CloudDebugTargetConfigurable(private val project: Project, config: CloudDebugTargetEnvironmentConfiguration) : SearchableConfigurable {
+    override fun getId(): String = "clouddebug"
+
+    override fun createComponent(): JComponent? = JLabel("Hello")
+
+    override fun isModified(): Boolean = false
+
+    override fun getDisplayName(): String = "Bob"
+
+    override fun apply() {
+        // dun do nothing
+    }
+
+}
+
+class CloudDebugTargetEnvironmentFactory(private val project: Project, private val config: CloudDebugTargetEnvironmentConfiguration) :
+    TargetEnvironmentFactory {
+
+    private val executable: ExecutableInstance.Executable by lazy {
+        val ex = ExecutableManager.getInstance().getExecutableIfPresent<CloudDebugExecutable>()
+        if(ex !is ExecutableInstance.Executable) {
+            runInEdt {
+                notifyError("Can't resolve cloud-debug cli")
+            }
+            throw RuntimeException("Can't resolve cloud-debug cli")
+        }
+        ex as ExecutableInstance.Executable
+    }
+
+    override fun createRequest(): TargetEnvironmentRequest = CloudDebugTargetEnvironmentRequest()
+
+    override fun getTargetConfiguration(): CloudDebugTargetEnvironmentConfiguration? = config
+
+    override fun getTargetPlatform(): TargetPlatform = TargetPlatform(Platform.UNIX, TargetPlatform.Arch.x64bit)
+
+    override fun prepareRemoteEnvironment(request: TargetEnvironmentRequest, indicator: ProgressIndicator): TargetEnvironment {
+        val description = CloudDebuggingResources.describeInstrumentedResource(project, config.cluster(), config.cluster())
+        if (description == null || description.status != CloudDebugConstants.INSTRUMENTED_STATUS || description.taskRole.isEmpty()) {
+            runInEdt {
+                notifyError(message("cloud_debug.execution.failed.not_set_up"))
+            }
+            throw RuntimeException("Resource not instrumented")
+        }
+        val role = description.taskRole
+
+        val instrumentResponse = runInstrument(project, executable, config.cluster(), config.service(), role, indicator)
+
+        return CloudDebugTargetEnvironment(project, targetPlatform, request as CloudDebugTargetEnvironmentRequest, executable, instrumentResponse.target, config)
+    }
+
+    inner class CloudDebugTargetEnvironmentRequest : TargetEnvironmentRequest {
+        private val ports = mutableListOf<PortValue>()
+
+        override fun createUpload(localPath: String): TargetValue<String> {
+
+            return TargetValue.fixed(localPath)
+        }
+
+        override fun bindTargetPort(targetPort: Int): TargetValue<Int> = PortValue(targetPort).also { ports.add(it) }
+
+        override fun getTargetPlatform(): TargetPlatform = targetPlatform
+
+        fun cancel() {
+            //TODO unwind port mappings
+        }
+    }
+}
+
+class PortValue(private val remotePort: Int) : DeferredLocalTargetValue<Int>(remotePort) {
+    private val localPort = 20027
+
+    init {
+        resolve(localPort)
+    }
+
+    fun binding() = "$localPort:$remotePort"
+}
+
+class CloudDebugTargetEnvironment(
+    private val project: Project,
+    private val targetPlatform: TargetPlatform,
+    private val request: CloudDebugTargetEnvironmentRequest,
+    private val executable: ExecutableInstance.Executable,
+    private val target: String,
+    private val config: CloudDebugTargetEnvironmentConfiguration
+) : TargetEnvironment {
+    override fun getRemotePlatform() = targetPlatform
+
+    override fun getRequest() = request
+
+    override fun createProcess(commandLine: TargetedCommandLine, indicator: ProgressIndicator): Process {
+        return buildBaseCmdLine(project, executable).withParameters("exec")
+            .withParameters("--target")
+            .withParameters(target)
+            /* TODO remove this when the cli conforms to the contract */
+            .withParameters("--selector")
+            .withParameters(config.containerName())
+            .withParameters(commandLine.getCommandPresentation(this)).createProcess()
+    }
+}
+
+private fun buildBaseCmdLine(project: Project, executable: ExecutableInstance.Executable) = executable.getCommandLine()
+    .withEnvironment(project.activeRegion().toEnvironmentVariables())
+    .withEnvironment(project.activeCredentialProvider().resolveCredentials().toEnvironmentVariables())
+
+private fun runInstrument(
+    project: Project,
+    executable: ExecutableInstance.Executable,
+    cluster: String,
+    service: String,
+    role: String,
+    progressIndicator: ProgressIndicator
+): InstrumentResponse {
+    // first instrument to grab the instrumentation target and ensure connection
+    val instrumentCmd = buildBaseCmdLine(project, executable)
+        .withParameters("instrument")
+        .withParameters("ecs")
+        .withParameters("service")
+        .withParameters("--cluster")
+        .withParameters(EcsUtils.clusterArnToName(cluster))
+        .withParameters("--service")
+        .withParameters(EcsUtils.originalServiceName(service))
+        .withParameters("--iam-role")
+        .withParameters(role)
+    return CapturingProcessHandler(instrumentCmd).runProcessWithProgressIndicator(progressIndicator).stdout.let {
+        CliOutputParser.parseInstrumentResponse(it)
+    } ?: throw RuntimeException("CLI provided no response")
+}


### PR DESCRIPTION
Hacked together POC that shows we should be able to use containers that have been enabled for cloud-debug as "Target Environments" using the 2020.1 experimental feature.