### PR TITLE
Update needed Java version to 11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ reported the issue. Please try to include as much information as you can. Detail
 
 ### Requirements
 
-* [Java 8](https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html)
+* [Java 11](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html)
 * [Git](https://git-scm.com/)
 * Dotnet Framework (Windows) or Mono (Linux, macOS)
   * macOS steps:


### PR DESCRIPTION
With the recent Gradle update, the Java 8 compiler now throws a NPE. Java 11 is now required to build the toolkit.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
