### PR TITLE
Fix generate changelog not working on JDK 11

### DIFF
--- a/buildSrc/src/Tasks.kt
+++ b/buildSrc/src/Tasks.kt
@@ -185,7 +185,7 @@ open class GenerateChangeLog : ChangeLogTask() {
 
     @OutputFile
     @Optional
-    var githubChangeLogFile: File? = File(project.relativePath("CHANGELOG.md"))
+    var githubChangeLogFile: File? = File(project.projectDir, "CHANGELOG.md")
         get() = if (generateGithub) field else null
 
     @TaskAction


### PR DESCRIPTION
## Testing
```
➜  aws-intellij-toolkit git:(fixChangeLog) ✗ ./gradlew createRelease generateChangeLog

> Configure project :jetbrains-rider
Using rd-gen: 0.192.36
Not running in JetBrains' network

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.1.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2s
2 actionable tasks: 2 executed
➜  aws-intellij-toolkit git:(fixChangeLog) ✗ git status
On branch fixChangeLog
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	new file:   .changes/1.15-SNAPSHOT.json
	deleted:    .changes/next-release/feature-9e1965ca-033a-4f00-b51d-7d7b0321535d.json
	modified:   CHANGELOG.md

```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
