### PR TITLE
Fix file type association for the CloudFormation Template indexer

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationTemplateIndex.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationTemplateIndex.kt
@@ -18,7 +18,7 @@ import com.intellij.util.indexing.ID
 import com.intellij.util.io.DataExternalizer
 import com.intellij.util.io.EnumeratorStringDescriptor
 import com.intellij.util.io.KeyDescriptor
-import org.jetbrains.yaml.YAMLLanguage
+import org.jetbrains.yaml.YAMLFileType
 import org.jetbrains.yaml.psi.YAMLKeyValue
 import software.aws.toolkits.jetbrains.services.cloudformation.yaml.YamlCloudFormationTemplate
 import java.io.DataInput
@@ -26,7 +26,7 @@ import java.io.DataOutput
 
 class CloudFormationTemplateIndex : FileBasedIndexExtension<String, MutableList<IndexedResource>>() {
     private val fileFilter by lazy {
-        val supportedFiles = arrayOf(YAMLLanguage.INSTANCE.associatedFileType)
+        val supportedFiles = arrayOf(YAMLFileType.YML)
 
         object : DefaultFileTypeSpecificInputFilter(*supportedFiles) {
             override fun acceptInput(file: VirtualFile): Boolean = file.isInLocalFileSystem


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In certain circumstances, other plugins can change the `associatedFileType` of `YAMLLanguage`. Instead of doing it that way, use the yaml file type directly with `YAMLFileType.YML`
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
