### PR TITLE
Upgrade gradle intellij plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ subprojects {
         }
 
         project.plugins.withId("org.jetbrains.intellij") {
-            systemProperty("log.dir", "${org.jetbrains.intellij.Utils.systemDir(project.intellij.sandboxDirectory, true)}/logs")
+            systemProperty("log.dir", "${project.intellij.sandboxDirectory}-test/logs")
         }
 
         mustRunAfter tasks.test

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ ideProfileName=2019.2
 kotlinVersion=1.3.70
 awsSdkVersion=2.11.9
 coroutinesVersion=1.3.3
-ideaPluginVersion=0.4.16
+ideaPluginVersion=0.4.20
 ktlintVersion=0.36.0
 jacksonVersion=2.9.8
 

--- a/intellijJVersions.gradle
+++ b/intellijJVersions.gradle
@@ -8,24 +8,22 @@ static def ideProfiles() {
                 "IC": [
                     sdkVersion: "IC-2019.2",
                     plugins: [
-                        "terminal",
-                        "yaml",
+                        "org.jetbrains.plugins.terminal",
+                        "org.jetbrains.plugins.yaml",
                         "PythonCore:2019.2.192.5728.98",
                         "java",
                         "gradle",
-                        "maven",
+                        "org.jetbrains.idea.maven",
                         "Docker:192.5728.74",
-                        "properties" // Used by Maven
                     ]
                 ],
                 "IU": [
                     sdkVersion: "IU-2019.2",
                     plugins: [
-                        "terminal",
-                        "yaml",
-                        "JavaScriptLanguage",
+                        "org.jetbrains.plugins.terminal",
+                        "org.jetbrains.plugins.yaml",
+                        "JavaScript",
                         "JavaScriptDebugger",
-                        "CSS",
                         "Pythonid:2019.2.192.5728.98"
                     ]
                 ],
@@ -34,7 +32,7 @@ static def ideProfiles() {
                     rdGenVersion: "0.192.36",
                     nugetVersion: "2019.2.0",
                     plugins: [
-                        "yaml"
+                        "org.jetbrains.plugins.yaml"
                     ]
                 ]
             ]
@@ -47,26 +45,23 @@ static def ideProfiles() {
                 "IC": [
                     sdkVersion: "IC-2019.3",
                     plugins: [
-                        "terminal",
-                        "yaml",
+                        "org.jetbrains.plugins.terminal",
+                        "org.jetbrains.plugins.yaml",
                         "PythonCore:193.5233.139",
                         "java",
-                        "gradle",
-                        "maven",
-                        "properties", // Used by Maven
+                        "com.intellij.gradle",
+                        "org.jetbrains.idea.maven",
                         "Docker:193.5233.140"
                     ]
                 ],
                 "IU": [
                     sdkVersion: "IU-2019.3",
                     plugins: [
-                        "terminal",
+                        "org.jetbrains.plugins.terminal",
                         "Pythonid:193.5233.109",
-                        "yaml",
-                        "stats-collector", // Transitive, used by JavaScriptLanguage
-                        "JavaScriptLanguage",
+                        "org.jetbrains.plugins.yaml",
+                        "JavaScript",
                         "JavaScriptDebugger",
-                        "CSS",
                     ]
                 ],
                 "RD": [
@@ -74,7 +69,7 @@ static def ideProfiles() {
                     rdGenVersion: "0.193.146",
                     nugetVersion: "2019.3.4",
                     plugins: [
-                        "yaml"
+                        "org.jetbrains.plugins.yaml"
                     ]
                 ]
             ]
@@ -86,29 +81,23 @@ static def ideProfiles() {
                 "IC": [
                     sdkVersion: "IC-2020.1",
                     plugins: [
-                        "terminal",
-                        "yaml",
+                        "org.jetbrains.plugins.terminal",
+                        "org.jetbrains.plugins.yaml",
                         "PythonCore:201.6668.31",
                         "java",
-                        "gradle",
-                        "repository-search", // Used by Maven
-                        "maven",
-                        "properties", // Used by Maven
+                        "com.intellij.gradle",
+                        "org.jetbrains.idea.maven",
                         "Docker:201.6668.30"
                     ]
                 ],
                 "IU": [
                     sdkVersion: "IU-2020.1",
                     plugins: [
-                        "terminal",
-                        "platform-images", // Used by a bunch of plugins
+                        "org.jetbrains.plugins.terminal",
                         "Pythonid:201.6668.31",
-                        "yaml",
-                        "stats-collector", // Transitive, used by JavaScriptLanguage
-                        "JavaScriptLanguage",
+                        "org.jetbrains.plugins.yaml",
+                        "JavaScript",
                         "JavaScriptDebugger",
-                        "CSS",
-                        "DatabaseTools"
                     ]
                 ],
                 "RD": [
@@ -116,7 +105,7 @@ static def ideProfiles() {
                     rdGenVersion: "0.201.69",
                     nugetVersion: "2020.1.0-eap05",
                     plugins: [
-                        "yaml"
+                        "org.jetbrains.plugins.yaml"
                     ]
                 ]
             ]

--- a/jetbrains-core/build.gradle
+++ b/jetbrains-core/build.gradle
@@ -44,7 +44,7 @@ sourceSets {
 }
 
 test {
-    systemProperty("log.dir", "${org.jetbrains.intellij.Utils.systemDir(project.intellij.sandboxDirectory, true)}/logs")
+    systemProperty("log.dir", "${project.intellij.sandboxDirectory}-test/logs")
 }
 
 task pluginChangeLog(type: GenerateChangeLog) {

--- a/jetbrains-rider/build.gradle
+++ b/jetbrains-rider/build.gradle
@@ -72,7 +72,7 @@ compileKotlin.dependsOn(generateModel)
 // TODO: Remove this FIX_WHEN_MIN_IS_193
 tasks.findByName("compileTestKotlin").onlyIf { resolveIdeProfileName() != "2019.2" /* Tests require 2019.3 or higher to build and run */ }
 test {
-    systemProperty("log.dir", "${org.jetbrains.intellij.Utils.systemDir(project.intellij.sandboxDirectory, true)}/logs")
+    systemProperty("log.dir", "${project.intellij.sandboxDirectory}-test/logs")
     useTestNG()
     environment("LOCAL_ENV_RUN", localEnv)
 }.onlyIf { resolveIdeProfileName() != "2019.2" /* Tests require 2019.3 or higher to build and run */ }

--- a/jetbrains-ultimate/build.gradle
+++ b/jetbrains-ultimate/build.gradle
@@ -20,7 +20,7 @@ intellij {
 }
 
 test {
-    systemProperty("log.dir", "${org.jetbrains.intellij.Utils.systemDir(project.intellij.sandboxDirectory, true)}/logs")
+    systemProperty("log.dir", "${project.intellij.sandboxDirectory}-test/logs")
 }
 
 runIde {


### PR DESCRIPTION
Changelog:
```
0.4.20

    fixed caching builtin plugins data
    add annotations-19.0.0 to compile classpath by default
    fix setting plugin name for Gradle 5.1..5.3 #481

0.4.19

    Use builtin JBR from alternativeIdePath IDE #358
    Enable dependencies for builtin plugins automatically #474
    Allow referring builtin plugins by their ids rather than directory name IDEA-233841
    Require 4.9 Gradle version, dropped deprecated stuff
    Do not add junit.jar into classpath, it may clash with junit-4.jar on certain JDKs

0.4.18

    Introduced runIdeForUiTests task #466
    Fix unpacking JBR with JCEF on Mac #468
    Publish plugin security update #472

0.4.17

    Fix platform prefix for DataGrip #458
    Enable plugin auto-reloading by default
    Upgrade plugins repository client
    Use new methods for Gradle 5.1 and higher #464
    Support JBR with JCEF #465
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
