### PR TITLE
CloudWatchLogs don't expand the table entry if we have logwrap enabled

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/actions/WrapLogsAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/actions/WrapLogsAction.kt
@@ -24,24 +24,29 @@ class WrapLogsAction(private val project: Project, private val getCurrentTableVi
     override fun setSelected(e: AnActionEvent, state: Boolean) {
         CloudwatchlogsTelemetry.wrapEvents(project, enabled = state)
         isSelected = state
+        val tableView = getCurrentTableView()
         if (isSelected) {
-            wrap()
+            wrap(tableView)
         } else {
-            unwrap()
+            unwrap(tableView)
         }
     }
 
-    private fun wrap() {
-        (getCurrentTableView().listTableModel.columnInfos[messageColumn] as? LogStreamMessageColumn)?.wrap()
-        redrawTable()
+    private fun wrap(table: TableView<LogStreamEntry>) {
+        // The ExpandableItemsHandler also unwraps the box even if word wrap is turned
+        // on, so enable/disable it based on if we are wrapping or not
+        table.setExpandableItemsEnabled(false)
+        (table.listTableModel.columnInfos[messageColumn] as? LogStreamMessageColumn)?.wrap()
+        table.redrawTable()
     }
 
-    private fun unwrap() {
-        (getCurrentTableView().listTableModel.columnInfos[messageColumn] as? LogStreamMessageColumn)?.unwrap()
-        redrawTable()
+    private fun unwrap(table: TableView<LogStreamEntry>) {
+        table.setExpandableItemsEnabled(true)
+        (table.listTableModel.columnInfos[messageColumn] as? LogStreamMessageColumn)?.unwrap()
+        table.redrawTable()
     }
 
-    private fun redrawTable() {
-        getCurrentTableView().listTableModel.fireTableDataChanged()
+    private fun TableView<LogStreamEntry>.redrawTable() {
+        listTableModel.fireTableDataChanged()
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

On mouse over, with logs wrapped, it would unwrap like:
<img width="1271" alt="Screen Shot 2020-03-27 at 8 55 35 AM" src="https://user-images.githubusercontent.com/11964782/77777373-b792ef80-700c-11ea-93f0-d9a36d4833fd.png">
Fix this behavior by setExpandableItemsEnabled
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
