### PR TITLE
Fixup (CloudFormation) and (CloudWatchLogs log) windows

### DIFF
--- a/.changes/next-release/bugfix-2c6ead5d-fa57-4d56-bdcd-dd97298bde8d.json
+++ b/.changes/next-release/bugfix-2c6ead5d-fa57-4d56-bdcd-dd97298bde8d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix Cloud Formation event viewer not expanding as the window expands"
+}

--- a/.changes/next-release/bugfix-6deb0922-5c9a-412d-ba2e-dbe8f28c578d.json
+++ b/.changes/next-release/bugfix-6deb0922-5c9a-412d-ba2e-dbe8f28c578d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix CloudWatch Logs logstream scrolling up automatically in certain circumstances"
+}

--- a/.changes/next-release/feature-e9007d39-3303-4404-8320-08f64c1c5917.json
+++ b/.changes/next-release/feature-e9007d39-3303-4404-8320-08f64c1c5917.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Add word wrap to CloudFormation status reasons on selection (#1863)"
+}

--- a/.changes/next-release/feature-e9007d39-3303-4404-8320-08f64c1c5917.json
+++ b/.changes/next-release/feature-e9007d39-3303-4404-8320-08f64c1c5917.json
@@ -1,4 +1,4 @@
 {
   "type" : "feature",
-  "description" : "Add word wrap to CloudFormation status reasons on selection (#1863)"
+  "description" : "Add word wrap to CloudFormation status reasons on selection (#1858)"
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsTable.kt
@@ -50,9 +50,9 @@ internal class EventsTableImpl : EventsTable, Disposable {
             message("cloudformation.stack.reason"),
             WrappingCellRenderer(wrapOnSelection = true, toggleableWrap = false)
         ) { e -> e.resourceStatusReason() ?: "" }
-    )
+    ).apply { component.border = IdeBorderFactory.createBorder(SideBorder.BOTTOM) }
 
-    override val component: JComponent = table.component.apply { border = IdeBorderFactory.createBorder(SideBorder.BOTTOM) }
+    override val component: JComponent = table.component
 
     override fun showBusyIcon() {
         table.showBusy(true)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsTable.kt
@@ -3,6 +3,8 @@
 package software.aws.toolkits.jetbrains.services.cloudformation.stack
 
 import com.intellij.openapi.Disposable
+import com.intellij.ui.IdeBorderFactory
+import com.intellij.ui.SideBorder
 import software.amazon.awssdk.services.cloudformation.model.StackEvent
 import software.aws.toolkits.jetbrains.utils.ui.WrappingCellRenderer
 import software.aws.toolkits.resources.message
@@ -50,7 +52,7 @@ internal class EventsTableImpl : EventsTable, Disposable {
         ) { e -> e.resourceStatusReason() ?: "" }
     )
 
-    override val component: JComponent = table.component
+    override val component: JComponent = table.component.apply { border = IdeBorderFactory.createBorder(SideBorder.BOTTOM) }
 
     override fun showBusyIcon() {
         table.showBusy(true)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsTable.kt
@@ -4,6 +4,7 @@ package software.aws.toolkits.jetbrains.services.cloudformation.stack
 
 import com.intellij.openapi.Disposable
 import software.amazon.awssdk.services.cloudformation.model.StackEvent
+import software.aws.toolkits.jetbrains.utils.ui.WrappingCellRenderer
 import software.aws.toolkits.resources.message
 import java.awt.Component
 import javax.swing.JComponent
@@ -43,7 +44,10 @@ internal class EventsTableImpl : EventsTable, Disposable {
         DynamicTableView.Field(message("cloudformation.stack.status"), renderer = StatusCellRenderer()) { e -> e.resourceStatusAsString() },
         DynamicTableView.Field(message("cloudformation.stack.logical_id")) { e -> e.logicalResourceId() },
         DynamicTableView.Field(message("cloudformation.stack.physical_id")) { e -> e.physicalResourceId() },
-        DynamicTableView.Field(message("cloudformation.stack.reason")) { e -> e.resourceStatusReason() ?: "" }
+        DynamicTableView.Field(
+            message("cloudformation.stack.reason"),
+            WrappingCellRenderer(wrapOnSelection = true, toggleableWrap = false)
+        ) { e -> e.resourceStatusReason() ?: "" }
     )
 
     override val component: JComponent = table.component

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/OutputsTableView.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/OutputsTableView.kt
@@ -3,6 +3,7 @@
 package software.aws.toolkits.jetbrains.services.cloudformation.stack
 
 import com.intellij.openapi.Disposable
+import com.intellij.util.ui.JBUI
 import software.amazon.awssdk.services.cloudformation.model.Output
 import software.aws.toolkits.resources.message
 import javax.swing.JComponent
@@ -15,7 +16,7 @@ class OutputsTableView : View, OutputsListener, Disposable {
         DynamicTableView.Field(message("cloudformation.stack.outputs.export")) { it.exportName() }
     )
 
-    override val component: JComponent = table.component
+    override val component: JComponent = table.component.apply { border = JBUI.Borders.empty() }
 
     override fun updatedOutputs(outputs: List<Output>) = table.updateItems(outputs.sortedBy { it.outputKey() }, clearExisting = true)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/OutputsTableView.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/OutputsTableView.kt
@@ -14,9 +14,9 @@ class OutputsTableView : View, OutputsListener, Disposable {
         DynamicTableView.Field(message("cloudformation.stack.outputs.value")) { it.outputValue() },
         DynamicTableView.Field(message("cloudformation.stack.outputs.description")) { it.description() },
         DynamicTableView.Field(message("cloudformation.stack.outputs.export")) { it.exportName() }
-    )
+    ).apply { component.border = JBUI.Borders.empty() }
 
-    override val component: JComponent = table.component.apply { border = JBUI.Borders.empty() }
+    override val component: JComponent = table.component
 
     override fun updatedOutputs(outputs: List<Output>) = table.updateItems(outputs.sortedBy { it.outputKey() }, clearExisting = true)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
@@ -12,6 +12,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.OnePixelSplitter
 import com.intellij.ui.components.JBTabbedPane
+import com.intellij.uiDesigner.core.GridConstraints
+import com.intellij.uiDesigner.core.GridLayoutManager
 import icons.AwsIcons
 import software.amazon.awssdk.services.cloudformation.model.StackStatus
 import software.aws.toolkits.jetbrains.core.AwsClientManager
@@ -76,10 +78,39 @@ private class StackUI(private val project: Project, private val stackName: Strin
         val mainPanel = OnePixelSplitter(false, TREE_TABLE_INITIAL_PROPORTION).apply {
             firstComponent = tree.component
             secondComponent = JBTabbedPane().apply {
-                this.add(message("cloudformation.stack.tab_labels.events"), JPanel().apply {
-                    layout = BoxLayout(this, BoxLayout.Y_AXIS)
-                    add(eventsTable.component)
-                    add(pageButtons.component)
+                this.add(message("cloudformation.stack.tab_labels.events"), JPanel(GridLayoutManager(2, 1)).apply {
+                    add(
+                        eventsTable.component,
+                        GridConstraints(
+                            0,
+                            0,
+                            1,
+                            1,
+                            0,
+                            GridConstraints.FILL_BOTH,
+                            GridConstraints.SIZEPOLICY_CAN_GROW or GridConstraints.SIZEPOLICY_WANT_GROW or GridConstraints.SIZEPOLICY_CAN_SHRINK,
+                            GridConstraints.SIZEPOLICY_CAN_GROW or GridConstraints.SIZEPOLICY_WANT_GROW or GridConstraints.SIZEPOLICY_CAN_SHRINK,
+                            null,
+                            null,
+                            null
+                        )
+                    )
+                    add(
+                        pageButtons.component,
+                        GridConstraints(
+                            1,
+                            0,
+                            1,
+                            1,
+                            0,
+                            GridConstraints.FILL_HORIZONTAL,
+                            GridConstraints.SIZEPOLICY_CAN_GROW or GridConstraints.SIZEPOLICY_WANT_GROW or GridConstraints.SIZEPOLICY_CAN_SHRINK,
+                            GridConstraints.SIZEPOLICY_CAN_GROW or GridConstraints.SIZEPOLICY_CAN_SHRINK,
+                            null,
+                            null,
+                            null
+                        )
+                    )
                 })
 
                 this.add(message("cloudformation.stack.tab_labels.outputs"), JPanel().apply {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
@@ -14,6 +14,7 @@ import com.intellij.ui.OnePixelSplitter
 import com.intellij.ui.components.JBTabbedPane
 import com.intellij.uiDesigner.core.GridConstraints
 import com.intellij.uiDesigner.core.GridLayoutManager
+import com.intellij.util.ui.JBUI
 import icons.AwsIcons
 import software.amazon.awssdk.services.cloudformation.model.StackStatus
 import software.aws.toolkits.jetbrains.core.AwsClientManager
@@ -111,6 +112,8 @@ private class StackUI(private val project: Project, private val stackName: Strin
                             null
                         )
                     )
+                    tabComponentInsets = JBUI.emptyInsets()
+                    border = JBUI.Borders.empty()
                 })
 
                 this.add(message("cloudformation.stack.tab_labels.outputs"), JPanel().apply {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogStreamTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogStreamTable.kt
@@ -66,6 +66,11 @@ class LogStreamTable(
             autoResizeMode = JTable.AUTO_RESIZE_LAST_COLUMN
             setPaintBusy(true)
             emptyText.text = message("loading_resource.loading")
+            // Set the row height to 20. This is a magic number, so let me explain. This is
+            // The height of a JLabel (16) + 1 inner border (top and bottom) + 1 outer border
+            // (top and bottom) = 20 total. If we don't do this, as we scroll to the bottom,
+            // it will spring back to the top in a very comical but very not great way
+            setRowHeight(20)
         }
 
         // TODO this also searches the date column which we don't want to do.

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
@@ -169,8 +169,6 @@ private fun JTextArea.speedSearchHighlighter(speedSearchEnabledComponent: JCompo
     }
 }
 
-// TODO for some reason this breaks the cloudwatch one so we can't just use it for cloudwatch. If you scroll too far,
-// it springs back up as the cells render which makes it look like it scrolls back.
 class WrappingCellRenderer(private val wrapOnSelection: Boolean, private val toggleableWrap: Boolean) : DefaultTableCellRenderer() {
     var wrap: Boolean = false
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
@@ -197,4 +197,3 @@ class WrappingCellRenderer(private val wrapOnSelection: Boolean, private val tog
         return component
     }
 }
-

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
@@ -24,7 +24,6 @@ import software.aws.toolkits.jetbrains.utils.formatText
 import java.awt.AlphaComposite
 import java.awt.Color
 import java.awt.Component
-import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.Shape
@@ -170,6 +169,8 @@ private fun JTextArea.speedSearchHighlighter(speedSearchEnabledComponent: JCompo
     }
 }
 
+// TODO for some reason this breaks the cloudwatch one so we can't just use it for cloudwatch. If you scroll too far,
+// it springs back up as the cells render which makes it look like it scrolls back.
 class WrappingCellRenderer(private val wrapOnSelection: Boolean, private val toggleableWrap: Boolean) : DefaultTableCellRenderer() {
     var wrap: Boolean = false
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/ui/UiUtils.kt
@@ -13,21 +13,34 @@ import com.intellij.ui.ClickListener
 import com.intellij.ui.EditorTextField
 import com.intellij.ui.JBColor
 import com.intellij.ui.JreHiDpiUtil
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.paint.LinePainter2D
+import com.intellij.ui.speedSearch.SpeedSearchSupply
 import com.intellij.util.ui.GraphicsUtil
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import software.aws.toolkits.jetbrains.utils.formatText
 import java.awt.AlphaComposite
 import java.awt.Color
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.Graphics
 import java.awt.Graphics2D
+import java.awt.Shape
 import java.awt.event.MouseEvent
 import java.awt.geom.RoundRectangle2D
 import javax.swing.AbstractButton
 import javax.swing.JComboBox
 import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JTable
+import javax.swing.JTextArea
 import javax.swing.JTextField
 import javax.swing.ListModel
+import javax.swing.table.DefaultTableCellRenderer
+import javax.swing.text.Highlighter
+import javax.swing.text.JTextComponent
 
 fun JTextField?.blankAsNull(): String? = if (this?.text?.isNotBlank() == true) {
     text
@@ -126,3 +139,63 @@ fun drawSearchMatch(graphics2D: Graphics2D, startXf: Float, endXf: Float, startY
     }
     config.restore()
 }
+
+fun Component.setSelectionHighlighting(table: JTable, isSelected: Boolean) {
+    if (isSelected) {
+        foreground = table.selectionForeground
+        background = table.selectionBackground
+    } else {
+        foreground = table.foreground
+        background = table.background
+    }
+}
+
+private class SpeedSearchHighlighter : Highlighter.HighlightPainter {
+    override fun paint(g: Graphics?, startingPoint: Int, endingPoint: Int, bounds: Shape?, component: JTextComponent?) {
+        component ?: return
+        val graphics = g as? Graphics2D ?: return
+        val beginningRect = component.modelToView(startingPoint)
+        val endingRect = component.modelToView(endingPoint)
+        drawSearchMatch(graphics, beginningRect.x.toFloat(), endingRect.x.toFloat(), beginningRect.y.toFloat(), beginningRect.height)
+    }
+}
+
+private fun JTextArea.speedSearchHighlighter(speedSearchEnabledComponent: JComponent) {
+    // matchingFragments does work with wrapped text but not around words if they are wrapped, so it will also need to be extended
+    // in the future
+    val speedSearch = SpeedSearchSupply.getSupply(speedSearchEnabledComponent) ?: return
+    val fragments = speedSearch.matchingFragments(text)?.iterator() ?: return
+    fragments.forEach {
+        highlighter?.addHighlight(it.startOffset, it.endOffset, SpeedSearchHighlighter())
+    }
+}
+
+class WrappingCellRenderer(private val wrapOnSelection: Boolean, private val toggleableWrap: Boolean) : DefaultTableCellRenderer() {
+    var wrap: Boolean = false
+
+    // JBTextArea has a different font from JBLabel (the default in a table) so harvest the font off of it
+    private val jLabelFont = JBLabel().font
+
+    override fun getTableCellRendererComponent(table: JTable?, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int): Component {
+        val defaultComponent = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+        table ?: return defaultComponent
+        val component = JBTextArea()
+
+        component.border = (defaultComponent as? JLabel)?.border ?: JBUI.Borders.empty(2, 2)
+        component.wrapStyleWord = (wrapOnSelection && isSelected) || (toggleableWrap && wrap)
+        component.lineWrap = (wrapOnSelection && isSelected) || (toggleableWrap && wrap)
+        component.font = jLabelFont
+        component.text = (value as? String)?.trim()
+        component.setSelectionHighlighting(table, isSelected)
+
+        component.setSize(table.columnModel.getColumn(column).width, component.preferredSize.height)
+        if (table.getRowHeight(row) != component.preferredSize.height) {
+            table.setRowHeight(row, component.preferredSize.height)
+        }
+
+        component.speedSearchHighlighter(table)
+
+        return component
+    }
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Allow CloudFormation window to resize based on window size
- Add line wrap on selection in CloudFormation status window
- Refactor the wrapping renderer from CloudWatchLogs so it can be reused
- Fix bug with CloudWatchLogs where if you scroll too fast, it would start scrolling back due to it adjusting cell size

## Screenshots (if appropriate)
<img width="1032" alt="Screen Shot 2020-06-25 at 1 06 55 PM" src="https://user-images.githubusercontent.com/11964782/85790774-a8900c00-b6e5-11ea-8bd2-7ff4006572e2.png">
<img width="754" alt="Screen Shot 2020-06-25 at 1 13 34 PM" src="https://user-images.githubusercontent.com/11964782/85790812-b8a7eb80-b6e5-11ea-83ca-e9e232f67656.png">
<img width="1059" alt="Screen Shot 2020-06-25 at 9 48 39 AM" src="https://user-images.githubusercontent.com/11964782/85776033-2c8dc800-b6d5-11ea-990a-a241b4932daf.png">
<img width="1068" alt="Screen Shot 2020-06-25 at 11 19 38 AM" src="https://user-images.githubusercontent.com/11964782/85776855-f13fc900-b6d5-11ea-9da4-5902bf19bfa7.png">

## Related issues
#1858

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
