### PR TITLE
Speed up the CloudDebug test case by not actually spinning up any de-…

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTestCase.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTestCase.kt
@@ -91,7 +91,7 @@ abstract class CloudDebugTestCase(private val taskDefName: String) {
     private fun createService(): Service {
         val cfnOutputs = cfnRule.outputs
         val service = ecsRule.createService {
-            it.desiredCount(1)
+            it.desiredCount(0)
             it.taskDefinition(taskDefName)
             it.cluster("CloudDebugTestECSCluster")
             it.launchType(LaunchType.FARGATE)


### PR DESCRIPTION
…instrumented services
Ran with Java test

Before: ~7 min 30s
After: ~5 min 10s

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
