### PR TITLE
Enabling the ability to register different extension points on newer IDE versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,12 @@ buildscript {
 
 apply from: 'intellijJVersions.gradle'
 
+def ideVersion = shortenVersion(resolveIdeProfileName())
+
 group 'software.aws.toolkits'
 // please check changelog generation logic if this format is changed
-version toolkitVersion + "-" + shortenVersion(resolveIdeProfileName())
+version "$toolkitVersion-$ideVersion".toString()
+
 
 repositories {
     maven { url "https://www.jetbrains.com/intellij-repository/snapshots/" }
@@ -94,15 +97,15 @@ subprojects {
     }
 
     sourceSets {
-        main.java.srcDir 'src'
-        main.resources.srcDir 'resources'
-        test.java.srcDir 'tst'
-        test.resources.srcDir 'tst-resources'
+        main.java.srcDirs = ['src', "src-$ideVersion"]
+        main.resources.srcDirs = ['resources', "resources-$ideVersion"]
+        test.java.srcDirs = ['tst', "tst-$ideVersion"]
+        test.resources.srcDirs = ['tst-resources', "tst-resources-$ideVersion"]
         integrationTest {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + test.output
-            java.srcDir 'it'
-            resources.srcDir 'it-resources'
+            java.srcDirs = ['it', "it-$ideVersion"]
+            resources.srcDirs = ['it-resources', "it-resources-$ideVersion"]
         }
     }
 
@@ -142,11 +145,18 @@ subprojects {
 
     idea {
         module {
+            sourceDirs += file("src-$ideVersion")
+            resourceDirs += file("resources-$ideVersion")
+            testSourceDirs += file("tst-$ideVersion")
+            testResourceDirs += file("tst-resources-$ideVersion")
+
             sourceDirs -= file("it")
             testSourceDirs += file("it")
+            testSourceDirs += file("it-$ideVersion")
 
             resourceDirs -= file("it-resources")
             testResourceDirs += file("it-resources")
+            testResourceDirs += file("it-resources-$ideVersion")
         }
     }
 

--- a/jetbrains-core/resources-201/META-INF/plugin-extra.xml
+++ b/jetbrains-core/resources-201/META-INF/plugin-extra.xml
@@ -1,0 +1,8 @@
+<!-- Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <extensions defaultExtensionNs="com.intellij">
+    	<!-- 201 only extension point registrations go here -->
+    </extensions>
+</idea-plugin>

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -88,6 +88,10 @@
         <xi:fallback/>
     </xi:include>
 
+    <xi:include href="/META-INF/plugin-extra.xml" xpointer="xpointer(/idea-plugin/*)">
+        <xi:fallback/>
+    </xi:include>
+
     <application-components>
         <component>
             <interface-class>software.aws.toolkits.jetbrains.components.telemetry.TelemetryComponent</interface-class>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Each build of the plugin targets a JetBrains SDK version (e.g `2019.3`), this extends that logic such that we can conditionally include of extension points (and classes) per framework version.

Assuming a "short code" number for each framework major-version (e.g. `193` for `2019.3`) the build-system will look for, and automatically include the following directories (relative to the project root, adjacent to their 'normal' counter-parts) into the appropriate `SourceSet` (if present):

- `src-193`
- `resources-193`
- `tst-193`
- `tst-resources-193`
- `it-193`
- `it-resources-193`

In addition, the `plugin.xml` optionally merges a `META-INF/plugin-extra.xml` plugin-file if it exists as part of that builds `resources` - so if a new extension point needs to be added for a future framework version it should be registered in a `plugin-extra.xml` file and included in the appropriate `resource` directory for the target build. See the example [`resources-201/META-INF/plugin-extra.xml`](https://github.com/aws/aws-toolkit-jetbrains/blob/7ac7f120c81b02e0706d69c4bcc2e6afac64958b/jetbrains-core/resources-201/META-INF/plugin-extra.xml).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We want the ability to add new features for new versions of the IDE without always having to bump the major version - this allows building features that are only included if the customer is on a recent version of the IDE.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
