### PR TITLE
Fix some deprecations

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/AwsToolkit.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/AwsToolkit.kt
@@ -11,6 +11,7 @@ object AwsToolkit {
 
     const val PLUGIN_NAME = "AWS Toolkit For JetBrains"
 
+    // Replace with PluginManagerCore FIX_WHEN_MIN_IS_193
     val PLUGIN_VERSION: String by lazy {
         PluginManager.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "Unknown"
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
@@ -51,6 +51,8 @@ import java.nio.file.Path
 class LocalLambdaRunConfigurationFactory(configuration: LambdaRunConfigurationType) : ConfigurationFactory(configuration) {
     override fun createTemplateConfiguration(project: Project) = LocalLambdaRunConfiguration(project, this)
     override fun getName(): String = "Local"
+    // Overwitten because it was deprecated in 2020.1
+    override fun getId(): String = name
 }
 
 class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactory) :

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeTable.kt
@@ -50,7 +50,8 @@ class S3TreeTable(
             val node = rowAtPoint(dropEvent.location).takeIf { it >= 0 }?.let { getNodeForRow(it) } ?: getRootNode()
             val data = try {
                 dropEvent.acceptDrop(DnDConstants.ACTION_COPY_OR_MOVE)
-                dropEvent.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<File>
+                val list = dropEvent.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>
+                list.filterIsInstance<File>()
             } catch (e: UnsupportedFlavorException) {
                 // When the drag and drop data is not what we expect (like when it is text) this is thrown and can be safey ignored
                 LOG.info(e) { "Unsupported flavor attempted to be dragged and dropped" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
While looking if the 
`ERROR - debugger.pydev.AbstractCommand - No connection (command:  501 ) ` errors broke debugging in 2020.1 (they didn't), I noticed that the base getId is now deprecated. Overwriting getId with the default behavior from previous versions. The API is available since 173, so we are good to do it.

Also fixed a raw cast warning and added a comment about when we can fix a deprecation.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
