### PR TITLE
Fix Rider building lambda into wrong directory

### DIFF
--- a/.changes/next-release/bugfix-cf15b891-593c-4493-b594-8fda9f30d031.json
+++ b/.changes/next-release/bugfix-cf15b891-593c-4493-b594-8fda9f30d031.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix Rider building Lambda into incorrect folders"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.exists
-import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutable
@@ -185,7 +184,7 @@ abstract class LambdaBuilder {
     /**
      * Returns the build directory of the project. Create this if it doesn't exist yet.
      */
-    private fun getBuildDirectory(module: Module): Path {
+    protected open fun getBuildDirectory(module: Module): Path {
         val contentRoot = module.rootManager.contentRoots.firstOrNull()
             ?: throw IllegalStateException(message("lambda.build.module_with_no_content_root", module.name))
         return Paths.get(contentRoot.path, ".aws-sam", "build")
@@ -193,9 +192,7 @@ abstract class LambdaBuilder {
 
     protected open fun additionalEnvironmentVariables(module: Module, samOptions: SamOptions): Map<String, String> = emptyMap()
 
-    companion object : RuntimeGroupExtensionPointObject<LambdaBuilder>(ExtensionPointName("aws.toolkit.lambda.builder")) {
-        private val LOG = getLogger<LambdaBuilder>()
-    }
+    companion object : RuntimeGroupExtensionPointObject<LambdaBuilder>(ExtensionPointName("aws.toolkit.lambda.builder"))
 }
 
 /**

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilderTestUtils.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilderTestUtils.kt
@@ -1,7 +1,7 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.lambda.java
+package software.aws.toolkits.jetbrains.services.lambda
 
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModuleRootManager
@@ -9,27 +9,16 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiElement
 import com.intellij.util.io.isFile
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.zipEntries
 import software.aws.toolkits.jetbrains.services.PathMapping
-import software.aws.toolkits.jetbrains.services.lambda.BuiltLambda
-import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
-import software.aws.toolkits.jetbrains.utils.setSamExecutableFromEnvironment
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.streams.toList
 
-abstract class BaseLambdaBuilderTest {
-    protected abstract val lambdaBuilder: LambdaBuilder
-
-    @Before
-    open fun setUp() {
-        setSamExecutableFromEnvironment()
-    }
-
-    protected fun buildLambda(
+object LambdaBuilderTestUtils {
+    fun LambdaBuilder.buildLambda(
         module: Module,
         handlerElement: PsiElement,
         runtime: Runtime,
@@ -39,10 +28,10 @@ abstract class BaseLambdaBuilderTest {
         val samOptions = SamOptions()
         samOptions.buildInContainer = useContainer
 
-        return lambdaBuilder.buildLambda(module, handlerElement, handler, runtime, 0, 0, emptyMap(), samOptions)
+        return this.buildLambda(module, handlerElement, handler, runtime, 0, 0, emptyMap(), samOptions)
     }
 
-    protected fun buildLambdaFromTemplate(
+    fun LambdaBuilder.buildLambdaFromTemplate(
         module: Module,
         template: Path,
         logicalId: String,
@@ -51,10 +40,10 @@ abstract class BaseLambdaBuilderTest {
         val samOptions = SamOptions()
         samOptions.buildInContainer = useContainer
 
-        return lambdaBuilder.buildLambdaFromTemplate(module, template, logicalId, samOptions)
+        return this.buildLambdaFromTemplate(module, template, logicalId, samOptions)
     }
 
-    protected fun packageLambda(
+    fun LambdaBuilder.packageLambda(
         module: Module,
         handlerElement: PsiElement,
         runtime: Runtime,
@@ -64,10 +53,10 @@ abstract class BaseLambdaBuilderTest {
         val samOptions = SamOptions()
         samOptions.buildInContainer = useContainer
 
-        return lambdaBuilder.packageLambda(module, handlerElement, handler, runtime, samOptions)
+        return this.packageLambda(module, handlerElement, handler, runtime, samOptions)
     }
 
-    protected fun verifyEntries(builtLambda: BuiltLambda, vararg entries: String) {
+    fun verifyEntries(builtLambda: BuiltLambda, vararg entries: String) {
         val basePath = builtLambda.codeLocation
         Files.walk(builtLambda.codeLocation).use {
             val lambdaEntries = it.filter(Path::isFile)
@@ -77,11 +66,11 @@ abstract class BaseLambdaBuilderTest {
         }
     }
 
-    protected fun verifyZipEntries(lambdaZip: Path, vararg entries: String) {
+    fun verifyZipEntries(lambdaZip: Path, vararg entries: String) {
         assertThat(zipEntries(lambdaZip)).containsAll(entries.toList())
     }
 
-    protected fun verifyPathMappings(module: Module, builtLambda: BuiltLambda, vararg mappings: Pair<String, String>) {
+    fun verifyPathMappings(module: Module, builtLambda: BuiltLambda, vararg mappings: Pair<String, String>) {
         val basePath = ModuleRootManager.getInstance(module).contentRoots[0].path
         val updatedPaths = mappings
             .map { (path, file) ->

--- a/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaBuilderTest.kt
+++ b/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaBuilderTest.kt
@@ -1,0 +1,83 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.dotnet
+
+import base.AwsReuseSolutionTestBase
+import com.intellij.openapi.module.ModuleManager
+import com.jetbrains.rider.projectView.solutionDirectory
+import com.jetbrains.rider.test.scriptingApi.relativePathToVirtualFile
+import org.assertj.core.api.Assertions.assertThat
+import org.testng.annotations.BeforeClass
+import org.testng.annotations.Test
+import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilderTestUtils
+import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilderTestUtils.buildLambdaFromTemplate
+import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilderTestUtils.packageLambda
+import software.aws.toolkits.jetbrains.services.lambda.dotnet.element.RiderLambdaHandlerFakePsiElement
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
+import software.aws.toolkits.jetbrains.utils.setSamExecutableFromEnvironment
+import java.nio.file.Paths
+
+class DotNetLambdaBuilderTest : AwsReuseSolutionTestBase() {
+    override fun getSolutionDirectoryName(): String = "SamHelloWorldApp"
+
+    private val sut = DotNetLambdaBuilder()
+
+    @BeforeClass
+    fun setUp() {
+        setSamExecutableFromEnvironment()
+    }
+
+    @Test
+    fun buildFromHandler() {
+        val handler = "HelloWorld::HelloWorld.Function::FunctionHandler"
+        val module = ModuleManager.getInstance(project).modules.first()
+
+        val handlerResolver = DotNetLambdaHandlerResolver()
+        val fieldId = handlerResolver.getFieldIdByHandlerName(project, handler)
+        val psiElement = RiderLambdaHandlerFakePsiElement(project, handler, fieldId).navigationElement
+
+        val builtLambda = sut.buildLambda(module, psiElement, handler, Runtime.DOTNETCORE2_1, 0, 0, emptyMap(), SamOptions())
+        LambdaBuilderTestUtils.verifyEntries(
+            builtLambda,
+            "HelloWorld.dll",
+            "HelloWorld.pdb"
+        )
+
+        assertThat(builtLambda.codeLocation).startsWith(project.solutionDirectory.toPath())
+    }
+
+    @Test
+    fun buildFromTemplate() {
+        val template = relativePathToVirtualFile("template.yaml", project.solutionDirectory)
+        val templatePath = Paths.get(template.path)
+        val module = ModuleManager.getInstance(project).modules.first()
+
+        val builtLambda = sut.buildLambdaFromTemplate(module, templatePath, "HelloWorldFunction")
+        LambdaBuilderTestUtils.verifyEntries(
+            builtLambda,
+            "HelloWorld.dll",
+            "HelloWorld.pdb"
+        )
+
+        assertThat(builtLambda.codeLocation).startsWith(project.solutionDirectory.toPath())
+    }
+
+    @Test
+    fun packageLambda() {
+        val handler = "HelloWorld::HelloWorld.Function::FunctionHandler"
+        val module = ModuleManager.getInstance(project).modules.first()
+
+        val handlerResolver = DotNetLambdaHandlerResolver()
+        val fieldId = handlerResolver.getFieldIdByHandlerName(project, handler)
+        val psiElement = RiderLambdaHandlerFakePsiElement(project, handler, fieldId).navigationElement
+
+        val packagedLambda = sut.packageLambda(module, psiElement, Runtime.DOTNETCORE2_1, handler)
+        LambdaBuilderTestUtils.verifyZipEntries(
+            packagedLambda,
+            "HelloWorld.dll",
+            "HelloWorld.pdb"
+        )
+    }
+}

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaBuilder.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaBuilder.kt
@@ -5,15 +5,21 @@ package software.aws.toolkits.jetbrains.services.lambda.dotnet
 
 import com.intellij.openapi.module.Module
 import com.intellij.psi.PsiElement
+import com.jetbrains.rider.projectView.solutionDirectory
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.dotnet.element.RiderLambdaHandlerFakePsiElement
 import software.aws.toolkits.resources.message
+import java.nio.file.Path
+import java.nio.file.Paths
 
 class DotNetLambdaBuilder : LambdaBuilder() {
-
     override fun baseDirectory(module: Module, handlerElement: PsiElement): String {
         val element = handlerElement as RiderLambdaHandlerFakePsiElement
         return element.getContainingProjectFile()?.parent?.path
             ?: throw IllegalStateException(message("lambda.run.configuration.handler_root_not_found"))
+    }
+
+    override fun getBuildDirectory(module: Module): Path {
+        return Paths.get(module.project.solutionDirectory.path, ".aws-sam", "build")
     }
 }

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaBuilder.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaBuilder.kt
@@ -19,7 +19,5 @@ class DotNetLambdaBuilder : LambdaBuilder() {
             ?: throw IllegalStateException(message("lambda.run.configuration.handler_root_not_found"))
     }
 
-    override fun getBuildDirectory(module: Module): Path {
-        return Paths.get(module.project.solutionDirectory.path, ".aws-sam", "build")
-    }
+    override fun getBuildDirectory(module: Module): Path = Paths.get(module.project.solutionDirectory.path, ".aws-sam", "build")
 }

--- a/jetbrains-rider/testData/solutions/SamHelloWorldApp/template.yaml
+++ b/jetbrains-rider/testData/solutions/SamHelloWorldApp/template.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./src/HelloWorld/
+      Handler: HelloWorld::HelloWorld.Function::FunctionHandler
+      Runtime: dotnetcore3.1
+


### PR DESCRIPTION
* Also add tests

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Related Issue(s)
#1747 

## Testing
New unit tests

Manual:

```
/usr/local/bin/sam build HelloWorldFunction --template /Users/<user>/RiderProjects/HelloWorld4/template.yaml --build-dir /Users/<user>/RiderProjects/HelloWorld4/.aws-sam/build
Building function 'HelloWorldFunction'
Running DotnetCliPackageBuilder:GlobalToolInstall
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
