### PR TITLE
Adding ability for build-system to handle IDE version ranges (e.g. 201+)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,15 +100,15 @@ subprojects {
     }
 
     sourceSets {
-        main.java.srcDirs = ['src', "src-$ideVersion"]
-        main.resources.srcDirs = ['resources', "resources-$ideVersion"]
-        test.java.srcDirs = ['tst', "tst-$ideVersion"]
-        test.resources.srcDirs = ['tst-resources', "tst-resources-$ideVersion"]
+        main.java.srcDirs = SourceUtils.findFolders(project, "src", ideVersion)
+        main.resources.srcDirs = SourceUtils.findFolders(project, "resources", ideVersion)
+        test.java.srcDirs = SourceUtils.findFolders(project, "tst", ideVersion)
+        test.resources.srcDirs = SourceUtils.findFolders(project, "tst-resources", ideVersion)
         integrationTest {
             compileClasspath += main.output + test.output
             runtimeClasspath += main.output + test.output
-            java.srcDirs = ['it', "it-$ideVersion"]
-            resources.srcDirs = ['it-resources', "it-resources-$ideVersion"]
+            java.srcDirs = SourceUtils.findFolders(project, "it", ideVersion)
+            resources.srcDirs = SourceUtils.findFolders(project, "it-resources", ideVersion)
         }
     }
 
@@ -150,8 +150,8 @@ subprojects {
 
     idea {
         module {
-            sourceDirs += file("src-$ideVersion")
-            resourceDirs += file("resources-$ideVersion")
+            sourceDirs += sourceSets.main.java.srcDirs
+            resourceDirs += sourceSets.main.resources.srcDirs
             testSourceDirs += file("tst-$ideVersion")
             testResourceDirs += file("tst-resources-$ideVersion")
 

--- a/buildSrc/src/SourcesUtils.kt
+++ b/buildSrc/src/SourcesUtils.kt
@@ -1,0 +1,50 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+@file:JvmName("SourceUtils")
+
+import org.gradle.api.Project
+import java.io.FileFilter
+
+/**
+ * Determines the sub-folders under a project that should be included based on ideVersion
+ *
+ * [project] the project to use as a directory base
+ * [type] is the type of the source folder (e.g. 'src', 'tst', 'resources')
+ * [ideVersion] is the 3 digit numerical version of the JetBrains SDK (e.g. 192, 201 etc)
+ */
+fun findFolders(project: Project, type: String, ideVersion: String): List<String> = project.projectDir.listFiles(FileFilter {
+    it.isDirectory && includeFolder(type, ideVersion, it.name)
+})?.map { it.name } ?: emptyList()
+
+/**
+ * Determines if a folder should be included based on the ideVersion being targeted
+ * [type] is the type of the source folder (e.g. 'src', 'tst', 'resources')
+ * [ideVersion] is the 3 digit numerical version of the JetBrains SDK (e.g. 192, 201 etc)
+ * [folderName] is the folder name to match on, relative to the project directory (e.g. 'tst-201')
+ *
+ * Examples:
+ * Given [includeFolder] is called with a [type] of "tst" and an [ideVersion] of "201"
+ *
+ * Then following will match:
+ *  - tst
+ *  - tst-201
+ *  - tst-201+
+ *  - tst-192+
+ *
+ * The following with *not* match:
+ *  - tst-resources
+ *  - tst-resources-201
+ *  - tst-192
+ *  - tst-202
+ *  - tst-202+
+ */
+internal fun includeFolder(type: String, ideVersion: String, folderName: String): Boolean {
+    val ideVersionAsInt = ideVersion.toInt()
+    val match = "$type(-(\\d{3}))?(\\+)?".toRegex().matchEntire(folderName) ?: return false
+    val (_, version, plus) = match.destructured
+    return when {
+        version.isBlank() -> true
+        plus.isBlank() -> version.toInt() == ideVersionAsInt
+        else -> version.toInt() <= ideVersionAsInt
+    }
+}

--- a/buildSrc/tst/SourceUtilsTest.kt
+++ b/buildSrc/tst/SourceUtilsTest.kt
@@ -1,0 +1,35 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class SourceUtilsTest(private val folderName: String, private val expected: Boolean) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0} -> {1}")
+        fun data(): Collection<Array<Any>> = listOf(
+            arrayOf("tst", true),
+            arrayOf("tst-201", true),
+            arrayOf("tst-190+", true),
+            arrayOf("tst-201+", true),
+
+            arrayOf("tst-resources", false),
+            arrayOf("tst-resources-201", false),
+            arrayOf("tst-192", false),
+            arrayOf("tst-202", false),
+            arrayOf("tst-202+", false),
+            arrayOf("random", false),
+            arrayOf("src-tst", false)
+        )
+    }
+
+    @Test
+    fun `correctly includes folder`() {
+        assertThat(includeFolder("tst", "201", folderName)).isEqualTo(expected)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ publishToken=
 publishChannel=
 
 # Common dependencies
-ideProfileName=2020.1
+ideProfileName=2019.3
 kotlinVersion=1.3.70
 awsSdkVersion=2.11.9
 coroutinesVersion=1.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ publishToken=
 publishChannel=
 
 # Common dependencies
-ideProfileName=2019.3
+ideProfileName=2020.1
 kotlinVersion=1.3.70
 awsSdkVersion=2.11.9
 coroutinesVersion=1.3.3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adding the ability to handle upwards version ranges for IDE versions - in an effort to avoid code-duplication. 

As an example if we're building for version `2020.2` (eg `202`), the following folders would be included into the `main` `sourceSet`:

* `src`
* `src-201+`
* `src-202`

The same login applies to `resources`, `tst`, `tst-resources`, `it`, `it-resources`.

This logic should be enhanced further in the future to:
* Validate that only one additional source-specific folder is included per type for a given target IDE version (since we have no intelligent way to 'merge' `plugin.xml` files)
* Add version-specific folders as `idea` source roots
* Bundle this logic in to a more fully-fledged plugin