### PR TITLE
Upgrade 2020.1 EAP, add missing plugin for Maven

### DIFF
--- a/intellijJVersions.gradle
+++ b/intellijJVersions.gradle
@@ -84,24 +84,25 @@ static def ideProfiles() {
             "untilVersion": "201.*",
             "products": [
                 "IC": [
-                    sdkVersion: "IC-201.5985.32-EAP-SNAPSHOT",
+                    sdkVersion: "IC-201.6668.13-EAP-SNAPSHOT",
                     plugins: [
                         "terminal",
                         "yaml",
-                        "PythonCore:201.5985.32",
+                        "PythonCore:201.6668.31",
                         "java",
                         "gradle",
+                        "repository-search", // Used by Maven
                         "maven",
                         "properties", // Used by Maven
-                        "Docker:201.5985.25"
+                        "Docker:201.6668.30"
                     ]
                 ],
                 "IU": [
-                    sdkVersion: "IU-201.5985.32-EAP-SNAPSHOT",
+                    sdkVersion: "IU-201.6668.13-EAP-SNAPSHOT",
                     plugins: [
                         "terminal",
                         "platform-images", // Used by a bunch of plugins
-                        "Pythonid:201.5985.32",
+                        "Pythonid:201.6668.31",
                         "yaml",
                         "stats-collector", // Transitive, used by JavaScriptLanguage
                         "JavaScriptLanguage",


### PR DESCRIPTION
* Upgrade our EAP version
* Maven now requires a new transitive plugin that was preventing maven plugin from starting

## Description
Error from logs:

```
2020-04-01 11:50:18 WARN  PluginManager:43 - Problems found loading plugins:
The Maven (id=org.jetbrains.idea.maven, path=~/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/201.6668.13-EAP-SNAPSHOT/a52b7b0e961698a573deaba9c549348c867d3a9f/ideaIC-201.6668.13-EAP-SNAPSHOT/plugins/maven/lib/maven.jar) plugin requires "org.jetbrains.idea.reposearch" plugin to be installed
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
