### PR TITLE
Fix OOM when running tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,7 @@ subprojects {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
         implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
         testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion"
+        testImplementation "org.mockito:mockito-core:$mockitoVersion"
         testImplementation "org.assertj:assertj-core:$assertjVersion"
         testImplementation "junit:junit:$junitVersion"
     }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -43,4 +43,5 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,7 @@ assertjVersion=3.15.0
 junitVersion=4.12
 junit5Version=5.6.2
 mockitoKotlinVersion=2.2.0
+mockitoVersion=3.4.0
 
 remoteRobotPort=8080
 remoteRobotVersion=0.9.35

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -49,8 +49,8 @@ class AwsResourceCacheTest {
 
     private val mockClock = mock<Clock>()
     private val mockResource = mock<Resource.Cached<String>>()
-    private val sut = DefaultAwsResourceCache(projectRule.project, mockClock, 1000, Duration.ofMinutes(1))
 
+    private lateinit var sut: AwsResourceCache
     private lateinit var cred1Identifier: ToolkitCredentialsIdentifier
     private lateinit var cred1Provider: ToolkitCredentialsProvider
     private lateinit var cred2Identifier: ToolkitCredentialsIdentifier
@@ -67,7 +67,9 @@ class AwsResourceCacheTest {
         cred2Identifier = credentialsManager.addCredentials("Cred2")
         cred2Provider = credentialsManager.getAwsCredentialProvider(cred2Identifier, MockRegionProvider.getInstance().defaultRegion())
 
+        sut = DefaultAwsResourceCache(projectRule.project, mockClock, 1000, Duration.ofMinutes(1))
         sut.clear()
+
         reset(mockClock, mockResource)
         whenever(mockResource.expiry()).thenReturn(DEFAULT_EXPIRY)
         whenever(mockResource.id).thenReturn("mock")

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CodeInsightTestFixtureRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CodeInsightTestFixtureRule.kt
@@ -24,6 +24,7 @@ import com.intellij.testFramework.runInEdtAndWait
 import com.intellij.testFramework.writeChild
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
+import org.mockito.Mockito
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import java.nio.file.Paths
@@ -66,6 +67,10 @@ open class CodeInsightTestFixtureRule(protected val testDescription: LightProjec
     }
 
     override fun finished(description: Description?) {
+        // Hack: Runs often enough that we keep our leaks down. https://github.com/mockito/mockito/pull/1619
+        // TODO: Investigate Mockk and remove this
+        Mockito.framework().clearInlineMocks()
+
         lazyFixture.ifSet {
             try {
                 fixture.tearDown()


### PR DESCRIPTION
* Fix project leak by not passing a disposable to the message bug in the resource cache
* Add hack to clear the inline mock cache that gets used when using Kotlin + Mockito
* Fix ResourceCache test using project rule incorrectly leading to leak

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
