### PR TITLE
Stabalize builds by downgrading Rider back to EAP

### DIFF
--- a/intellijJVersions.gradle
+++ b/intellijJVersions.gradle
@@ -112,9 +112,9 @@ static def ideProfiles() {
                     ]
                 ],
                 "RD": [
-                    sdkVersion: "RD-2020.1",
+                    sdkVersion: "RD-2020.1-SNAPSHOT",
                     rdGenVersion: "0.201.69",
-                    nugetVersion: "2020.1.0",
+                    nugetVersion: "2020.1.0-eap05",
                     plugins: [
                         "yaml"
                     ]

--- a/intellijJVersions.gradle
+++ b/intellijJVersions.gradle
@@ -113,7 +113,7 @@ static def ideProfiles() {
                 ],
                 "RD": [
                     sdkVersion: "RD-2020.1",
-                    rdGenVersion: "0.201.78",
+                    rdGenVersion: "0.201.69",
                     nugetVersion: "2020.1.0",
                     plugins: [
                         "yaml"


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
