### PR TITLE
Preserve tree state when refreshing all or part of the explorer

### DIFF
--- a/.changes/next-release/feature-2ec05719-0a3f-4f07-b007-340a9037e778.json
+++ b/.changes/next-release/feature-2ec05719-0a3f-4f07-b007-340a9037e778.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "On refresh, AWS explorer tree nodes will no longer be collapsed"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -96,13 +96,14 @@ class ExplorerToolWindow(private val project: Project) : SimpleToolWindowPanel(t
     }
 
     /**
-     * Invalidates tree nodes, causing IntelliJ to redraw the tree
+     * Invalidates tree nodes, causing IntelliJ to redraw the tree. Preserves node state.
      * Provide an AbstractTreeNode in order to redraw the tree from that point downwards
-     * Otherwise redraws (and collapses) the entire tree
+     * Otherwise redraws the entire tree
      *
      * @param selectedNode AbstractTreeNode to redraw the tree from
      */
     fun invalidateTree(selectedNode: AbstractTreeNode<*>? = null) {
+        // save the state and reapply it after we invalidate (which is the point where the state is wiped)
         val state = TreeState.createOn(awsTree)
         if (selectedNode != null) {
             structureTreeModel.invalidate(selectedNode, true)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -103,7 +103,8 @@ class ExplorerToolWindow(private val project: Project) : SimpleToolWindowPanel(t
      * @param selectedNode AbstractTreeNode to redraw the tree from
      */
     fun invalidateTree(selectedNode: AbstractTreeNode<*>? = null) {
-        // save the state and reapply it after we invalidate (which is the point where the state is wiped)
+        // Save the state and reapply it after we invalidate (which is the point where the state is wiped).
+        // Items are expanded again if their user object is unchanged (.equals()).
         val state = TreeState.createOn(awsTree)
         if (selectedNode != null) {
             structureTreeModel.invalidate(selectedNode, true)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.Location
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.ide.util.treeView.NodeDescriptor
 import com.intellij.ide.util.treeView.NodeRenderer
+import com.intellij.ide.util.treeView.TreeState
 import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.DataKey
@@ -102,11 +103,13 @@ class ExplorerToolWindow(private val project: Project) : SimpleToolWindowPanel(t
      * @param selectedNode AbstractTreeNode to redraw the tree from
      */
     fun invalidateTree(selectedNode: AbstractTreeNode<*>? = null) {
+        val state = TreeState.createOn(awsTree)
         if (selectedNode != null) {
             structureTreeModel.invalidate(selectedNode, true)
         } else {
             structureTreeModel.invalidate()
         }
+        state.applyTo(awsTree)
     }
 
     private fun createTree(model: TreeModel): Tree {
@@ -231,10 +234,12 @@ object ExplorerDataKeys {
      * Returns all the selected resource nodes. getData() will return null if not all selected items are same type
      */
     val SELECTED_RESOURCE_NODES = DataKey.create<List<AwsExplorerResourceNode<*>>>("aws.explorer.resourceNodes")
+
     /**
      * Returns the selected Service node. getData() will return null if more than one item is selected
      */
     val SELECTED_SERVICE_NODE = DataKey.create<AwsExplorerNode<*>>("aws.explorer.serviceNode")
+
     /**
      * Returns all the explorer nodes. getData() will return null if not all selected items are same type
      */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related issue
#1704
## Screenshots
### Refresh whole tree
![Kapture 2020-04-09 at 13 30 26](https://user-images.githubusercontent.com/11964782/78939498-1f175900-7a69-11ea-9520-b2e8ea3a0054.gif)
### Delete an object (takes a while because of S3)
![Kapture 2020-04-09 at 13 32 49](https://user-images.githubusercontent.com/11964782/78939499-1fafef80-7a69-11ea-80e3-c45bc963a548.gif)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
