### PR TITLE
Fix runUnderRealCredentials failing to switch back to fake creds

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
@@ -150,6 +150,7 @@ abstract class ProjectAccountSettingsManager(private val project: Project) : Sim
             } finally {
                 incModificationCount()
                 AwsTelemetry.validateCredentials(project, success = isValidConnectionSettings())
+                validationJob = null
             }
         }
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -37,6 +37,10 @@ class MockCredentialsManager : CredentialManager() {
         return credentialIdentifier
     }
 
+    fun removeCredentials(credentialIdentifier: ToolkitCredentialsIdentifier) {
+        removeProvider(credentialIdentifier)
+    }
+
     override fun factoryMapping(): Map<String, CredentialProviderFactory> = mapOf(MockCredentialProviderFactory.id to MockCredentialProviderFactory)
 
     companion object {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockProjectAccountSettingsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockProjectAccountSettingsManager.kt
@@ -59,17 +59,17 @@ fun <T> runUnderRealCredentials(project: Project, block: () -> T): T {
     val manager = MockProjectAccountSettingsManager.getInstance(project)
     val credentialsManager = MockCredentialsManager.getInstance()
     val oldActive = manager.connectionSettings()?.credentials
+    val realCredentialsProvider = credentialsManager.addCredentials("RealCredentials", credentials)
     try {
         println("Running using real credentials")
 
-        val realCredentialsProvider = credentialsManager.addCredentials("RealCredentials", credentials)
         manager.changeCredentialProviderAndWait(realCredentialsProvider)
 
         return block.invoke()
     } finally {
-        credentialsManager.reset()
         oldActive?.let {
             manager.changeCredentialProviderAndWait(credentialsManager.getCredentialIdentifierById(oldActive.id))
         }
+        credentialsManager.removeCredentials(realCredentialsProvider)
     }
 }


### PR DESCRIPTION
When we reset the cred manager, it causes a switch to dummy creds due to the active has now been removed. This ends up getting cancelled by the explicit switch back to oldActive which is the same (DUMMY). So instead switch the active, before the removal of the real creds

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
