### PR TITLE
Fix SAM Gradle Hello World syncing twice (#2003)

### DIFF
--- a/.changes/next-release/bugfix-c6ad4272-6b5b-4ca5-b8a2-4c6684432870.json
+++ b/.changes/next-release/bugfix-c6ad4272-6b5b-4ca5-b8a2-4c6684432870.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix SAM Gradle Hello World syncing twice (#2003)"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamProjectWizard.kt
@@ -98,7 +98,9 @@ abstract class JavaGradleSamProjectTemplate : JavaSamProjectTemplate() {
 
         val importSpecBuilder = ImportSpecBuilder(rootModel.project, GradleConstants.SYSTEM_ID)
             .forceWhenUptodate()
-            .useDefaultCallback()
+            // replaces useDefaultCallback which is removed in 2020.3
+            // FIX_WHEN_MIN_IS_202 remove this callback (since we don't use it)
+            .callback(null)
             .use(ProgressExecutionMode.IN_BACKGROUND_ASYNC)
 
         ExternalSystemUtil.refreshProjects(importSpecBuilder)
@@ -140,7 +142,6 @@ class SamHelloWorldGradle : JavaGradleSamProjectTemplate() {
         sourceCreatingProject: Project,
         indicator: ProgressIndicator
     ) {
-        super.postCreationAction(settings, contentRoot, rootModel, sourceCreatingProject, indicator)
         val buildFile = locateBuildFile(contentRoot, "build.gradle") ?: return
 
         val gradleProjectSettings = GradleProjectSettings().apply {
@@ -151,12 +152,7 @@ class SamHelloWorldGradle : JavaGradleSamProjectTemplate() {
         val externalSystemSettings = ExternalSystemApiUtil.getSettings(rootModel.project, GradleConstants.SYSTEM_ID)
         externalSystemSettings.setLinkedProjectsSettings(setOf(gradleProjectSettings))
 
-        val importSpecBuilder = ImportSpecBuilder(rootModel.project, GradleConstants.SYSTEM_ID)
-            .forceWhenUptodate()
-            .useDefaultCallback()
-            .use(ProgressExecutionMode.IN_BACKGROUND_ASYNC)
-
-        ExternalSystemUtil.refreshProjects(importSpecBuilder)
+        super.postCreationAction(settings, contentRoot, rootModel, sourceCreatingProject, indicator)
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Don't call `ExternalSystemUtil.refreshProjects` twice. It's called in the parent class, and removed from all of the child classes except for the one for `Hello World`. Also, move the call to super to the bottom to align with the other child classes (setup everything then sync)
## Related Issue(s)
#2003

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
