### PR TITLE
Fix integration tests using real creds after they were reset

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployTest.kt
@@ -171,9 +171,10 @@ class SamDeployTest {
         }
     }
 
-    private fun createChangeSet(templateFile: VirtualFile, stackName: String, parameters: Map<String, String> = emptyMap()): String? {
-        val deployDialog = runInEdtAndGet {
-            runUnderRealCredentials(projectRule.project) {
+    private fun createChangeSet(templateFile: VirtualFile, stackName: String, parameters: Map<String, String> = emptyMap()): String? =
+        runUnderRealCredentials(projectRule.project) {
+            val deployDialog = runInEdtAndGet {
+
                 SamDeployDialog(
                     projectRule.project,
                     stackName,
@@ -187,10 +188,9 @@ class SamDeployTest {
                     Disposer.register(projectRule.fixture.testRootDisposable, it.disposable)
                 }
             }
-        }
 
-        return deployDialog.deployFuture.get(5, TimeUnit.MINUTES)
-    }
+            deployDialog.deployFuture.get(5, TimeUnit.MINUTES)
+        }
 
     private fun runAssertsAndClean(stackName: String, asserts: () -> Unit) {
         try {


### PR DESCRIPTION
```

java.util.concurrent.ExecutionException: software.aws.toolkits.core.credentials.CredentialProviderNotFoundException: Provider ID RealCredentials was removed, can't resolve credentials
--
at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2022)
at software.aws.toolkits.jetbrains.services.lambda.deploy.SamDeployTest.createChangeSet(SamDeployTest.kt:192)
at software.aws.toolkits.jetbrains.services.lambda.deploy.SamDeployTest.createChangeSet$default(SamDeployTest.kt:174)
at software.aws.toolkits.jetbrains.services.lambda.deploy.SamDeployTest$deployAppUsingSam$1.invoke(SamDeployTest.kt:64)
at software.aws.toolkits.jetbrains.services.lambda.deploy.SamDeployTest$deployAppUsingSam$1.invoke(SamDeployTest.kt:30)
at software.aws.toolkits.jetbrains.services.lambda.deploy.SamDeployTest.runAssertsAndClean(SamDeployTest.kt:197)
at software.aws.toolkits.jetbrains.services.lambda.deploy.SamDeployTest.deployAppUsingSam(SamDeployTest.kt:63)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:566)


```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
