### PR TITLE
Render the release into a per-release changelog

### DIFF
--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogGenerator.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogGenerator.kt
@@ -13,7 +13,7 @@ import kotlin.streams.toList
 /**
  * Generates a combined change log file based in Markdown syntax
  */
-class ChangeLogGenerator(private val writers: List<ChangeLogWriter>, private val logger: Logger) {
+class ChangeLogGenerator(private val writers: List<ChangeLogWriter>, private val logger: Logger): AutoCloseable {
     fun addUnreleasedChanges(unreleasedFiles: List<Path>) {
         val entries = unreleasedFiles.parallelStream()
             .map { readFile<Entry>(it.toFile()) }
@@ -50,7 +50,7 @@ class ChangeLogGenerator(private val writers: List<ChangeLogWriter>, private val
         }
     }
 
-    fun close() {
+    override fun close() {
         writers.forEach { it.close() }
     }
 

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogGenerator.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/ChangeLogGenerator.kt
@@ -13,7 +13,7 @@ import kotlin.streams.toList
 /**
  * Generates a combined change log file based in Markdown syntax
  */
-class ChangeLogGenerator(private val writers: List<ChangeLogWriter>, private val logger: Logger): AutoCloseable {
+class ChangeLogGenerator(private val writers: List<ChangeLogWriter>, private val logger: Logger) : AutoCloseable {
     fun addUnreleasedChanges(unreleasedFiles: List<Path>) {
         val entries = unreleasedFiles.parallelStream()
             .map { readFile<Entry>(it.toFile()) }

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
@@ -35,7 +35,7 @@ open class CreateRelease @Inject constructor(projectLayout: ProjectLayout) : Cha
     val releaseFile: RegularFileProperty = project.objects.fileProperty().convention(changesDirectory.file(releaseVersion.map { "$it.json" }))
 
     @OutputFile
-    val changeLogFile : RegularFileProperty = project.objects.fileProperty().convention(projectLayout.buildDirectory.file("releaseChangeLog.md"))
+    val changeLogFile: RegularFileProperty = project.objects.fileProperty().convention(projectLayout.buildDirectory.file("releaseChangeLog.md"))
 
     @TaskAction
     fun create() {

--- a/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
@@ -3,16 +3,22 @@
 
 package software.aws.toolkits.gradle.changelog.tasks
 
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import software.aws.toolkits.gradle.changelog.ChangeLogGenerator
+import software.aws.toolkits.gradle.changelog.GithubWriter
 import software.aws.toolkits.gradle.changelog.ReleaseCreator
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import javax.inject.Inject
 
-open class CreateRelease : ChangeLogTask() {
+open class CreateRelease @Inject constructor(projectLayout: ProjectLayout) : ChangeLogTask() {
     @Input
     val releaseDate: Property<String> = project.objects.property(String::class.java).convention(DateTimeFormatter.ISO_DATE.format(LocalDate.now()))
 
@@ -21,8 +27,15 @@ open class CreateRelease : ChangeLogTask() {
         (project.version as String).substringBeforeLast('-')
     })
 
+    @Input
+    @Optional
+    val issuesUrl: Provider<String?> = project.objects.property(String::class.java).convention("https://github.com/aws/aws-toolkit-jetbrains/issues")
+
     @OutputFile
     val releaseFile: RegularFileProperty = project.objects.fileProperty().convention(changesDirectory.file(releaseVersion.map { "$it.json" }))
+
+    @OutputFile
+    val changeLogFile : RegularFileProperty = project.objects.fileProperty().convention(projectLayout.buildDirectory.file("releaseChangeLog.md"))
 
     @TaskAction
     fun create() {
@@ -37,6 +50,11 @@ open class CreateRelease : ChangeLogTask() {
         if (git != null) {
             git.stage(releaseFile.get().asFile.absoluteFile)
             git.stage(nextReleaseDirectory.get().asFile.absoluteFile)
+        }
+
+        val generator = ChangeLogGenerator(listOf(GithubWriter(changeLogFile.get().asFile.toPath(), issuesUrl.get())), logger)
+        generator.use {
+            generator.addReleasedChanges(listOf(releaseFile.get().asFile.toPath()))
         }
     }
 }


### PR DESCRIPTION
During a release, renders the latest release entry as a standalone markdown file for GitHub

```
cat build/releaseChangeLog.md
# _1.18-SNAPSHOT_ (2020-08-28)
- **(Feature)** Add support for Lambda runtime java8.al2
- **(Feature)** Save update Lambda code settings
- **(Feature)** Several enhancements to the UX around connecting to AWS including:
  - Making connection settings more visible (now visible in the AWS Explorer)
  - Automatically selecting 'default' profile if it exists
  - Better visibility of connection validation workflow (more information when unable to connect)
  - Handling of default regions on credential profile
  - Better UX around partitions
  - Adding ability to refresh connection from the UI
- **(Feature)** Support colons (`:`) in credential profile names
- **(Bug Fix)** Fix Rider building Lambda into incorrect folders
- **(Bug Fix)** Fix several uncaught exceptions caused by plugins being installed but not enabled
- **(Bug Fix)** Fix issue where templates > 51200 bytes would not deploy with "Deploy Serverless Application" ([#1973](https://github.com/aws/aws-toolkit-jetbrains/issues/1973))
- **(Bug Fix)** Fix removing a source_profile leading to an IDE error on profile file refresh
- **(Bug Fix)** Improved rendering speed of wrapped text in CloudWatch logs and CloudFormation events tables
- **(Bug Fix)** Fix SAM Gradle Hello World syncing twice ([#2003](https://github.com/aws/aws-toolkit-jetbrains/issues/2003))
- **(Bug Fix)** Improve watching of the AWS profile files to incorporate changes made to the files outisde of the IDE
- **(Bug Fix)** Fix several cases where features not supported by the host IDE are shown ([#1980](https://github.com/aws/aws-toolkit-jetbrains/issues/1980))
- **(Bug Fix)** Fix the CloudWatch Logs table breaking when the service returns an exception during loading more entries ([#1951](https://github.com/aws/aws-toolkit-jetbrains/issues/1951))
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
