### PR TITLE
Add the ability to attach actions to explorer's info state

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialStatusNotification.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialStatusNotification.kt
@@ -4,8 +4,6 @@
 package software.aws.toolkits.jetbrains.core.credentials
 
 import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 import software.aws.toolkits.jetbrains.utils.createNotificationExpiringAction
 import software.aws.toolkits.jetbrains.utils.createShowMoreInfoDialogAction
@@ -31,11 +29,7 @@ class CredentialStatusNotification(private val project: Project) : ConnectionSet
                         newState.cause.localizedMessage
                     ),
                     createNotificationExpiringAction(actionManager.getAction("aws.settings.upsertCredentials")),
-                    createNotificationExpiringAction(object : AnAction(message("settings.retry")) {
-                        override fun actionPerformed(e: AnActionEvent) {
-                            actionManager.getAction("aws.settings.refresh").actionPerformed(e)
-                        }
-                    })
+                    createNotificationExpiringAction(RefreshConnectionAction(message("settings.retry")))
                 )
             )
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ProjectAccountSettingsManager.kt
@@ -3,10 +3,12 @@
 
 package software.aws.toolkits.jetbrains.core.credentials
 
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SimpleModificationTracker
+import com.intellij.util.ExceptionUtil
 import com.intellij.util.messages.Topic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -250,6 +252,8 @@ sealed class ConnectionState(val displayMessage: String, val isTerminal: Boolean
      */
     open val shortMessage: String = displayMessage
 
+    open val actions: List<AnAction> = emptyList()
+
     object InitializingToolkit : ConnectionState(message("settings.states.initializing"), isTerminal = false)
 
     object ValidatingConnection : ConnectionState(message("settings.states.validating"), isTerminal = false) {
@@ -271,8 +275,10 @@ sealed class ConnectionState(val displayMessage: String, val isTerminal: Boolean
         isTerminal = true
     )
 
-    class InvalidConnection(val cause: Exception) : ConnectionState(message("settings.states.invalid", cause.localizedMessage), isTerminal = true) {
+    class InvalidConnection(val cause: Exception) : ConnectionState(message("settings.states.invalid", ExceptionUtil.getMessage(cause) ?: ExceptionUtil.getThrowableText(cause)), isTerminal = true) {
         override val shortMessage = message("settings.states.invalid.short")
+
+        override val actions = listOf(RefreshConnectionAction(message("settings.retry")))
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/RefreshConnectionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/RefreshConnectionAction.kt
@@ -10,8 +10,7 @@ import com.intellij.openapi.project.DumbAware
 import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.resources.message
 
-class RefreshConnectionAction : AnAction(message("settings.refresh.description"), null, AllIcons.Actions.Refresh), DumbAware {
-
+class RefreshConnectionAction(text: String = message("settings.refresh.description")) : AnAction(text, null, AllIcons.Actions.Refresh), DumbAware {
     override fun update(e: AnActionEvent) {
         val project = e.project ?: return
         e.presentation.isEnabled = when (val state = ProjectAccountSettingsManager.getInstance(project).connectionState) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -5,6 +5,7 @@
 package software.aws.toolkits.jetbrains.core.explorer
 
 import com.intellij.execution.Location
+import com.intellij.ide.DataManager
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.ide.util.treeView.NodeDescriptor
 import com.intellij.ide.util.treeView.NodeRenderer
@@ -13,6 +14,7 @@ import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataKey
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.Separator
@@ -22,12 +24,16 @@ import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.ui.DoubleClickListener
+import com.intellij.ui.HyperlinkAdapter
+import com.intellij.ui.HyperlinkLabel
 import com.intellij.ui.JBColor
 import com.intellij.ui.PopupHandler
 import com.intellij.ui.ScrollPaneFactory
 import com.intellij.ui.TreeUIHelper
-import com.intellij.ui.components.panels.Wrapper
+import com.intellij.ui.components.panels.NonOpaquePanel
 import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.ui.GridBag
+import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import software.aws.toolkits.jetbrains.core.credentials.ChangeAccountSettingsMode
 import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettingsStateChangeNotifier
@@ -47,13 +53,13 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceLocationNode
 import software.aws.toolkits.jetbrains.ui.tree.AsyncTreeModel
 import software.aws.toolkits.jetbrains.ui.tree.StructureTreeModel
 import java.awt.Component
+import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
-import java.awt.Insets
 import java.awt.event.MouseEvent
 import javax.swing.JComponent
-import javax.swing.JPanel
 import javax.swing.JTextPane
 import javax.swing.JTree
+import javax.swing.event.HyperlinkEvent
 import javax.swing.text.SimpleAttributeSet
 import javax.swing.text.StyleConstants
 import javax.swing.tree.DefaultMutableTreeNode
@@ -61,7 +67,7 @@ import javax.swing.tree.TreeModel
 
 class ExplorerToolWindow(project: Project) : SimpleToolWindowPanel(true, true), ConnectionSettingsStateChangeNotifier {
     private val actionManager = ActionManagerEx.getInstanceEx()
-    private val treePanelWrapper: Wrapper = Wrapper()
+    private val treePanelWrapper = NonOpaquePanel()
     private val awsTreeModel = AwsExplorerTreeStructure(project)
     private val structureTreeModel = StructureTreeModel(awsTreeModel, project)
     private val awsTree = createTree(AsyncTreeModel(structureTreeModel, true, project))
@@ -76,39 +82,58 @@ class ExplorerToolWindow(project: Project) : SimpleToolWindowPanel(true, true), 
 
         toolbar = ActionManager.getInstance().createActionToolbar(ActionPlaces.TOOLBAR, group, true).component
 
+        background = UIUtil.getTreeBackground()
         setContent(treePanelWrapper)
 
         project.messageBus.connect().subscribe(ProjectAccountSettingsManager.CONNECTION_SETTINGS_STATE_CHANGED, this)
         settingsStateChanged(accountSettingsManager.connectionState)
     }
 
-    private fun createInfoPanel(text: String, error: Boolean = false): JComponent {
-        val panel = JPanel(GridBagLayout())
+    private fun createInfoPanel(state: ConnectionState): JComponent {
+        val panel = NonOpaquePanel(GridBagLayout())
+
+        val gridBag = GridBag()
+        gridBag.defaultAnchor = GridBagConstraints.CENTER
+        gridBag.defaultInsets = JBUI.insetsBottom(JBUI.scale(6))
 
         val textPane = JTextPane().apply {
-            this.text = text
-            val center = SimpleAttributeSet().apply {
-                StyleConstants.setAlignment(this, StyleConstants.ALIGN_CENTER)
-                StyleConstants.setForeground(this, UIUtil.getInactiveTextColor())
+            val textColor = if(state is ConnectionState.InvalidConnection) {
+                JBColor.red
+            } else {
+                UIUtil.getInactiveTextColor()
             }
+
             with(styledDocument) {
+                val center = SimpleAttributeSet().apply {
+                    StyleConstants.setAlignment(this, StyleConstants.ALIGN_CENTER)
+                    StyleConstants.setForeground(this, textColor)
+                }
                 setParagraphAttributes(0, length, center, false)
             }
-            margin = Insets(10, 10, 10, 10)
-            isEditable = false
-            if (error) {
-                with(styledDocument) {
-                    val errorStyle = SimpleAttributeSet().apply {
-                        StyleConstants.setForeground(this, JBColor.red)
-                    }
-                    setCharacterAttributes(0, length, errorStyle, false)
-                }
-            }
-        }
-        panel.background = textPane.background
 
-        panel.add(textPane)
+            text = state.displayMessage
+            isEditable = false
+        }
+
+        panel.add(textPane, gridBag.nextLine().next())
+
+        state.actions.forEach {
+            panel.add(createActionLabel(it), gridBag.nextLine().next())
+        }
+        
         return panel
+    }
+
+    private fun createActionLabel(action: AnAction): HyperlinkLabel {
+        val label = HyperlinkLabel(action.templateText ?: "BUG: $action lacks a text description")
+        label.addHyperlinkListener(object : HyperlinkAdapter() {
+            override fun hyperlinkActivated(e: HyperlinkEvent) {
+                val event = AnActionEvent.createFromAnAction(action, e.inputEvent, ActionPlaces.UNKNOWN, DataManager.getInstance().getDataContext(label))
+                action.actionPerformed(event)
+            }
+        })
+
+        return label
     }
 
     override fun settingsStateChanged(newState: ConnectionState) {
@@ -119,7 +144,7 @@ class ExplorerToolWindow(project: Project) : SimpleToolWindowPanel(true, true), 
                         invalidateTree()
                         awsTreePanel
                     }
-                    else -> createInfoPanel(newState.displayMessage, error = newState is ConnectionState.InvalidConnection)
+                    else -> createInfoPanel(newState)
                 }
             )
         }


### PR DESCRIPTION
## Description
Let's us attach actions to guide users on what they can do in each state

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
<img width="314" alt="Screen Shot 2020-06-03 at 5 16 37 PM" src="https://user-images.githubusercontent.com/8992246/83701328-2a48ba00-a5be-11ea-9b5b-8f4434c8f5cf.png">


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
