### PR TITLE
Gradle buildSrc cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import toolkits.gradle.changelog.tasks.GenerateGithubChangeLog
+import software.aws.toolkits.gradle.changelog.tasks.GenerateGithubChangeLog
+import software.aws.toolkits.gradle.resources.ValidateMessages
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -278,31 +279,8 @@ task ktlint(type: JavaExec, group: "verification") {
     outputs.dir("${project.buildDir}/reports/ktlint/")
 }
 
-task validateLocalizedMessages(group: "verification") {
-    doLast {
-        BufferedReader files = Files.newBufferedReader(Paths.get("${project.rootDir}/resources/resources/software/aws/toolkits/resources/localized_messages.properties"))
-        files
-            .lines()
-            .map({ item ->
-                if (item == null || item.isEmpty()) {
-                    return ""
-                }
-                String[] chunks = item.split("=")
-                if (chunks.length <= 1) {
-                    return ""
-                } else {
-                    return chunks[0]
-                }
-            })
-            .filter({ item -> !item.isEmpty() })
-            .reduce({ item1, item2 ->
-                if (item1 > item2) {
-                    throw new GradleException("localization file is not sorted:" + item1 + " > " + item2)
-                }
-
-                return item2
-            })
-    }
+tasks.register('validateLocalizedMessages', ValidateMessages) {
+    paths = [file("${project.rootDir}/resources/resources/software/aws/toolkits/resources/localized_messages.properties")]
 }
 
 check.dependsOn ktlint

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -60,7 +60,7 @@ gradlePlugin {
     plugins {
         create("changeLog") {
             id = "toolkit-change-log"
-            implementationClass = "toolkits.gradle.changelog.ChangeLogPlugin"
+            implementationClass = "software.aws.toolkits.gradle.changelog.ChangeLogPlugin"
         }
     }
 }

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLog.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLog.kt
@@ -1,7 +1,7 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.MapperFeature

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogGenerator.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogGenerator.kt
@@ -1,7 +1,7 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import org.gradle.api.logging.Logging
 import java.nio.file.Path

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogGenerator.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogGenerator.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.gradle.changelog
 
-import org.gradle.api.logging.Logging
+import org.gradle.api.logging.Logger
 import java.nio.file.Path
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -13,20 +13,20 @@ import kotlin.streams.toList
 /**
  * Generates a combined change log file based in Markdown syntax
  */
-class ChangeLogGenerator(private val writers: List<ChangeLogWriter>) {
+class ChangeLogGenerator(private val writers: List<ChangeLogWriter>, private val logger: Logger) {
     fun addUnreleasedChanges(unreleasedFiles: List<Path>) {
         val entries = unreleasedFiles.parallelStream()
             .map { readFile<Entry>(it.toFile()) }
             .toList().filterNotNull()
         val unreleasedEntry = ReleaseEntry(LocalDate.now(), "Pending Release", entries)
-        LOGGER.info("Adding unreleased entry: $unreleasedEntry")
+        logger.info("Adding unreleased entry: $unreleasedEntry")
         generateEntry(unreleasedEntry)
     }
 
     fun addReleasedChanges(changelogFiles: List<Path>) {
         val versions = mutableSetOf<String>()
 
-        LOGGER.info("Including release change logs: $changelogFiles")
+        logger.info("Including release change logs: $changelogFiles")
         changelogFiles.parallelStream()
             .map { readFile<ReleaseEntry>(it.toFile()) }
             .toList()
@@ -38,7 +38,7 @@ class ChangeLogGenerator(private val writers: List<ChangeLogWriter>) {
             }
             .sortedByDescending { it.date }
             .forEach {
-                LOGGER.info("Adding release entry: $it")
+                logger.info("Adding release entry: $it")
                 generateEntry(it)
             }
     }
@@ -55,8 +55,6 @@ class ChangeLogGenerator(private val writers: List<ChangeLogWriter>) {
     }
 
     companion object {
-        private val LOGGER = Logging.getLogger(ChangeLogGenerator::class.java)
-
         fun renderEntry(releaseEntry: ReleaseEntry): String {
             val renderedEntry = StringBuilder()
 

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogPlugin.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogPlugin.kt
@@ -1,12 +1,12 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import toolkits.gradle.changelog.tasks.CreateRelease
-import toolkits.gradle.changelog.tasks.NewChange
+import software.aws.toolkits.gradle.changelog.tasks.CreateRelease
+import software.aws.toolkits.gradle.changelog.tasks.NewChange
 
 @Suppress("unused") // Plugin is created by buildSrc/build.gradle
 class ChangeLogPlugin : Plugin<Project> {

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogWriter.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogWriter.kt
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.gradle.changelog

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogWriter.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogWriter.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 abstract class ChangeLogWriter(issueUrl: String? = null) {
     private val issueUrl = issueUrl?.trimEnd('/')?.plus("/")

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/GitStager.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/GitStager.kt
@@ -1,7 +1,7 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import org.eclipse.jgit.api.Git
 import java.io.File

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/GithubWriter.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/GithubWriter.kt
@@ -1,7 +1,7 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import java.nio.file.Path
 

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/JetBrainsWriter.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/JetBrainsWriter.kt
@@ -1,7 +1,7 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import org.commonmark.node.AbstractVisitor
 import org.commonmark.node.Heading

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ReleaseCreator.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ReleaseCreator.kt
@@ -1,7 +1,7 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import java.io.File
 import java.time.LocalDate

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/ChangeLogTask.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/ChangeLogTask.kt
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog.tasks
+package software.aws.toolkits.gradle.changelog.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -9,7 +9,7 @@ import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import toolkits.gradle.changelog.GitStager
+import software.aws.toolkits.gradle.changelog.GitStager
 
 abstract class ChangeLogTask : DefaultTask() {
     @Internal

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
@@ -1,14 +1,14 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog.tasks
+package software.aws.toolkits.gradle.changelog.tasks
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import toolkits.gradle.changelog.ReleaseCreator
+import software.aws.toolkits.gradle.changelog.ReleaseCreator
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/GenerateChangeLog.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/GenerateChangeLog.kt
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog.tasks
+package software.aws.toolkits.gradle.changelog.tasks
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -10,10 +10,10 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import toolkits.gradle.changelog.ChangeLogGenerator
-import toolkits.gradle.changelog.ChangeLogWriter
-import toolkits.gradle.changelog.GithubWriter
-import toolkits.gradle.changelog.JetBrainsWriter
+import software.aws.toolkits.gradle.changelog.ChangeLogGenerator
+import software.aws.toolkits.gradle.changelog.ChangeLogWriter
+import software.aws.toolkits.gradle.changelog.GithubWriter
+import software.aws.toolkits.gradle.changelog.JetBrainsWriter
 
 /* ktlint-disable custom-ktlint-rules:log-not-lazy */
 abstract class GenerateChangeLog(private val shouldStage: Boolean) : ChangeLogTask() {

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/GenerateChangeLog.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/GenerateChangeLog.kt
@@ -31,7 +31,7 @@ abstract class GenerateChangeLog(private val shouldStage: Boolean) : ChangeLogTa
     fun generate() {
         val writer = createWriter()
         logger.info("Generating Changelog with $writer")
-        val generator = ChangeLogGenerator(listOf(writer))
+        val generator = ChangeLogGenerator(listOf(writer), logger)
         if (includeUnreleased.get()) {
             val unreleasedEntries = nextReleaseDirectory.jsonFiles().files
 

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/NewChange.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/NewChange.kt
@@ -1,13 +1,13 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog.tasks
+package software.aws.toolkits.gradle.changelog.tasks
 
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-import toolkits.gradle.changelog.ChangeType
-import toolkits.gradle.changelog.Entry
-import toolkits.gradle.changelog.MAPPER
+import software.aws.toolkits.gradle.changelog.ChangeType
+import software.aws.toolkits.gradle.changelog.Entry
+import software.aws.toolkits.gradle.changelog.MAPPER
 import java.io.File
 import java.util.Scanner
 import java.util.UUID

--- a/buildSrc/src/software/aws/toolkits/gradle/resources/ValidateMessages.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/resources/ValidateMessages.kt
@@ -9,11 +9,16 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
+import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
 import java.io.File
 
 open class ValidateMessages : DefaultTask() {
     @InputFiles
     lateinit var paths: List<File>
+
+    init {
+        group = VERIFICATION_GROUP
+    }
 
     @TaskAction
     fun validateMessage() {

--- a/buildSrc/src/software/aws/toolkits/gradle/resources/ValidateMessages.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/resources/ValidateMessages.kt
@@ -17,6 +17,7 @@ open class ValidateMessages : DefaultTask() {
 
     @TaskAction
     fun validateMessage() {
+        var hasError = false
         paths.map {
             it.absolutePath to it.readLines()
         }.forEach { (filePath, fileLines) ->
@@ -27,18 +28,22 @@ open class ValidateMessages : DefaultTask() {
                     if (it.contains("=")) {
                         it
                     } else {
-                        LOG.warn(""""Invalid message in $filePath does not contain a '=': "$it"""")
+                        LOG.warn(""""$filePath contains invalid message missing a '=': "$it"""")
                         null
                     }
                 }
                 .map { it.split("=").first() }
                 .reduce { item1, item2 ->
                     if (item1 > item2) {
-                        throw GradleException("""localization file $filePath is not sorted:"$item1" > "$item2"""")
+                        LOG.error("""$filePath is not sorted:"$item1" > "$item2"""")
+                        hasError = true
                     }
 
                     item2
                 }
+            if (hasError) {
+                throw GradleException("$filePath has one or more out of order items!")
+            }
         }
     }
 

--- a/buildSrc/src/software/aws/toolkits/gradle/resources/ValidateMessages.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/resources/ValidateMessages.kt
@@ -1,0 +1,48 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.gradle.resources
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+open class ValidateMessages : DefaultTask() {
+    @InputFiles
+    lateinit var paths: List<File>
+
+    @TaskAction
+    fun validateMessage() {
+        paths.map {
+            it.absolutePath to it.readLines()
+        }.forEach { (filePath, fileLines) ->
+            fileLines
+                // filter out blank lines and comments
+                .filter { it.isNotBlank() && it.trim().firstOrNull() != '#' }
+                .mapNotNull {
+                    if (it.contains("=")) {
+                        it
+                    } else {
+                        LOG.warn(""""Invalid message in $filePath does not contain a '=': "$it"""")
+                        null
+                    }
+                }
+                .map { it.split("=").first() }
+                .reduce { item1, item2 ->
+                    if (item1 > item2) {
+                        throw GradleException("""localization file $filePath is not sorted:"$item1" > "$item2"""")
+                    }
+
+                    item2
+                }
+        }
+    }
+
+    private companion object {
+        val LOG: Logger = Logging.getLogger(ValidateMessages::class.java)
+    }
+}

--- a/buildSrc/src/software/aws/toolkits/gradle/sdk/GenerateSdk.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/sdk/GenerateSdk.kt
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.gradle.sdk

--- a/buildSrc/src/software/aws/toolkits/gradle/sdk/GenerateSdk.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/sdk/GenerateSdk.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.sdk
+package software.aws.toolkits.gradle.sdk
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.InputDirectory

--- a/buildSrc/tst/software/aws/toolkits/gradle/changelog/ChangeLogGeneratorTest.kt
+++ b/buildSrc/tst/software/aws/toolkits/gradle/changelog/ChangeLogGeneratorTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.inOrder
@@ -14,9 +14,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.mockito.ArgumentMatchers.anyString
-import toolkits.gradle.changelog.ChangeLogGenerator.Companion.renderEntry
-import toolkits.gradle.changelog.ChangeType.BUGFIX
-import toolkits.gradle.changelog.ChangeType.FEATURE
+import software.aws.toolkits.gradle.changelog.ChangeLogGenerator.Companion.renderEntry
+import software.aws.toolkits.gradle.changelog.ChangeType.BUGFIX
+import software.aws.toolkits.gradle.changelog.ChangeType.FEATURE
 import java.nio.file.Path
 import java.time.LocalDate
 

--- a/buildSrc/tst/software/aws/toolkits/gradle/changelog/GitStagerTest.kt
+++ b/buildSrc/tst/software/aws/toolkits/gradle/changelog/GitStagerTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jgit.api.Git

--- a/buildSrc/tst/software/aws/toolkits/gradle/changelog/GithubWriterTest.kt
+++ b/buildSrc/tst/software/aws/toolkits/gradle/changelog/GithubWriterTest.kt
@@ -1,13 +1,13 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import toolkits.gradle.changelog.ChangeLogGenerator.Companion.renderEntry
+import software.aws.toolkits.gradle.changelog.ChangeLogGenerator.Companion.renderEntry
 import java.time.LocalDate
 
 class GithubWriterTest {

--- a/buildSrc/tst/software/aws/toolkits/gradle/changelog/JetBrainsWriterTest.kt
+++ b/buildSrc/tst/software/aws/toolkits/gradle/changelog/JetBrainsWriterTest.kt
@@ -1,13 +1,13 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import toolkits.gradle.changelog.ChangeLogGenerator.Companion.renderEntry
+import software.aws.toolkits.gradle.changelog.ChangeLogGenerator.Companion.renderEntry
 import java.time.LocalDate
 
 class JetBrainsWriterTest {

--- a/buildSrc/tst/software/aws/toolkits/gradle/changelog/ReleaseCreatorTest.kt
+++ b/buildSrc/tst/software/aws/toolkits/gradle/changelog/ReleaseCreatorTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package toolkits.gradle.changelog
+package software.aws.toolkits.gradle.changelog
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule

--- a/jetbrains-core/build.gradle.kts
+++ b/jetbrains-core/build.gradle.kts
@@ -5,7 +5,7 @@ import groovy.lang.Closure
 import org.jetbrains.intellij.tasks.PatchPluginXmlTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import software.aws.toolkits.telemetry.generator.gradle.GenerateTelemetry
-import toolkits.gradle.changelog.tasks.GeneratePluginChangeLog
+import software.aws.toolkits.gradle.changelog.tasks.GeneratePluginChangeLog
 
 plugins {
     id("org.jetbrains.intellij")

--- a/telemetry-client/build.gradle.kts
+++ b/telemetry-client/build.gradle.kts
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import toolkits.gradle.sdk.GenerateSdk
+import software.aws.toolkits.gradle.sdk.GenerateSdk
 
 val awsSdkVersion: String by project
 


### PR DESCRIPTION
- Move `buildSrc` from namespace `toolkits.*` to `software.aws.toolkits.*`
- Move `validateLocalizedMessages` into buildSrc and convert to Kotlin + give it better messages

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
