### PR TITLE
Fix issue 1707 - Deploy serverless application window breaking

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.project.Project
@@ -21,9 +22,9 @@ import software.aws.toolkits.jetbrains.core.credentials.ProjectAccountSettingsMa
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutable
-import software.aws.toolkits.jetbrains.services.cloudformation.stack.StackWindowManager
 import software.aws.toolkits.jetbrains.services.cloudformation.describeStack
 import software.aws.toolkits.jetbrains.services.cloudformation.executeChangeSetAndWait
+import software.aws.toolkits.jetbrains.services.cloudformation.stack.StackWindowManager
 import software.aws.toolkits.jetbrains.services.cloudformation.validateSamTemplateHasResources
 import software.aws.toolkits.jetbrains.services.cloudformation.validateSamTemplateLambdaRuntimes
 import software.aws.toolkits.jetbrains.services.lambda.deploy.DeployServerlessApplicationDialog
@@ -80,26 +81,28 @@ class DeployServerlessApplicationAction : AnAction(
                 return@thenAccept
             }
 
-            // Force save before we deploy
-            FileDocumentManager.getInstance().saveAllDocuments()
+            runInEdt {
+                // Force save before we deploy
+                FileDocumentManager.getInstance().saveAllDocuments()
 
-            val stackDialog = DeployServerlessApplicationDialog(project, templateFile)
-            stackDialog.show()
-            if (!stackDialog.isOK) {
-                SamTelemetry.deploy(project, Result.CANCELLED)
-                return@thenAccept
-            }
+                val stackDialog = DeployServerlessApplicationDialog(project, templateFile)
+                stackDialog.show()
+                if (!stackDialog.isOK) {
+                    SamTelemetry.deploy(project, Result.CANCELLED)
+                    return@runInEdt
+                }
 
-            saveSettings(project, templateFile, stackDialog)
+                saveSettings(project, templateFile, stackDialog)
 
-            val stackName = stackDialog.stackName
-            val stackId = stackDialog.stackId
+                val stackName = stackDialog.stackName
+                val stackId = stackDialog.stackId
 
-            if (stackId == null) {
-                continueDeployment(project, stackName, templateFile, stackDialog)
-            } else {
-                warnResourceOperationAgainstCodePipeline(project, stackName, stackId, TaggingResourceType.CLOUDFORMATION_STACK, Operation.DEPLOY) {
+                if (stackId == null) {
                     continueDeployment(project, stackName, templateFile, stackDialog)
+                } else {
+                    warnResourceOperationAgainstCodePipeline(project, stackName, stackId, TaggingResourceType.CLOUDFORMATION_STACK, Operation.DEPLOY) {
+                        continueDeployment(project, stackName, templateFile, stackDialog)
+                    }
                 }
             }
         }
@@ -154,12 +157,12 @@ class DeployServerlessApplicationAction : AnAction(
     /**
      * Determines the relevant Sam Template, returns null if one can't be found.
      */
-    private fun getSamTemplateFile(e: AnActionEvent): VirtualFile? {
-        val virtualFiles = e.getData(PlatformDataKeys.VIRTUAL_FILE_ARRAY) ?: return null
-        val virtualFile = virtualFiles.singleOrNull() ?: return null
+    private fun getSamTemplateFile(e: AnActionEvent): VirtualFile? = runReadAction {
+        val virtualFiles = e.getData(PlatformDataKeys.VIRTUAL_FILE_ARRAY) ?: return@runReadAction null
+        val virtualFile = virtualFiles.singleOrNull() ?: return@runReadAction null
 
         if (templateYamlRegex.matches(virtualFile.name)) {
-            return virtualFile
+            return@runReadAction virtualFile
         }
 
         // If the module node was selected, see if there is a template file in the top level folder
@@ -171,11 +174,11 @@ class DeployServerlessApplicationAction : AnAction(
             }
 
             if (childTemplateFiles.size == 1) {
-                return childTemplateFiles.single()
+                return@runReadAction childTemplateFiles.single()
             }
         }
 
-        return null
+        return@runReadAction null
     }
 
     private fun saveSettings(project: Project, templateFile: VirtualFile, stackDialog: DeployServerlessApplicationDialog) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

1707 is happening because `getSamTemplateFile` called by `DeployServerlessApplicationAction` moved from being in the action to being in a future. wrap `getSamTemplateFile` in `runReadAction` so it works on whatever thread it's called from.

Additionally, lines below `FileDocumentManager.getInstance().saveAllDocuments()` 100% need to run in edt, so wrapped those in a `runInEdt`

Looking through the rest of the diff from porting SAM to executable manager, this seems to be the only place we were getting the executable to use it on `edt`
## Related issue
#1707 

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
