### PR TITLE
Use SigInt to stop SAM local invoke

### DIFF
--- a/.changes/next-release/bugfix-788d4d6c-05d1-4779-991f-2a78b44a17fa.json
+++ b/.changes/next-release/bugfix-788d4d6c-05d1-4779-991f-2a78b44a17fa.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Change the way we stop SAM CLI processes when debugging to allow docker container to shut down"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamRunningState.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamRunningState.kt
@@ -5,8 +5,8 @@ package software.aws.toolkits.jetbrains.services.lambda.execution.local
 
 import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.executors.DefaultDebugExecutor
+import com.intellij.execution.process.KillableColoredProcessHandler
 import com.intellij.execution.process.ProcessHandler
-import com.intellij.execution.process.ProcessHandlerFactory
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.util.io.FileUtil
 import software.aws.toolkits.jetbrains.core.credentials.toEnvironmentVariables
@@ -70,7 +70,9 @@ class SamRunningState(
 
         runner.patchCommandLine(commandLine)
 
-        return ProcessHandlerFactory.getInstance().createColoredProcessHandler(commandLine)
+        // Unix: Sends SIGINT on destroy so Docker container is shut down
+        // Windows: Run with mediator to allow for Cntrl+C to be used
+        return KillableColoredProcessHandler(commandLine, true)
     }
 
     private fun createEventFile(): String {


### PR DESCRIPTION
* On Linux use SigInt
* On Windows run with mediator wrapper so that cntrl+c is passed

I do not have access to a Windows machine but at least on OSX, the docker contianer is now shutdown when stop is called on Run/Debug

This may help #1763

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
