### PR TITLE
Make sure plugins are enabled instead of just installed

### DIFF
--- a/.changes/next-release/bugfix-d2b78feb-6a6d-4e7f-81dc-af756d3d92a0.json
+++ b/.changes/next-release/bugfix-d2b78feb-6a6d-4e7f-81dc-af756d3d92a0.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix several uncaught exceptions caused by plugins being installed but not enabled"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/plugins/PluginUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/plugins/PluginUtils.kt
@@ -1,0 +1,9 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.plugins
+
+import com.intellij.ide.plugins.PluginManagerCore.getPlugin
+import com.intellij.openapi.extensions.PluginId
+
+fun pluginIsInstalledAndEnabled(pluginId: String): Boolean = getPlugin(PluginId.findId(pluginId))?.isEnabled == true

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/actions/StartRemoteShellAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/actions/StartRemoteShellAction.kt
@@ -4,11 +4,9 @@
 package software.aws.toolkits.jetbrains.services.clouddebug.actions
 
 import com.intellij.execution.process.CapturingProcessHandler
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.runInEdt
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
@@ -25,6 +23,7 @@ import software.aws.toolkits.jetbrains.core.executables.CloudDebugExecutable
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutable
+import software.aws.toolkits.jetbrains.core.plugins.pluginIsInstalledAndEnabled
 import software.aws.toolkits.jetbrains.services.clouddebug.CliOutputParser
 import software.aws.toolkits.jetbrains.services.clouddebug.CloudDebugConstants
 import software.aws.toolkits.jetbrains.services.clouddebug.CloudDebugConstants.INSTRUMENTED_STATUS
@@ -46,7 +45,7 @@ class StartRemoteShellAction(private val project: Project, private val container
 ) {
 
     private val disabled by lazy {
-        !PluginManager.isPluginInstalled(PluginId.findId("org.jetbrains.plugins.terminal")) ||
+        !pluginIsInstalledAndEnabled("org.jetbrains.plugins.terminal") ||
             // exec doesn't allow you to go into the sidecar container
             container.containerDefinition.name() == CloudDebugConstants.CLOUD_DEBUG_SIDECAR_CONTAINER_NAME ||
             !EcsUtils.isInstrumented(container.service.serviceArn())

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/execution/ImportFromDockerfile.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/execution/ImportFromDockerfile.kt
@@ -5,8 +5,6 @@ package software.aws.toolkits.jetbrains.services.ecs.execution
 
 import com.intellij.docker.dockerFile.DockerFileType
 import com.intellij.docker.dockerFile.parser.psi.DockerPsiCommand
-import com.intellij.ide.plugins.PluginManager
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.project.Project
@@ -22,6 +20,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import software.aws.toolkits.core.utils.tryOrNull
+import software.aws.toolkits.jetbrains.core.plugins.pluginIsInstalledAndEnabled
 import software.aws.toolkits.resources.message
 import java.awt.event.ActionEvent
 import java.awt.event.ActionListener
@@ -29,7 +28,7 @@ import java.io.File
 
 object DockerUtil {
     @JvmStatic
-    fun dockerPluginAvailable() = PluginId.findId("Docker")?.let { PluginManager.isPluginInstalled(it) } == true
+    fun dockerPluginAvailable() = pluginIsInstalledAndEnabled("Docker")
 }
 
 class ImportFromDockerfile @JvmOverloads constructor(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaBuilder.kt
@@ -3,8 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.java
 
-import com.intellij.ide.plugins.PluginManager
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.module.Module
@@ -13,6 +11,7 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiElement
 import org.jetbrains.idea.maven.project.MavenProjectsManager
+import software.aws.toolkits.jetbrains.core.plugins.pluginIsInstalledAndEnabled
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.resources.message
@@ -48,7 +47,7 @@ class JavaLambdaBuilder : LambdaBuilder() {
             ?: throw IllegalStateException(message("lambda.build.unable_to_locate_project_root", module))
 
     private fun isMaven(module: Module): Boolean {
-        if (PluginManager.getPlugin(PluginId.getId("org.jetbrains.idea.maven"))?.isEnabled == true) {
+        if (pluginIsInstalledAndEnabled("org.jetbrains.idea.maven")) {
             return MavenProjectsManager.getInstance(module.project).isMavenizedModule(module)
         }
 


### PR DESCRIPTION
- The docker plugin check made the local lambda config page not load and throw if Docker was installed but not enabled.
- Centralize the logic 
<!--- Provide a general summary of your changes in the Title above -->

## Related issues
#1926 

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
