### PR TITLE
Fix Milan showing up as 'Europe Milan' instead of just 'Milan'

### DIFF
--- a/core/src/software/aws/toolkits/core/region/AwsRegion.kt
+++ b/core/src/software/aws/toolkits/core/region/AwsRegion.kt
@@ -19,7 +19,7 @@ data class AwsRegion(val id: String, val name: String, val partitionId: String) 
     }
 
     val displayName: String = when {
-        category == "Europe" -> "${name.trimPrefixAndRemoveBrackets("EU")} ($id)"
+        category == "Europe" -> "${name.removePrefix("Europe").trimPrefixAndRemoveBrackets("EU")} ($id)"
         category == "North America" -> "${name.removePrefix("US West").trimPrefixAndRemoveBrackets("US East")} ($id)"
         category != null && name.startsWith(category) -> "${name.trimPrefixAndRemoveBrackets(category)} ($id)"
         else -> name

--- a/core/tst/software/aws/toolkits/core/region/AwsRegionTest.kt
+++ b/core/tst/software/aws/toolkits/core/region/AwsRegionTest.kt
@@ -19,6 +19,7 @@ class AwsRegionTest(private val region: AwsRegion, private val expectedCategory:
             arrayOf(AwsRegion("ap-northeast-1", "Asia Pacific (Tokyo)", "aws"), "Asia Pacific", "Tokyo (ap-northeast-1)"),
             arrayOf(AwsRegion("ca-central-1", "Canada (Central)", "aws"), "North America", "Canada Central (ca-central-1)"),
             arrayOf(AwsRegion("eu-central-1", "EU (Frankfurt)", "aws"), "Europe", "Frankfurt (eu-central-1)"),
+            arrayOf(AwsRegion("eu-south-1", "Europe (Milan)", "aws"), "Europe", "Milan (eu-south-1)"),
             arrayOf(AwsRegion("sa-east-1", "South America (Sao Paulo)", "aws"), "South America", "Sao Paulo (sa-east-1)"),
             arrayOf(AwsRegion("us-east-1", "US East (N. Virginia)", "aws"), "North America", "N. Virginia (us-east-1)"),
             arrayOf(AwsRegion("us-west-1", "US West (N. California)", "aws"), "North America", "N. California (us-west-1)"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Before:
<img width="266" alt="Screen Shot 2020-04-30 at 12 03 43 PM" src="https://user-images.githubusercontent.com/11964782/80749765-cffa9c00-8adb-11ea-89df-a5eab0fc3fff.png">
After:
<img width="294" alt="Screen Shot 2020-04-30 at 12 13 02 PM" src="https://user-images.githubusercontent.com/11964782/80749869-fd474a00-8adb-11ea-9938-6d146aa42b69.png">

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
