### PR TITLE
Enable New Project for Lambda 3.1 and "Run"

### DIFF
--- a/.changes/next-release/breaking-06dec205-58a0-442d-9d53-b7c141910671.json
+++ b/.changes/next-release/breaking-06dec205-58a0-442d-9d53-b7c141910671.json
@@ -1,0 +1,4 @@
+{
+  "type" : "breaking",
+  "description" : "Minimum SAM CLI version has been increased to 0.47.0"
+}

--- a/.changes/next-release/feature-55ae3b21-a7ab-4f46-8165-10b533c54634.json
+++ b/.changes/next-release/feature-55ae3b21-a7ab-4f46-8165-10b533c54634.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Add support for creating and running Lambdas with dotnet core 3.1. Debug support will come in a future release"
+}

--- a/.changes/next-release/removal-e236f4cd-8c5a-483d-83c6-86b5d4211594.json
+++ b/.changes/next-release/removal-e236f4cd-8c5a-483d-83c6-86b5d4211594.json
@@ -1,0 +1,4 @@
+{
+  "type" : "removal",
+  "description" : "Removed the ability to create a new SAM project for dotnet core 2.0 since it is a deprecated runtime"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ publishChannel=
 # Common dependencies
 ideProfileName=2019.2
 kotlinVersion=1.3.70
-awsSdkVersion=2.10.60
+awsSdkVersion=2.11.9
 coroutinesVersion=1.3.3
 ideaPluginVersion=0.4.16
 ktlintVersion=0.36.0

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
@@ -51,6 +51,7 @@ enum class RuntimeGroup {
         /**
          * Lazily apply the predicate to each [RuntimeGroup] and return the first match (or null)
          */
+        @JvmStatic
         fun find(predicate: (RuntimeGroup) -> Boolean): RuntimeGroup? = RuntimeGroup.values().asSequence().filter(predicate).firstOrNull()
 
         fun determineRuntime(project: Project?): Runtime? = project?.let { _ ->

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamDebugSupport.kt
@@ -10,6 +10,7 @@ import com.intellij.util.net.NetUtils
 import com.intellij.xdebugger.XDebugProcessStarter
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.resolvedPromise
+import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPointObject
 
 interface SamDebugSupport {
@@ -37,7 +38,7 @@ interface SamDebugSupport {
         debugPorts: List<Int>
     ): XDebugProcessStarter?
 
-    fun isSupported(): Boolean = true
+    fun isSupported(runtime: Runtime): Boolean = true // Default behavior is all runtimes in the runtime group are supported
 
     fun getDebugPorts(): List<Int> = listOf(NetUtils.tryToFindAvailableSocketPort())
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
@@ -66,7 +66,7 @@ class SamInvokeRunner : AsyncProgramRunner<RunnerSettings>() {
             val runtimeGroup = runtimeValue?.runtimeGroup ?: return false
 
             return SamDebugSupport.supportedRuntimeGroups.contains(runtimeGroup) &&
-                SamDebugSupport.getInstance(runtimeGroup)?.isSupported() ?: false
+                SamDebugSupport.getInstance(runtimeGroup)?.isSupported(runtimeValue) ?: false
         }
 
         return false

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
-import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutableIfPresent
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplate
@@ -21,8 +20,6 @@ import java.nio.file.Paths
 
 class SamCommon {
     companion object {
-        private val logger = getLogger<SamCommon>()
-
         val mapper = jacksonObjectMapper()
         const val SAM_BUILD_DIR = ".aws-sam"
         const val SAM_INFO_VERSION_KEY = "version"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamExecutable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamExecutable.kt
@@ -18,7 +18,7 @@ class SamExecutable : ExecutableType<SemVer>, AutoResolvable, Validatable {
     override val id: String = "samCli"
 
     // inclusive
-    val samMinVersion = SemVer("0.38.0", 0, 38, 0)
+    val samMinVersion = SemVer("0.47.0", 0, 47, 0)
     // exclusive
     val samMaxVersion = SemVer("0.50.0", 0, 50, 0)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitSelectionPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitSelectionPanel.java
@@ -11,6 +11,7 @@ import com.intellij.uiDesigner.core.GridConstraints;
 import java.awt.Dimension;
 import java.awt.event.ItemEvent;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -32,6 +33,7 @@ import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance;
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager;
 import software.aws.toolkits.jetbrains.core.executables.ExecutableType;
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder;
+import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup;
 import software.aws.toolkits.jetbrains.services.lambda.SamNewProjectSettings;
 import software.aws.toolkits.jetbrains.services.lambda.SamProjectTemplate;
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable;
@@ -79,12 +81,15 @@ public class SamInitSelectionPanel implements ValidatablePanel {
         this.currentAwsCredentialSelectorLabel = null;
         this.currentAwsCredentialSelector = null;
 
-        LambdaBuilder.Companion.getSupportedRuntimeGroups()
-                               .stream()
-                               .flatMap(x -> x.getRuntimes().stream())
-                               .sorted()
-                               .filter(runtimeFilter)
-                               .forEach(y -> runtimeComboBox.addItem(y));
+        // TODO: Move this to Kotlin...
+        // Source all templates, find all the runtimes they support, then filter those by what the IDE supports
+        Set<RuntimeGroup> supportedRuntimeGroups = LambdaBuilder.Companion.getSupportedRuntimeGroups();
+        SamProjectTemplate.SAM_TEMPLATES.stream()
+                                        .flatMap(template -> template.supportedRuntimes().stream())
+                                        .sorted()
+                                        .filter(runtimeFilter)
+                                        .filter(r -> supportedRuntimeGroups.contains(RuntimeGroup.find(runtimeGroup -> runtimeGroup.getRuntimes().contains(r))))
+                                        .forEach(y -> runtimeComboBox.addItem(y));
 
         SamInitProjectBuilderCommon.setupSamSelectionElements(samExecutableField, editSamExecutableButton, samLabel);
 

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
@@ -16,7 +16,8 @@ class DotNetRuntimeGroup : SdkBasedRuntimeGroupInformation() {
     override val runtimes: Set<Runtime>
         get() = setOf(
                 Runtime.DOTNETCORE2_0,
-                Runtime.DOTNETCORE2_1
+                Runtime.DOTNETCORE2_1,
+                Runtime.DOTNETCORE3_1
         )
 
     override val languageIds: Set<String>

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
@@ -33,6 +33,7 @@ import com.jetbrains.rider.run.IDebuggerOutputListener
 import com.jetbrains.rider.run.bindToSettings
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
+import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.trace
@@ -85,7 +86,12 @@ class DotNetSamDebugSupport : SamDebugSupport {
     /**
      * Check whether the JatBrains.Rider.Worker.Launcher app (that is required to run Debugger) is downloaded into Rider SDK.
      */
-    override fun isSupported(): Boolean {
+    override fun isSupported(runtime: Runtime): Boolean {
+        // TODO: Remove when SAM adds debug support
+        if (runtime == Runtime.DOTNETCORE3_1) {
+            return false
+        }
+
         val debugLauncherFile = File(DotNetDebuggerUtils.debuggerBinDir, "${DotNetDebuggerUtils.dotnetCoreDebuggerLauncherName}.dll")
 
         val debuggerLauncherExists = debugLauncherFile.exists()

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectTemplate.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectTemplate.kt
@@ -14,7 +14,7 @@ class DotNetSamProjectTemplate : SamProjectTemplate() {
 
     override fun getDescription(): String? = message("sam.init.template.hello_world.description")
 
-    override fun supportedRuntimes(): Set<Runtime> = setOf(Runtime.DOTNETCORE2_0, Runtime.DOTNETCORE2_1)
+    override fun supportedRuntimes(): Set<Runtime> = setOf(Runtime.DOTNETCORE2_1, Runtime.DOTNETCORE3_1)
 
     override fun templateParameters(): TemplateParameters = AppBasedTemplate("hello-world", "cli-package")
 }

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
@@ -3,12 +3,10 @@
 
 package software.aws.toolkits.jetbrains.utils
 
-import com.intellij.openapi.application.PathManager
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.lambda.validOrNull
-import java.io.File
 import java.io.IOException
 
 object DotNetRuntimeUtils {
@@ -45,7 +43,6 @@ object DotNetRuntimeUtils {
         return Runtime.fromValue("dotnetcore${version.split('.').take(2).joinToString(".")}").validOrNull
             ?: DEFAULT_DOTNET_CORE_RUNTIME
     }
-    val DEBUGGER_BIN_DIR = File("${PathManager.getTempPath()}/ReSharperHost")
 
     const val RUNTIME_CONFIG_JSON_21 = """{
   "runtimeOptions": {


### PR DESCRIPTION
* Enable Run Lambda for DotNet Core 3.1, debug will come in a future release
* Fix New Project template always using latest version instead of selected version
* Improve how we add supported templates to UI to prevent adding runtimes with no templates
* Increase min sam version to 0.46.0 to support dotnet 3.1

## Testing
Manual, need to revive #1323

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
