### PR TITLE
Fix #2022. Handle exception thrown on run lambda debug under dotnetcore3.1

### DIFF
--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/LambdaDaemonHost.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/LambdaDaemonHost.kt
@@ -19,6 +19,7 @@ import com.intellij.psi.SmartPointerManager
 import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
 import com.jetbrains.rider.model.lambdaDaemonModel
 import com.jetbrains.rider.projectView.solution
+import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetLambdaHandlerResolver
 import software.aws.toolkits.jetbrains.services.lambda.dotnet.element.RiderLambdaHandlerFakePsiElement
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfigurationType
@@ -95,8 +96,12 @@ class LambdaDaemonHost(project: Project) : LifetimedProjectComponent(project) {
         val configurationType = ConfigurationTypeUtil.findConfigurationType(LambdaRunConfigurationType::class.java)
         val runConfigurations = runManager.getConfigurationsList(configurationType)
 
+        val isDebug = executor is DefaultDebugExecutor
+
         var settings = runConfigurations.filterIsInstance<LocalLambdaRunConfiguration>().firstOrNull { configuration ->
-            configuration.handler() == handler
+            configuration.handler() == handler &&
+                // TODO: Get rid of the check when SAM CLI provide support for dotnet 3.1 lambda debug
+                (if (isDebug) configuration.runtime() != Runtime.DOTNETCORE3_1 else true)
         }?.let { configuration ->
             runManager.findSettings(configuration)
         }
@@ -107,7 +112,12 @@ class LambdaDaemonHost(project: Project) : LifetimedProjectComponent(project) {
             val template = runManager.getConfigurationTemplate(factory)
 
             val configuration = template.configuration as LocalLambdaRunConfiguration
-            val runtime = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime()
+            val activeRuntime = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime()
+
+            // TODO: Get rid of the check when SAM CLI provide support for dotnet 3.1 lambda debug
+            val runtime =
+                if (isDebug && activeRuntime == Runtime.DOTNETCORE3_1) DotNetRuntimeUtils.defaultDotNetCoreRuntime
+                else activeRuntime
 
             LocalLambdaRunConfigurationProducer.setAccountOptions(configuration)
             configuration.useHandler(runtime, handler)

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
@@ -13,20 +13,20 @@ object DotNetRuntimeUtils {
 
     private val logger = getLogger<DotNetRuntimeUtils>()
 
-    val DEFAULT_DOTNET_CORE_RUNTIME: Runtime = Runtime.DOTNETCORE2_1
+    val defaultDotNetCoreRuntime: Runtime = Runtime.DOTNETCORE2_1
 
     /**
      * Get information about current .NET runtime
      *
      * @return the [software.amazon.awssdk.services.lambda.model.Runtime] instance of current available runtime or
-     *         [DEFAULT_DOTNET_CORE_RUNTIME] value if not defined.
+     *         defaultDotnetCoreRuntime value if not defined.
      */
     fun getCurrentDotNetCoreRuntime(): Runtime {
         val runtimeList = try {
             java.lang.Runtime.getRuntime().exec("dotnet --list-runtimes").inputStream.bufferedReader().readLines()
         } catch (e: IOException) {
             logger.warn { "Error getting current runtime version: $e" }
-            return DEFAULT_DOTNET_CORE_RUNTIME
+            return defaultDotNetCoreRuntime
         }
 
         val versionRegex = Regex("(\\d+.\\d+.\\d+)")
@@ -38,10 +38,10 @@ object DotNetRuntimeUtils {
             }
             .filterNotNull()
 
-        val version = versions.maxBy { it } ?: return DEFAULT_DOTNET_CORE_RUNTIME
+        val version = versions.maxBy { it } ?: return defaultDotNetCoreRuntime
 
         return Runtime.fromValue("dotnetcore${version.split('.').take(2).joinToString(".")}").validOrNull
-            ?: DEFAULT_DOTNET_CORE_RUNTIME
+            ?: defaultDotNetCoreRuntime
     }
 
     const val RUNTIME_CONFIG_JSON_21 = """{


### PR DESCRIPTION
* Ignore all run configurations with dotnetcore 3.1 runtime when use a debug option from lambda gutter mark
* Set runtime to a default value dotnetcore2.1 when select debug from gutter mark to prevent exception

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Rider have an option to run a lambda from gutter mark. Options are provide by Rider backend logic. On the frontend we lots through existing run configurations and ignore `runtime` setting when select a debug option. This cause a runtime exception when start debugger.

We rather should show a lambda local run configuration dialog with runtime preset to `dotnetcore2.1`. User should be notified explicitly about the error when debugging under dotnetcore3.1.

## Motivation and Context

## Related Issue(s)
#2022 

## Testing
- Checked for empty run configurations
- Check for configurations with dotnetcore3.1 runtimes
- Check for configurations with non-dotnetcore3.1 runtimes

## Screenshots (if appropriate)
None

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
