### PR TITLE
Minor bug fixes for CloudWatch Logs

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogsServiceNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogsServiceNode.kt
@@ -30,7 +30,7 @@ class CloudWatchLogsNode(
     CloudWatchLogsClient.SERVICE_NAME,
     logGroupName,
     // TODO get icon for CloudWatch
-    AwsIcons.Resources.CLOUDFORMATION_STACK
+    AwsIcons.Logos.AWS
 ) {
     override fun resourceType() = "group"
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/LogStreamActor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/LogStreamActor.kt
@@ -81,7 +81,7 @@ sealed class LogStreamActor(
         try {
             val items = loadBlock()
             withContext(edtContext) {
-                table.listTableModel.addRows(items)
+                table.listTableModel.items = items
             }
             table.emptyText.text = emptyText
         } catch (e: ResourceNotFoundException) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogStream.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogStream.kt
@@ -5,13 +5,10 @@ package software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.DefaultActionGroup
-import com.intellij.openapi.actionSystem.Separator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.util.Disposer
-import com.intellij.ui.PopupHandler
 import com.intellij.ui.SearchTextField
 import com.intellij.ui.components.breadcrumbs.Breadcrumbs
 import kotlinx.coroutines.CoroutineScope
@@ -20,7 +17,6 @@ import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient
 import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.LogStreamActor
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.actions.OpenCurrentInEditorAction
-import software.aws.toolkits.jetbrains.services.cloudwatch.logs.actions.ShowLogsAroundActionGroup
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.actions.TailLogsAction
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.actions.WrapLogsAction
 import software.aws.toolkits.jetbrains.utils.ApplicationThreadPoolScope
@@ -65,7 +61,6 @@ class CloudWatchLogStream(
         Disposer.register(this, logStreamTable)
         searchField.textEditor.emptyText.text = message("cloudwatch.logs.filter_logs")
 
-        addAction()
         addActionToolbar()
         addSearchListener()
 
@@ -111,21 +106,6 @@ class CloudWatchLogStream(
                 }
             }
         })
-    }
-
-    private fun addAction() {
-        val actionGroup = DefaultActionGroup()
-        actionGroup.add(OpenCurrentInEditorAction(project, logStream) {
-            searchStreamTable?.logsTable?.listTableModel?.items ?: logStreamTable.logsTable.listTableModel.items
-        })
-        actionGroup.add(Separator())
-        actionGroup.add(ShowLogsAroundActionGroup(logGroup, logStream, logStreamTable.logsTable))
-        PopupHandler.installPopupHandler(
-            logStreamTable.logsTable,
-            actionGroup,
-            ActionPlaces.EDITOR_POPUP,
-            ActionManager.getInstance()
-        )
     }
 
     private fun addActionToolbar() {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogStreamTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogStreamTable.kt
@@ -36,7 +36,7 @@ import javax.swing.SortOrder
 
 class LogStreamTable(
     val project: Project,
-    private val client: CloudWatchLogsClient,
+    client: CloudWatchLogsClient,
     private val logGroup: String,
     private val logStream: String,
     type: TableType
@@ -53,7 +53,7 @@ class LogStreamTable(
     private val logStreamActor: LogStreamActor
 
     init {
-        val model = ListTableModel<LogStreamEntry>(
+        val model = ListTableModel(
             arrayOf(LogStreamDateColumn(), LogStreamMessageColumn()),
             mutableListOf<LogStreamEntry>(),
             // Don't sort in the model because the requests come sorted

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogStreamTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogStreamTable.kt
@@ -4,8 +4,13 @@
 package software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.Separator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
+import com.intellij.ui.PopupHandler
 import com.intellij.ui.ScrollPaneFactory
 import com.intellij.ui.TableSpeedSearch
 import com.intellij.ui.table.TableView
@@ -18,6 +23,8 @@ import software.aws.toolkits.jetbrains.services.cloudwatch.logs.LogStreamActor
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.LogStreamEntry
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.LogStreamFilterActor
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.LogStreamListActor
+import software.aws.toolkits.jetbrains.services.cloudwatch.logs.actions.OpenCurrentInEditorAction
+import software.aws.toolkits.jetbrains.services.cloudwatch.logs.actions.ShowLogsAroundActionGroup
 import software.aws.toolkits.jetbrains.utils.ApplicationThreadPoolScope
 import software.aws.toolkits.resources.message
 import java.awt.event.AdjustmentEvent
@@ -29,9 +36,9 @@ import javax.swing.SortOrder
 
 class LogStreamTable(
     val project: Project,
-    val client: CloudWatchLogsClient,
-    logGroup: String,
-    logStream: String,
+    private val client: CloudWatchLogsClient,
+    private val logGroup: String,
+    private val logStream: String,
     type: TableType
 ) : CoroutineScope by ApplicationThreadPoolScope("LogStreamTable"), Disposable {
 
@@ -85,6 +92,20 @@ class LogStreamTable(
                 }
             }
         })
+        addActionsToTable()
+    }
+
+    private fun addActionsToTable() {
+        val actionGroup = DefaultActionGroup()
+        actionGroup.add(OpenCurrentInEditorAction(project, logStream) { logsTable.listTableModel.items })
+        actionGroup.add(Separator())
+        actionGroup.add(ShowLogsAroundActionGroup(logGroup, logStream, logsTable))
+        PopupHandler.installPopupHandler(
+            logsTable,
+            actionGroup,
+            ActionPlaces.EDITOR_POPUP,
+            ActionManager.getInstance()
+        )
     }
 
     private fun JScrollBar.isAtBottom(): Boolean = value == (maximum - visibleAmount)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/resources/CloudWatchResources.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/resources/CloudWatchResources.kt
@@ -9,6 +9,6 @@ import software.aws.toolkits.jetbrains.core.ClientBackedCachedResource
 object CloudWatchResources {
     val LIST_LOG_GROUPS =
         ClientBackedCachedResource(CloudWatchLogsClient::class, "cwl.log_groups") {
-            describeLogGroups().logGroups().filterNotNull().toList()
+            describeLogGroupsPaginator().logGroups().filterNotNull().toList()
         }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Update the explorer icon to match the window icon for now (instead of using the CloudFormation icon)
- Fix right click on table not working after search
- Add forgotten refresh button to Log Stream table
- Fix showing all of the log groups in the explorer
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
