### PR TITLE
Disable debug for java8.al2

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/java/JavaLocalLambdaRunConfigurationIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -169,6 +170,7 @@ class JavaLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runtim
 
     @Test
     fun samIsExecutedWithDebugger() {
+        assumeTrue(runtime != Runtime.JAVA8_AL2)
         projectRule.addBreakpoint()
 
         val runConfiguration = createHandlerBasedRunConfiguration(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamDebugSupport.kt
@@ -45,7 +45,5 @@ class JavaSamDebugSupport : SamDebugSupport {
         }
     }
 
-    override fun isSupported(runtime: Runtime): Boolean {
-        return runtime != Runtime.JAVA8_AL2
-    }
+    override fun isSupported(runtime: Runtime): Boolean = runtime != Runtime.JAVA8_AL2
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamDebugSupport.kt
@@ -13,6 +13,7 @@ import com.intellij.xdebugger.XDebugProcess
 import com.intellij.xdebugger.XDebugProcessStarter
 import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.impl.XDebugSessionImpl
+import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamDebugSupport
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamRunningState
 
@@ -42,5 +43,9 @@ class JavaSamDebugSupport : SamDebugSupport {
                 return JavaDebugProcess.create(session, debuggerSession)
             }
         }
+    }
+
+    override fun isSupported(runtime: Runtime): Boolean {
+        return runtime != Runtime.JAVA8_AL2
     }
 }


### PR DESCRIPTION
Java8.al2 debug did not make it into SAM 1.1.0

Disable it for now

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
