### PR TITLE
Make the Lambda sub-system dynamic plugin compatible

### DIFF
--- a/jetbrains-core/resources/META-INF/ext-java.xml
+++ b/jetbrains-core/resources/META-INF/ext-java.xml
@@ -7,11 +7,11 @@
     </extensions>
 
     <extensions defaultExtensionNs="aws.toolkit.lambda">
-        <runtimeGroup runtimeGroup="JAVA" implementation="software.aws.toolkits.jetbrains.services.lambda.java.JavaRuntimeGroup"/>
-        <builder runtimeGroup="JAVA" implementation="software.aws.toolkits.jetbrains.services.lambda.java.JavaLambdaBuilder"/>
-        <sam.debugSupport runtimeGroup="JAVA" implementation="software.aws.toolkits.jetbrains.services.lambda.java.JavaSamDebugSupport"/>
-        <handlerResolver runtimeGroup="JAVA" implementation="software.aws.toolkits.jetbrains.services.lambda.java.JavaLambdaHandlerResolver"/>
-        <sam.projectWizard runtimeGroup="JAVA" implementation="software.aws.toolkits.jetbrains.services.lambda.java.JavaSamProjectWizard"/>
+        <runtimeGroup implementation="software.aws.toolkits.jetbrains.services.lambda.java.JavaRuntimeGroup"/>
+        <builder id="JAVA" implementationClass="software.aws.toolkits.jetbrains.services.lambda.java.JavaLambdaBuilder"/>
+        <sam.debugSupport id="JAVA" implementationClass="software.aws.toolkits.jetbrains.services.lambda.java.JavaSamDebugSupport"/>
+        <handlerResolver id="JAVA" implementationClass="software.aws.toolkits.jetbrains.services.lambda.java.JavaLambdaHandlerResolver"/>
+        <sam.projectWizard id="JAVA" implementationClass="software.aws.toolkits.jetbrains.services.lambda.java.JavaSamProjectWizard"/>
     </extensions>
     <extensions defaultExtensionNs="aws.toolkit.clouddebug">
         <debuggerSupport implementation="software.aws.toolkits.jetbrains.services.clouddebug.java.JvmDebuggerSupport"/>

--- a/jetbrains-core/resources/META-INF/ext-python.xml
+++ b/jetbrains-core/resources/META-INF/ext-python.xml
@@ -7,11 +7,11 @@
     </extensions>
 
     <extensions defaultExtensionNs="aws.toolkit.lambda">
-        <runtimeGroup runtimeGroup="PYTHON" implementation="software.aws.toolkits.jetbrains.services.lambda.python.PythonRuntimeGroup"/>
-        <builder runtimeGroup="PYTHON" implementation="software.aws.toolkits.jetbrains.services.lambda.python.PythonLambdaBuilder"/>
-        <handlerResolver runtimeGroup="PYTHON" implementation="software.aws.toolkits.jetbrains.services.lambda.python.PythonLambdaHandlerResolver"/>
-        <sam.debugSupport runtimeGroup="PYTHON" implementation="software.aws.toolkits.jetbrains.services.lambda.python.PythonSamDebugSupport"/>
-        <sam.projectWizard runtimeGroup="PYTHON" implementation="software.aws.toolkits.jetbrains.services.lambda.python.PythonSamProjectWizard"/>
+        <runtimeGroup implementation="software.aws.toolkits.jetbrains.services.lambda.python.PythonRuntimeGroup"/>
+        <builder id="PYTHON" implementationClass="software.aws.toolkits.jetbrains.services.lambda.python.PythonLambdaBuilder"/>
+        <handlerResolver id="PYTHON" implementationClass="software.aws.toolkits.jetbrains.services.lambda.python.PythonLambdaHandlerResolver"/>
+        <sam.debugSupport id="PYTHON" implementationClass="software.aws.toolkits.jetbrains.services.lambda.python.PythonSamDebugSupport"/>
+        <sam.projectWizard id="PYTHON" implementationClass="software.aws.toolkits.jetbrains.services.lambda.python.PythonSamProjectWizard"/>
     </extensions>
     <extensions defaultExtensionNs="aws.toolkit.clouddebug">
         <debuggerSupport implementation="software.aws.toolkits.jetbrains.services.clouddebug.python.PythonDebuggerSupport"/>

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -101,34 +101,26 @@
     <extensionPoints>
         <extensionPoint name="credentialProviderFactory" interface="software.aws.toolkits.core.credentials.CredentialProviderFactory"/>
 
-        <extensionPoint name="lambda.runtimeGroup" beanClass="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPoint">
-            <with attribute="implementation" implements="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupInformation"/>
-            <with attribute="runtimeGroup" implements="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup"/>
+        <extensionPoint name="lambda.runtimeGroup" interface="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup" dynamic="true"/>
+
+        <extensionPoint name="lambda.builder" beanClass="software.aws.toolkits.jetbrains.core.IdBasedExtensionPoint" dynamic="true">
+            <with attribute="implementationClass" implements="software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder"/>
         </extensionPoint>
 
-        <extensionPoint name="lambda.builder" beanClass="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPoint">
-            <with attribute="implementation" implements="software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder"/>
-            <with attribute="runtimeGroup" implements="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup"/>
+        <extensionPoint name="lambda.sam.debugSupport" beanClass="software.aws.toolkits.jetbrains.core.IdBasedExtensionPoint" dynamic="true">
+            <with attribute="implementationClass" implements="software.aws.toolkits.jetbrains.services.lambda.execution.local.SamDebugSupport"/>
         </extensionPoint>
 
-        <extensionPoint name="lambda.sam.debugSupport" beanClass="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPoint">
-            <with attribute="implementation" implements="software.aws.toolkits.jetbrains.services.lambda.execution.local.SamDebugSupport"/>
-            <with attribute="runtimeGroup" implements="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup"/>
+        <extensionPoint name="lambda.handlerResolver" beanClass="software.aws.toolkits.jetbrains.core.IdBasedExtensionPoint" dynamic="true">
+            <with attribute="implementationClass" implements="software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver"/>
         </extensionPoint>
 
-        <extensionPoint name="lambda.handlerResolver" beanClass="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPoint">
-            <with attribute="implementation" implements="software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver"/>
-            <with attribute="runtimeGroup" implements="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup"/>
+        <extensionPoint name="lambda.sam.projectWizard" beanClass="software.aws.toolkits.jetbrains.core.IdBasedExtensionPoint" dynamic="true">
+            <with attribute="implementationClass" implements="software.aws.toolkits.jetbrains.services.lambda.SamProjectWizard"/>
         </extensionPoint>
 
-        <extensionPoint name="lambda.sam.projectWizard" beanClass="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPoint">
-            <with attribute="implementation" implements="software.aws.toolkits.jetbrains.services.lambda.SamProjectWizard"/>
-            <with attribute="runtimeGroup" implements="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup"/>
-        </extensionPoint>
-
-        <extensionPoint name="lambda.handlerCompletion" beanClass="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPoint">
-            <with attribute="implementation" implements="software.aws.toolkits.jetbrains.services.lambda.completion.HandlerCompletion"/>
-            <with attribute="runtimeGroup" implements="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup"/>
+        <extensionPoint name="lambda.handlerCompletion" beanClass="software.aws.toolkits.jetbrains.core.IdBasedExtensionPoint" dynamic="true">
+            <with attribute="implementationClass" implements="software.aws.toolkits.jetbrains.services.lambda.completion.HandlerCompletion"/>
         </extensionPoint>
 
         <extensionPoint name="executable" interface="software.aws.toolkits.jetbrains.core.executables.ExecutableType" dynamic="true"/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/IdBasedExtensionPoint.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/IdBasedExtensionPoint.kt
@@ -1,0 +1,28 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.aws.toolkits.jetbrains.core
+
+import com.intellij.openapi.extensions.CustomLoadingExtensionPointBean
+import com.intellij.util.KeyedLazyInstance
+import com.intellij.util.xmlb.annotations.Attribute
+
+/**
+ * Extension point that is used to tie multiple extension points together by a common ID.
+ *
+ * For example, if you have a "parent" extension point that defines a new ID, i.e Lambda runtime.
+ * "Children" extension points that support it can then use the same ID to correlate each other,
+ * i.e Lambda building, Lambda handler can be looked up using the same ID as defined by the Runtime parent EP.
+ *
+ * Additional attributes can be defined on the EP by extending this class.
+ */
+open class IdBasedExtensionPoint<T> : CustomLoadingExtensionPointBean<T>(), KeyedLazyInstance<T> {
+    @Attribute("id")
+    lateinit var id: String
+
+    @Attribute("implementationClass")
+    lateinit var implementationClass: String
+
+    override fun getImplementationClassName(): String = implementationClass
+
+    override fun getKey(): String = id
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
@@ -34,7 +34,7 @@ object Lambda {
     private val LOG = getLogger<Lambda>()
 
     fun findPsiElementsForHandler(project: Project, runtime: Runtime, handler: String): Array<NavigatablePsiElement> {
-        val resolver = runtime.runtimeGroup?.let { LambdaHandlerResolver.getInstance(it) } ?: return emptyArray()
+        val resolver = runtime.runtimeGroup?.let { LambdaHandlerResolver.getInstanceOrNull(it) } ?: return emptyArray()
 
         // Don't search through ".aws-sam" folders
         val samBuildFileScopes = GlobalSearchScope.filesScope(project, findSamBuildContents(project))
@@ -50,7 +50,7 @@ object Lambda {
 
     fun isHandlerValid(project: Project, runtime: Runtime, handler: String): Boolean = ReadAction.compute<Boolean, Throwable> {
         runtime.runtimeGroup?.let {
-            LambdaHandlerResolver.getInstance(it)
+            LambdaHandlerResolver.getInstanceOrNull(it)
         }?.isHandlerValid(project, handler) == true
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilderUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilderUtils.kt
@@ -33,7 +33,7 @@ object LambdaBuilderUtils {
         module: Module,
         runtimeGroup: RuntimeGroup,
         request: BuildLambdaRequest,
-        lambdaBuilder: LambdaBuilder = LambdaBuilder.getInstanceOrThrow(runtimeGroup)
+        lambdaBuilder: LambdaBuilder = LambdaBuilder.getInstance(runtimeGroup)
     ): CompletionStage<BuiltLambda> {
         val buildViewManager = ServiceManager.getService(module.project, BuildViewManager::class.java)
 
@@ -51,7 +51,7 @@ object LambdaBuilderUtils {
         module: Module,
         runtimeGroup: RuntimeGroup,
         request: PackageLambdaFromHandler,
-        lambdaBuilder: LambdaBuilder = LambdaBuilder.getInstanceOrThrow(runtimeGroup)
+        lambdaBuilder: LambdaBuilder = LambdaBuilder.getInstance(runtimeGroup)
     ): CompletionStage<Path> {
         val buildViewManager = ServiceManager.getService(module.project, BuildViewManager::class.java)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
@@ -51,9 +51,7 @@ interface RuntimeGroup {
         @JvmStatic
         fun find(predicate: (RuntimeGroup) -> Boolean): RuntimeGroup? = registeredRuntimeGroups().firstOrNull(predicate)
 
-        fun findById(id: String): RuntimeGroup? = find { it.id == id }
-
-        fun getById(id: String): RuntimeGroup = findById(id) ?: throw IllegalStateException("No RuntimeGroup with $id is registered")
+        fun getById(id: String): RuntimeGroup = find { it.id == id } ?: throw IllegalStateException("No RuntimeGroup with $id is registered")
 
         fun determineRuntime(project: Project?): Runtime? = project?.let { _ ->
             registeredRuntimeGroups().asSequence().mapNotNull { it.determineRuntime(project) }.firstOrNull()
@@ -103,8 +101,8 @@ fun AnActionEvent.runtime(): Runtime? {
 abstract class RuntimeGroupExtensionPointObject<T>(private val extensionPointName: ExtensionPointName<IdBasedExtensionPoint<T>>) {
     private val collector = KeyedExtensionCollector<T, String>(extensionPointName.name)
 
-    fun getInstance(runtimeGroup: RuntimeGroup): T? = collector.findSingle(runtimeGroup.id)
-    fun getInstanceOrThrow(runtimeGroup: RuntimeGroup): T = getInstance(runtimeGroup)
+    fun getInstanceOrNull(runtimeGroup: RuntimeGroup): T? = collector.findSingle(runtimeGroup.id)
+    fun getInstance(runtimeGroup: RuntimeGroup): T = getInstanceOrNull(runtimeGroup)
         ?: throw IllegalStateException("Attempted to retrieve feature for unsupported runtime group $runtimeGroup")
 
     fun supportedRuntimeGroups(): Set<RuntimeGroup> {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
@@ -7,7 +7,6 @@ package software.aws.toolkits.jetbrains.services.lambda
 import com.intellij.lang.Language
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
-import com.intellij.openapi.extensions.AbstractExtensionPointBean
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleType
@@ -17,108 +16,55 @@ import com.intellij.openapi.projectRoots.SdkType
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.KeyedExtensionCollector
-import com.intellij.openapi.util.LazyInstance
-import com.intellij.util.KeyedLazyInstance
-import com.intellij.util.xmlb.annotations.Attribute
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.core.IdBasedExtensionPoint
 
 /**
  * Grouping of Lambda [Runtime] by parent language.
  *
- * A Lambda [Runtime] belongs to a single [RuntimeGroup], a [RuntimeGroup] may have several
- * Lambda [Runtime]s, [Language]s or [Sdk]s.
+ * A Lambda [Runtime] belongs to a single [RuntimeGroup], a [RuntimeGroup] may have several Lambda [Runtime]s, [Language]s or [Sdk]s.
  */
-enum class RuntimeGroup {
-    JAVA,
-    PYTHON,
-    NODEJS,
-    DOTNET;
-
-    private val info by lazy {
-        RuntimeGroupInformation.getInstances(this)
-    }
-
-    val runtimes: Set<Runtime> by lazy { info.flatMap { it.runtimes }.toSet() }
-    val languageIds: Set<String> by lazy { info.flatMap { it.languageIds }.toSet() }
-
-    fun determineRuntime(project: Project): Runtime? = info.asSequence().mapNotNull { it.determineRuntime(project) }.firstOrNull()
-    fun determineRuntime(module: Module): Runtime? = info.asSequence().mapNotNull { it.determineRuntime(module) }.firstOrNull()
-    fun getModuleType(): ModuleType<*>? = info.asSequence().mapNotNull { it.getModuleType() }.firstOrNull()
-    fun getIdeSdkType(): SdkType? = info.asSequence().mapNotNull { it.getIdeSdkType() }.firstOrNull()
-    fun supportsSamBuild(): Boolean = info.asSequence().all { it.supportsSamBuild() }
-
-    internal companion object {
-        /**
-         * Lazily apply the predicate to each [RuntimeGroup] and return the first match (or null)
-         */
-        @JvmStatic
-        fun find(predicate: (RuntimeGroup) -> Boolean): RuntimeGroup? = RuntimeGroup.values().asSequence().filter(predicate).firstOrNull()
-
-        fun determineRuntime(project: Project?): Runtime? = project?.let { _ ->
-            values().asSequence().mapNotNull { it.determineRuntime(project) }.firstOrNull()
-        }
-
-        fun determineRuntime(module: Module?): Runtime? = module?.let { _ ->
-            values().asSequence().mapNotNull { it.determineRuntime(module) }.firstOrNull()
-        }
-
-        fun determineRuntimeGroup(project: Project?): RuntimeGroup? = project?.let { _ ->
-            values().asSequence().find { it.determineRuntime(project) != null }
-        }
-    }
-}
-
-/**
- * Represents information about a specific [Runtime] or [RuntimeGroup]. A single [RuntimeGroup] can have more than one RuntimeGroupInformation
- * registered.
- */
-interface RuntimeGroupInformation {
+interface RuntimeGroup {
+    val id: String
     val runtimes: Set<Runtime>
     val languageIds: Set<String>
 
-    /**
-     * Attempt to determine the runtime from the [project] level scope.
-     */
-    fun determineRuntime(project: Project): Runtime?
+    fun determineRuntime(project: Project): Runtime? = null
+    fun determineRuntime(module: Module): Runtime? = null
+    fun getModuleType(): ModuleType<*>? = null
+    fun getIdeSdkType(): SdkType? = null
+    fun supportsSamBuild(): Boolean = true
 
-    /**
-     * Attempt to determine the runtime from the [module] level scope.
-     * Do not fall back to [Project] level scope; logic controlling fallback to [Project] scope should be done at the call-site.
-     */
-    fun determineRuntime(module: Module): Runtime?
+    companion object {
+        private val EP_NAM = ExtensionPointName.create<RuntimeGroup>("aws.toolkit.lambda.runtimeGroup")
 
-    /**
-     * The IDE module type that should be associated with this runtime group
-     */
-    fun getModuleType(): ModuleType<*>?
+        @JvmStatic
+        fun find(predicate: (RuntimeGroup) -> Boolean): RuntimeGroup? = registeredRuntimeGroups().firstOrNull(predicate)
 
-    /**
-     * The IDE SDK type that this runtime group supports
-     */
-    fun getIdeSdkType(): SdkType?
+        fun finById(id: String) = find { it.id == id }
 
-    /**
-     * Whether this runtime group supports SAM build so that SAM template with runtimes of this type could be deployed to AWS.
-     */
-    fun supportsSamBuild(): Boolean
+        fun determineRuntime(project: Project?): Runtime? = project?.let { _ ->
+            registeredRuntimeGroups().asSequence().mapNotNull { it.determineRuntime(project) }.firstOrNull()
+        }
 
-    companion object : RuntimeGroupExtensionPointObject<RuntimeGroupInformation>(ExtensionPointName("aws.toolkit.lambda.runtimeGroup")) {
-        fun getInstances(runtimeGroup: RuntimeGroup): List<RuntimeGroupInformation> = collector.forKey(runtimeGroup)
+        fun determineRuntime(module: Module?): Runtime? = module?.let { _ ->
+            registeredRuntimeGroups().asSequence().mapNotNull { it.determineRuntime(module) }.firstOrNull()
+        }
+
+        fun determineRuntimeGroup(project: Project?): RuntimeGroup? = project?.let { _ ->
+            registeredRuntimeGroups().find { it.determineRuntime(project) != null }
+        }
+
+        fun registeredRuntimeGroups(): List<RuntimeGroup> = EP_NAM.extensionList
     }
 }
 
-abstract class SdkBasedRuntimeGroupInformation : RuntimeGroupInformation {
+abstract class SdkBasedRuntimeGroup : RuntimeGroup {
     protected abstract fun runtimeForSdk(sdk: Sdk): Runtime?
 
     override fun determineRuntime(project: Project): Runtime? = ProjectRootManager.getInstance(project).projectSdk?.let { runtimeForSdk(it) }
 
     override fun determineRuntime(module: Module): Runtime? = ModuleRootManager.getInstance(module).sdk?.let { runtimeForSdk(it) }
-
-    override fun getModuleType(): ModuleType<*>? = null
-
-    override fun getIdeSdkType(): SdkType? = null
-
-    override fun supportsSamBuild(): Boolean = false
 }
 
 val Runtime?.validOrNull: Runtime? get() = this?.takeUnless { it == Runtime.UNKNOWN_TO_SDK_VERSION }
@@ -139,38 +85,24 @@ fun AnActionEvent.runtime(): Runtime? {
 }
 
 /**
- * A bean that represents an extension point based on a [RuntimeGroup]
- */
-class RuntimeGroupExtensionPoint<T> : AbstractExtensionPointBean(), KeyedLazyInstance<T> {
-
-    @Attribute("implementation")
-    lateinit var implementation: String
-
-    /**
-     * The [RuntimeGroup] that this extension point refers to
-     */
-    @Attribute("runtimeGroup")
-    lateinit var runtimeGroup: RuntimeGroup
-
-    private val instance = object : LazyInstance<T>() {
-        override fun getInstanceClass(): Class<T> = findClass(implementation)
-    }
-
-    override fun getKey(): String = runtimeGroup.name
-
-    override fun getInstance(): T = instance.value
-}
-
-/**
  * To be implemented on a companion object of the extension point object to expose factory methods.
  * See [software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder]
  */
-abstract class RuntimeGroupExtensionPointObject<T>(private val extensionPointName: ExtensionPointName<RuntimeGroupExtensionPoint<T>>) {
-    protected val collector = KeyedExtensionCollector<T, RuntimeGroup>(extensionPointName.name)
-    fun getInstance(runtimeGroup: RuntimeGroup): T? = collector.findSingle(runtimeGroup)
-    fun getInstanceOrThrow(runtimeGroup: RuntimeGroup): T =
-        getInstance(runtimeGroup) ?: throw IllegalStateException("Attempted to retrieve feature for unsupported runtime group $runtimeGroup")
+abstract class RuntimeGroupExtensionPointObject<T>(private val extensionPointName: ExtensionPointName<IdBasedExtensionPoint<T>>) {
+    private val collector = KeyedExtensionCollector<T, String>(extensionPointName.name)
 
-    val supportedRuntimeGroups: Set<RuntimeGroup> by lazy { extensionPointName.extensions.map { it.runtimeGroup }.toSet() }
-    val supportedLanguages: Set<Language> by lazy { supportedRuntimeGroups.flatMap { it.languageIds }.mapNotNull { Language.findLanguageByID(it) }.toSet() }
+    fun getInstance(runtimeGroup: RuntimeGroup): T? = collector.findSingle(runtimeGroup.id)
+    fun getInstanceOrThrow(runtimeGroup: RuntimeGroup): T = getInstance(runtimeGroup)
+        ?: throw IllegalStateException("Attempted to retrieve feature for unsupported runtime group $runtimeGroup")
+
+    fun supportedRuntimeGroups(): Set<RuntimeGroup> {
+        val alRuntimeGroups = RuntimeGroup.registeredRuntimeGroups()
+        val supportedIds = extensionPointName.extensions.map { it.id }
+        return alRuntimeGroups.filter { supportedIds.contains(it.id) }.toSet()
+    }
+
+    fun supportedLanguages(): Set<Language> {
+        val supportedRuntimeGroups = supportedRuntimeGroups()
+        return supportedRuntimeGroups.asSequence().flatMap { it.languageIds.asSequence() }.mapNotNull { Language.findLanguageByID(it) }.toSet()
+    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
@@ -20,6 +20,16 @@ import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.core.IdBasedExtensionPoint
 
 /**
+ * IDs for built-in runtime groups that ship with toolkit
+ */
+object BuiltInRuntimeGroups {
+    const val Python = "PYTHON"
+    const val Dotnet = "DOTNET"
+    const val Java = "JAVA"
+    const val NodeJs = "NODEJS"
+}
+
+/**
  * Grouping of Lambda [Runtime] by parent language.
  *
  * A Lambda [Runtime] belongs to a single [RuntimeGroup], a [RuntimeGroup] may have several Lambda [Runtime]s, [Language]s or [Sdk]s.
@@ -41,7 +51,9 @@ interface RuntimeGroup {
         @JvmStatic
         fun find(predicate: (RuntimeGroup) -> Boolean): RuntimeGroup? = registeredRuntimeGroups().firstOrNull(predicate)
 
-        fun finById(id: String) = find { it.id == id }
+        fun findById(id: String): RuntimeGroup? = find { it.id == id }
+
+        fun getById(id: String): RuntimeGroup = findById(id) ?: throw IllegalStateException("No RuntimeGroup with $id is registered")
 
         fun determineRuntime(project: Project?): Runtime? = project?.let { _ ->
             registeredRuntimeGroups().asSequence().mapNotNull { it.determineRuntime(project) }.firstOrNull()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/SamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/SamProjectWizard.kt
@@ -187,7 +187,7 @@ abstract class SamProjectTemplate {
 
         @JvmField
         val SAM_TEMPLATES =
-            SamProjectWizard.supportedRuntimeGroups.flatMap {
+            SamProjectWizard.supportedRuntimeGroups().flatMap {
                 SamProjectWizard.getInstanceOrThrow(it).listTemplates()
             }
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/SamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/SamProjectWizard.kt
@@ -188,7 +188,7 @@ abstract class SamProjectTemplate {
         @JvmField
         val SAM_TEMPLATES =
             SamProjectWizard.supportedRuntimeGroups().flatMap {
-                SamProjectWizard.getInstanceOrThrow(it).listTemplates()
+                SamProjectWizard.getInstance(it).listTemplates()
             }
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
@@ -153,7 +153,7 @@ class DeployServerlessApplicationAction : AnAction(
         super.update(e)
 
         // If there are no supported runtime groups, it will never succeed so don't show it
-        e.presentation.isVisible = if (LambdaHandlerResolver.supportedRuntimeGroups.isEmpty()) {
+        e.presentation.isVisible = if (LambdaHandlerResolver.supportedRuntimeGroups().isEmpty()) {
             false
         } else {
             getSamTemplateFile(e) != null

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
@@ -53,7 +53,7 @@ class UpdateFunctionConfigurationAction : UpdateFunctionAction(EditFunctionMode.
 
 class UpdateFunctionCodeAction : UpdateFunctionAction(EditFunctionMode.UPDATE_CODE, message("lambda.function.updateCode.action")) {
     override fun update(selected: LambdaFunctionNode, e: AnActionEvent) {
-        if (selected.value.runtime.runtimeGroup?.let { LambdaBuilder.getInstance(it) } != null) {
+        if (selected.value.runtime.runtimeGroup?.let { LambdaBuilder.getInstanceOrNull(it) } != null) {
             return
         }
         e.presentation.isVisible = false

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/completion/HandlerCompletionProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/completion/HandlerCompletionProvider.kt
@@ -21,7 +21,7 @@ class HandlerCompletionProvider(private val project: Project, runtime: Runtime?)
     private val handlerCompletion: HandlerCompletion? by lazy {
         val runtimeGroup = runtime?.runtimeGroup ?: RuntimeGroup.determineRuntime(project)?.runtimeGroup ?: return@lazy null
 
-        return@lazy HandlerCompletion.getInstance(runtimeGroup) ?: let {
+        return@lazy HandlerCompletion.getInstanceOrNull(runtimeGroup) ?: let {
             logger.info { "Lambda handler completion provider is not registered for runtime: ${runtimeGroup.id}. Completion is not supported." }
             null
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/completion/HandlerCompletionProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/completion/HandlerCompletionProvider.kt
@@ -13,7 +13,6 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
-import java.lang.IllegalStateException
 
 class HandlerCompletionProvider(private val project: Project, runtime: Runtime?) : TextCompletionProvider {
 
@@ -23,7 +22,7 @@ class HandlerCompletionProvider(private val project: Project, runtime: Runtime?)
         val runtimeGroup = runtime?.runtimeGroup ?: RuntimeGroup.determineRuntime(project)?.runtimeGroup ?: return@lazy null
 
         return@lazy HandlerCompletion.getInstance(runtimeGroup) ?: let {
-            logger.info { "Lambda handler completion provider is not registered for runtime: ${runtimeGroup.name}. Completion is not supported." }
+            logger.info { "Lambda handler completion provider is not registered for runtime: ${runtimeGroup.id}. Completion is not supported." }
             null
         }
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfigurationType.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/LambdaRunConfigurationType.kt
@@ -20,10 +20,10 @@ class LambdaRunConfigurationType :
         AwsIcons.Resources.LAMBDA_FUNCTION
     ) {
     init {
-        // Although it should work, isApplicable doesn't seem to work for locallambdarunconfigurationfactory
-        // and it still shows up when it is not applicalbe. So we have to decide in the configuration to add it or not.
+        // Although it should work, isApplicable doesn't seem to work for LocalLambdaRunConfigurationFactory
+        // and it still shows up when it is not applicable. So we have to decide in the configuration to add it or not.
         // TODO see if this is resolvable
-        if (LambdaHandlerResolver.supportedRuntimeGroups.isNotEmpty()) {
+        if (LambdaHandlerResolver.supportedRuntimeGroups().isNotEmpty()) {
             addFactory(LocalLambdaRunConfigurationFactory(this))
         }
         addFactory(RemoteLambdaRunConfigurationFactory(this))

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
@@ -143,7 +143,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
     override fun getRefactoringElementListener(element: PsiElement?): RefactoringElementListener? {
         element?.run {
             val handlerResolver = element.language.runtimeGroup?.let { runtimeGroup ->
-                LambdaHandlerResolver.getInstance(runtimeGroup)
+                LambdaHandlerResolver.getInstanceOrNull(runtimeGroup)
             } ?: return null
 
             val handlerPsi = handlerPsiElement() ?: return null
@@ -262,7 +262,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
         val handler = serializableOptions.functionOptions.handler ?: return null
         return runtime()
             ?.runtimeGroup
-            ?.let { LambdaHandlerResolver.getInstance(it) }
+            ?.let { LambdaHandlerResolver.getInstanceOrNull(it) }
             ?.handlerDisplayName(handler) ?: handler
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
@@ -52,7 +52,7 @@ class LocalLambdaRunConfigurationProducer : LazyRunConfigurationProducer<LocalLa
 
     private fun setupFromSourceFile(element: PsiElement, context: ConfigurationContext, configuration: LocalLambdaRunConfiguration): Boolean {
         val runtimeGroup = element.language.runtimeGroup ?: return false
-        if (runtimeGroup !in LambdaHandlerResolver.supportedRuntimeGroups) {
+        if (runtimeGroup !in LambdaHandlerResolver.supportedRuntimeGroups()) {
             return false
         }
         val resolver = LambdaHandlerResolver.getInstanceOrThrow(runtimeGroup)
@@ -76,7 +76,7 @@ class LocalLambdaRunConfigurationProducer : LazyRunConfigurationProducer<LocalLa
 
     private fun isFromSourceFileContext(element: PsiElement, configuration: LocalLambdaRunConfiguration): Boolean {
         val runtimeGroup = element.language.runtimeGroup ?: return false
-        if (runtimeGroup !in LambdaHandlerResolver.supportedRuntimeGroups) {
+        if (runtimeGroup !in LambdaHandlerResolver.supportedRuntimeGroups()) {
             return false
         }
         val resolver = LambdaHandlerResolver.getInstanceOrThrow(runtimeGroup)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
@@ -55,7 +55,7 @@ class LocalLambdaRunConfigurationProducer : LazyRunConfigurationProducer<LocalLa
         if (runtimeGroup !in LambdaHandlerResolver.supportedRuntimeGroups()) {
             return false
         }
-        val resolver = LambdaHandlerResolver.getInstanceOrThrow(runtimeGroup)
+        val resolver = LambdaHandlerResolver.getInstance(runtimeGroup)
         val handler = resolver.determineHandler(element) ?: return false
         val runtime = RuntimeGroup.determineRuntime(context.module) ?: RuntimeGroup.determineRuntime(context.project)
 
@@ -79,7 +79,7 @@ class LocalLambdaRunConfigurationProducer : LazyRunConfigurationProducer<LocalLa
         if (runtimeGroup !in LambdaHandlerResolver.supportedRuntimeGroups()) {
             return false
         }
-        val resolver = LambdaHandlerResolver.getInstanceOrThrow(runtimeGroup)
+        val resolver = LambdaHandlerResolver.getInstance(runtimeGroup)
         val handler = resolver.determineHandler(element) ?: return false
         return configuration.handler() == handler
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditor.kt
@@ -25,7 +25,7 @@ class LocalLambdaRunSettingsEditor(project: Project) : SettingsEditor<LocalLambd
         // This code is executed once when run configuration form is opened.
         project.service<LambdaHandlerValidator>().clearRequests()
 
-        val supported = LambdaBuilder.supportedRuntimeGroups.flatMap { it.runtimes }.sorted()
+        val supported = LambdaBuilder.supportedRuntimeGroups().flatMap { it.runtimes }.sorted()
         val selected = RuntimeGroup.determineRuntime(project)?.let { if (it in supported) it else null }
         view = LocalLambdaRunSettingsEditorPanel(project)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamDebugger.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamDebugger.kt
@@ -24,7 +24,7 @@ internal class SamDebugger(runtimeGroup: RuntimeGroup) : SamRunner() {
         private val logger = getLogger<SamDebugger>()
     }
 
-    private val debugExtension = SamDebugSupport.getInstanceOrThrow(runtimeGroup)
+    private val debugExtension = SamDebugSupport.getInstance(runtimeGroup)
 
     private val debugPorts = debugExtension.getDebugPorts()
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
@@ -67,7 +67,7 @@ class SamInvokeRunner : AsyncProgramRunner<RunnerSettings>() {
             val runtimeGroup = runtimeValue?.runtimeGroup ?: return false
 
             return SamDebugSupport.supportedRuntimeGroups().contains(runtimeGroup) &&
-                SamDebugSupport.getInstance(runtimeGroup)?.isSupported(runtimeValue) ?: false
+                SamDebugSupport.getInstanceOrNull(runtimeGroup)?.isSupported(runtimeValue) ?: false
         }
 
         return false

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
@@ -66,7 +66,7 @@ class SamInvokeRunner : AsyncProgramRunner<RunnerSettings>() {
 
             val runtimeGroup = runtimeValue?.runtimeGroup ?: return false
 
-            return SamDebugSupport.supportedRuntimeGroups.contains(runtimeGroup) &&
+            return SamDebugSupport.supportedRuntimeGroups().contains(runtimeGroup) &&
                 SamDebugSupport.getInstance(runtimeGroup)?.isSupported(runtimeValue) ?: false
         }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaRuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaRuntimeGroup.kt
@@ -12,9 +12,14 @@ import com.intellij.openapi.projectRoots.JavaSdkVersion
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkType
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroupInformation
+import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
-class JavaRuntimeGroup : SdkBasedRuntimeGroupInformation() {
+class JavaRuntimeGroup : SdkBasedRuntimeGroup() {
+    companion object {
+        val INSTANCE = JavaRuntimeGroup()
+    }
+
+    override val id: String = "JAVA"
     override val runtimes = setOf(Runtime.JAVA8, Runtime.JAVA11)
     override val languageIds = setOf(JavaLanguage.INSTANCE.id)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaRuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaRuntimeGroup.kt
@@ -12,14 +12,11 @@ import com.intellij.openapi.projectRoots.JavaSdkVersion
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkType
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
 class JavaRuntimeGroup : SdkBasedRuntimeGroup() {
-    companion object {
-        val INSTANCE = JavaRuntimeGroup()
-    }
-
-    override val id: String = "JAVA"
+    override val id: String = BuiltInRuntimeGroups.Java
     override val runtimes = setOf(Runtime.JAVA8, Runtime.JAVA11)
     override val languageIds = setOf(JavaLanguage.INSTANCE.id)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamProjectWizard.kt
@@ -20,7 +20,6 @@ import org.jetbrains.plugins.gradle.util.GradleConstants
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.logWhenNull
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.SamNewProjectSettings
 import software.aws.toolkits.jetbrains.services.lambda.SamProjectTemplate
 import software.aws.toolkits.jetbrains.services.lambda.SamProjectWizard
@@ -37,13 +36,11 @@ import software.aws.toolkits.resources.message
 import java.nio.file.Paths
 
 class JavaSamProjectWizard : SamProjectWizard {
-    override fun createSchemaSelectionPanel(
-        generator: SamProjectGenerator
-    ): SchemaSelectionPanel =
-        SchemaResourceSelectorSelectionPanel(generator.builder, RuntimeGroup.JAVA, generator.defaultSourceCreatingProject)
+    override fun createSchemaSelectionPanel(generator: SamProjectGenerator): SchemaSelectionPanel =
+        SchemaResourceSelectorSelectionPanel(generator.builder, JavaRuntimeGroup.INSTANCE, generator.defaultSourceCreatingProject)
 
     override fun createSdkSelectionPanel(generator: SamProjectGenerator): SdkSelectionPanel =
-        IntelliJSdkSelectionPanel(generator.builder, RuntimeGroup.JAVA)
+        IntelliJSdkSelectionPanel(generator.builder, JavaRuntimeGroup.INSTANCE)
 
     override fun listTemplates(): Collection<SamProjectTemplate> = listOf(
         SamHelloWorldMaven(),

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamProjectWizard.kt
@@ -20,6 +20,7 @@ import org.jetbrains.plugins.gradle.util.GradleConstants
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.logWhenNull
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.SamNewProjectSettings
 import software.aws.toolkits.jetbrains.services.lambda.SamProjectTemplate
 import software.aws.toolkits.jetbrains.services.lambda.SamProjectWizard
@@ -37,10 +38,10 @@ import java.nio.file.Paths
 
 class JavaSamProjectWizard : SamProjectWizard {
     override fun createSchemaSelectionPanel(generator: SamProjectGenerator): SchemaSelectionPanel =
-        SchemaResourceSelectorSelectionPanel(generator.builder, JavaRuntimeGroup.INSTANCE, generator.defaultSourceCreatingProject)
+        SchemaResourceSelectorSelectionPanel(generator.builder, generator.defaultSourceCreatingProject)
 
     override fun createSdkSelectionPanel(generator: SamProjectGenerator): SdkSelectionPanel =
-        IntelliJSdkSelectionPanel(generator.builder, JavaRuntimeGroup.INSTANCE)
+        IntelliJSdkSelectionPanel(generator.builder, BuiltInRuntimeGroups.Java)
 
     override fun listTemplates(): Collection<SamProjectTemplate> = listOf(
         SamHelloWorldMaven(),

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
@@ -11,34 +11,33 @@ import com.jetbrains.python.PythonModuleTypeBase
 import com.jetbrains.python.psi.LanguageLevel
 import com.jetbrains.python.sdk.PythonSdkType
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroupInformation
+import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
-class PythonRuntimeGroup : SdkBasedRuntimeGroupInformation() {
+class PythonRuntimeGroup : SdkBasedRuntimeGroup() {
+    companion object {
+        val INSTANCE = PythonRuntimeGroup()
+    }
 
+    override val id: String = "PYTHON"
     override val runtimes: Set<Runtime> = setOf(
         Runtime.PYTHON2_7,
         Runtime.PYTHON3_6,
         Runtime.PYTHON3_7,
         Runtime.PYTHON3_8
     )
-
     override val languageIds: Set<String> = setOf(PythonLanguage.INSTANCE.id)
 
-    override fun runtimeForSdk(sdk: Sdk): Runtime? = determineRuntimeForSdk(sdk)
+    override fun runtimeForSdk(sdk: Sdk): Runtime? = when {
+        sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON38) -> Runtime.PYTHON3_8
+        sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON37) -> Runtime.PYTHON3_7
+        sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isPy3K -> Runtime.PYTHON3_6
+        sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isPython2 -> Runtime.PYTHON2_7
+        else -> null
+    }
 
     override fun getModuleType(): ModuleType<*> = PythonModuleTypeBase.getInstance()
 
     override fun getIdeSdkType(): SdkType = PythonSdkType.getInstance()
 
     override fun supportsSamBuild(): Boolean = true
-
-    companion object {
-        fun determineRuntimeForSdk(sdk: Sdk) = when {
-            sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON38) -> Runtime.PYTHON3_8
-            sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON37) -> Runtime.PYTHON3_7
-            sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isPy3K -> Runtime.PYTHON3_6
-            sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isPython2 -> Runtime.PYTHON2_7
-            else -> null
-        }
-    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
@@ -11,14 +11,11 @@ import com.jetbrains.python.PythonModuleTypeBase
 import com.jetbrains.python.psi.LanguageLevel
 import com.jetbrains.python.sdk.PythonSdkType
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
 class PythonRuntimeGroup : SdkBasedRuntimeGroup() {
-    companion object {
-        val INSTANCE = PythonRuntimeGroup()
-    }
-
-    override val id: String = "PYTHON"
+    override val id: String = BuiltInRuntimeGroups.Python
     override val runtimes: Set<Runtime> = setOf(
         Runtime.PYTHON2_7,
         Runtime.PYTHON3_6,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PlatformUtils
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.SamNewProjectSettings
 import software.aws.toolkits.jetbrains.services.lambda.SamProjectTemplate
 import software.aws.toolkits.jetbrains.services.lambda.SamProjectWizard
@@ -29,16 +28,13 @@ import software.aws.toolkits.resources.message
 import java.nio.file.Paths
 
 class PythonSamProjectWizard : SamProjectWizard {
-    override fun createSchemaSelectionPanel(
-        generator: SamProjectGenerator
-    ): SchemaSelectionPanel =
-        SchemaResourceSelectorSelectionPanel(generator.builder, RuntimeGroup.PYTHON, generator.defaultSourceCreatingProject)
+    override fun createSchemaSelectionPanel(generator: SamProjectGenerator): SchemaSelectionPanel =
+        SchemaResourceSelectorSelectionPanel(generator.builder, PythonRuntimeGroup.INSTANCE, generator.defaultSourceCreatingProject)
 
-    override fun createSdkSelectionPanel(generator: SamProjectGenerator): SdkSelectionPanel =
-        when {
-            PlatformUtils.isPyCharm() -> PyCharmSdkSelectionPanel(generator.step)
-            else -> IntelliJSdkSelectionPanel(generator.builder, RuntimeGroup.PYTHON)
-        }
+    override fun createSdkSelectionPanel(generator: SamProjectGenerator): SdkSelectionPanel = when {
+        PlatformUtils.isPyCharm() -> PyCharmSdkSelectionPanel(generator.step)
+        else -> IntelliJSdkSelectionPanel(generator.builder, PythonRuntimeGroup.INSTANCE)
+    }
 
     override fun listTemplates(): Collection<SamProjectTemplate> = listOf(
         SamHelloWorldPython(),

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PlatformUtils
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.SamNewProjectSettings
 import software.aws.toolkits.jetbrains.services.lambda.SamProjectTemplate
 import software.aws.toolkits.jetbrains.services.lambda.SamProjectWizard
@@ -29,11 +30,11 @@ import java.nio.file.Paths
 
 class PythonSamProjectWizard : SamProjectWizard {
     override fun createSchemaSelectionPanel(generator: SamProjectGenerator): SchemaSelectionPanel =
-        SchemaResourceSelectorSelectionPanel(generator.builder, PythonRuntimeGroup.INSTANCE, generator.defaultSourceCreatingProject)
+        SchemaResourceSelectorSelectionPanel(generator.builder, generator.defaultSourceCreatingProject)
 
     override fun createSdkSelectionPanel(generator: SamProjectGenerator): SdkSelectionPanel = when {
         PlatformUtils.isPyCharm() -> PyCharmSdkSelectionPanel(generator.step)
-        else -> IntelliJSdkSelectionPanel(generator.builder, PythonRuntimeGroup.INSTANCE)
+        else -> IntelliJSdkSelectionPanel(generator.builder, BuiltInRuntimeGroups.Python)
     }
 
     override fun listTemplates(): Collection<SamProjectTemplate> = listOf(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialog.kt
@@ -217,7 +217,7 @@ class EditFunctionDialog(
 
         val s3Bucket = view.sourceBucket.selectedItem as String
 
-        val lambdaBuilder = psiFile.language.runtimeGroup?.let { LambdaBuilder.getInstance(it) } ?: return
+        val lambdaBuilder = psiFile.language.runtimeGroup?.let { LambdaBuilder.getInstanceOrNull(it) } ?: return
         val lambdaCreator = LambdaCreatorFactory.create(AwsClientManager.getInstance(project), lambdaBuilder)
 
         FileDocumentManager.getInstance().saveAllDocuments()
@@ -338,7 +338,7 @@ class UploadToLambdaValidator {
         val runtime = view.runtime.selected()
             ?: return ValidationInfo(message("lambda.upload_validation.runtime"), view.runtime)
 
-        runtime.runtimeGroup?.let { LambdaBuilder.getInstance(it) } ?: return ValidationInfo(
+        runtime.runtimeGroup?.let { LambdaBuilder.getInstanceOrNull(it) } ?: return ValidationInfo(
             message("lambda.upload_validation.unsupported_runtime", runtime),
             view.runtime
         )

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
@@ -44,7 +44,7 @@ class LambdaLineMarker : LineMarkerProviderDescriptor() {
         }
 
         val runtimeGroup = element.language.runtimeGroup ?: return null
-        val handlerResolver = LambdaHandlerResolver.getInstance(runtimeGroup) ?: return null
+        val handlerResolver = LambdaHandlerResolver.getInstanceOrNull(runtimeGroup) ?: return null
         val handler = handlerResolver.determineHandler(element) ?: return null
 
         return if (handlerResolver.shouldShowLineMarker(handler) || shouldShowLineMarker(element.containingFile, handler, runtimeGroup)) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
@@ -52,7 +52,7 @@ class LambdaLineMarker : LineMarkerProviderDescriptor() {
 
             val smartPsiElementPointer = SmartPointerManager.createPointer(element)
 
-            if (element.language in LambdaBuilder.supportedLanguages) {
+            if (element.language in LambdaBuilder.supportedLanguages()) {
                 val executorActions = ExecutorAction.getActions(1)
                 executorActions.forEach {
                     actionGroup.add(LineMarkerActionWrapper(element, it))

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/Schemas.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/Schemas.kt
@@ -5,18 +5,19 @@ package software.aws.toolkits.jetbrains.services.schemas
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import software.amazon.awssdk.services.schemas.model.SchemaSummary
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
+import software.aws.toolkits.jetbrains.services.lambda.java.JavaRuntimeGroup
+import software.aws.toolkits.jetbrains.services.lambda.python.PythonRuntimeGroup
 import software.aws.toolkits.resources.message
 
 enum class SchemaCodeLangs(
     val apiValue: String,
     val text: String,
     val extension: String,
-    val runtimeGroup: RuntimeGroup
+    val runtimeGroupId: String
 ) {
-    JAVA8("Java8", message("schemas.schema.SchemaCodeLangs.JAVA8"), "java", RuntimeGroup.JAVA),
-    PYTHON3_6("Python36", message("schemas.schema.SchemaCodeLangs.PYTHON3_6"), "py", RuntimeGroup.PYTHON),
-    TYPESCRIPT("TypeScript3", message("schemas.schema.SchemaCodeLangs.TYPESCRIPT"), "ts", RuntimeGroup.NODEJS);
+    JAVA8("Java8", message("schemas.schema.SchemaCodeLangs.JAVA8"), "java", JavaRuntimeGroup.INSTANCE.id),
+    PYTHON3_6("Python36", message("schemas.schema.SchemaCodeLangs.PYTHON3_6"), "py", PythonRuntimeGroup.INSTANCE.id),
+    TYPESCRIPT("TypeScript3", message("schemas.schema.SchemaCodeLangs.TYPESCRIPT"), "ts", "NODEJS");
 
     override fun toString() = text
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/Schemas.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/Schemas.kt
@@ -5,8 +5,7 @@ package software.aws.toolkits.jetbrains.services.schemas
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import software.amazon.awssdk.services.schemas.model.SchemaSummary
-import software.aws.toolkits.jetbrains.services.lambda.java.JavaRuntimeGroup
-import software.aws.toolkits.jetbrains.services.lambda.python.PythonRuntimeGroup
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.resources.message
 
 enum class SchemaCodeLangs(
@@ -15,9 +14,9 @@ enum class SchemaCodeLangs(
     val extension: String,
     val runtimeGroupId: String
 ) {
-    JAVA8("Java8", message("schemas.schema.SchemaCodeLangs.JAVA8"), "java", JavaRuntimeGroup.INSTANCE.id),
-    PYTHON3_6("Python36", message("schemas.schema.SchemaCodeLangs.PYTHON3_6"), "py", PythonRuntimeGroup.INSTANCE.id),
-    TYPESCRIPT("TypeScript3", message("schemas.schema.SchemaCodeLangs.TYPESCRIPT"), "ts", "NODEJS");
+    JAVA8("Java8", message("schemas.schema.SchemaCodeLangs.JAVA8"), "java", BuiltInRuntimeGroups.Java),
+    PYTHON3_6("Python36", message("schemas.schema.SchemaCodeLangs.PYTHON3_6"), "py", BuiltInRuntimeGroups.Python),
+    TYPESCRIPT("TypeScript3", message("schemas.schema.SchemaCodeLangs.TYPESCRIPT"), "ts", BuiltInRuntimeGroups.NodeJs);
 
     override fun toString() = text
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/IntelliJSdkSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/IntelliJSdkSelectionPanel.kt
@@ -8,16 +8,15 @@ import com.intellij.ide.util.projectWizard.WizardContext
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.ui.ValidationInfo
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedSdkSettings
 import software.aws.toolkits.jetbrains.services.lambda.SdkSettings
-import software.aws.toolkits.jetbrains.services.lambda.java.JavaRuntimeGroup
-import software.aws.toolkits.jetbrains.services.lambda.python.PythonRuntimeGroup
 import software.aws.toolkits.resources.message
 import javax.swing.JComponent
 import javax.swing.JLabel
 
-class IntelliJSdkSelectionPanel(val builder: SamProjectBuilder, val runtimeGroup: RuntimeGroup) : SdkSelectionPanelBase() {
+class IntelliJSdkSelectionPanel(private val builder: SamProjectBuilder, private val runtimeGroupId: String) : SdkSelectionPanelBase() {
     private var currentSdk: Sdk? = null
     private val dummyContext = object : WizardContext(null, {}) {
         override fun setProjectJdk(sdk: Sdk?) {
@@ -42,10 +41,11 @@ class IntelliJSdkSelectionPanel(val builder: SamProjectBuilder, val runtimeGroup
     override fun getSdkSettings(): SdkSettings {
         currentSdkPanel.updateDataModel()
 
-        return when (runtimeGroup.id) {
-            JavaRuntimeGroup.INSTANCE.id, PythonRuntimeGroup.INSTANCE.id -> SdkBasedSdkSettings(sdk = currentSdk)
-            "DOTNET" -> object : SdkSettings {}
-            else -> throw RuntimeException("Unrecognized runtime group: $runtimeGroup")
+        // TODO: This should probably be EP based
+        return when (runtimeGroupId) {
+            BuiltInRuntimeGroups.Java, BuiltInRuntimeGroups.Python -> SdkBasedSdkSettings(sdk = currentSdk)
+            BuiltInRuntimeGroups.Dotnet -> object : SdkSettings {}
+            else -> throw RuntimeException("Unrecognized runtime group ID: $runtimeGroupId")
         }
     }
 
@@ -54,7 +54,7 @@ class IntelliJSdkSelectionPanel(val builder: SamProjectBuilder, val runtimeGroup
         SdkSettingsStep(
             dummyContext,
             builder,
-            { t: SdkTypeId? -> t == runtimeGroup.getIdeSdkType() },
+            { t: SdkTypeId? -> t == RuntimeGroup.getById(runtimeGroupId).getIdeSdkType() },
             null
         )
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/IntelliJSdkSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/IntelliJSdkSelectionPanel.kt
@@ -11,6 +11,8 @@ import com.intellij.openapi.ui.ValidationInfo
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedSdkSettings
 import software.aws.toolkits.jetbrains.services.lambda.SdkSettings
+import software.aws.toolkits.jetbrains.services.lambda.java.JavaRuntimeGroup
+import software.aws.toolkits.jetbrains.services.lambda.python.PythonRuntimeGroup
 import software.aws.toolkits.resources.message
 import javax.swing.JComponent
 import javax.swing.JLabel
@@ -40,9 +42,9 @@ class IntelliJSdkSelectionPanel(val builder: SamProjectBuilder, val runtimeGroup
     override fun getSdkSettings(): SdkSettings {
         currentSdkPanel.updateDataModel()
 
-        return when (runtimeGroup) {
-            RuntimeGroup.JAVA, RuntimeGroup.PYTHON -> SdkBasedSdkSettings(sdk = currentSdk)
-            RuntimeGroup.DOTNET -> object : SdkSettings {}
+        return when (runtimeGroup.id) {
+            JavaRuntimeGroup.INSTANCE.id, PythonRuntimeGroup.INSTANCE.id -> SdkBasedSdkSettings(sdk = currentSdk)
+            "DOTNET" -> object : SdkSettings {}
             else -> throw RuntimeException("Unrecognized runtime group: $runtimeGroup")
         }
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitSelectionPanel.java
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamInitSelectionPanel.java
@@ -83,7 +83,7 @@ public class SamInitSelectionPanel implements ValidatablePanel {
 
         // TODO: Move this to Kotlin...
         // Source all templates, find all the runtimes they support, then filter those by what the IDE supports
-        Set<RuntimeGroup> supportedRuntimeGroups = LambdaBuilder.Companion.getSupportedRuntimeGroups();
+        Set<RuntimeGroup> supportedRuntimeGroups = LambdaBuilder.Companion.supportedRuntimeGroups();
         SamProjectTemplate.SAM_TEMPLATES.stream()
                                         .flatMap(template -> template.supportedRuntimes().stream())
                                         .sorted()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SchemaResourceSelectorSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SchemaResourceSelectorSelectionPanel.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.ComboboxSpeedSearch
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 import software.aws.toolkits.jetbrains.ui.AwsConnection
 import software.aws.toolkits.jetbrains.ui.ResourceSelector
@@ -19,14 +18,12 @@ import javax.swing.JPanel
 
 class SchemaResourceSelectorSelectionPanel(
     val builder: SamProjectBuilder,
-    val runtimeGroup: RuntimeGroup,
     val project: Project,
     // Subsequent parameters injectable for unit tests to enable mocking because ResourceSelector has inconsistent unit test behaviour
     val resourceSelectorBuilder: ResourceSelector.ResourceBuilder = ResourceSelector.builder(project),
     useSpeedSearch: Boolean = true,
     rootPanelBuilder: () -> JPanel = { JPanel(BorderLayout()) }
-) :
-    SchemaSelectionPanelBase(project) {
+) : SchemaSelectionPanelBase(project) {
 
     override val schemaSelectionLabel: JLabel? = JLabel(message("sam.init.schema.label"))
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SchemaSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SchemaSelectionPanel.kt
@@ -45,7 +45,7 @@ interface SchemaSelectionPanel {
         ): SchemaSelectionPanel =
             runtime.runtimeGroup?.let { runtimeGroup ->
                 if (selectedTemplate.supportsDynamicSchemas())
-                    SamProjectWizard.getInstanceOrThrow(runtimeGroup).createSchemaSelectionPanel(generator)
+                    SamProjectWizard.getInstance(runtimeGroup).createSchemaSelectionPanel(generator)
                 else
                     NoOpSchemaSelectionPanel()
             } ?: NoOpSchemaSelectionPanel()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SdkSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SdkSelectionPanel.kt
@@ -29,7 +29,7 @@ interface SdkSelectionPanel {
         @JvmStatic
         fun create(runtime: Runtime, generator: SamProjectGenerator): SdkSelectionPanel =
             runtime.runtimeGroup?.let {
-                SamProjectWizard.getInstanceOrThrow(it).createSdkSelectionPanel(generator)
+                SamProjectWizard.getInstance(it).createSdkSelectionPanel(generator)
             } ?: NoOpSdkSelectionPanel()
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolverTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolverTest.kt
@@ -13,8 +13,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.Lambda
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
+import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.openClass
 
@@ -417,7 +419,7 @@ class JavaLambdaHandlerResolverTest {
 
     @Test
     fun handlerDisplayNames() {
-        val sut = LambdaHandlerResolver.getInstanceOrThrow(JavaRuntimeGroup.INSTANCE)
+        val sut = LambdaHandlerResolver.getInstanceOrThrow(RuntimeGroup.getById(BuiltInRuntimeGroups.Java))
 
         assertThat(sut.handlerDisplayName("com.example.LambdaHandler::handleRequest")).isEqualTo("LambdaHandler.handleRequest")
         assertThat(sut.handlerDisplayName("com.example.LambdaHandler")).isEqualTo("LambdaHandler")

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolverTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolverTest.kt
@@ -15,7 +15,6 @@ import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.services.lambda.Lambda
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.openClass
 
@@ -418,7 +417,7 @@ class JavaLambdaHandlerResolverTest {
 
     @Test
     fun handlerDisplayNames() {
-        val sut = LambdaHandlerResolver.getInstanceOrThrow(RuntimeGroup.JAVA)
+        val sut = LambdaHandlerResolver.getInstanceOrThrow(JavaRuntimeGroup.INSTANCE)
 
         assertThat(sut.handlerDisplayName("com.example.LambdaHandler::handleRequest")).isEqualTo("LambdaHandler.handleRequest")
         assertThat(sut.handlerDisplayName("com.example.LambdaHandler")).isEqualTo("LambdaHandler")

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolverTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolverTest.kt
@@ -419,7 +419,7 @@ class JavaLambdaHandlerResolverTest {
 
     @Test
     fun handlerDisplayNames() {
-        val sut = LambdaHandlerResolver.getInstanceOrThrow(RuntimeGroup.getById(BuiltInRuntimeGroups.Java))
+        val sut = LambdaHandlerResolver.getInstance(RuntimeGroup.getById(BuiltInRuntimeGroups.Java))
 
         assertThat(sut.handlerDisplayName("com.example.LambdaHandler::handleRequest")).isEqualTo("LambdaHandler.handleRequest")
         assertThat(sut.handlerDisplayName("com.example.LambdaHandler")).isEqualTo("LambdaHandler")

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolverTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolverTest.kt
@@ -257,7 +257,7 @@ class PythonLambdaHandlerResolverTest {
         }
     }
 
-    private fun getHandlerResolver() = Runtime.PYTHON3_6.runtimeGroup?.let { LambdaHandlerResolver.getInstance(it) }!!
+    private fun getHandlerResolver() = Runtime.PYTHON3_6.runtimeGroup?.let { LambdaHandlerResolver.getInstanceOrNull(it) }!!
     private fun findHandler(handler: String): Array<NavigatablePsiElement> =
         Lambda.findPsiElementsForHandler(projectRule.project, Runtime.PYTHON3_6, handler)
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/wizard/SchemaSelectionPanelTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/wizard/SchemaSelectionPanelTest.kt
@@ -16,7 +16,6 @@ import org.junit.Test
 import software.amazon.awssdk.services.schemas.model.DescribeSchemaResponse
 import software.aws.toolkits.jetbrains.core.MockResourceCache
 import software.aws.toolkits.jetbrains.core.Resource
-import software.aws.toolkits.jetbrains.services.lambda.java.JavaRuntimeGroup
 import software.aws.toolkits.jetbrains.services.schemas.SchemaTemplateParameters
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources.LIST_REGISTRIES_AND_SCHEMAS
@@ -63,7 +62,6 @@ class SchemaSelectionPanelTest {
         File(javaClass.getResource("/customerUploadedEventSchemaMultipleTypes.json.txt").toURI()).readText(Charsets.UTF_8)
 
     private val mockSamProjectBuilder = mock<SamProjectBuilder>()
-    private val runtimeGroup = JavaRuntimeGroup.INSTANCE
 
     private val mockResourceSelector = mock<ResourceSelector<SchemaSelectionItem>>()
     private val mockPanel = mock<JPanel>()
@@ -80,7 +78,6 @@ class SchemaSelectionPanelTest {
 
         schemaSelectionPanel = SchemaResourceSelectorSelectionPanel(
             mockSamProjectBuilder,
-            runtimeGroup,
             projectRule.project,
             resourceSelectorBuilder = mockResourceSelectorBuilder,
             useSpeedSearch = false,

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/wizard/SchemaSelectionPanelTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/wizard/SchemaSelectionPanelTest.kt
@@ -16,7 +16,7 @@ import org.junit.Test
 import software.amazon.awssdk.services.schemas.model.DescribeSchemaResponse
 import software.aws.toolkits.jetbrains.core.MockResourceCache
 import software.aws.toolkits.jetbrains.core.Resource
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
+import software.aws.toolkits.jetbrains.services.lambda.java.JavaRuntimeGroup
 import software.aws.toolkits.jetbrains.services.schemas.SchemaTemplateParameters
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources.LIST_REGISTRIES_AND_SCHEMAS
@@ -63,7 +63,7 @@ class SchemaSelectionPanelTest {
         File(javaClass.getResource("/customerUploadedEventSchemaMultipleTypes.json.txt").toURI()).readText(Charsets.UTF_8)
 
     private val mockSamProjectBuilder = mock<SamProjectBuilder>()
-    private val RUNTIME_GROUP = RuntimeGroup.JAVA
+    private val runtimeGroup = JavaRuntimeGroup.INSTANCE
 
     private val mockResourceSelector = mock<ResourceSelector<SchemaSelectionItem>>()
     private val mockPanel = mock<JPanel>()
@@ -80,7 +80,7 @@ class SchemaSelectionPanelTest {
 
         schemaSelectionPanel = SchemaResourceSelectorSelectionPanel(
             mockSamProjectBuilder,
-            RUNTIME_GROUP,
+            runtimeGroup,
             projectRule.project,
             resourceSelectorBuilder = mockResourceSelectorBuilder,
             useSpeedSearch = false,

--- a/jetbrains-rider/resources/META-INF/ext-rider.xml
+++ b/jetbrains-rider/resources/META-INF/ext-rider.xml
@@ -24,12 +24,12 @@
     </extensions>
 
     <extensions defaultExtensionNs="aws.toolkit.lambda">
-        <runtimeGroup runtimeGroup="DOTNET" implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetRuntimeGroup"/>
-        <builder runtimeGroup="DOTNET" implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetLambdaBuilder"/>
-        <handlerResolver runtimeGroup="DOTNET" implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetLambdaHandlerResolver"/>
-        <handlerCompletion runtimeGroup="DOTNET" implementation="software.aws.toolkits.jetbrains.services.lambda.completion.DotNetHandlerCompletion"/>
-        <sam.debugSupport runtimeGroup="DOTNET" implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetSamDebugSupport"/>
-        <sam.projectWizard runtimeGroup="DOTNET" implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetSamProjectWizard"/>
+        <runtimeGroup implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetRuntimeGroup"/>
+        <builder id="DOTNET" implementationClass="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetLambdaBuilder"/>
+        <handlerResolver id="DOTNET" implementationClass="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetLambdaHandlerResolver"/>
+        <handlerCompletion id="DOTNET" implementationClass="software.aws.toolkits.jetbrains.services.lambda.completion.DotNetHandlerCompletion"/>
+        <sam.debugSupport id="DOTNET" implementationClass="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetSamDebugSupport"/>
+        <sam.projectWizard id="DOTNET" implementationClass="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetSamProjectWizard"/>
     </extensions>
 
     <extensions defaultExtensionNs="aws.toolkit.clouddebug">

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
@@ -8,24 +8,27 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.jetbrains.rider.ideaInterop.fileTypes.csharp.CSharpLanguage
 import com.jetbrains.rider.ideaInterop.fileTypes.vb.VbLanguage
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroupInformation
+import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 import software.aws.toolkits.jetbrains.utils.DotNetRuntimeUtils
 
-class DotNetRuntimeGroup : SdkBasedRuntimeGroupInformation() {
+class DotNetRuntimeGroup : SdkBasedRuntimeGroup() {
+    companion object {
+        val INSTANCE = DotNetRuntimeGroup()
+    }
 
-    override val runtimes: Set<Runtime>
-        get() = setOf(
-                Runtime.DOTNETCORE2_1,
-                Runtime.DOTNETCORE3_1
-        )
+    override val id: String = "DOTNET"
 
-    override val languageIds: Set<String>
-        get() = setOf(CSharpLanguage.id, VbLanguage.id)
+    override val runtimes: Set<Runtime> = setOf(
+        Runtime.DOTNETCORE2_1,
+        Runtime.DOTNETCORE3_1
+    )
+
+    override val languageIds: Set<String> = setOf(
+        CSharpLanguage.id,
+        VbLanguage.id
+    )
 
     override fun runtimeForSdk(sdk: Sdk): Runtime? = null
 
-    override fun supportsSamBuild(): Boolean = true
-
-    override fun determineRuntime(project: Project): Runtime? =
-        DotNetRuntimeUtils.getCurrentDotNetCoreRuntime()
+    override fun determineRuntime(project: Project): Runtime? = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime()
 }

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
@@ -8,15 +8,12 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.jetbrains.rider.ideaInterop.fileTypes.csharp.CSharpLanguage
 import com.jetbrains.rider.ideaInterop.fileTypes.vb.VbLanguage
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 import software.aws.toolkits.jetbrains.utils.DotNetRuntimeUtils
 
 class DotNetRuntimeGroup : SdkBasedRuntimeGroup() {
-    companion object {
-        val INSTANCE = DotNetRuntimeGroup()
-    }
-
-    override val id: String = "DOTNET"
+    override val id: String = BuiltInRuntimeGroups.Dotnet
 
     override val runtimes: Set<Runtime> = setOf(
         Runtime.DOTNETCORE2_1,

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/ui/wizard/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/ui/wizard/DotNetSamProjectGenerator.kt
@@ -26,7 +26,7 @@ import com.jetbrains.rider.ui.themes.RiderTheme
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutableIfPresent
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
+import software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetRuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.jetbrains.utils.DotNetRuntimeUtils
 import software.aws.toolkits.resources.message
@@ -56,7 +56,7 @@ class DotNetSamProjectGenerator(
     private val generator = SamProjectGenerator()
     private val samPanel = SamInitSelectionPanel(generator) {
         // Only show templates for DotNet in Rider
-        RuntimeGroup.DOTNET.runtimes.contains(it)
+        DotNetRuntimeGroup.INSTANCE.runtimes.contains(it)
     }
 
     private val projectStructurePanel: JTabbedPane

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/ui/wizard/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/ui/wizard/DotNetSamProjectGenerator.kt
@@ -26,7 +26,8 @@ import com.jetbrains.rider.ui.themes.RiderTheme
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutableIfPresent
-import software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetRuntimeGroup
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
+import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.jetbrains.utils.DotNetRuntimeUtils
 import software.aws.toolkits.resources.message
@@ -56,7 +57,7 @@ class DotNetSamProjectGenerator(
     private val generator = SamProjectGenerator()
     private val samPanel = SamInitSelectionPanel(generator) {
         // Only show templates for DotNet in Rider
-        DotNetRuntimeGroup.INSTANCE.runtimes.contains(it)
+        RuntimeGroup.getById(BuiltInRuntimeGroups.Dotnet).runtimes.contains(it)
     }
 
     private val projectStructurePanel: JTabbedPane

--- a/jetbrains-ultimate/resources/META-INF/ext-nodejs.xml
+++ b/jetbrains-ultimate/resources/META-INF/ext-nodejs.xml
@@ -7,12 +7,13 @@
     </extensions>
 
     <extensions defaultExtensionNs="aws.toolkit.lambda">
-        <runtimeGroup runtimeGroup="NODEJS" implementation="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsRuntimeGroup"/>
-        <builder runtimeGroup="NODEJS" implementation="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsLambdaBuilder"/>
-        <handlerResolver runtimeGroup="NODEJS" implementation="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsLambdaHandlerResolver"/>
-        <sam.debugSupport runtimeGroup="NODEJS" implementation="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsSamDebugSupport"/>
-        <sam.projectWizard runtimeGroup="NODEJS" implementation="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsSamProjectWizard"/>
+        <runtimeGroup id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsRuntimeGroup"/>
+        <builder id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsLambdaBuilder"/>
+        <handlerResolver id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsLambdaHandlerResolver"/>
+        <sam.debugSupport id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsSamDebugSupport"/>
+        <sam.projectWizard id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsSamProjectWizard"/>
     </extensions>
+
     <extensions defaultExtensionNs="aws.toolkit.clouddebug">
         <debuggerSupport implementation="software.aws.toolkits.jetbrains.services.clouddebug.nodejs.NodeJsDebuggerSupport"/>
     </extensions>

--- a/jetbrains-ultimate/resources/META-INF/ext-nodejs.xml
+++ b/jetbrains-ultimate/resources/META-INF/ext-nodejs.xml
@@ -7,7 +7,7 @@
     </extensions>
 
     <extensions defaultExtensionNs="aws.toolkit.lambda">
-        <runtimeGroup id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsRuntimeGroup"/>
+        <runtimeGroup implementation="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsRuntimeGroup"/>
         <builder id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsLambdaBuilder"/>
         <handlerResolver id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsLambdaHandlerResolver"/>
         <sam.debugSupport id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsSamDebugSupport"/>

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
@@ -12,14 +12,11 @@ import com.intellij.openapi.module.WebModuleTypeBase
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
 class NodeJsRuntimeGroup : SdkBasedRuntimeGroup() {
-    companion object {
-        val INSTANCE = NodeJsRuntimeGroup()
-    }
-
-    override val id: String = "NODEJS"
+    override val id: String = BuiltInRuntimeGroups.NodeJs
 
     override val runtimes: Set<Runtime> = setOf(
         Runtime.NODEJS10_X,

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
@@ -12,9 +12,15 @@ import com.intellij.openapi.module.WebModuleTypeBase
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroupInformation
+import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
-class NodeJsRuntimeGroup : SdkBasedRuntimeGroupInformation() {
+class NodeJsRuntimeGroup : SdkBasedRuntimeGroup() {
+    companion object {
+        val INSTANCE = NodeJsRuntimeGroup()
+    }
+
+    override val id: String = "NODEJS"
+
     override val runtimes: Set<Runtime> = setOf(
         Runtime.NODEJS10_X,
         Runtime.NODEJS12_X

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolverTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolverTest.kt
@@ -11,7 +11,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.utils.rules.NodeJsCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.addLambdaHandler
 import software.aws.toolkits.jetbrains.utils.rules.addPackageJsonFile
@@ -275,7 +274,7 @@ class NodeJsLambdaHandlerResolverTest {
     }
 
     private fun assertDetermineHandler(handlerElement: PsiElement, expectedHandlerFullName: String?) {
-        val resolver = LambdaHandlerResolver.getInstanceOrThrow(RuntimeGroup.NODEJS)
+        val resolver = LambdaHandlerResolver.getInstanceOrThrow(NodeJsRuntimeGroup.INSTANCE)
 
         runInEdtAndWait {
             if (expectedHandlerFullName != null) {
@@ -287,7 +286,7 @@ class NodeJsLambdaHandlerResolverTest {
     }
 
     private fun assertFindPsiElements(handler: String, shouldBeFound: Boolean) {
-        val resolver = LambdaHandlerResolver.getInstanceOrThrow(RuntimeGroup.NODEJS)
+        val resolver = LambdaHandlerResolver.getInstanceOrThrow(NodeJsRuntimeGroup.INSTANCE)
         runInEdtAndWait {
             val project = projectRule.fixture.project
             val lambdas = resolver.findPsiElements(project, handler, GlobalSearchScope.allScope(project))

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolverTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolverTest.kt
@@ -10,7 +10,9 @@ import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
+import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.utils.rules.NodeJsCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.addLambdaHandler
 import software.aws.toolkits.jetbrains.utils.rules.addPackageJsonFile
@@ -274,7 +276,7 @@ class NodeJsLambdaHandlerResolverTest {
     }
 
     private fun assertDetermineHandler(handlerElement: PsiElement, expectedHandlerFullName: String?) {
-        val resolver = LambdaHandlerResolver.getInstanceOrThrow(NodeJsRuntimeGroup.INSTANCE)
+        val resolver = LambdaHandlerResolver.getInstanceOrThrow(RuntimeGroup.getById(BuiltInRuntimeGroups.NodeJs))
 
         runInEdtAndWait {
             if (expectedHandlerFullName != null) {
@@ -286,7 +288,7 @@ class NodeJsLambdaHandlerResolverTest {
     }
 
     private fun assertFindPsiElements(handler: String, shouldBeFound: Boolean) {
-        val resolver = LambdaHandlerResolver.getInstanceOrThrow(NodeJsRuntimeGroup.INSTANCE)
+        val resolver = LambdaHandlerResolver.getInstanceOrThrow(RuntimeGroup.getById(BuiltInRuntimeGroups.NodeJs))
         runInEdtAndWait {
             val project = projectRule.fixture.project
             val lambdas = resolver.findPsiElements(project, handler, GlobalSearchScope.allScope(project))

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolverTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolverTest.kt
@@ -276,7 +276,7 @@ class NodeJsLambdaHandlerResolverTest {
     }
 
     private fun assertDetermineHandler(handlerElement: PsiElement, expectedHandlerFullName: String?) {
-        val resolver = LambdaHandlerResolver.getInstanceOrThrow(RuntimeGroup.getById(BuiltInRuntimeGroups.NodeJs))
+        val resolver = LambdaHandlerResolver.getInstance(RuntimeGroup.getById(BuiltInRuntimeGroups.NodeJs))
 
         runInEdtAndWait {
             if (expectedHandlerFullName != null) {
@@ -288,7 +288,7 @@ class NodeJsLambdaHandlerResolverTest {
     }
 
     private fun assertFindPsiElements(handler: String, shouldBeFound: Boolean) {
-        val resolver = LambdaHandlerResolver.getInstanceOrThrow(RuntimeGroup.getById(BuiltInRuntimeGroups.NodeJs))
+        val resolver = LambdaHandlerResolver.getInstance(RuntimeGroup.getById(BuiltInRuntimeGroups.NodeJs))
         runInEdtAndWait {
             val project = projectRule.fixture.project
             val lambdas = resolver.findPsiElements(project, handler, GlobalSearchScope.allScope(project))


### PR DESCRIPTION
* Nuke the RuntimeGroup enum
* Merge RuntimeGroup with RuntimeGroupInfo
* Migrate vals to funs so that it always queries the EP system
* Use IDs to reference RuntimeGroups now, this could use more clean up in the future

This is draft, because I am not 100% happy with that `RuntimeGroup.findById("JAVA") != JavaRuntimeGroup.INSTANCE`, but the APIs should be considered stable

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
