### PR TITLE
Add more logs for cloud debug for integration tests

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/execution/Steps.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/execution/Steps.kt
@@ -200,7 +200,7 @@ abstract class CliBasedStep : Step() {
                 logEvent.level?.let { previousLevel.set(it) }
             }
             // output to the log for diagnostic and integrations tests
-            LOG.info { event.text.trim() }
+            LOG.debug { event.text.trim() }
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
@@ -141,7 +141,8 @@ abstract class LambdaBuilder {
             val processHandler = ProcessHandlerFactory.getInstance().createColoredProcessHandler(commandLine)
             processHandler.addProcessListener(object : ProcessAdapter() {
                 override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
-                    // output to the log for diagnostic and integrations tests
+                    // TODO find a way to show this in the UI
+                    // log output is for diagnostic and integrations tests as well
                     LOG.info { event.text.trim() }
                 }
 


### PR DESCRIPTION
- Re-add SAM TODO
- Make cloudwatchlogs output `debug` instead of `info`
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
