### PR TITLE
Fix CloudWatch logs time text being pushed too low

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/TableUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/TableUtils.kt
@@ -28,6 +28,8 @@ import javax.swing.JPanel
 import javax.swing.JTable
 import javax.swing.JTextArea
 import javax.swing.SortOrder
+import javax.swing.border.CompoundBorder
+import javax.swing.border.EmptyBorder
 import javax.swing.table.DefaultTableCellRenderer
 import javax.swing.table.TableCellRenderer
 import javax.swing.table.TableRowSorter
@@ -152,8 +154,13 @@ private class ResizingDateColumnRenderer(showSeconds: Boolean) : TableCellRender
         // Make sure the background matches for selection
         wrapper.background = component.background
         // if a component is selected, it puts a border on it, move the border to the wrapper instead
-        wrapper.border = component.border
-        component.border = null
+        if (isSelected) {
+            // this border has an outside and inside border, take only the outside border
+            wrapper.border = (component.border as? CompoundBorder)?.outsideBorder
+            component.border = EmptyBorder(-1, 0, 0, 0)
+        } else {
+            component.border = null
+        }
         return wrapper
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/TableUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/TableUtils.kt
@@ -157,6 +157,7 @@ private class ResizingDateColumnRenderer(showSeconds: Boolean) : TableCellRender
         if (isSelected) {
             // this border has an outside and inside border, take only the outside border
             wrapper.border = (component.border as? CompoundBorder)?.outsideBorder
+            // Push the text up to compensate for the new border
             component.border = EmptyBorder(-1, 0, 0, 0)
         } else {
             component.border = null


### PR DESCRIPTION
## Related Issue(s)
#1694

## Screenshots (if appropriate)
<img width="224" alt="Screen Shot 2020-04-09 at 11 05 07 AM" src="https://user-images.githubusercontent.com/11964782/78926653-46aef700-7a52-11ea-8fe7-a8cdb3bee491.png">
<img width="188" alt="Screen Shot 2020-04-09 at 11 07 02 AM" src="https://user-images.githubusercontent.com/11964782/78926656-47e02400-7a52-11ea-96ee-422b1019e584.png">
