### PR TITLE
Enable kotlin in buildSrc the correct way

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 
@@ -17,11 +17,6 @@ buildscript {
     val props = java.util.Properties()
     file("${project.projectDir.parent}/gradle.properties").inputStream().use { props.load(it) }
     props.entries.forEach { it: Map.Entry<Any, Any> -> project.extensions.add(it.key.toString(), it.value) }
-
-    val kotlinVersion: String by project
-    dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-    }
 }
 
 repositories {
@@ -32,11 +27,8 @@ repositories {
 }
 
 plugins {
-    // TODO this really doesn't work. The plugin block requires a const string but the above
-    // hack we had in place to copy the properties also fixes this for now.
-    val kotlinVersion: String by project
-    kotlin("jvm") version kotlinVersion
     `java-gradle-plugin`
+    `kotlin-dsl`
 }
 
 sourceSets {
@@ -44,16 +36,15 @@ sourceSets {
         java.srcDir("src")
     }
     test {
-        java.srcDir("src")
+        java.srcDir("tst")
     }
 }
 
 dependencies {
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
-    api("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     api("org.eclipse.jgit:org.eclipse.jgit:5.0.2.201807311906-r")
-    api("com.atlassian.commonmark:commonmark:0.11.0")
+    api("com.atlassian.commonmark:commonmark:0.15.2")
     api("software.amazon.awssdk:codegen:$awsSdkVersion")
 
     implementation("gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:$ideaPluginVersion")

--- a/buildSrc/src/software/aws/toolkits/gradle/BuildScriptUtils.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/BuildScriptUtils.kt
@@ -14,7 +14,7 @@ import org.jetbrains.intellij.IntelliJPluginExtension
 inline fun <reified T : Task> Project.removeTask() {
     // For some reason in buildSrc, we can't use the <> version
     tasks.withType(T::class.java) {
-        it.enabled = false
+        enabled = false
     }
 }
 

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogPlugin.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogPlugin.kt
@@ -12,21 +12,21 @@ import software.aws.toolkits.gradle.changelog.tasks.NewChange
 class ChangeLogPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.tasks.register("createRelease", CreateRelease::class.java) {
-            it.description = "Generates a release entry from unreleased changelog entries"
+            description = "Generates a release entry from unreleased changelog entries"
         }
 
         project.tasks.register("newChange", NewChange::class.java) {
-            it.description = "Creates a new change entry for inclusion in the Change Log"
+            description = "Creates a new change entry for inclusion in the Change Log"
         }
 
         project.tasks.register("newFeature", NewChange::class.java) {
-            it.description = "Creates a new feature change entry for inclusion in the Change Log"
-            it.defaultChangeType = ChangeType.FEATURE
+            description = "Creates a new feature change entry for inclusion in the Change Log"
+            defaultChangeType = ChangeType.FEATURE
         }
 
         project.tasks.register("newBugFix", NewChange::class.java) {
-            it.description = "Creates a new bug-fix change entry for inclusion in the Change Log"
-            it.defaultChangeType = ChangeType.BUGFIX
+            description = "Creates a new bug-fix change entry for inclusion in the Change Log"
+            defaultChangeType = ChangeType.BUGFIX
         }
     }
 }

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/ChangeLogTask.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/ChangeLogTask.kt
@@ -22,6 +22,6 @@ abstract class ChangeLogTask : DefaultTask() {
     val nextReleaseDirectory: DirectoryProperty = project.objects.directoryProperty().convention(changesDirectory.dir("next-release"))
 
     protected fun DirectoryProperty.jsonFiles(): FileTree = this.asFileTree.matching {
-        it.include("*.json")
+        include("*.json")
     }
 }

--- a/buildSrc/tst/software/aws/toolkits/gradle/SourceUtilsTest.kt
+++ b/buildSrc/tst/software/aws/toolkits/gradle/SourceUtilsTest.kt
@@ -1,6 +1,8 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+package software.aws.toolkits.gradle
+
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/buildSrc/tst/software/aws/toolkits/gradle/changelog/ChangeLogGeneratorTest.kt
+++ b/buildSrc/tst/software/aws/toolkits/gradle/changelog/ChangeLogGeneratorTest.kt
@@ -77,7 +77,7 @@ class ChangeLogGeneratorTest {
         )
 
         val writer = mock<ChangeLogWriter>()
-        val sut = ChangeLogGenerator(listOf(writer))
+        val sut = ChangeLogGenerator(listOf(writer), mock())
         sut.addReleasedChanges(listOf(first, third, second))
         sut.close()
 
@@ -148,7 +148,7 @@ class ChangeLogGeneratorTest {
             """
         )
 
-        val sut = ChangeLogGenerator(mock())
+        val sut = ChangeLogGenerator(mock(), mock())
         sut.addReleasedChanges(listOf(first, second))
     }
 
@@ -171,7 +171,7 @@ class ChangeLogGeneratorTest {
 
         val firstWriter = mock<ChangeLogWriter>()
         val secondWriter = mock<ChangeLogWriter>()
-        val sut = ChangeLogGenerator(listOf(firstWriter, secondWriter))
+        val sut = ChangeLogGenerator(listOf(firstWriter, secondWriter), mock())
         sut.addReleasedChanges(listOf(entry))
         sut.close()
 
@@ -184,7 +184,7 @@ class ChangeLogGeneratorTest {
     @Test
     fun basicWrite() {
         val writer = mock<ChangeLogWriter>()
-        val sut = ChangeLogGenerator(listOf(writer))
+        val sut = ChangeLogGenerator(listOf(writer), mock())
 
         val first = createFile(
             """
@@ -246,7 +246,7 @@ class ChangeLogGeneratorTest {
     @Test
     fun canHandleMarkdown() {
         val writer = mock<ChangeLogWriter>()
-        val sut = ChangeLogGenerator(listOf(writer))
+        val sut = ChangeLogGenerator(listOf(writer), mock())
 
         val first = createFile(
             """
@@ -289,7 +289,7 @@ class ChangeLogGeneratorTest {
     @Test
     fun canHandleMultiLine() {
         val writer = mock<ChangeLogWriter>()
-        val sut = ChangeLogGenerator(listOf(writer))
+        val sut = ChangeLogGenerator(listOf(writer), mock())
 
         val first = createFile(
             """


### PR DESCRIPTION
* Tests did not run
* Enable kotlin in buildSrc the correct way
* Few receivers changed from 'it' to 'this' because of that
* Upgrade our markdown renderer

https://docs.gradle.org/6.5/userguide/kotlin_dsl.html#sec:kotlin-dsl_plugin

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
