### PR TITLE
Refactor how we pass around SdkHttpClient

### DIFF
--- a/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
+++ b/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
@@ -27,7 +27,7 @@ import kotlin.reflect.KClass
 /**
  * An SPI for caching of AWS clients inside of a toolkit
  */
-abstract class ToolkitClientManager(private val sdkHttpClient: SdkHttpClient) {
+abstract class ToolkitClientManager {
     data class AwsClientKey(
         val credentialProviderId: String,
         val region: AwsRegion,
@@ -36,6 +36,7 @@ abstract class ToolkitClientManager(private val sdkHttpClient: SdkHttpClient) {
 
     private val cachedClients = ConcurrentHashMap<AwsClientKey, SdkClient>()
 
+    protected abstract val sdkHttpClient: SdkHttpClient
     protected abstract val userAgent: String
 
     inline fun <reified T : SdkClient> getClient(

--- a/core/src/software/aws/toolkits/core/credentials/CredentialProviderFactory.kt
+++ b/core/src/software/aws/toolkits/core/credentials/CredentialProviderFactory.kt
@@ -26,5 +26,9 @@ interface CredentialProviderFactory {
     /**
      * Creates an [AwsCredentialsProvider] for the specified [ToolkitCredentialsIdentifier] scoped to the specified [region]
      */
-    fun createAwsCredentialProvider(providerId: ToolkitCredentialsIdentifier, region: AwsRegion, sdkClient: SdkHttpClient): AwsCredentialsProvider
+    fun createAwsCredentialProvider(
+        providerId: ToolkitCredentialsIdentifier,
+        region: AwsRegion,
+        sdkHttpClientSupplier: () -> SdkHttpClient
+    ): AwsCredentialsProvider
 }

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/core/AwsSdkClientProxyTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/core/AwsSdkClientProxyTest.kt
@@ -5,7 +5,9 @@ package software.aws.toolkits.jetbrains.core
 
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.ApplicationRule
+import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.runInEdtAndWait
 import com.intellij.util.net.HttpConfigurable
 import com.nhaarman.mockitokotlin2.any
@@ -30,7 +32,13 @@ class AwsSdkClientProxyTest {
     @JvmField
     val application = ApplicationRule()
 
+    @Rule
+    @JvmField
+    val disposableRule = DisposableRule()
+
     private val proxyServletSpy = spy(ConnectHandler())
+
+    private lateinit var awsSdkClient: AwsSdkClient
 
     private val proxyServer = Server().also {
         it.addConnector(ServerConnector(it))
@@ -44,6 +52,9 @@ class AwsSdkClientProxyTest {
 
     @Before
     fun setUp() {
+        awsSdkClient = AwsSdkClient()
+        Disposer.register(disposableRule.disposable, awsSdkClient)
+
         val httpConfigurable = HttpConfigurable.getInstance()
         httpConfigurable.USE_HTTP_PROXY = true
         httpConfigurable.PROXY_HOST = "localhost"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsClientManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsClientManager.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import software.amazon.awssdk.core.SdkClient
+import software.amazon.awssdk.http.SdkHttpClient
 import software.aws.toolkits.core.ToolkitClientManager
 import software.aws.toolkits.core.credentials.CredentialProviderNotFoundException
 import software.aws.toolkits.core.credentials.ToolkitCredentialsChangeListener
@@ -23,8 +24,7 @@ import software.aws.toolkits.jetbrains.AwsToolkit
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsManager
 
-open class AwsClientManager(project: Project, sdkClient: AwsSdkClient) :
-    ToolkitClientManager(sdkClient.sdkHttpClient), Disposable {
+open class AwsClientManager(project: Project) : ToolkitClientManager(), Disposable {
 
     private val accountSettingsManager = ProjectAccountSettingsManager.getInstance(project)
 
@@ -42,6 +42,9 @@ open class AwsClientManager(project: Project, sdkClient: AwsSdkClient) :
     override fun dispose() {
         shutdown()
     }
+
+    override val sdkHttpClient: SdkHttpClient
+        get() = AwsSdkClient.getInstance().sdkHttpClient
 
     override val userAgent = AwsClientManager.userAgent
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
@@ -81,7 +81,7 @@ abstract class CredentialManager : SimpleModificationTracker() {
                     ?: throw CredentialProviderNotFoundException("No provider found with ID ${providerId.id}")
 
                 try {
-                    providerFactory.createAwsCredentialProvider(providerId, region, AwsSdkClient.getInstance().sdkHttpClient)
+                    providerFactory.createAwsCredentialProvider(providerId, region) { AwsSdkClient.getInstance().sdkHttpClient }
                 } catch (e: Exception) {
                     throw CredentialProviderNotFoundException("Failed to create underlying AwsCredentialProvider", e)
                 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
@@ -153,7 +153,7 @@ class ProfileCredentialProviderFactory : CredentialProviderFactory, Disposable {
     override fun createAwsCredentialProvider(
         providerId: ToolkitCredentialsIdentifier,
         region: AwsRegion,
-        sdkClient: SdkHttpClient
+        sdkHttpClientSupplier: () -> SdkHttpClient
     ): AwsCredentialsProvider {
         val profileProviderId = providerId as? ProfileCredentialsIdentifier
             ?: throw IllegalStateException("ProfileCredentialProviderFactory can only handle ProfileCredentialsIdentifier, but got ${providerId::class}")
@@ -161,7 +161,7 @@ class ProfileCredentialProviderFactory : CredentialProviderFactory, Disposable {
         val profile = profileHolder.getProfile(profileProviderId.profileName)
             ?: throw IllegalStateException("Profile ${profileProviderId.profileName} looks to have been removed")
 
-        return createAwsCredentialProvider(profile, region, sdkClient)
+        return createAwsCredentialProvider(profile, region, sdkHttpClientSupplier())
     }
 
     private fun createAwsCredentialProvider(

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -148,7 +148,7 @@ class AwsClientManagerTest {
     }
 
     // Test against real version so bypass ServiceManager for the client manager
-    private fun getClientManager(project: Project = projectRule.project) = AwsClientManager(project, AwsSdkClient.getInstance())
+    private fun getClientManager(project: Project = projectRule.project) = AwsClientManager(project)
 
     class DummyServiceClient(val httpClient: SdkHttpClient) : TestClient() {
         companion object {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsSdkClientTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsSdkClientTest.kt
@@ -9,6 +9,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.junit.WireMockRule
+import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.ApplicationRule
 import com.intellij.util.net.ssl.CertificateManager
 import org.assertj.core.api.Assertions.assertThat
@@ -47,10 +48,14 @@ class AwsSdkClientTest {
 
         val request = mockSdkRequest("https://localhost:" + wireMock.httpsPort())
 
-        val httpClient = AwsSdkClient.getInstance().sdkHttpClient
-        val response = httpClient.prepareRequest(
-            HttpExecuteRequest.builder().request(request).build()
-        ).call()
+        val awsSdkClient = AwsSdkClient()
+        val response = try {
+            awsSdkClient.sdkHttpClient.prepareRequest(
+                HttpExecuteRequest.builder().request(request).build()
+            ).call()
+        } finally {
+            Disposer.dispose(awsSdkClient)
+        }
 
         assertThat(response.httpResponse().isSuccessful).isTrue()
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.core.utils.delegateMock
 import software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule
 import kotlin.reflect.KClass
 
-class MockClientManager(project: Project) : AwsClientManager(project, AwsSdkClient.getInstance()) {
+class MockClientManager(project: Project) : AwsClientManager(project) {
     private data class Key(
         val clazz: KClass<out SdkClient>,
         val region: AwsRegion? = null,

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialManagerTest.kt
@@ -233,7 +233,7 @@ class CredentialManagerTest {
         override fun createAwsCredentialProvider(
             providerId: ToolkitCredentialsIdentifier,
             region: AwsRegion,
-            sdkClient: SdkHttpClient
+            sdkHttpClientSupplier: () -> SdkHttpClient
         ): AwsCredentialsProvider = credentialsMapping.getValue(providerId.id).getValue(region)
 
         private fun createCredentialIdentifier(providerId: String): TestCredentialProviderIdentifier = TestCredentialProviderIdentifier(providerId, id)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -63,7 +63,7 @@ class MockCredentialsManager : CredentialManager() {
         override fun createAwsCredentialProvider(
             providerId: ToolkitCredentialsIdentifier,
             region: AwsRegion,
-            sdkClient: SdkHttpClient
+            sdkHttpClientSupplier: () -> SdkHttpClient
         ): ToolkitCredentialsProvider = ToolkitCredentialsProvider(providerId, (providerId as MockCredentialIdentifier).credentials)
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
@@ -182,11 +182,7 @@ class ProfileCredentialProviderFactoryTest {
 
         val providerFactory = createProviderFactory()
         val validProfile = findCredentialIdentifier(BAR_PROFILE_NAME)
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        ).resolveCredentials()
+        val credentialsProvider = providerFactory.createProvider(validProfile).resolveCredentials()
 
         assertThat(credentialsProvider).isInstanceOfSatisfying(AwsBasicCredentials::class.java) {
             assertThat(it.accessKeyId()).isEqualTo("BarAccessKey")
@@ -200,11 +196,7 @@ class ProfileCredentialProviderFactoryTest {
 
         val providerFactory = createProviderFactory()
         val validProfile = findCredentialIdentifier(FOO_PROFILE_NAME)
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        ).resolveCredentials()
+        val credentialsProvider = providerFactory.createProvider(validProfile).resolveCredentials()
 
         assertThat(credentialsProvider).isInstanceOfSatisfying(AwsSessionCredentials::class.java) {
             assertThat(it.accessKeyId()).isEqualTo("FooAccessKey")
@@ -244,11 +236,7 @@ class ProfileCredentialProviderFactoryTest {
         val providerFactory = createProviderFactory()
         println(credentialChangeEvent.allValues)
         val validProfile = findCredentialIdentifier("role")
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        ).resolveCredentials()
+        val credentialsProvider = providerFactory.createProvider(validProfile).resolveCredentials()
 
         assertThat(credentialsProvider).isInstanceOfSatisfying(AwsSessionCredentials::class.java) {
             assertThat(it.accessKeyId()).isEqualTo("AccessKey")
@@ -290,11 +278,7 @@ class ProfileCredentialProviderFactoryTest {
 
         val providerFactory = createProviderFactory()
         val validProfile = findCredentialIdentifier("role")
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        ).resolveCredentials()
+        val credentialsProvider = providerFactory.createProvider(validProfile).resolveCredentials()
 
         assertThat(credentialsProvider).isInstanceOfSatisfying(AwsSessionCredentials::class.java) {
             assertThat(it.accessKeyId()).isEqualTo("AccessKey")
@@ -346,11 +330,7 @@ class ProfileCredentialProviderFactoryTest {
 
         val providerFactory = createProviderFactory()
         val validProfile = findCredentialIdentifier("role")
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        ).resolveCredentials()
+        val credentialsProvider = providerFactory.createProvider(validProfile).resolveCredentials()
 
         assertThat(credentialsProvider).isInstanceOfSatisfying(AwsSessionCredentials::class.java) {
             assertThat(it.accessKeyId()).isEqualTo("AccessKey")
@@ -374,11 +354,7 @@ class ProfileCredentialProviderFactoryTest {
 
         val providerFactory = createProviderFactory()
         val validProfile = findCredentialIdentifier("foo")
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        )
+        val credentialsProvider = providerFactory.createProvider(validProfile)
 
         verify(profileLoadCallback).invoke(
             check {
@@ -425,11 +401,7 @@ class ProfileCredentialProviderFactoryTest {
 
         val providerFactory = createProviderFactory()
         val validProfile = findCredentialIdentifier("foo")
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        )
+        val credentialsProvider = providerFactory.createProvider(validProfile)
 
         assertThat(credentialsProvider.resolveCredentials()).isInstanceOfSatisfying(AwsSessionCredentials::class.java) {
             assertThat(it.accessKeyId()).isEqualTo("FooAccessKey")
@@ -440,7 +412,7 @@ class ProfileCredentialProviderFactoryTest {
         profileFile.writeToFile("")
 
         assertThatThrownBy {
-            providerFactory.createAwsCredentialProvider(validProfile, MockRegionProvider.getInstance().defaultRegion(), mockSdkHttpClient)
+            providerFactory.createProvider(validProfile)
         }.isInstanceOf(IllegalStateException::class.java)
 
         verify(profileLoadCallback).invoke(
@@ -476,11 +448,7 @@ class ProfileCredentialProviderFactoryTest {
         )
 
         val validProfile = findCredentialIdentifier("foo")
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        )
+        val credentialsProvider = providerFactory.createProvider(validProfile)
 
         assertThat(credentialsProvider.resolveCredentials()).isInstanceOfSatisfying(AwsSessionCredentials::class.java) {
             assertThat(it.accessKeyId()).isEqualTo("FooAccessKey")
@@ -529,11 +497,7 @@ class ProfileCredentialProviderFactoryTest {
         )
 
         val validProfile = findCredentialIdentifier("foo")
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        )
+        val credentialsProvider = providerFactory.createProvider(validProfile)
 
         assertThat(credentialsProvider.resolveCredentials()).isInstanceOfSatisfying(AwsSessionCredentials::class.java) {
             assertThat(it.accessKeyId()).isEqualTo("FooAccessKey")
@@ -555,11 +519,7 @@ class ProfileCredentialProviderFactoryTest {
 
         val providerFactory = createProviderFactory()
         val validProfile = findCredentialIdentifier("foo")
-        val credentialsProvider = providerFactory.createAwsCredentialProvider(
-            validProfile,
-            MockRegionProvider.getInstance().defaultRegion(),
-            mockSdkHttpClient
-        )
+        val credentialsProvider = providerFactory.createProvider(validProfile)
 
         assertThat(credentialsProvider.resolveCredentials()).isInstanceOfSatisfying(AwsSessionCredentials::class.java) {
             assertThat(it.accessKeyId()).isEqualTo("FooAccessKey")
@@ -570,7 +530,7 @@ class ProfileCredentialProviderFactoryTest {
         VfsTestUtil.deleteFile(LocalFileSystem.getInstance().findFileByIoFile(profileFile)!!)
 
         assertThatThrownBy {
-            providerFactory.createAwsCredentialProvider(validProfile, MockRegionProvider.getInstance().defaultRegion(), mockSdkHttpClient)
+            providerFactory.createProvider(validProfile)
         }.isInstanceOf(IllegalStateException::class.java)
 
         verify(profileLoadCallback).invoke(
@@ -642,6 +602,12 @@ class ProfileCredentialProviderFactoryTest {
             override fun abort() {}
         }
     }
+
+    private fun ProfileCredentialProviderFactory.createProvider(validProfile: ToolkitCredentialsIdentifier) = this.createAwsCredentialProvider(
+        validProfile,
+        MockRegionProvider.getInstance().defaultRegion(),
+        sdkHttpClientSupplier = { mockSdkHttpClient }
+    )
 
     private companion object {
         val TEST_PROFILE_FILE_CONTENTS = """


### PR DESCRIPTION
* Do not pass it as a constructor arg to prevent starting it up too early
* Use a supplier to the credentials system since it is only needed for STS calls and not always, this prevents spinning it up in tests as much
* Cut down on chances of triggering a thread leak in unit tests
* Tests that do need it should manually create and dispose it

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
