### PR TITLE
Pass JAVA_HOME to SAM when building not in a contianer

### DIFF
--- a/.changes/next-release/bugfix-6edc88ed-0bfa-491c-9298-9d4a47d5ee24.json
+++ b/.changes/next-release/bugfix-6edc88ed-0bfa-491c-9298-9d4a47d5ee24.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "The project SDK is now passed as JAVA_HOME to SAM when building Java functions when not using the build in container option"
+}

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilderTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilderTest.kt
@@ -11,6 +11,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.rules.EnvironmentVariableHelper
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
@@ -27,12 +28,19 @@ class JavaLambdaBuilderTest : BaseLambdaBuilderTest() {
     @JvmField
     val projectRule = HeavyJavaCodeInsightTestFixtureRule()
 
+    @Rule
+    @JvmField
+    val envVarsRule = EnvironmentVariableHelper()
+
     override val lambdaBuilder: LambdaBuilder
         get() = JavaLambdaBuilder()
 
     @Before
     override fun setUp() {
         super.setUp()
+
+        envVarsRule.remove("JAVA_HOME")
+
         projectRule.fixture.addModule("main")
         projectRule.setUpJdk()
     }

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilderTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilderTest.kt
@@ -3,16 +3,21 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.java
 
+import com.intellij.testFramework.IdeaTestUtil
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.addFileToModule
 import software.aws.toolkits.jetbrains.utils.rules.addModule
 import software.aws.toolkits.jetbrains.utils.setUpGradleProject
+import software.aws.toolkits.jetbrains.utils.setUpJdk
 import software.aws.toolkits.jetbrains.utils.setUpMavenProject
 import software.aws.toolkits.resources.message
 import java.nio.file.Paths
@@ -29,6 +34,7 @@ class JavaLambdaBuilderTest : BaseLambdaBuilderTest() {
     override fun setUp() {
         super.setUp()
         projectRule.fixture.addModule("main")
+        projectRule.setUpJdk()
     }
 
     @Test
@@ -153,5 +159,33 @@ class JavaLambdaBuilderTest : BaseLambdaBuilderTest() {
             buildLambda(projectRule.module, handlerPsi, Runtime.JAVA8, "com.example.SomeClass")
         }.isInstanceOf(IllegalStateException::class.java)
             .hasMessageEndingWith(message("lambda.build.java.unsupported_build_system", projectRule.module.name))
+    }
+
+    @Test
+    fun javaHomePassedWhenNotInContainer() {
+        val commandLine = runBlocking {
+            JavaLambdaBuilder().constructSamBuildCommand(
+                projectRule.module,
+                Paths.get("."),
+                "SomeId",
+                SamOptions(buildInContainer = false),
+                Paths.get(".")
+            )
+        }
+        assertThat(commandLine.environment).extractingByKey("JAVA_HOME").isEqualTo(IdeaTestUtil.requireRealJdkHome())
+    }
+
+    @Test
+    fun javaHomeNotPassedWheInContainer() {
+        val commandLine = runBlocking {
+            JavaLambdaBuilder().constructSamBuildCommand(
+                projectRule.module,
+                Paths.get("."),
+                "SomeId",
+                SamOptions(buildInContainer = true),
+                Paths.get(".")
+            )
+        }
+        assertThat(commandLine.environment).doesNotContainKey("JAVA_HOME")
     }
 }

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLocalLambdaRunConfigurationIntegrationTest.kt
@@ -26,6 +26,7 @@ import software.aws.toolkits.jetbrains.utils.rules.addClass
 import software.aws.toolkits.jetbrains.utils.rules.addModule
 import software.aws.toolkits.jetbrains.utils.setSamExecutableFromEnvironment
 import software.aws.toolkits.jetbrains.utils.setUpGradleProject
+import software.aws.toolkits.jetbrains.utils.setUpJdk
 
 @RunWith(Parameterized::class)
 class JavaLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runtime) {
@@ -69,6 +70,8 @@ class JavaLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runtim
             Runtime.JAVA11 -> "11"
             else -> throw NotImplementedError()
         }
+
+        projectRule.setUpJdk()
 
         projectRule.setUpGradleProject(compatibility)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamTemplateUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamTemplateUtils.kt
@@ -7,14 +7,17 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.testFramework.LightVirtualFile
+import com.intellij.util.io.createFile
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
+import software.aws.toolkits.core.utils.writeText
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplate
 import software.aws.toolkits.jetbrains.services.cloudformation.Function
 import software.aws.toolkits.jetbrains.services.cloudformation.SERVERLESS_FUNCTION_TYPE
 import software.aws.toolkits.jetbrains.utils.yamlWriter
 import java.io.File
+import java.nio.file.Path
 
 object SamTemplateUtils {
     private val LOG = getLogger<SamTemplateUtils>()
@@ -45,11 +48,10 @@ object SamTemplateUtils {
     }
 
     @JvmStatic
-    fun functionFromElement(element: PsiElement): Function? =
-        CloudFormationTemplate.convertPsiToResource(element) as? Function
+    fun functionFromElement(element: PsiElement): Function? = CloudFormationTemplate.convertPsiToResource(element) as? Function
 
     fun writeDummySamTemplate(
-        tempFile: File,
+        tempFile: Path,
         logicalId: String,
         runtime: Runtime,
         codeUri: String,
@@ -58,6 +60,7 @@ object SamTemplateUtils {
         memorySize: Int,
         envVars: Map<String, String> = emptyMap()
     ) {
+        tempFile.createFile()
         tempFile.writeText(yamlWriter {
             mapping("Resources") {
                 mapping(logicalId) {
@@ -72,7 +75,7 @@ object SamTemplateUtils {
                         if (envVars.isNotEmpty()) {
                             mapping("Environment") {
                                 mapping("Variables") {
-                                    envVars.forEach { key, value ->
+                                    envVars.forEach { (key, value) ->
                                         keyValue(key, value)
                                     }
                                 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamTemplateUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamTemplateUtils.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.util.io.createFile
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.utils.exists
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.core.utils.writeText
@@ -60,7 +61,9 @@ object SamTemplateUtils {
         memorySize: Int,
         envVars: Map<String, String> = emptyMap()
     ) {
-        tempFile.createFile()
+        if (!tempFile.exists()) {
+            tempFile.createFile()
+        }
         tempFile.writeText(yamlWriter {
             mapping("Resources") {
                 mapping(logicalId) {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/ExecutableTestUtils.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/ExecutableTestUtils.kt
@@ -9,7 +9,8 @@ import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import java.nio.file.Paths
 
 fun setSamExecutableFromEnvironment() {
+    val samPath = Paths.get(System.getenv().getOrDefault("SAM_CLI_EXEC", SamExecutable().resolve().toString()))
     ExecutableManager.getInstance()
-        .setExecutablePath(ExecutableType.getInstance<SamExecutable>(), Paths.get(System.getenv().getOrDefault("SAM_CLI_EXEC", "sam")))
+        .setExecutablePath(ExecutableType.getInstance<SamExecutable>(), samPath)
         .toCompletableFuture().join()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Pulls the project SDK and sets it as the JAVA_HOME if we are not building the Lambda in a container

## Motivation and Context
This will use the same JDK to build the function as what the IDE is using

## Related Issue(s)
#1803

## Testing
Manual test shows the warning about newer JDK goes away when running sam build but the Project SDK matches the runtime

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
