### PR TITLE
Upgrade telemetry version to support dotnet 3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ coroutinesVersion=1.3.3
 ideaPluginVersion=0.4.20
 ktlintVersion=0.36.0
 jacksonVersion=2.9.8
-telemetryVersion=0.0.30
+telemetryVersion=0.0.34
 
 assertjVersion=3.15.0
 junitVersion=4.12


### PR DESCRIPTION
## Related Issue(s)
#1878
https://github.com/aws/aws-toolkit-common/pull/44

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
