### PR TITLE
Start making the toolkit a dynamic plugin

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -130,10 +130,9 @@
         <extensionPoint name="clouddebug.debuggerSupport" interface="software.aws.toolkits.jetbrains.services.clouddebug.DebuggerSupport"/>
         <extensionPoint name="notice" interface="software.aws.toolkits.jetbrains.core.notification.NoticeType"/>
 
-        <extensionPoint name="explorer.serviceNode" interface="software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode"/>
-
-        <extensionPoint name="explorer.nodeProcessor" interface="software.aws.toolkits.jetbrains.core.explorer.AwsExplorerNodeProcessor"/>
-        <extensionPoint name="explorer.treeStructure" interface="software.aws.toolkits.jetbrains.core.explorer.AwsExplorerTreeStructureProvider"/>
+        <extensionPoint name="explorer.serviceNode" interface="software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode" dynamic="true"/>
+        <extensionPoint name="explorer.nodeProcessor" interface="software.aws.toolkits.jetbrains.core.explorer.AwsExplorerNodeProcessor" dynamic="true"/>
+        <extensionPoint name="explorer.treeStructure" interface="software.aws.toolkits.jetbrains.core.explorer.AwsExplorerTreeStructureProvider" dynamic="true"/>
     </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -128,7 +128,7 @@
         <extensionPoint name="executable" interface="software.aws.toolkits.jetbrains.core.executables.ExecutableType" dynamic="true"/>
 
         <extensionPoint name="clouddebug.debuggerSupport" interface="software.aws.toolkits.jetbrains.services.clouddebug.DebuggerSupport"/>
-        <extensionPoint name="notice" interface="software.aws.toolkits.jetbrains.core.notification.NoticeType"/>
+        <extensionPoint name="notice" interface="software.aws.toolkits.jetbrains.core.notification.NoticeType" dynamic="true"/>
 
         <extensionPoint name="explorer.serviceNode" interface="software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode" dynamic="true"/>
         <extensionPoint name="explorer.nodeProcessor" interface="software.aws.toolkits.jetbrains.core.explorer.AwsExplorerNodeProcessor" dynamic="true"/>

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -125,7 +125,7 @@
             <with attribute="runtimeGroup" implements="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup"/>
         </extensionPoint>
 
-        <extensionPoint name="executable" interface="software.aws.toolkits.jetbrains.core.executables.ExecutableType"/>
+        <extensionPoint name="executable" interface="software.aws.toolkits.jetbrains.core.executables.ExecutableType" dynamic="true"/>
 
         <extensionPoint name="clouddebug.debuggerSupport" interface="software.aws.toolkits.jetbrains.services.clouddebug.DebuggerSupport"/>
         <extensionPoint name="notice" interface="software.aws.toolkits.jetbrains.core.notification.NoticeType"/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableType.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableType.kt
@@ -21,7 +21,7 @@ interface ExecutableType<VersionScheme> {
     companion object {
         val EP_NAME = ExtensionPointName<ExecutableType<*>>("aws.toolkit.executable")
 
-        internal fun executables(): List<ExecutableType<*>> = EP_NAME.extensions.toList()
+        internal fun executables(): List<ExecutableType<*>> = EP_NAME.extensionList
 
         @JvmStatic
         fun <T : ExecutableType<*>> getExecutable(clazz: Class<T>): T = executables().filterIsInstance(clazz).first()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/nodes/AwsExplorerRootNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/nodes/AwsExplorerRootNode.kt
@@ -16,11 +16,14 @@ import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 class AwsExplorerRootNode(private val nodeProject: Project) : AbstractTreeNode<Any>(nodeProject, Object()) {
     private val regionProvider = AwsRegionProvider.getInstance()
     private val settings = ProjectAccountSettingsManager.getInstance(nodeProject)
-    private val EP_NAME = ExtensionPointName<AwsExplorerServiceNode>("aws.toolkit.explorer.serviceNode")
 
     override fun getChildren(): List<AwsExplorerNode<*>> = EP_NAME.extensionList
         .filter { regionProvider.isServiceSupported(settings.activeRegion, it.serviceId) }
         .map { it.buildServiceRootNode(nodeProject) }
 
     override fun update(presentation: PresentationData) { }
+
+    companion object {
+        private val EP_NAME = ExtensionPointName<AwsExplorerServiceNode>("aws.toolkit.explorer.serviceNode")
+    }
 }


### PR DESCRIPTION
## Description
**This is going into a feature branch**

This PR is low hanging fruit in this endeavor.

Work after this is larger refactors but good for the toolkit in the long term like making Lambda support 100% dynamic and not using an enum inside of it.

Remaining work before we can start testing.

1. Cred Factories will need to be marked dynamic, but need to fix that it is tied to project disposable first, as well as clear any credential identifier loaded from them.
2. Lambda support is tied to a hard coded enum instead of a string ID
3. Cloud debug is tied to a hard coded enum
4. `moduleType` is dynamic, but not till 202. For testing we can comment out project wizard or find a way off our custom module type.
5. `webHelpProvider` is dynamic, but not till 202. For testing we can comment this out.

Note: Rider does not support dynamic plugins yet so we are blocked there

## Motivation and Context
Hot reload the plugin and not require IDE restart in the long term? Short term, more flexibility.

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
