### PR TITLE
Fix refresh on delete (CF/Lambda)

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
@@ -45,10 +45,10 @@ abstract class DeleteResourceAction<in T : AwsExplorerResourceNode<*>>(text: Str
                 ApplicationManager.getApplication().executeOnPooledThread {
                     try {
                         performDelete(selected)
-                        notifyInfo(message("delete_resource.deleted", resourceType, resourceName))
+                        notifyInfo(project = selected.project, title = message("aws.notification.title"), content = message("delete_resource.deleted", resourceType, resourceName))
                         AwsTelemetry.deleteResource(selected.project, ServiceType.from(selected.serviceId), success = true)
                     } catch (e: Exception) {
-                        e.notifyError(message("delete_resource.delete_failed", resourceType, resourceName), selected.project)
+                        e.notifyError(project = selected.project, title = message("delete_resource.delete_failed", resourceType, resourceName))
                         AwsTelemetry.deleteResource(selected.project, ServiceType.from(selected.serviceId), success = false)
                     }
                 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
@@ -45,7 +45,7 @@ abstract class DeleteResourceAction<in T : AwsExplorerResourceNode<*>>(text: Str
                 ApplicationManager.getApplication().executeOnPooledThread {
                     try {
                         performDelete(selected)
-                        notifyInfo(project = selected.project, title = message("aws.notification.title"), content = message("delete_resource.deleted", resourceType, resourceName))
+                        notifyInfo(project = selected.project, title = message("delete_resource.deleted", resourceType, resourceName))
                         AwsTelemetry.deleteResource(selected.project, ServiceType.from(selected.serviceId), success = true)
                     } catch (e: Exception) {
                         e.notifyError(project = selected.project, title = message("delete_resource.delete_failed", resourceType, resourceName))

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/actions/DeleteStackAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/actions/DeleteStackAction.kt
@@ -7,8 +7,10 @@ import com.intellij.openapi.application.runInEdt
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.explorer.actions.DeleteResourceAction
-import software.aws.toolkits.jetbrains.services.cloudformation.stack.StackWindowManager
+import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationStackNode
+import software.aws.toolkits.jetbrains.services.cloudformation.resources.CloudFormationResources
+import software.aws.toolkits.jetbrains.services.cloudformation.stack.StackWindowManager
 import software.aws.toolkits.jetbrains.services.cloudformation.waitForStackDeletionComplete
 import software.aws.toolkits.jetbrains.utils.TaggingResourceType
 import software.aws.toolkits.resources.message
@@ -24,5 +26,6 @@ class DeleteStackAction : DeleteResourceAction<CloudFormationStackNode>(
             StackWindowManager.getInstance(selected.nodeProject).openStack(selected.stackName, selected.stackId)
         }
         client.waitForStackDeletionComplete(selected.stackName)
+        selected.nodeProject.refreshAwsTree(CloudFormationResources.LIST_STACKS)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeleteFunctionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeleteFunctionAction.kt
@@ -6,7 +6,9 @@ package software.aws.toolkits.jetbrains.services.lambda.actions
 import software.amazon.awssdk.services.lambda.LambdaClient
 import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.explorer.actions.DeleteResourceAction
+import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunctionNode
+import software.aws.toolkits.jetbrains.services.lambda.resources.LambdaResources
 import software.aws.toolkits.jetbrains.utils.TaggingResourceType
 import software.aws.toolkits.resources.message
 
@@ -15,5 +17,6 @@ class DeleteFunctionAction : DeleteResourceAction<LambdaFunctionNode>(message("l
         val project = selected.nodeProject
         val client: LambdaClient = AwsClientManager.getInstance(project).getClient()
         client.deleteFunction { it.functionName(selected.functionName()) }
+        selected.nodeProject.refreshAwsTree(LambdaResources.LIST_FUNCTIONS)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/DeleteBucketAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/DeleteBucketAction.kt
@@ -15,7 +15,6 @@ import software.aws.toolkits.jetbrains.services.s3.editor.S3VirtualBucket
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
 import software.aws.toolkits.jetbrains.utils.TaggingResourceType
 import software.aws.toolkits.resources.message
-import software.aws.toolkits.telemetry.S3Telemetry
 
 class DeleteBucketAction : DeleteResourceAction<S3BucketNode>(message("s3.delete.bucket.action"), TaggingResourceType.S3_BUCKET) {
     override fun performDelete(selected: S3BucketNode) {
@@ -33,6 +32,5 @@ class DeleteBucketAction : DeleteResourceAction<S3BucketNode>(message("s3.delete
 
         client.deleteBucketAndContents(selected.displayName())
         selected.nodeProject.refreshAwsTree(S3Resources.LIST_BUCKETS)
-        S3Telemetry.deleteBucket(selected.nodeProject, success = true)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/DeleteBucketAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/DeleteBucketAction.kt
@@ -14,31 +14,25 @@ import software.aws.toolkits.jetbrains.services.s3.S3BucketNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3VirtualBucket
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
 import software.aws.toolkits.jetbrains.utils.TaggingResourceType
-import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.S3Telemetry
 
 class DeleteBucketAction : DeleteResourceAction<S3BucketNode>(message("s3.delete.bucket.action"), TaggingResourceType.S3_BUCKET) {
     override fun performDelete(selected: S3BucketNode) {
-        try {
-            val client: S3Client = AwsClientManager.getInstance(selected.nodeProject).getClient()
+        val client: S3Client = AwsClientManager.getInstance(selected.nodeProject).getClient()
 
-            val fileEditorManager = FileEditorManager.getInstance(selected.nodeProject)
-            fileEditorManager.openFiles.forEach {
-                if (it is S3VirtualBucket && it.s3Bucket.name() == selected.displayName()) {
-                    // Wait so that we know it closes successfully, otherwise this operation is not a success
-                    runInEdtAndWait {
-                        fileEditorManager.closeFile(it)
-                    }
+        val fileEditorManager = FileEditorManager.getInstance(selected.nodeProject)
+        fileEditorManager.openFiles.forEach {
+            if (it is S3VirtualBucket && it.s3Bucket.name() == selected.displayName()) {
+                // Wait so that we know it closes successfully, otherwise this operation is not a success
+                runInEdtAndWait {
+                    fileEditorManager.closeFile(it)
                 }
             }
-
-            client.deleteBucketAndContents(selected.displayName())
-            selected.nodeProject.refreshAwsTree(S3Resources.LIST_BUCKETS)
-            S3Telemetry.deleteBucket(selected.nodeProject, success = true)
-        } catch (e: Exception) {
-            notifyError(message("s3.delete.bucket_failed", selected.bucket.name(), e.message ?: ""))
-            S3Telemetry.deleteBucket(selected.nodeProject, success = false)
         }
+
+        client.deleteBucketAndContents(selected.displayName())
+        selected.nodeProject.refreshAwsTree(S3Resources.LIST_BUCKETS)
+        S3Telemetry.deleteBucket(selected.nodeProject, success = true)
     }
 }

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -177,7 +177,6 @@ s3.delete.object.description=Are you sure you want to delete {0, choice, 1#this 
 s3.delete.object.failed=Delete object failed
 s3.delete.object.delete=Delete
 s3.delete.object.cancel=Cancel
-s3.delete.bucket_failed=Failed to delete bucket {0}
 s3.download.object.action=Download...
 s3.download.object.failed=Failed to download object {0}
 s3.download.object.browse.title=Select Download Location...


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Refresh the AWS explorer on CloudFormation/Lambda delete
- Refactor S3 delete to take advantage of its parent class's messages
- Fix the delete resource messages to actually show up
## Related Issue(s)
#286

## Screenshot
<img width="440" alt="Screen Shot 2020-04-09 at 2 14 48 PM" src="https://user-images.githubusercontent.com/11964782/78941418-8256ba80-7a6c-11ea-9713-8b0c1b1ed2e7.png">
<img width="383" alt="Screen Shot 2020-04-09 at 1 18 51 PM" src="https://user-images.githubusercontent.com/11964782/78937103-baf29600-7a64-11ea-81e9-c950c2d4b87b.png">



## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
