### PR TITLE
Stop pulling endpoints from S3 as a backup option

### DIFF
--- a/core/src/software/aws/toolkits/core/region/Partitions.kt
+++ b/core/src/software/aws/toolkits/core/region/Partitions.kt
@@ -49,10 +49,7 @@ object PartitionParser {
 }
 
 object ServiceEndpointResource : RemoteResource {
-    override val urls: List<String> = listOf(
-        "https://idetoolkits.amazonwebservices.com/endpoints.json",
-        "https://aws-toolkit-endpoints.s3.amazonaws.com/endpoints.json"
-    )
+    override val urls: List<String> = listOf("https://idetoolkits.amazonwebservices.com/endpoints.json")
     override val name: String = "service-endpoints.json"
     override val ttl: Duration? = Duration.ofHours(24)
     override val initialValue: (() -> InputStream)? = { BundledResources.ENDPOINTS_FILE }

--- a/resources/build.gradle
+++ b/resources/build.gradle
@@ -12,9 +12,7 @@ sourceSets {
 task downloadResources(type: Download) {
     dest "$buildDir/downloaded-resources/software/aws/toolkits/resources/"
 
-    src([
-        "https://aws-toolkit-endpoints.s3.amazonaws.com/endpoints.json"
-    ])
+    src(["https://idetoolkits.amazonwebservices.com/endpoints.json"])
 
     onlyIfModified true
     useETag true


### PR DESCRIPTION
- Stop pulling endpoints from S3 as a backup option
- Also pull from CloudFront during build as well

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
