### PR TITLE
Convert ProfileWatcher to an app service to decouple it

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -152,6 +152,8 @@
         <applicationService serviceInterface="software.aws.toolkits.jetbrains.core.credentials.CredentialManager"
                             serviceImplementation="software.aws.toolkits.jetbrains.core.credentials.DefaultCredentialManager"
                             testServiceImplementation="software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager"/>
+        <applicationService serviceInterface="software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileWatcher"
+                            serviceImplementation="software.aws.toolkits.jetbrains.core.credentials.profiles.DefaultProfileWatcher"/>
         <applicationService serviceInterface="software.aws.toolkits.jetbrains.settings.AwsSettings"
                             serviceImplementation="software.aws.toolkits.jetbrains.settings.DefaultAwsSettings"
                             testServiceImplementation="software.aws.toolkits.jetbrains.settings.MockAwsSettings" />

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.core.credentials.profiles
 
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
@@ -70,8 +69,7 @@ private class ProfileCredentialsIdentifierSso(
 ) : ProfileCredentialsIdentifier(profileName, defaultRegionId),
     SsoRequiredInteractiveCredentials
 
-class ProfileCredentialProviderFactory : CredentialProviderFactory, Disposable {
-    private val profileWatcher = ProfileWatcher(this)
+class ProfileCredentialProviderFactory : CredentialProviderFactory {
     private val profileHolder = ProfileHolder()
 
     override val id = PROFILE_FACTORY_ID
@@ -80,9 +78,9 @@ class ProfileCredentialProviderFactory : CredentialProviderFactory, Disposable {
         // Load the initial data, then start the background watcher
         loadProfiles(credentialLoadCallback, true)
 
-        profileWatcher.start(onFileChange = {
+        ProfileWatcher.getInstance().addListener {
             loadProfiles(credentialLoadCallback, false)
-        })
+        }
     }
 
     private fun loadProfiles(credentialLoadCallback: CredentialsChangeListener, initialLoad: Boolean) {
@@ -170,8 +168,6 @@ class ProfileCredentialProviderFactory : CredentialProviderFactory, Disposable {
             )
         }
     }
-
-    override fun dispose() {}
 
     override fun createAwsCredentialProvider(
         providerId: CredentialIdentifier,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
@@ -4,35 +4,45 @@
 package software.aws.toolkits.jetbrains.core.credentials.profiles
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.components.service
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.AsyncFileListener
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.util.containers.ContainerUtil
 import software.amazon.awssdk.profiles.ProfileFileLocation
 
-class ProfileWatcher(parentDisposable: Disposable) : AsyncFileListener, Disposable {
-    private val watchRoots = mutableSetOf<LocalFileSystem.WatchRequest>()
-    private var onUpdate: (() -> Unit)? = null
+interface ProfileWatcher {
+    fun addListener(listener: () -> Unit)
 
-    init {
-        Disposer.register(parentDisposable, this)
+    companion object {
+        fun getInstance() = service<ProfileWatcher>()
     }
+}
+
+class DefaultProfileWatcher : AsyncFileListener, Disposable, ProfileWatcher {
+    private val listeners = ContainerUtil.createLockFreeCopyOnWriteList<() -> Unit>()
+    private val watchRoots = mutableSetOf<LocalFileSystem.WatchRequest>()
 
     private val watchLocationsStrings = setOf(
         FileUtil.normalize(ProfileFileLocation.configurationFilePath().toAbsolutePath().toString()),
         FileUtil.normalize(ProfileFileLocation.credentialsFilePath().toAbsolutePath().toString())
     )
 
-    override fun prepareChange(events: MutableList<out VFileEvent>): AsyncFileListener.ChangeApplier? {
+    init {
+        watchRoots.addAll(LocalFileSystem.getInstance().addRootsToWatch(watchLocationsStrings, false))
+        VirtualFileManager.getInstance().addAsyncFileListener(this, this)
+    }
+
+    override fun prepareChange(events: List<VFileEvent>): AsyncFileListener.ChangeApplier? {
         val isRelevant = events.any { VfsUtilCore.isUnder(it.path, watchLocationsStrings) }
 
         return if (isRelevant) {
             object : AsyncFileListener.ChangeApplier {
                 override fun afterVfsChange() {
-                    onUpdate?.invoke()
+                    listeners.forEach { it() }
                 }
             }
         } else {
@@ -40,14 +50,12 @@ class ProfileWatcher(parentDisposable: Disposable) : AsyncFileListener, Disposab
         }
     }
 
-    fun start(onFileChange: () -> Unit) {
-        onUpdate = onFileChange
-
-        watchRoots.addAll(LocalFileSystem.getInstance().addRootsToWatch(watchLocationsStrings, false))
-        VirtualFileManager.getInstance().addAsyncFileListener(this, this)
+    override fun addListener(listener: () -> Unit) {
+        listeners.add(listener)
     }
 
     override fun dispose() {
         LocalFileSystem.getInstance().removeWatchedRoots(watchRoots)
+        listeners.clear()
     }
 }


### PR DESCRIPTION
This change decouples and makes ProfileCredentialProviderFactory not tied to the file watching directly

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
