### PR TITLE
Fixing flaky SAM test

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTest.kt
@@ -27,9 +27,12 @@ class SamCommonTest {
     @JvmField
     val projectRule = HeavyJavaCodeInsightTestFixtureRule()
 
+    private val executableManager = ExecutableManager.getInstance()
+
     @Test
     fun getVersion_badPath() {
-        ExecutableManager.getInstance().setExecutablePath(SamExecutable(), Paths.get("/bad/path/that/will/not/work")).toCompletableFuture()
+        executableManager.removeExecutable(SamExecutable())
+        executableManager.setExecutablePath(SamExecutable(), Paths.get("/bad/path/that/will/not/work")).toCompletableFuture()
             .get(1, TimeUnit.SECONDS)
         val actualVersion = SamCommon.getVersionString()
         assertThat(actualVersion).isEqualTo("UNKNOWN")
@@ -38,7 +41,8 @@ class SamCommonTest {
     @Test
     fun getVersion_Valid_exitNonZero() {
         val samPath = makeATestSam("stderr", exitCode = 100)
-        ExecutableManager.getInstance().setExecutablePath(SamExecutable(), samPath).toCompletableFuture().get(1, TimeUnit.SECONDS)
+        executableManager.removeExecutable(SamExecutable())
+        executableManager.setExecutablePath(SamExecutable(), samPath).toCompletableFuture().get(1, TimeUnit.SECONDS)
         val actualVersion = SamCommon.getVersionString()
         assertThat(actualVersion).isEqualTo("UNKNOWN")
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
SamCommonTest often failed if the ExecutableManagerTest had run first - the state needs to be cleared from ExecutableManager starting.
