### PR TITLE
default region handling

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
@@ -118,7 +118,7 @@ abstract class ProjectAccountSettingsManager(private val project: Project) : Sim
 
             identifier.defaultRegionId?.let { regionProvider[it] }?.let { credentialRegion ->
                 selectedRegion.let {
-                    if (it == null || it.partitionId != credentialRegion.partitionId) {
+                    if (it?.partitionId != credentialRegion.partitionId) {
                         selectedRegion = credentialRegion
                     }
                 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
@@ -115,6 +115,14 @@ abstract class ProjectAccountSettingsManager(private val project: Project) : Sim
             recentlyUsedProfiles.add(identifier.id)
 
             selectedCredentialIdentifier = identifier
+
+            identifier.defaultRegionId?.let { regionProvider[it] }?.let { credentialRegion ->
+                selectedRegion.let {
+                    if (it == null || it.partitionId != credentialRegion.partitionId) {
+                        selectedRegion = credentialRegion
+                    }
+                }
+            }
         }
     }
 
@@ -127,16 +135,6 @@ abstract class ProjectAccountSettingsManager(private val project: Project) : Sim
 
             selectedRegion = region
             selectedPartition = regionProvider.partitions()[region.partitionId]
-        }
-    }
-
-    /**
-     * Changes the partition and then validates them. Notifies listeners of results
-     */
-    fun changePartition(partition: AwsPartition) {
-        changeFieldsAndNotify {
-            selectedRegion = null
-            selectedPartition = partition
         }
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ChangeAccountSettingsActionGroupTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ChangeAccountSettingsActionGroupTest.kt
@@ -8,7 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.region.anAwsRegion
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProvider.RegionProviderRule
 
 class ChangeAccountSettingsActionGroupTest {
 
@@ -18,7 +18,7 @@ class ChangeAccountSettingsActionGroupTest {
 
     @Rule
     @JvmField
-    val regionProviderRule = MockRegionProvider.RegionProviderRule(projectRule)
+    val regionProviderRule = RegionProviderRule()
 
     @Rule
     @JvmField

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
@@ -15,11 +15,13 @@ import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.credentials.ToolkitCredentialsIdentifier
 import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.core.region.anAwsRegion
 import software.aws.toolkits.core.rules.EnvironmentVariableHelper
 import software.aws.toolkits.core.utils.test.notNull
 import software.aws.toolkits.jetbrains.core.MockResourceCache
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProvider.RegionProviderRule
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.toElement
 import java.nio.file.Files
@@ -33,11 +35,13 @@ class DefaultProjectAccountSettingsManagerTest {
     @JvmField
     val environmentVariableHelper = EnvironmentVariableHelper()
 
-    private lateinit var mockRegionManager: MockRegionProvider
+    @Rule
+    @JvmField
+    val regionProviderRule = RegionProviderRule()
+
     private lateinit var mockCredentialManager: MockCredentialsManager
     private lateinit var manager: DefaultProjectAccountSettingsManager
     private lateinit var mockResourceCache: MockResourceCache
-    private lateinit var queue: MutableList<Any>
 
     @Before
     fun setUp() {
@@ -47,9 +51,6 @@ class DefaultProjectAccountSettingsManagerTest {
         System.getProperties().remove("aws.region")
         environmentVariableHelper.remove("AWS_REGION")
 
-        queue = mutableListOf()
-
-        mockRegionManager = MockRegionProvider.getInstance()
         mockCredentialManager = MockCredentialsManager.getInstance()
         manager = DefaultProjectAccountSettingsManager(projectRule.project)
         mockResourceCache = MockResourceCache.getInstance(projectRule.project)
@@ -57,19 +58,18 @@ class DefaultProjectAccountSettingsManagerTest {
 
     @After
     fun tearDown() {
-        mockRegionManager.reset()
         mockCredentialManager.reset()
         mockResourceCache.clear()
     }
 
     @Test
-    fun testNoActiveCredentials() {
+    fun `Starts with no active credentials`() {
         assertThat(manager.isValidConnectionSettings()).isFalse()
         assertThat(manager.recentlyUsedCredentials()).isEmpty()
     }
 
     @Test
-    fun testNoActiveCredentialsSelectsDefaultProfileIfPresent() {
+    fun `On load, automatically selects default profile if present and no other active credentials`() {
         val credentials = mockCredentialManager.addCredentials("profile:default")
         markConnectionSettingsAsValid(credentials, AwsRegionProvider.getInstance().defaultRegion())
 
@@ -82,7 +82,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun noActiveRegionUsesDefaultCredentialRegion() {
+    fun `On load, default region of credential is used if there is no other active region`() {
         val element = """
             <AccountState>
                 <option name="activeProfile" value="Mock" />
@@ -105,7 +105,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testMakingCredentialActive() {
+    fun `Activated credential are validated and added to the recently used list`() {
         changeRegion(AwsRegionProvider.getInstance().defaultRegion())
 
         assertThat(manager.recentlyUsedCredentials()).isEmpty()
@@ -133,7 +133,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testMakingRegionActive() {
+    fun `Activated regions are validated and added to the recently used list`() {
         val mockRegionProvider = MockRegionProvider.getInstance()
         val mockRegion1 = mockRegionProvider.addRegion(AwsRegion("MockRegion-1", "MockRegion-1", "aws"))
         val mockRegion2 = mockRegionProvider.addRegion(AwsRegion("MockRegion-2", "MockRegion-2", "aws"))
@@ -153,7 +153,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testMakingRegionActiveFiresNotification() {
+    fun `Activating a region fires a state change notification`() {
         val project = projectRule.project
 
         var gotNotification = false
@@ -171,7 +171,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testMakingCredentialsActiveFiresNotification() {
+    fun `Activating a credential fires a state change notification`() {
         val project = projectRule.project
 
         var gotNotification = false
@@ -191,7 +191,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testSavingActiveRegion() {
+    fun `Active region is persisted`() {
         manager.changeRegion(AwsRegion.GLOBAL)
         val element = Element("AccountState")
         serializeStateInto(manager, element)
@@ -210,7 +210,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testSavingActiveCredential() {
+    fun `Active credential is persisted`() {
         mockResourceCache.addValidAwsCredential(manager.activeRegion.id, "Mock", "222222222222")
         changeCredentialProvider(mockCredentialManager.addCredentials("Mock"))
         val element = Element("AccountState")
@@ -230,7 +230,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testLoadingActiveCredential() {
+    fun `Active credential can be restored from persistence`() {
         val element = """
             <AccountState>
                 <option name="activeProfile" value="Mock" />
@@ -254,7 +254,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testLoadingActiveRegion() {
+    fun `Active region can be restored from persistence`() {
         val element = """
             <AccountState>
                 <option name="activeRegion" value="${MockRegionProvider.getInstance().defaultRegion().id}" />
@@ -270,14 +270,14 @@ class DefaultProjectAccountSettingsManagerTest {
 
         manager.waitUntilConnectionStateIsStable()
 
-        val region = mockRegionManager[MockRegionProvider.getInstance().defaultRegion().id]
+        val region = regionProviderRule.regionProvider[MockRegionProvider.getInstance().defaultRegion().id]
         assertThat(manager.selectedRegion).isEqualTo(region)
         assertThat(manager.selectedPartition?.id).isEqualTo(region?.partitionId)
         assertThat(manager.recentlyUsedRegions()).element(0).isEqualTo(region)
     }
 
     @Test
-    fun testLoadingRegionThatNoLongerExistsReturnsNull() {
+    fun `Attempting to restore a region that no longer exists is handled gracefully`() {
         val element = """
             <AccountState>
                 <option name="activeRegion" value="DoesNotExist" />
@@ -297,7 +297,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testLoadingCredentialThatNoLongerExistsReturnsNull() {
+    fun `Attempting to restore a credential that no longer exists is handled gracefully`() {
         val element = """
             <AccountState>
                 <option name="activeProfile" value="DoesNotExist" />
@@ -319,7 +319,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testLoadingInvalidActiveCredentialNotSelected() {
+    fun `Credentials are validated when restored from persistence`() {
         val mockCredentials = mockCredentialManager.addCredentials("Mock")
 
         markConnectionSettingsAsInvalid(mockCredentials, MockRegionProvider.getInstance().defaultRegion())
@@ -343,7 +343,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testLoadingDefaultProfileIfNoPrevious() {
+    fun `On load, default credential is selected if no other credential is active`() {
         val credentials = mockCredentialManager.addCredentials("profile:default")
         markConnectionSettingsAsValid(credentials, MockRegionProvider.getInstance().defaultRegion())
 
@@ -363,7 +363,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun testRemovingActiveProfileFallsBackToNothing() {
+    fun `Removal of the active credential falls back to "no credential selected" state`() {
         val defaultCredentials = mockCredentialManager.addCredentials("profile:default")
         val adminCredentials = mockCredentialManager.addCredentials("profile:admin")
 
@@ -385,7 +385,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun canRefreshTheStateWhichTriggersRevalidation() {
+    fun `Refreshing state triggers connection to be re-validated`() {
         val defaultCredentials = mockCredentialManager.addCredentials("profile:default")
 
         markConnectionSettingsAsInvalid(defaultCredentials, AwsRegionProvider.getInstance().defaultRegion())
@@ -403,7 +403,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun connectionStateRefreshedAutomaticallyIfInvalidProfileUpdated() {
+    fun `A change to the selected credential triggers a refresh if the current state is invalid`() {
         val defaultCredentials = mockCredentialManager.addCredentials("profile:default")
 
         markConnectionSettingsAsInvalid(defaultCredentials, AwsRegionProvider.getInstance().defaultRegion())
@@ -418,6 +418,41 @@ class DefaultProjectAccountSettingsManagerTest {
         manager.waitUntilConnectionStateIsStable()
 
         assertThat(manager.isValidConnectionSettings()).isTrue()
+    }
+
+    @Test
+    fun `If region is null and credential has a default region, use it`() {
+        val defaultRegionForCredentials = anAwsRegion().also { regionProviderRule.regionProvider.addRegion(it) }
+        val credentials = mockCredentialManager.addCredentials("profile:whatever", regionId = defaultRegionForCredentials.id)
+
+        manager.selectedRegion = null
+        markConnectionSettingsAsValid(credentials, defaultRegionForCredentials)
+
+        manager.changeCredentialProvider(credentials)
+        manager.waitUntilConnectionStateIsStable()
+
+        assertThat(manager.connectionState).isInstanceOfSatisfying(ConnectionState.ValidConnection::class.java) {
+            assertThat(it.credentials.id).isEqualTo(credentials.id)
+            assertThat(it.region.id).isEqualTo(defaultRegionForCredentials.id)
+        }
+    }
+
+    @Test
+    fun `Credential with a default region that's different from the currently select partition, uses the credentials region`() {
+        val defaultRegionForCredentials = anAwsRegion().also { regionProviderRule.regionProvider.addRegion(it) }
+        val credentials = mockCredentialManager.addCredentials("profile:whatever", regionId = defaultRegionForCredentials.id)
+
+        manager.selectedRegion = anAwsRegion()
+
+        markConnectionSettingsAsValid(credentials, defaultRegionForCredentials)
+
+        manager.changeCredentialProvider(credentials)
+        manager.waitUntilConnectionStateIsStable()
+
+        assertThat(manager.connectionState).isInstanceOfSatisfying(ConnectionState.ValidConnection::class.java) {
+            assertThat(it.credentials.id).isEqualTo(credentials.id)
+            assertThat(it.region.id).isEqualTo(defaultRegionForCredentials.id)
+        }
     }
 
     private fun markConnectionSettingsAsValid(credentialsIdentifier: ToolkitCredentialsIdentifier, region: AwsRegion) {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultProjectAccountSettingsManagerTest.kt
@@ -363,7 +363,7 @@ class DefaultProjectAccountSettingsManagerTest {
     }
 
     @Test
-    fun `Removal of the active credential falls back to "no credential selected" state`() {
+    fun `Removal of the active credential falls back to 'no credential selected' state`() {
         val defaultCredentials = mockCredentialManager.addCredentials("profile:default")
         val adminCredentials = mockCredentialManager.addCredentials("profile:admin")
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockProjectAccountSettingsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockProjectAccountSettingsManager.kt
@@ -46,6 +46,11 @@ class MockProjectAccountSettingsManager(project: Project) : ProjectAccountSettin
         waitUntilConnectionStateIsStable()
     }
 
+    fun nullifyRegionAndWait() {
+        changeConnectionSettings(selectedCredentialIdentifier, null, null)
+        waitUntilConnectionStateIsStable()
+    }
+
     fun setConnectionState(state: ConnectionState) {
         connectionState = state
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -4,12 +4,15 @@
 package software.aws.toolkits.jetbrains.core.region
 
 import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.project.Project
 import com.intellij.testFramework.ProjectRule
 import org.junit.rules.ExternalResource
 import software.aws.toolkits.core.region.AwsPartition
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.region.Service
 import software.aws.toolkits.core.region.ToolkitRegionProvider
+import software.aws.toolkits.jetbrains.utils.rules.ClearableLazy
+import software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule
 
 class MockRegionProvider : ToolkitRegionProvider() {
     private val overrideRegions: MutableMap<String, AwsRegion> = mutableMapOf()
@@ -57,15 +60,8 @@ class MockRegionProvider : ToolkitRegionProvider() {
         fun getInstance(): MockRegionProvider = ServiceManager.getService(ToolkitRegionProvider::class.java) as MockRegionProvider
     }
 
-    class RegionProviderRule(projectRule: ProjectRule) : ExternalResource() {
-        val regionProvider by lazy {
-            projectRule.project // For ServiceManager to be wired
-            getInstance()
-        }
-
-        override fun before() {
-            regionProvider.reset()
-        }
+    class RegionProviderRule : ExternalResource() {
+        val regionProvider by lazy { getInstance() }
 
         override fun after() {
             regionProvider.reset()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -4,15 +4,11 @@
 package software.aws.toolkits.jetbrains.core.region
 
 import com.intellij.openapi.components.ServiceManager
-import com.intellij.openapi.project.Project
-import com.intellij.testFramework.ProjectRule
 import org.junit.rules.ExternalResource
 import software.aws.toolkits.core.region.AwsPartition
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.region.Service
 import software.aws.toolkits.core.region.ToolkitRegionProvider
-import software.aws.toolkits.jetbrains.utils.rules.ClearableLazy
-import software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule
 
 class MockRegionProvider : ToolkitRegionProvider() {
     private val overrideRegions: MutableMap<String, AwsRegion> = mutableMapOf()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkits.jetbrains.core.region
 
 import com.intellij.openapi.components.ServiceManager
-import org.junit.rules.ExternalResource
+import com.intellij.testFramework.ApplicationRule
 import software.aws.toolkits.core.region.AwsPartition
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.region.Service
@@ -56,7 +56,7 @@ class MockRegionProvider : ToolkitRegionProvider() {
         fun getInstance(): MockRegionProvider = ServiceManager.getService(ToolkitRegionProvider::class.java) as MockRegionProvider
     }
 
-    class RegionProviderRule : ExternalResource() {
+    class RegionProviderRule : ApplicationRule() {
         val regionProvider by lazy { getInstance() }
 
         override fun after() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/JavaCodeInsightTestFixtureRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/JavaCodeInsightTestFixtureRule.kt
@@ -60,7 +60,7 @@ class JavaCodeInsightTestFixtureRule(testDescription: DefaultLightProjectDescrip
  *
  * If you wish to have just a [Project], you may use Intellij's [com.intellij.testFramework.ProjectRule]
  */
-class HeavyJavaCodeInsightTestFixtureRule() : CodeInsightTestFixtureRule() {
+class HeavyJavaCodeInsightTestFixtureRule : CodeInsightTestFixtureRule() {
     override fun createTestFixture(): CodeInsightTestFixture {
         val fixtureBuilder = IdeaTestFixtureFactory.getFixtureFactory().createFixtureBuilder(testName)
         val newFixture = JavaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixtureBuilder.fixture)


### PR DESCRIPTION
Change default region handling so that we select default region if region is null, and automatically switch regions if the default region's partition on a newly selected credential is different.
![2020-06-01_22-04-05](https://user-images.githubusercontent.com/4661536/83481947-e8036980-a453-11ea-9ef0-c0743e32e080.gif)
