### PR TITLE
Wait to close S3 bucket file descriptor on delete

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/DeleteBucketAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/DeleteBucketAction.kt
@@ -3,13 +3,13 @@
 
 package software.aws.toolkits.jetbrains.services.s3.bucketActions
 
-import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.testFramework.runInEdtAndWait
 import software.amazon.awssdk.services.s3.S3Client
 import software.aws.toolkits.core.s3.deleteBucketAndContents
 import software.aws.toolkits.jetbrains.core.AwsClientManager
-import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.core.explorer.actions.DeleteResourceAction
+import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.s3.S3BucketNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3VirtualBucket
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
@@ -26,7 +26,8 @@ class DeleteBucketAction : DeleteResourceAction<S3BucketNode>(message("s3.delete
             val fileEditorManager = FileEditorManager.getInstance(selected.nodeProject)
             fileEditorManager.openFiles.forEach {
                 if (it is S3VirtualBucket && it.s3Bucket.name() == selected.displayName()) {
-                    runInEdt {
+                    // Wait so that we know it closes successfully, otherwise this operation is not a success
+                    runInEdtAndWait {
                         fileEditorManager.closeFile(it)
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
- `runInEdtAndWait` instead of `runInEdt` closing the file descriptor on S3 bucket delete. This was making the test fail intermittently as runInEdt would be dispatched after the assert
- It also has the side effect of catching exceptions and making the delete action as failed, which it really is if we can't close the bucket viewer.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
