### PR TITLE
Add new assertions ktlint rule to enforce using the correct one

### DIFF
--- a/core/tst/software/aws/toolkits/core/region/AwsRegionTest.kt
+++ b/core/tst/software/aws/toolkits/core/region/AwsRegionTest.kt
@@ -3,8 +3,7 @@
 
 package software.aws.toolkits.core.region
 
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -32,11 +31,11 @@ class AwsRegionTest(private val region: AwsRegion, private val expectedCategory:
 
     @Test
     fun displayNameShouldMatch() {
-        assertThat(region.displayName, equalTo(expectedDisplayName))
+        assertThat(region.displayName).isEqualTo(expectedDisplayName)
     }
 
     @Test
     fun categoryShouldMatch() {
-        assertThat(region.category, equalTo(expectedCategory))
+        assertThat(region.category).isEqualTo(expectedCategory)
     }
 }

--- a/core/tst/software/aws/toolkits/core/utils/LogUtilsTest.kt
+++ b/core/tst/software/aws/toolkits/core/utils/LogUtilsTest.kt
@@ -23,8 +23,7 @@ class LogUtilsTest {
     @Test
     fun exceptionIsLoggedAndSuppressedInTryOrNull() {
         val expectedException = RuntimeException("Boom")
-        val result = log.tryOrNull("message", level = Level.WARN) { throw expectedException }
-
+        log.tryOrNull("message", level = Level.WARN) { throw expectedException }
         verify(log).warn(any(), eq(expectedException))
     }
 
@@ -148,7 +147,7 @@ class LogUtilsTest {
 
     @Test
     fun logWhenNull() {
-        val result = log.logWhenNull("message", level = Level.WARN) { null }
+        log.logWhenNull("message", level = Level.WARN) { null }
         verify(log).warn("message", null)
     }
 

--- a/core/tst/software/aws/toolkits/core/utils/LogUtilsTest.kt
+++ b/core/tst/software/aws/toolkits/core/utils/LogUtilsTest.kt
@@ -10,8 +10,7 @@ import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.slf4j.Logger
@@ -27,7 +26,6 @@ class LogUtilsTest {
         val result = log.tryOrNull("message", level = Level.WARN) { throw expectedException }
 
         verify(log).warn(any(), eq(expectedException))
-        assertThat(result, equalTo(null))
     }
 
     @Test
@@ -35,7 +33,7 @@ class LogUtilsTest {
         val expectedException = RuntimeException("Boom")
         val exception = catch { log.tryOrThrowNullable("message") { throw expectedException } }
         verify(log).error(any(), eq(expectedException))
-        assertThat(exception === expectedException, equalTo(true))
+        assertThat(exception).isEqualTo(expectedException)
     }
 
     @Test
@@ -43,7 +41,7 @@ class LogUtilsTest {
         val expectedException = RuntimeException("Boom")
         val exception = catch { log.tryOrThrow<Unit>("message") { throw expectedException } }
         verify(log).error(any(), eq(expectedException))
-        assertThat(exception === expectedException, equalTo(true))
+        assertThat(exception).isEqualTo(expectedException)
     }
 
     @Test
@@ -56,7 +54,7 @@ class LogUtilsTest {
     fun smartCastToNonNullOnTryOrThrow() {
         val nullableValue: String = log.tryOrThrow("message") { mightBeNull(shouldBeNull = false) }
         val nonNullableValue: String = log.tryOrThrow("message") { willNeverBeNull() }
-        assertThat(nullableValue, equalTo(nonNullableValue))
+        assertThat(nullableValue).isEqualTo(nonNullableValue)
     }
 
     @Test
@@ -152,7 +150,6 @@ class LogUtilsTest {
     fun logWhenNull() {
         val result = log.logWhenNull("message", level = Level.WARN) { null }
         verify(log).warn("message", null)
-        assertThat(result, equalTo(null))
     }
 
     @Before

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
@@ -7,8 +7,8 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.ExtensionTestUtil
 import com.intellij.testFramework.ProjectRule
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -50,7 +50,7 @@ class ExecutableBackedCacheResourceTest {
     fun testExecutableIsNotInstalledCausesException() {
         createMockExecutable("invalidBinary")
 
-        Assertions.assertThatThrownBy {
+        assertThatThrownBy {
             executeCacheResource {}
         }.isInstanceOf(IllegalStateException::class.java)
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugStartupCommandTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugStartupCommandTest.kt
@@ -4,7 +4,8 @@
 package software.aws.toolkits.jetbrains.services.clouddebug
 
 import com.intellij.execution.configurations.RuntimeConfigurationError
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import software.aws.toolkits.resources.message
 
@@ -15,7 +16,7 @@ class CloudDebugStartupCommandTest {
     @Test
     fun emptyStartupCommandThrowsAnException() {
         val containerName = "myContainer"
-        Assertions.assertThatThrownBy { startupCommand.validateStartupCommand("", containerName) }
+        assertThatThrownBy { startupCommand.validateStartupCommand("", containerName) }
             .isInstanceOf(RuntimeConfigurationError::class.java)
             .hasMessage(message("cloud_debug.run_configuration.missing.start_command", containerName))
     }
@@ -27,11 +28,11 @@ class CloudDebugStartupCommandTest {
 
     @Test
     fun autoFillIsNotSupportedByDefault() {
-        Assertions.assertThat(startupCommand.isStartCommandAutoFillSupported).isFalse()
+        assertThat(startupCommand.isStartCommandAutoFillSupported).isFalse()
     }
 
     @Test
     fun defaultHintTextIsEmptyString() {
-        Assertions.assertThat(startupCommand.getStartupCommandTextFieldHintText()).isEqualTo("")
+        assertThat(startupCommand.getStartupCommandTextFieldHintText()).isEqualTo("")
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/clouddebug/JavaStartCommandAugmenterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/clouddebug/JavaStartCommandAugmenterTest.kt
@@ -4,7 +4,8 @@
 package software.aws.toolkits.jetbrains.services.clouddebug
 
 import com.intellij.execution.configurations.RuntimeConfigurationException
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import software.aws.toolkits.jetbrains.services.clouddebug.java.JvmDebuggerSupport
 import software.aws.toolkits.resources.message
@@ -14,18 +15,18 @@ class JavaStartCommandAugmenterTest {
 
     @Test
     fun augmenterAddsEnivronmentVariable() {
-        Assertions.assertThat(augmenter.augmentStatement("java -jar x.jar", listOf(123), "")).contains("${CloudDebugConstants.REMOTE_DEBUG_PORT_ENV}=123", "")
+        assertThat(augmenter.augmentStatement("java -jar x.jar", listOf(123), "")).contains("${CloudDebugConstants.REMOTE_DEBUG_PORT_ENV}=123", "")
     }
 
     @Test
     fun augmenterAddsPort() {
         val augmentedStatement = augmenter.augmentStatement("java -jar x.jar", listOf(123), "")
-        Assertions.assertThat(augmentedStatement).contains("address=123").contains("-agentlib:jdwp")
+        assertThat(augmentedStatement).contains("address=123").contains("-agentlib:jdwp")
     }
 
     @Test
     fun augmenterEmptyPortsArray() {
-        Assertions.assertThatThrownBy { augmenter.augmentStatement("java -jar x.jar", listOf(), "") }
+        assertThatThrownBy { augmenter.augmentStatement("java -jar x.jar", listOf(), "") }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage(message("cloud_debug.step.augment_statement.missing_debug_port"))
     }
@@ -33,54 +34,54 @@ class JavaStartCommandAugmenterTest {
     @Test
     fun singleQuotesThrows() {
         val statement = "'/whatever/java' -jar abc.jar"
-        Assertions.assertThatThrownBy { augmenter.automaticallyAugmentable(statement) }.isInstanceOf(RuntimeConfigurationException::class.java)
+        assertThatThrownBy { augmenter.automaticallyAugmentable(statement) }.isInstanceOf(RuntimeConfigurationException::class.java)
     }
 
     @Test
     fun augmenterDoesNotAddAdditionalDebugger() {
         val augmentedStatement = augmenter.augmentStatement("java -jar x.jar", listOf(123), "")
-        Assertions.assertThat(augmentedStatement).contains("java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=123 -jar x.jar")
+        assertThat(augmentedStatement).contains("java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=123 -jar x.jar")
     }
 
     @Test
     fun augmenterDetectsAlreadyAugmentable() {
         val statement = "java -jar x.jar"
-        Assertions.assertThat(augmenter.automaticallyAugmentable(statement)).isTrue()
+        assertThat(augmenter.automaticallyAugmentable(statement)).isTrue()
     }
 
     @Test
     fun badlyConfiguredStartThrows() {
         var statement = "java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=123 -jar x.jar"
-        Assertions.assertThatThrownBy { augmenter.automaticallyAugmentable(statement) }.isInstanceOf(RuntimeConfigurationException::class.java)
+        assertThatThrownBy { augmenter.automaticallyAugmentable(statement) }.isInstanceOf(RuntimeConfigurationException::class.java)
         statement = "java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=1234 -jar x.jar"
-        Assertions.assertThatThrownBy { augmenter.automaticallyAugmentable(statement) }.isInstanceOf(RuntimeConfigurationException::class.java)
+        assertThatThrownBy { augmenter.automaticallyAugmentable(statement) }.isInstanceOf(RuntimeConfigurationException::class.java)
     }
 
     @Test
     fun augmentableWorksForPaths() {
         var statement = "/abc/java -jar abc.jar"
-        Assertions.assertThat(augmenter.automaticallyAugmentable(statement)).isTrue()
+        assertThat(augmenter.automaticallyAugmentable(statement)).isTrue()
         statement = "\"/abc/ bla/java\" -jar abc.jar"
-        Assertions.assertThat(augmenter.automaticallyAugmentable(statement)).isTrue()
+        assertThat(augmenter.automaticallyAugmentable(statement)).isTrue()
     }
 
     @Test
     fun augmenterWorksForPaths() {
         var statement = "/abc/java -jar abc.jar"
-        Assertions.assertThat(augmenter.augmentStatement(statement, listOf(123), "")).contains("/abc/java -agentlib:jdwp")
+        assertThat(augmenter.augmentStatement(statement, listOf(123), "")).contains("/abc/java -agentlib:jdwp")
         statement = "\"/abc/ bla/java\" -jar abc.jar"
-        Assertions.assertThat(augmenter.augmentStatement(statement, listOf(123), "")).contains("\"/abc/ bla/java\" -agentlib:jdwp")
+        assertThat(augmenter.augmentStatement(statement, listOf(123), "")).contains("\"/abc/ bla/java\" -agentlib:jdwp")
     }
 
     @Test
     fun doesNotAugmentBadInput() {
         var statement = "/whatever/Notjava -jar abc.jar"
-        Assertions.assertThat(augmenter.automaticallyAugmentable(statement)).isFalse()
+        assertThat(augmenter.automaticallyAugmentable(statement)).isFalse()
         statement = "\"/whatever/notjava\" -jar abc.jar"
-        Assertions.assertThat(augmenter.automaticallyAugmentable(statement)).isFalse()
+        assertThat(augmenter.automaticallyAugmentable(statement)).isFalse()
         statement = "startjava.sh some input"
-        Assertions.assertThat(augmenter.automaticallyAugmentable(statement)).isFalse()
+        assertThat(augmenter.automaticallyAugmentable(statement)).isFalse()
         statement = "java"
-        Assertions.assertThat(augmenter.automaticallyAugmentable(statement)).isFalse()
+        assertThat(augmenter.automaticallyAugmentable(statement)).isFalse()
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/clouddebug/JavaStartCommandAugmenterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/clouddebug/JavaStartCommandAugmenterTest.kt
@@ -12,21 +12,22 @@ import software.aws.toolkits.resources.message
 
 class JavaStartCommandAugmenterTest {
     private val augmenter = JvmDebuggerSupport()
+    private val basicRun = "java -jar x.jar"
 
     @Test
     fun augmenterAddsEnivronmentVariable() {
-        assertThat(augmenter.augmentStatement("java -jar x.jar", listOf(123), "")).contains("${CloudDebugConstants.REMOTE_DEBUG_PORT_ENV}=123", "")
+        assertThat(augmenter.augmentStatement(basicRun, listOf(123), "")).contains("${CloudDebugConstants.REMOTE_DEBUG_PORT_ENV}=123", "")
     }
 
     @Test
     fun augmenterAddsPort() {
-        val augmentedStatement = augmenter.augmentStatement("java -jar x.jar", listOf(123), "")
+        val augmentedStatement = augmenter.augmentStatement(basicRun, listOf(123), "")
         assertThat(augmentedStatement).contains("address=123").contains("-agentlib:jdwp")
     }
 
     @Test
     fun augmenterEmptyPortsArray() {
-        assertThatThrownBy { augmenter.augmentStatement("java -jar x.jar", listOf(), "") }
+        assertThatThrownBy { augmenter.augmentStatement(basicRun, listOf(), "") }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage(message("cloud_debug.step.augment_statement.missing_debug_port"))
     }
@@ -39,14 +40,13 @@ class JavaStartCommandAugmenterTest {
 
     @Test
     fun augmenterDoesNotAddAdditionalDebugger() {
-        val augmentedStatement = augmenter.augmentStatement("java -jar x.jar", listOf(123), "")
+        val augmentedStatement = augmenter.augmentStatement(basicRun, listOf(123), "")
         assertThat(augmentedStatement).contains("java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=123 -jar x.jar")
     }
 
     @Test
     fun augmenterDetectsAlreadyAugmentable() {
-        val statement = "java -jar x.jar"
-        assertThat(augmenter.automaticallyAugmentable(statement)).isTrue()
+        assertThat(augmenter.automaticallyAugmentable(basicRun)).isTrue()
     }
 
     @Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/clouddebug/PythonStartCommandAugmenterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/clouddebug/PythonStartCommandAugmenterTest.kt
@@ -3,8 +3,8 @@
 
 package software.aws.toolkits.jetbrains.services.clouddebug
 
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import software.aws.toolkits.jetbrains.services.clouddebug.python.PythonDebuggerSupport
 import software.aws.toolkits.resources.message
@@ -60,7 +60,7 @@ class PythonStartCommandAugmenterTest {
 
     @Test
     fun augmenterEmptyPortsArray() {
-        Assertions.assertThatThrownBy { augmenter.augmentStatement("python3 test.py", listOf(), "/abc/pydevd.py") }
+        assertThatThrownBy { augmenter.augmentStatement("python3 test.py", listOf(), "/abc/pydevd.py") }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage(message("cloud_debug.step.augment_statement.missing_debug_port"))
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/LogGroupActorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/LogGroupActorTest.kt
@@ -9,7 +9,8 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
@@ -45,8 +46,8 @@ class LogGroupActorTest : BaseCoroutineTest() {
             actor.channel.send(LogActor.Message.LoadInitial)
             tableModel.waitForModelToBeAtLeast(1)
         }
-        Assertions.assertThat(tableModel.items.size).isOne()
-        Assertions.assertThat(tableModel.items.first().logStreamName()).isEqualTo("name")
+        assertThat(tableModel.items.size).isOne()
+        assertThat(tableModel.items.first().logStreamName()).isEqualTo("name")
     }
 
     @Test
@@ -56,7 +57,7 @@ class LogGroupActorTest : BaseCoroutineTest() {
             actor.channel.send(LogActor.Message.LoadInitial)
             waitForTrue { table.emptyText.text == message("cloudwatch.logs.failed_to_load_streams", "abc") }
         }
-        Assertions.assertThat(tableModel.items).isEmpty()
+        assertThat(tableModel.items).isEmpty()
     }
 
     @Test
@@ -69,16 +70,16 @@ class LogGroupActorTest : BaseCoroutineTest() {
             actor.channel.send(LogActor.Message.LoadForward)
             tableModel.waitForModelToBeAtLeast(2)
         }
-        Assertions.assertThat(tableModel.items.size).isEqualTo(2)
-        Assertions.assertThat(tableModel.items.first().logStreamName()).isEqualTo("name")
-        Assertions.assertThat(tableModel.items[1].logStreamName()).isEqualTo("name2")
+        assertThat(tableModel.items.size).isEqualTo(2)
+        assertThat(tableModel.items.first().logStreamName()).isEqualTo("name")
+        assertThat(tableModel.items[1].logStreamName()).isEqualTo("name2")
     }
 
     @Test
     fun writeChannelAndCoroutineIsDisposed() {
         val channel = actor.channel
         actor.dispose()
-        Assertions.assertThatThrownBy {
+        assertThatThrownBy {
             runBlocking {
                 channel.send(LogActor.Message.LoadForward)
             }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/LogGroupSearchActorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/LogGroupSearchActorTest.kt
@@ -9,7 +9,8 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
@@ -46,8 +47,8 @@ class LogGroupSearchActorTest : BaseCoroutineTest() {
             actor.channel.send(LogActor.Message.LoadInitialFilter("name"))
             tableModel.waitForModelToBeAtLeast(1)
         }
-        Assertions.assertThat(tableModel.items.size).isOne()
-        Assertions.assertThat(tableModel.items.first().logStreamName()).isEqualTo("name-cool")
+        assertThat(tableModel.items.size).isOne()
+        assertThat(tableModel.items.first().logStreamName()).isEqualTo("name-cool")
     }
 
     @Test
@@ -60,9 +61,9 @@ class LogGroupSearchActorTest : BaseCoroutineTest() {
             actor.channel.send(LogActor.Message.LoadForward)
             tableModel.waitForModelToBeAtLeast(2)
         }
-        Assertions.assertThat(tableModel.items.size).isEqualTo(2)
-        Assertions.assertThat(tableModel.items.first().logStreamName()).isEqualTo("name-cool")
-        Assertions.assertThat(tableModel.items[1].logStreamName()).isEqualTo("name-2")
+        assertThat(tableModel.items.size).isEqualTo(2)
+        assertThat(tableModel.items.first().logStreamName()).isEqualTo("name-cool")
+        assertThat(tableModel.items[1].logStreamName()).isEqualTo("name-2")
     }
 
     @Test
@@ -75,15 +76,15 @@ class LogGroupSearchActorTest : BaseCoroutineTest() {
             actor.channel.send(LogActor.Message.LoadBackward)
             tableModel.waitForModelToBeAtLeast(1)
         }
-        Assertions.assertThat(tableModel.items.size).isOne()
-        Assertions.assertThat(tableModel.items.first().logStreamName()).isEqualTo("name-cool")
+        assertThat(tableModel.items.size).isOne()
+        assertThat(tableModel.items.first().logStreamName()).isEqualTo("name-cool")
     }
 
     @Test
     fun writeChannelAndCoroutineIsDisposed() {
         val channel = actor.channel
         actor.dispose()
-        Assertions.assertThatThrownBy {
+        assertThatThrownBy {
             runBlocking {
                 channel.send(LogActor.Message.LoadBackward)
             }
@@ -116,6 +117,6 @@ class LogGroupSearchActorTest : BaseCoroutineTest() {
                 table.emptyText.text == message("cloudwatch.logs.failed_to_load_streams", "abc")
             }
         }
-        Assertions.assertThat(tableModel.items).isEmpty()
+        assertThat(tableModel.items).isEmpty()
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/BaseLambdaBuilderTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/BaseLambdaBuilderTest.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiElement
 import com.intellij.util.io.isFile
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import software.amazon.awssdk.services.lambda.model.Runtime
@@ -92,6 +91,6 @@ abstract class BaseLambdaBuilderTest {
                     file
                 )
             }
-        Assertions.assertThat(builtLambda.mappings).containsAll(updatedPaths)
+        assertThat(builtLambda.mappings).containsAll(updatedPaths)
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/CopyBucketTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/CopyBucketTest.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.testFramework.ProjectRule
 import com.intellij.testFramework.TestActionEvent
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.s3.model.Bucket
@@ -25,6 +25,6 @@ class CopyBucketTest {
         val copyAction = CopyBucketNameAction()
         copyAction.actionPerformed(bucket, TestActionEvent(DataContext { projectRule.project }))
         val content = CopyPasteManager.getInstance().contents
-        Assertions.assertThat(content?.getTransferData(DataFlavor.stringFlavor)).isEqualTo("foo")
+        assertThat(content?.getTransferData(DataFlavor.stringFlavor)).isEqualTo("foo")
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/clouddebug/ArtifactMappingPopupTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/clouddebug/ArtifactMappingPopupTest.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.jetbrains.ui.clouddebug
 
 import com.intellij.testFramework.ProjectRule
 import net.miginfocom.swing.MigLayout
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.jetbrains.services.ecs.execution.ArtifactMapping
@@ -26,16 +26,18 @@ class ArtifactMappingPopupTest {
     @Test
     fun artifactsPopupContainsNoElements() {
         val popup = ArtifactMappingPopup.createPopup(emptyList()) { }
-        Assertions.assertThat(popup.listStep.values.size).isEqualTo(0)
+        assertThat(popup.listStep.values.size).isEqualTo(0)
     }
 
     @Test
     fun artifactsPopupContainsValidMapping() {
-        val popup = ArtifactMappingPopup.createPopup(listOf(
-            ArtifactMapping(localPath = "/tmp/local/path", remotePath = "/tmp/remote/path"),
-            ArtifactMapping(localPath = "/tmp/another/local/path", remotePath = "/tmp/another/remote/path")
-        )) { }
-        Assertions.assertThat(popup.listStep.values.size).isEqualTo(2)
+        val popup = ArtifactMappingPopup.createPopup(
+            listOf(
+                ArtifactMapping(localPath = "/tmp/local/path", remotePath = "/tmp/remote/path"),
+                ArtifactMapping(localPath = "/tmp/another/local/path", remotePath = "/tmp/another/remote/path")
+            )
+        ) { }
+        assertThat(popup.listStep.values.size).isEqualTo(2)
     }
 
     @Test
@@ -49,7 +51,7 @@ class ArtifactMappingPopupTest {
         val component =
             renderer.getListCellRendererComponent(list = JList(model), value = artifact, index = 0, selected = true, hasFocus = true)
 
-        Assertions.assertThat(((component as JPanel).layout as MigLayout).columnConstraints)
+        assertThat(((component as JPanel).layout as MigLayout).columnConstraints)
             .isEqualTo(expectedLayoutConstraint(PathMappingPopupCellRenderer.LEFT_COMPONENT_MIN_WIDTH))
     }
 
@@ -67,7 +69,7 @@ class ArtifactMappingPopupTest {
         val component =
             renderer.getListCellRendererComponent(list = JList(model), value = artifact, index = 0, selected = true, hasFocus = true)
 
-        Assertions.assertThat(((component as JPanel).layout as MigLayout).columnConstraints)
+        assertThat(((component as JPanel).layout as MigLayout).columnConstraints)
             .isEqualTo(expectedLayoutConstraint(PathMappingPopupCellRenderer.LEFT_COMPONENT_MAX_WIDTH))
     }
 }

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/clouddebug/DotNetStartupCommandTest.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/clouddebug/DotNetStartupCommandTest.kt
@@ -8,7 +8,7 @@ import com.jetbrains.rdclient.util.idea.pumpMessages
 import com.jetbrains.rider.projectView.solutionDirectory
 import com.jetbrains.rider.test.asserts.shouldBeTrue
 import com.jetbrains.rider.test.scriptingApi.buildSolutionWithReSharperBuild
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 import software.aws.toolkits.jetbrains.services.ecs.execution.ArtifactMapping
@@ -39,7 +39,7 @@ class DotNetStartupCommandTest : AwsReuseSolutionTestBase() {
         )
 
         pumpMessages(Duration.ofSeconds(2).toMillis()) { command.isNotEmpty() }
-        Assertions.assertThat(command).isEqualTo(originalCommand)
+        assertThat(command).isEqualTo(originalCommand)
     }
 
     @Test
@@ -69,6 +69,6 @@ class DotNetStartupCommandTest : AwsReuseSolutionTestBase() {
         pumpMessages(Duration.ofSeconds(2).toMillis()) { command.isNotEmpty() }
 
         val expectedCommand = "dotnet /tmp/remote/path/netcoreapp2.1/HelloWorld.dll"
-        Assertions.assertThat(command).isEqualTo(expectedCommand)
+        assertThat(command).isEqualTo(expectedCommand)
     }
 }

--- a/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/clouddebug/nodejs/NodeJsDebugEndToEndTest.kt
+++ b/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/clouddebug/nodejs/NodeJsDebugEndToEndTest.kt
@@ -8,7 +8,7 @@ import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.testFramework.runInEdtAndWait
 import com.intellij.xdebugger.XDebuggerUtil
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
@@ -102,7 +102,7 @@ class NodeJsDebugEndToEndTest : CloudDebugTestCase("CloudDebugTestECSClusterTask
             configuration.checkConfiguration()
             executeRunConfiguration(configuration, DefaultDebugExecutor.EXECUTOR_ID)
         }
-        Assertions.assertThat(debuggerIsHit.get()).isTrue()
+        assertThat(debuggerIsHit.get()).isTrue()
     }
 
     private fun addNodeFile(): String {

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/clouddebug/NodejsStartCommandAugmenterTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/clouddebug/NodejsStartCommandAugmenterTest.kt
@@ -10,11 +10,12 @@ import software.aws.toolkits.jetbrains.services.clouddebug.nodejs.NodeJsDebugger
 import software.aws.toolkits.resources.message
 
 class NodejsStartCommandAugmenterTest {
-    val augmenter = NodeJsDebuggerSupport()
+    private val augmenter = NodeJsDebuggerSupport()
+    private val nodeRun = "node abc.js"
 
     @Test
     fun augmenterAddsEnvironmentVariable() {
-        assertThat(augmenter.augmentStatement("node abc.js", listOf(123), ""))
+        assertThat(augmenter.augmentStatement(nodeRun, listOf(123), ""))
             .contains("${CloudDebugConstants.REMOTE_DEBUG_PORT_ENV}=123")
         assertThat(augmenter.augmentStatement("nodejs abc.js", listOf(123), ""))
             .contains("${CloudDebugConstants.REMOTE_DEBUG_PORT_ENV}=123")
@@ -22,7 +23,7 @@ class NodejsStartCommandAugmenterTest {
 
     @Test
     fun augmenterAddsPort() {
-        assertThat(augmenter.augmentStatement("node abc.js", listOf(123), ""))
+        assertThat(augmenter.augmentStatement(nodeRun, listOf(123), ""))
             .contains("--inspect-brk=localhost:123")
         assertThat(augmenter.augmentStatement("nodejs abc.js", listOf(123), ""))
             .contains("--inspect-brk=localhost:123")
@@ -30,7 +31,7 @@ class NodejsStartCommandAugmenterTest {
 
     @Test
     fun augmenterEmptyPortsArray() {
-        assertThatThrownBy { augmenter.augmentStatement("node abc.js", listOf(), "") }
+        assertThatThrownBy { augmenter.augmentStatement(nodeRun, listOf(), "") }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage(message("cloud_debug.step.augment_statement.missing_debug_port"))
     }

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/clouddebug/NodejsStartCommandAugmenterTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/clouddebug/NodejsStartCommandAugmenterTest.kt
@@ -3,7 +3,8 @@
 
 package software.aws.toolkits.jetbrains.services.clouddebug
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import software.aws.toolkits.jetbrains.services.clouddebug.nodejs.NodeJsDebuggerSupport
 import software.aws.toolkits.resources.message
@@ -13,54 +14,54 @@ class NodejsStartCommandAugmenterTest {
 
     @Test
     fun augmenterAddsEnvironmentVariable() {
-        Assertions.assertThat(augmenter.augmentStatement("node abc.js", listOf(123), ""))
+        assertThat(augmenter.augmentStatement("node abc.js", listOf(123), ""))
             .contains("${CloudDebugConstants.REMOTE_DEBUG_PORT_ENV}=123")
-        Assertions.assertThat(augmenter.augmentStatement("nodejs abc.js", listOf(123), ""))
+        assertThat(augmenter.augmentStatement("nodejs abc.js", listOf(123), ""))
             .contains("${CloudDebugConstants.REMOTE_DEBUG_PORT_ENV}=123")
     }
 
     @Test
     fun augmenterAddsPort() {
-        Assertions.assertThat(augmenter.augmentStatement("node abc.js", listOf(123), ""))
+        assertThat(augmenter.augmentStatement("node abc.js", listOf(123), ""))
             .contains("--inspect-brk=localhost:123")
-        Assertions.assertThat(augmenter.augmentStatement("nodejs abc.js", listOf(123), ""))
+        assertThat(augmenter.augmentStatement("nodejs abc.js", listOf(123), ""))
             .contains("--inspect-brk=localhost:123")
     }
 
     @Test
     fun augmenterEmptyPortsArray() {
-        Assertions.assertThatThrownBy { augmenter.augmentStatement("node abc.js", listOf(), "") }
+        assertThatThrownBy { augmenter.augmentStatement("node abc.js", listOf(), "") }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage(message("cloud_debug.step.augment_statement.missing_debug_port"))
     }
 
     @Test
     fun augmenterIgnoresNonNode() {
-        Assertions.assertThat(augmenter.automaticallyAugmentable("node.sh abc")).isFalse()
-        Assertions.assertThat(augmenter.automaticallyAugmentable("java abc")).isFalse()
+        assertThat(augmenter.automaticallyAugmentable("node.sh abc")).isFalse()
+        assertThat(augmenter.automaticallyAugmentable("java abc")).isFalse()
     }
 
     @Test
     fun augmenterWorksForPaths() {
-        Assertions.assertThat(augmenter.automaticallyAugmentable("/abc/node abc.js")).isTrue()
-        Assertions.assertThat(augmenter.automaticallyAugmentable("/abc/nodejs abc.js")).isTrue()
-        Assertions.assertThat(augmenter.automaticallyAugmentable("\"/abc space in path/node\" abc.js")).isTrue()
-        Assertions.assertThat(augmenter.automaticallyAugmentable("\"/abc space in path/nodejs\" abc.js")).isTrue()
+        assertThat(augmenter.automaticallyAugmentable("/abc/node abc.js")).isTrue()
+        assertThat(augmenter.automaticallyAugmentable("/abc/nodejs abc.js")).isTrue()
+        assertThat(augmenter.automaticallyAugmentable("\"/abc space in path/node\" abc.js")).isTrue()
+        assertThat(augmenter.automaticallyAugmentable("\"/abc space in path/nodejs\" abc.js")).isTrue()
     }
 
     @Test
     fun augmenterDoesNotAugmentWeirdPaths() {
-        Assertions.assertThat(augmenter.automaticallyAugmentable("/abc/notnode abc.js")).isFalse()
-        Assertions.assertThat(augmenter.automaticallyAugmentable("node.sh abc.js")).isFalse()
-        Assertions.assertThat(augmenter.automaticallyAugmentable("node")).isFalse()
-        Assertions.assertThat(augmenter.automaticallyAugmentable("\"/abc space in path/notnode\" abc.js")).isFalse()
+        assertThat(augmenter.automaticallyAugmentable("/abc/notnode abc.js")).isFalse()
+        assertThat(augmenter.automaticallyAugmentable("node.sh abc.js")).isFalse()
+        assertThat(augmenter.automaticallyAugmentable("node")).isFalse()
+        assertThat(augmenter.automaticallyAugmentable("\"/abc space in path/notnode\" abc.js")).isFalse()
     }
 
     @Test
     fun augmenterAugmentsPathsCorrectly() {
-        Assertions.assertThat(augmenter.augmentStatement("/abc/node abc.js", listOf(123), ""))
+        assertThat(augmenter.augmentStatement("/abc/node abc.js", listOf(123), ""))
             .contains("/abc/node --inspect-brk=localhost:123 abc.js")
-        Assertions.assertThat(augmenter.augmentStatement("\"/abc space in path/node\" abc.js", listOf(123), ""))
+        assertThat(augmenter.augmentStatement("\"/abc space in path/node\" abc.js", listOf(123), ""))
             .contains("\"/abc space in path/node\" --inspect-brk=localhost:123 abc.js")
     }
 }

--- a/ktlint-rules/src/software/aws/toolkits/ktlint/rules/BannedImportsRule.kt
+++ b/ktlint-rules/src/software/aws/toolkits/ktlint/rules/BannedImportsRule.kt
@@ -1,0 +1,27 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.ktlint.rules
+
+import com.pinterest.ktlint.core.Rule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtImportDirective
+
+class BannedImportsRule : Rule("banned-imports") {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        val element = node.psi ?: return
+        if (element is KtImportDirective) {
+            if (element.importedFqName?.asString() == "org.assertj.core.api.Assertions") {
+                emit(node.startOffset, "Import the assertion you want to use directly instead of importing the top level Assertions", false)
+            }
+
+            if (element.importedFqName?.asString()?.startsWith("org.hamcrest") == true) {
+                emit(node.startOffset, "Use AssertJ instead of Hamcrest assertions", false)
+            }
+        }
+    }
+}

--- a/ktlint-rules/src/software/aws/toolkits/ktlint/rules/CustomRuleSetProvider.kt
+++ b/ktlint-rules/src/software/aws/toolkits/ktlint/rules/CustomRuleSetProvider.kt
@@ -15,6 +15,7 @@ class CustomRuleSetProvider : RuleSetProvider {
         ExpressionBodyRule(),
         LazyLogRule(),
         DialogModalityRule(),
+        BannedImportsRule(),
         NoWildcardImportsRule() // Disabled by default, so including in our rule set
     )
 }

--- a/ktlint-rules/tst/software/aws/toolkits/ktlint/rules/BannedImportsRuleTest.kt
+++ b/ktlint-rules/tst/software/aws/toolkits/ktlint/rules/BannedImportsRuleTest.kt
@@ -1,0 +1,44 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.ktlint.rules
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class BannedImportsRuleTest {
+    private val rule = BannedImportsRule()
+
+    @Test
+    fun `Importing Assert fails`() {
+        assertThat(rule.lint("import org.assertj.core.api.Assertions"))
+            .containsExactly(
+                LintError(
+                    1,
+                    1,
+                    "banned-imports",
+                    "Import the assertion you want to use directly instead of importing the top level Assertions"
+                )
+            )
+    }
+
+    @Test
+    fun `Importing Hamcrest fails`() {
+        assertThat(rule.lint("import org.hamcrest.AnyClass"))
+            .containsExactly(
+                LintError(
+                    1,
+                    1,
+                    "banned-imports",
+                    "Use AssertJ instead of Hamcrest assertions"
+                )
+            )
+    }
+
+    @Test
+    fun `Importing Assert assertThat succeeds`() {
+        assertThat(rule.lint("import org.assertj.core.api.Assertions.assertThat")).isEmpty()
+    }
+}

--- a/ktlint-rules/tst/software/aws/toolkits/ktlint/rules/DialogModalityRuleTest.kt
+++ b/ktlint-rules/tst/software/aws/toolkits/ktlint/rules/DialogModalityRuleTest.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.ktlint.rules
 
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
@@ -16,7 +16,7 @@ class DialogModalityRuleTest {
     @Test
     fun runInEdtCallsShouldSpecifyModalityWhenCalledWithinDialog() {
         assertExpected(
-                """
+            """
             class Blah : DialogWrapper {
               fun blah() {
                 runInEdt { }
@@ -29,19 +29,20 @@ class DialogModalityRuleTest {
     @Test
     fun callsThatSpecifyModalityAnyAreFine() {
         assertExpected(
-                """
+            """
             class Blah : DialogWrapper {
               fun blah() {
                 runInEdt(ModalityState.any()) { }
               }
             }
-        """)
+        """
+        )
     }
 
     @Test
     fun callsThatSpecifyWrongModalityAreNotFine() {
         assertExpected(
-                """
+            """
             class Blah : DialogWrapper() {
               fun blah() {
                 runInEdt(ModalityState.current()) { }
@@ -52,12 +53,12 @@ class DialogModalityRuleTest {
     }
 
     private fun assertExpected(@Language("kotlin") kotlinText: String, vararg expectedErrors: Pair<Int, Int>) {
-        Assertions.assertThat(rule.lint(kotlinText.trimIndent())).containsExactly(*expectedErrors.map {
+        assertThat(rule.lint(kotlinText.trimIndent())).containsExactly(*expectedErrors.map {
             LintError(
-                    it.first,
-                    it.second,
-                    rule.id,
-                    "Call to runInEdt without ModalityState.any() within Dialog will not run until Dialog exits."
+                it.first,
+                it.second,
+                rule.id,
+                "Call to runInEdt without ModalityState.any() within Dialog will not run until Dialog exits."
             )
         }.toTypedArray())
     }

--- a/resources/tst/software/aws/toolkits/resources/BundledResourcesTest.kt
+++ b/resources/tst/software/aws/toolkits/resources/BundledResourcesTest.kt
@@ -3,8 +3,7 @@
 
 package software.aws.toolkits.resources
 
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -23,7 +22,7 @@ class BundledResourcesTest(private val file: InputStream) {
     @Test
     fun fileExistsAndHasContent() {
         file.use {
-            assertThat(it.read() > 0, equalTo(true))
+            assertThat(it.read()).isGreaterThan(0)
         }
     }
 }


### PR DESCRIPTION
- Ban importing Assertions to prevent doing Assertions.assertThat
- Ban Hamcrest assertions so it doesn't accidentally get used again in the future

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
