### PR TITLE
Fix issue launching remote terminal on 2020.2

### DIFF
--- a/.changes/next-release/bugfix-44f91df3-3dcf-48dd-af38-95acb6c8236f.json
+++ b/.changes/next-release/bugfix-44f91df3-3dcf-48dd-af38-95acb6c8236f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix remote terminal start issue on 2020.2"
+}


### PR DESCRIPTION
Swap to `CloudTerminalProcess` instead of patching the command list of `LocalTerminalDirectRunner` in hopes that this API is more static

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Tested on 2019.3 and 2020.2

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
