### PR TITLE
Standardize our interaction with MockClientManager

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/CopyBucketTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/CopyBucketTest.kt
@@ -9,10 +9,7 @@ import com.intellij.testFramework.TestActionEvent
 import org.assertj.core.api.Assertions
 import org.junit.Rule
 import org.junit.Test
-import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.Bucket
-import software.aws.toolkits.core.utils.delegateMock
-import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.services.s3.bucketActions.CopyBucketNameAction
 import java.awt.datatransfer.DataFlavor
 
@@ -22,15 +19,8 @@ class CopyBucketTest {
     @JvmField
     val projectRule = ProjectRule()
 
-    @JvmField
-    @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
-
     @Test
     fun copyBucketName() {
-        val s3Mock = delegateMock<S3Client>()
-        mockClientManagerRule.manager().register(S3Client::class, s3Mock)
-
         val bucket = S3BucketNode(projectRule.project, Bucket.builder().name("foo").build())
         val copyAction = CopyBucketNameAction()
         copyAction.actionPerformed(bucket, TestActionEvent(DataContext { projectRule.project }))

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3ServiceNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3ServiceNodeTest.kt
@@ -7,10 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.Bucket
-import software.aws.toolkits.core.utils.delegateMock
-import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.core.MockResourceCache
 import software.aws.toolkits.jetbrains.core.credentials.MockProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
@@ -27,17 +24,10 @@ class S3ServiceNodeTest {
     @Rule
     val projectRule = ProjectRule()
 
-    @Rule
-    @JvmField
-    val mockClientManager = MockClientManagerRule { projectRule.project }
-
-    private val mockClient = delegateMock<S3Client>()
-
     @Before
     fun setUp() {
         resourceCache().clear()
         MockProjectAccountSettingsManager.getInstance(projectRule.project).reset()
-        mockClientManager.manager().register(S3Client::class, mockClient)
     }
 
     @Test


### PR DESCRIPTION
* Standardize our usage, put guardrails in to prevent multiple ways to do same thing
* Remove places where it was not actually needed / used

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Was going to use this in new tests and realized we were doing things differently in 2 places, align on using the `@Rule` way since it is safer

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
