### PR TITLE
Clean up telemetry service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ allprojects {
     }
 
     tasks.withType(org.jetbrains.intellij.tasks.RunIdeTask) {
-        systemProperty("aws.toolkits.enableTelemetry", false)
         intellij {
             if (System.env.ALTERNATIVE_IDE) {
                 if(file(System.env.ALTERNATIVE_IDE).exists()) {

--- a/core/src/software/aws/toolkits/core/telemetry/TelemetryBatcher.kt
+++ b/core/src/software/aws/toolkits/core/telemetry/TelemetryBatcher.kt
@@ -15,11 +15,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 interface TelemetryBatcher {
-    fun enqueue(event: MetricEvent) {
-        enqueue(listOf(event))
-    }
-
-    fun enqueue(events: Collection<MetricEvent>)
+    fun enqueue(event: MetricEvent)
 
     fun flush(retry: Boolean)
 
@@ -66,13 +62,13 @@ class DefaultTelemetryBatcher(
         flush(false)
     }
 
-    override fun enqueue(events: Collection<MetricEvent>) {
+    override fun enqueue(event: MetricEvent) {
         if (!isTelemetryEnabled.get()) {
             return
         }
 
         try {
-            eventQueue.addAll(events)
+            eventQueue.add(event)
         } catch (e: Exception) {
             LOG.warn(e) { "Failed to add metric to queue" }
         }

--- a/core/src/software/aws/toolkits/core/telemetry/TelemetryBatcher.kt
+++ b/core/src/software/aws/toolkits/core/telemetry/TelemetryBatcher.kt
@@ -119,7 +119,7 @@ class DefaultTelemetryBatcher(
     }
 
     companion object {
-        private val LOG = getLogger<TelemetryBatcher>()
+        private val LOG = getLogger<DefaultTelemetryBatcher>()
         private const val DEFAULT_MAX_BATCH_SIZE = 20
         private const val DEFAULT_MAX_QUEUE_SIZE = 10000
         private const val DEFAULT_PUBLISH_INTERVAL = 5L

--- a/core/tst/software/aws/toolkits/core/telemetry/TelemetryBatcherTest.kt
+++ b/core/tst/software/aws/toolkits/core/telemetry/TelemetryBatcherTest.kt
@@ -119,7 +119,7 @@ class TelemetryBatcherTest {
     }
 
     @Test
-    fun testNotSendingTelemetry() {
+    fun testNotSendingWhileDisabled() {
         batcher.onTelemetryEnabledChanged(false)
 
         batcher.enqueue(createEmptyMetricEvent())

--- a/core/tst/software/aws/toolkits/core/telemetry/TelemetryBatcherTest.kt
+++ b/core/tst/software/aws/toolkits/core/telemetry/TelemetryBatcherTest.kt
@@ -54,11 +54,9 @@ class TelemetryBatcherTest {
         val publishCaptor = argumentCaptor<Collection<MetricEvent>>()
 
         val totalEvents = MAX_BATCH_SIZE + 1
-        val events = ArrayList<MetricEvent>()
         repeat(totalEvents) {
-            events.add(createEmptyMetricEvent())
+            batcher.enqueue(createEmptyMetricEvent())
         }
-        batcher.enqueue(events)
         batcher.flush(false)
 
         verifyBlocking(publisher, times(2)) { publish(publishCaptor.capture()) }

--- a/core/tst/software/aws/toolkits/core/telemetry/TelemetryBatcherTest.kt
+++ b/core/tst/software/aws/toolkits/core/telemetry/TelemetryBatcherTest.kt
@@ -10,7 +10,9 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.stub
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verifyBlocking
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyCollection
 import org.mockito.stubbing.Answer
@@ -18,16 +20,12 @@ import software.amazon.awssdk.core.exception.SdkServiceException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-class TestTelemetryBatcher(publisher: TelemetryPublisher, maxBatchSize: Int, maxQueueSize: Int) :
-    DefaultTelemetryBatcher(publisher, maxBatchSize, maxQueueSize) {
-    fun eventQueue() = eventQueue
-}
-
 class TelemetryBatcherTest {
     private var publisher: TelemetryPublisher = mock()
-    private var batcher: TestTelemetryBatcher = TestTelemetryBatcher(publisher, MAX_BATCH_SIZE, MAX_QUEUE_SIZE)
+    private var batcher = DefaultTelemetryBatcher(publisher, MAX_BATCH_SIZE, MAX_QUEUE_SIZE)
 
-    init {
+    @Before
+    fun setUp() {
         batcher.onTelemetryEnabledChanged(true)
     }
 
@@ -85,7 +83,7 @@ class TelemetryBatcherTest {
         verifyBlocking(publisher, times(1)) { publish(publishCaptor.capture()) }
 
         assertThat(publishCaptor.allValues).hasSize(1)
-        assertThat(batcher.eventQueue()).hasSize(1)
+        assertThat(batcher.eventQueue).hasSize(1)
     }
 
     @Test
@@ -95,7 +93,7 @@ class TelemetryBatcherTest {
         publisher.stub {
             onBlocking { publisher.publish(anyCollection()) }
                 .doThrow(SdkServiceException.builder().statusCode(400).build())
-                .doAnswer(Answer<Unit> {})
+                .doAnswer(Answer {})
         }
 
         batcher.enqueue(createEmptyMetricEvent())
@@ -104,7 +102,7 @@ class TelemetryBatcherTest {
         verifyBlocking(publisher, times(1)) { publish(publishCaptor.capture()) }
 
         assertThat(publishCaptor.allValues).hasSize(1)
-        assertThat(batcher.eventQueue()).hasSize(0)
+        assertThat(batcher.eventQueue).hasSize(0)
     }
 
     @Test
@@ -120,6 +118,32 @@ class TelemetryBatcherTest {
 
         assertThat(publishCaptor.allValues).hasSize(1)
         assertThat(publishCaptor.firstValue.toList()).hasSize(1)
+    }
+
+    @Test
+    fun testNotSendingTelemetry() {
+        batcher.onTelemetryEnabledChanged(false)
+
+        batcher.enqueue(createEmptyMetricEvent())
+        batcher.flush(false)
+
+        verifyZeroInteractions(publisher)
+
+        assertThat(batcher.eventQueue).isEmpty()
+    }
+
+    @Test
+    fun verifyOptOut() {
+        batcher.enqueue(createEmptyMetricEvent())
+        assertThat(batcher.eventQueue).isNotEmpty
+
+        batcher.onTelemetryEnabledChanged(false)
+
+        batcher.flush(false)
+
+        verifyZeroInteractions(publisher)
+
+        assertThat(batcher.eventQueue).isEmpty()
     }
 
     private fun createEmptyMetricEvent(): MetricEvent = DefaultMetricEvent.builder().build()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
@@ -276,3 +276,9 @@ fun Project.activeCredentialProvider(): ToolkitCredentialsProvider = ProjectAcco
  * underlying AWS account.
  */
 fun Project.activeAwsAccount(): String? = tryOrNull { AwsResourceCache.getInstance(this).getResourceNow(StsResources.ACCOUNT) }
+
+/**
+ * The underlying AWS account for current active credential provider of the project if known. Return null if credential provider is not set or we have
+ * not cached it.
+ */
+fun Project.activeAwsAccountIfKnown(): String? = tryOrNull { AwsResourceCache.getInstance(this).getResourceIfPresent(StsResources.ACCOUNT) }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
@@ -60,20 +60,6 @@ abstract class TelemetryService(private val publisher: TelemetryPublisher, priva
         return metricEvent
     }
 
-    fun record(metricEventMetadata: MetricEventMetadata, buildEvent: MetricEvent.Builder.() -> Unit): MetricEvent {
-        val builder = DefaultMetricEvent.builder()
-        builder.awsAccount(metricEventMetadata.awsAccount)
-        builder.awsRegion(metricEventMetadata.awsRegion)
-
-        buildEvent(builder)
-
-        val event = builder.build()
-
-        batcher.enqueue(event)
-
-        return event
-    }
-
     @Synchronized
     fun setTelemetryEnabled(isEnabled: Boolean) {
         batcher.onTelemetryEnabledChanged(isEnabled and TELEMETRY_ENABLED)
@@ -95,6 +81,20 @@ abstract class TelemetryService(private val publisher: TelemetryPublisher, priva
         }
 
         batcher.shutdown()
+    }
+
+    fun record(metricEventMetadata: MetricEventMetadata, buildEvent: MetricEvent.Builder.() -> Unit): MetricEvent {
+        val builder = DefaultMetricEvent.builder()
+        builder.awsAccount(metricEventMetadata.awsAccount)
+        builder.awsRegion(metricEventMetadata.awsRegion)
+
+        buildEvent(builder)
+
+        val event = builder.build()
+
+        batcher.enqueue(event)
+
+        return event
     }
 
     suspend fun sendFeedback(sentiment: Sentiment, comment: String) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettings.kt
@@ -7,8 +7,9 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import java.util.prefs.Preferences
+import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import java.util.UUID
+import java.util.prefs.Preferences
 
 interface AwsSettings {
     var isTelemetryEnabled: Boolean
@@ -36,6 +37,7 @@ class DefaultAwsSettings : PersistentStateComponent<AwsConfiguration>, AwsSettin
         get() = state.isTelemetryEnabled ?: true
         set(value) {
             state.isTelemetryEnabled = value
+            TelemetryService.getInstance().setTelemetryEnabled(value)
         }
 
     override var promptedForTelemetry: Boolean

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettingsConfigurable.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettingsConfigurable.java
@@ -34,8 +34,6 @@ import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance;
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager;
 import software.aws.toolkits.jetbrains.core.executables.ExecutableType;
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable;
-import software.aws.toolkits.jetbrains.services.telemetry.TelemetryEnabledChangedNotifier;
-import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService;
 
 public class AwsSettingsConfigurable implements SearchableConfigurable {
     private static final String CLOUDDEBUG = "clouddebug";
@@ -56,16 +54,12 @@ public class AwsSettingsConfigurable implements SearchableConfigurable {
     private JPanel remoteDebugSettings;
     private JPanel applicationLevelSettings;
 
-    private final TelemetryEnabledChangedNotifier publisher;
-
     public AwsSettingsConfigurable(Project project) {
         this.project = project;
 
         applicationLevelSettings.setBorder(IdeBorderFactory.createTitledBorder(message("aws.settings.global_label")));
         serverlessSettings.setBorder(IdeBorderFactory.createTitledBorder(message("aws.settings.serverless_label")));
         remoteDebugSettings.setBorder(IdeBorderFactory.createTitledBorder(message("aws.settings.remote_debug_label")));
-
-        publisher = TelemetryService.syncPublisher();
 
         SwingHelper.setPreferredWidth(samExecutablePath, this.panel.getWidth());
         SwingHelper.setPreferredWidth(cloudDebugExecutablePath, this.panel.getWidth());
@@ -261,15 +255,7 @@ public class AwsSettingsConfigurable implements SearchableConfigurable {
 
     private void saveTelemetrySettings() {
         AwsSettings awsSettings = AwsSettings.getInstance();
-        boolean oldSetting = awsSettings.isTelemetryEnabled();
-        try {
-            awsSettings.setTelemetryEnabled(enableTelemetry.isSelected());
-        } finally {
-            boolean newSetting = awsSettings.isTelemetryEnabled();
-            if (newSetting != oldSetting) {
-                publisher.notify(newSetting);
-            }
-        }
+        awsSettings.setTelemetryEnabled(enableTelemetry.isSelected());
     }
 
     private void saveLambdaSettings() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/MockTelemetryService.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/MockTelemetryService.kt
@@ -4,19 +4,14 @@
 package software.aws.toolkits.jetbrains.services.telemetry
 
 import software.amazon.awssdk.services.toolkittelemetry.model.Sentiment
-import software.aws.toolkits.core.telemetry.DefaultMetricEvent
+import software.aws.toolkits.core.telemetry.DefaultTelemetryBatcher
 import software.aws.toolkits.core.telemetry.MetricEvent
+import software.aws.toolkits.core.telemetry.TelemetryPublisher
 
-class MockTelemetryService : TelemetryService {
-    override fun record(metricEventMetadata: TelemetryService.MetricEventMetadata, buildEvent: MetricEvent.Builder.() -> Unit): MetricEvent {
-        val builder = DefaultMetricEvent.builder()
-        buildEvent(builder)
-        builder.awsAccount(metricEventMetadata.awsAccount)
-        builder.awsRegion(metricEventMetadata.awsRegion)
-        return builder.build()
-    }
+class MockTelemetryService() : TelemetryService(NoOpPublisher(), DefaultTelemetryBatcher(NoOpPublisher()))
+
+class NoOpPublisher() : TelemetryPublisher {
+    override suspend fun publish(metricEvents: Collection<MetricEvent>) {}
 
     override suspend fun sendFeedback(sentiment: Sentiment, comment: String) {}
-
-    override fun dispose() {}
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
@@ -110,7 +110,7 @@ class TelemetryServiceTest {
 
         telemetryService.record(projectRule.project) {
             datum("Foo")
-        }.join()
+        }
         telemetryService.dispose()
 
         verify(batcher, times(3)).enqueue(eventCaptor.capture())
@@ -141,7 +141,7 @@ class TelemetryServiceTest {
 
         telemetryService.record(projectRule.project) {
             datum("Foo")
-        }.join()
+        }
         telemetryService.dispose()
 
         verify(batcher, times(3)).enqueue(eventCaptor.capture())
@@ -181,8 +181,8 @@ class TelemetryServiceTest {
     }
 
     private fun assertMetricEventsContains(events: Collection<MetricEvent>, event: String, awsAccount: String, awsRegion: String) {
-        val metricEvent = events.find {
-            it.data.find { it.name == event } != null && it.awsAccount == awsAccount && it.awsRegion == awsRegion
+        val metricEvent = events.find { e ->
+            e.data.find { it.name == event } != null && e.awsAccount == awsAccount && e.awsRegion == awsRegion
         }
 
         assertThat(metricEvent).isNotNull

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
@@ -18,24 +18,18 @@ import org.junit.Test
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.telemetry.DefaultMetricEvent.Companion.METADATA_NA
 import software.aws.toolkits.core.telemetry.DefaultMetricEvent.Companion.METADATA_NOT_SET
-import software.aws.toolkits.core.telemetry.DefaultTelemetryBatcher
 import software.aws.toolkits.core.telemetry.MetricEvent
+import software.aws.toolkits.core.telemetry.TelemetryBatcher
 import software.aws.toolkits.jetbrains.core.MockResourceCache
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
 import software.aws.toolkits.jetbrains.core.credentials.MockProjectAccountSettingsManager
 import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
-import software.aws.toolkits.jetbrains.settings.MockAwsSettings
-import java.util.UUID
+import software.aws.toolkits.jetbrains.settings.AwsSettings
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class TelemetryServiceTest {
-    private val batcher = mock<DefaultTelemetryBatcher> {
-        on { enqueue(any<MetricEvent>()) }.then {
-            mock.enqueue(listOf(it.getArgument<MetricEvent>(0)))
-            null
-        }
-    }
+    private class TestTelemetryService(batcher: TelemetryBatcher) : TelemetryService(NoOpPublisher(), batcher)
 
     @Rule
     @JvmField
@@ -43,15 +37,22 @@ class TelemetryServiceTest {
 
     @After
     fun tearDown() {
+        AwsSettings.getInstance().isTelemetryEnabled = false
+
         MockProjectAccountSettingsManager.getInstance(projectRule.project).reset()
         MockCredentialsManager.getInstance().reset()
         MockRegionProvider.getInstance().reset()
     }
 
     @Test
-    fun testInitialChangeEvent() {
+    fun testInitialTelemetrySetting() {
+        AwsSettings.getInstance().isTelemetryEnabled = true
+
         val changeCountDown = CountDownLatch(1)
         val changeCaptor = argumentCaptor<Boolean>()
+
+        val batcher = createMockBatcher()
+
         batcher.stub {
             on(batcher.onTelemetryEnabledChanged(changeCaptor.capture()))
                 .doAnswer {
@@ -59,11 +60,7 @@ class TelemetryServiceTest {
                 }
         }
 
-        DefaultTelemetryService(
-            MockAwsSettings(true, true, UUID.randomUUID())
-        ).also {
-            it.batcher = batcher
-        }
+        TestTelemetryService(batcher)
 
         changeCountDown.await(5, TimeUnit.SECONDS)
         verify(batcher).onTelemetryEnabledChanged(true)
@@ -73,8 +70,13 @@ class TelemetryServiceTest {
 
     @Test
     fun testTriggeredChangeEvent() {
-        val changeCountDown = CountDownLatch(2)
+        AwsSettings.getInstance().isTelemetryEnabled = true
+
+        val changeCountDown = CountDownLatch(3)
         val changeCaptor = argumentCaptor<Boolean>()
+
+        val batcher = createMockBatcher()
+
         batcher.stub {
             on(batcher.onTelemetryEnabledChanged(changeCaptor.capture()))
                 .doAnswer {
@@ -82,20 +84,18 @@ class TelemetryServiceTest {
                 }
         }
 
-        DefaultTelemetryService(
-            MockAwsSettings(true, true, UUID.randomUUID())
-        ).also {
-            it.batcher = batcher
-        }
+        val telemetryService = TestTelemetryService(batcher)
 
-        TelemetryService.syncPublisher().notify(false)
+        telemetryService.setTelemetryEnabled(false)
+        telemetryService.setTelemetryEnabled(true)
 
         changeCountDown.await(5, TimeUnit.SECONDS)
-        verify(batcher).onTelemetryEnabledChanged(true)
+        verify(batcher, times(2)).onTelemetryEnabledChanged(true)
         verify(batcher).onTelemetryEnabledChanged(false)
-        assertThat(changeCaptor.allValues).hasSize(2)
+        assertThat(changeCaptor.allValues).hasSize(3)
         assertThat(changeCaptor.firstValue).isEqualTo(true)
         assertThat(changeCaptor.secondValue).isEqualTo(false)
+        assertThat(changeCaptor.thirdValue).isEqualTo(true)
     }
 
     @Test
@@ -105,11 +105,9 @@ class TelemetryServiceTest {
         accountSettings.changeCredentialProvider(null)
 
         val eventCaptor = argumentCaptor<Collection<MetricEvent>>()
-        val telemetryService = DefaultTelemetryService(
-            MockAwsSettings(true, true, UUID.randomUUID())
-        ).also {
-            it.batcher = batcher
-        }
+
+        val batcher = createMockBatcher()
+        val telemetryService = TestTelemetryService(batcher)
 
         telemetryService.record(projectRule.project) {
             datum("Foo")
@@ -139,11 +137,8 @@ class TelemetryServiceTest {
         MockResourceCache.getInstance(projectRule.project).addValidAwsCredential("foo-region", "profile:admin", "111111111111")
 
         val eventCaptor = argumentCaptor<Collection<MetricEvent>>()
-        val telemetryService = DefaultTelemetryService(
-            MockAwsSettings(true, true, UUID.randomUUID())
-        ).also {
-            it.batcher = batcher
-        }
+        val batcher = createMockBatcher()
+        val telemetryService = TestTelemetryService(batcher)
 
         telemetryService.record(projectRule.project) {
             datum("Foo")
@@ -168,11 +163,9 @@ class TelemetryServiceTest {
         accountSettings.changeRegion(mockRegion)
 
         val eventCaptor = argumentCaptor<Collection<MetricEvent>>()
-        val telemetryService = DefaultTelemetryService(
-            MockAwsSettings(true, true, UUID.randomUUID())
-        ).also {
-            it.batcher = batcher
-        }
+
+        val batcher = createMockBatcher()
+        val telemetryService = TestTelemetryService(batcher)
 
         telemetryService.record(
             TelemetryService.MetricEventMetadata(
@@ -186,6 +179,13 @@ class TelemetryServiceTest {
 
         verify(batcher, times(3)).enqueue(eventCaptor.capture())
         assertMetricEventsContains(eventCaptor.allValues.flatten(), "Foo", "222222222222", "bar-region")
+    }
+
+    private fun createMockBatcher() = mock<TelemetryBatcher> {
+        on { enqueue(any<MetricEvent>()) }.then {
+            mock.enqueue(listOf(it.getArgument<MetricEvent>(0)))
+            null
+        }
     }
 
     private fun assertMetricEventsContains(events: Collection<MetricEvent>, event: String, awsAccount: String, awsRegion: String) {

--- a/jetbrains-rider/build.gradle
+++ b/jetbrains-rider/build.gradle
@@ -80,10 +80,6 @@ tasks.integrationTest {
     environment("LOCAL_ENV_RUN", localEnv)
 }
 
-runIde {
-    systemProperty("aws.toolkits.enableTelemetry", false)
-}
-
 jar {
     archiveBaseName.set('aws-intellij-toolkit-rider')
 }

--- a/jetbrains-ultimate/build.gradle
+++ b/jetbrains-ultimate/build.gradle
@@ -23,10 +23,6 @@ test {
     systemProperty("log.dir", "${project.intellij.sandboxDirectory}-test/logs")
 }
 
-runIde {
-    systemProperty("aws.toolkits.enableTelemetry", false)
-}
-
 jar {
     archiveBaseName = 'aws-intellij-toolkit-ultimate'
 }


### PR DESCRIPTION
* Remove the notification topic on changes
* Remove uneeded batcher interface and test impl
* Move disabling telemetry out of the UI code and into the state component
* Move disabling telemetry override to a single spot
* Cleanup how we disable telemetry and no longer flips out the batchers, which was confusing

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
