### PR TITLE
SQS code style and minor UI cleanup

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaPolicies.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaPolicies.kt
@@ -10,53 +10,54 @@ const val LAMBDA_PRINCIPAL = "lambda.amazonaws.com"
 @Language("JSON")
 val DEFAULT_ASSUME_ROLE_POLICY =
     """
-{
-  "Version": "2012-10-17",
-  "Statement": [
     {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
     }
-  ]
-}
-""".trim()
+    """.trim()
 
 @Language("JSON")
 val DEFAULT_POLICY =
     """
-{
-  "Version": "2012-10-17",
-  "Statement": [
     {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "*"
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+          ],
+          "Resource": "*"
+        }
+      ]
     }
-  ]
-}
-""".trim()
+    """.trim()
 
 @Language("JSON")
-fun createSqsPollerPolicy(arn: String): String = """
-{
-  "Version": "2012-10-17",
-  "Statement": [
+fun createSqsPollerPolicy(arn: String): String =
+    """
     {
-      "Effect": "Allow",
-      "Action": [
-        "sqs:DeleteMessage",
-        "sqs:GetQueueAttributes", 
-        "sqs:ReceiveMessage"
-      ],
-      "Resource": "$arn"
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "sqs:DeleteMessage",
+            "sqs:GetQueueAttributes", 
+            "sqs:ReceiveMessage"
+          ],
+          "Resource": "$arn"
+        }
+      ]
     }
-  ]
-}
-""".trim()
+    """.trim()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sns/resources/SnsResources.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sns/resources/SnsResources.kt
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.sqs.resources
+package software.aws.toolkits.jetbrains.services.sns.resources
 
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.Topic
@@ -14,4 +14,5 @@ object SnsResources {
     }
 }
 
+// Topic arns are in the format: arn:<partition>:sns:<region>:<accountId>:<name> and cannot contain ':'
 fun Topic.getName(): String = topicArn().substringAfterLast(':')

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sns/resources/SnsResources.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sns/resources/SnsResources.kt
@@ -14,5 +14,5 @@ object SnsResources {
     }
 }
 
-// Topic arns are in the format: arn:<partition>:sns:<region>:<accountId>:<name> and cannot contain ':'
+// SNS topic ARNs are in the format: arn:<partition>:sns:<region>:<accountId>:<name> and cannot contain ':'
 fun Topic.getName(): String = topicArn().substringAfterLast(':')

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/ConfirmIamPolicyDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/ConfirmIamPolicyDialog.kt
@@ -22,12 +22,12 @@ import java.awt.Component
 import javax.swing.JComponent
 
 class ConfirmIamPolicyDialog(
-    private val project: Project,
+    project: Project,
     private val iamClient: IamClient,
     private val lambdaClient: LambdaClient,
     private val functionName: String,
     private val queue: Queue,
-    private val parent: Component? = null
+    parent: Component? = null
 ) : DialogWrapper(project, parent, false, IdeModalityType.PROJECT), CoroutineScope by ApplicationThreadPoolScope("ConfirmIamPolicy") {
     private val rolePolicy: String by lazy { createSqsPollerPolicy(queue.arn) }
     private val policyName: String by lazy { "AWSLambdaSQSPollerExecutionRole-$functionName-${queue.queueName}-${queue.region.id}" }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/Queue.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/Queue.kt
@@ -7,9 +7,14 @@ import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.resources.message
 
 // TODO This does not support FIPS
+
+/**
+ * @param queueUrl The format for queueUrl is https://sqs.<region>.amazonaws.com/<accountId>/<queueName>
+ * queueName cannot contain '/', so it is safe enough to do string manipulation on it
+ */
 class Queue(val queueUrl: String, val region: AwsRegion) {
     val accountId: String by lazy {
-        val id = queueUrl.substringAfter("${region.id}").substringAfter("/").substringBefore("/")
+        val id = queueUrl.substringBeforeLast("/").substringAfterLast("/")
         if ((id == queueUrl) || (id.length != 12) || id.isBlank()) {
             throw IllegalArgumentException(message("sqs.url.parse_error"))
         } else {
@@ -18,7 +23,7 @@ class Queue(val queueUrl: String, val region: AwsRegion) {
     }
 
     val queueName: String by lazy {
-        val name = queueUrl.substringAfter("$accountId/")
+        val name = queueUrl.substringAfterLast("/")
         if (name == queueUrl || name.isBlank()) {
             throw IllegalArgumentException(message("sqs.url.parse_error"))
         } else {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/Queue.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/Queue.kt
@@ -4,15 +4,14 @@
 package software.aws.toolkits.jetbrains.services.sqs
 
 import software.aws.toolkits.core.region.AwsRegion
-import java.lang.IllegalArgumentException
 import software.aws.toolkits.resources.message
 
-/*This does not support FIPS*/
+// TODO This does not support FIPS
 class Queue(val queueUrl: String, val region: AwsRegion) {
     val accountId: String by lazy {
         val id = queueUrl.substringAfter("${region.id}").substringAfter("/").substringBefore("/")
         if ((id == queueUrl) || (id.length != 12) || id.isBlank()) {
-                throw IllegalArgumentException(message("sqs.url.parse_error"))
+            throw IllegalArgumentException(message("sqs.url.parse_error"))
         } else {
             id
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/SqsExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/SqsExplorerNodes.kt
@@ -43,6 +43,6 @@ class SqsQueueNode(
     override fun displayName(): String = queue.queueName
 
     override fun onDoubleClick() {
-        SqsWindow.getInstance(nodeProject)?.pollMessage(queue)
+        SqsWindow.getInstance(nodeProject).pollMessage(queue)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/SubscribeSnsPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/SubscribeSnsPanel.kt
@@ -7,8 +7,8 @@ import com.intellij.ide.HelpTooltip
 import com.intellij.openapi.project.Project
 import com.intellij.ui.IdeBorderFactory
 import software.amazon.awssdk.services.sns.model.Topic
-import software.aws.toolkits.jetbrains.services.sqs.resources.SnsResources
-import software.aws.toolkits.jetbrains.services.sqs.resources.getName
+import software.aws.toolkits.jetbrains.services.sns.resources.SnsResources
+import software.aws.toolkits.jetbrains.services.sns.resources.getName
 import software.aws.toolkits.jetbrains.ui.ResourceSelector
 import software.aws.toolkits.resources.message
 import javax.swing.JLabel

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/DeleteQueueAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/DeleteQueueAction.kt
@@ -15,9 +15,10 @@ import software.aws.toolkits.resources.message
 
 class DeleteQueueAction : DeleteResourceAction<SqsQueueNode>(message("sqs.delete.queue.action"), TaggingResourceType.SQS_QUEUE) {
     override fun performDelete(selected: SqsQueueNode) {
-        val client = selected.nodeProject.awsClient<SqsClient>()
-        SqsWindow.getInstance(selected.nodeProject).closeQueue(selected.queueUrl)
+        val project = selected.nodeProject
+        val client = project.awsClient<SqsClient>()
+        SqsWindow.getInstance(project).closeQueue(selected.queueUrl)
         client.deleteQueue { it.queueUrl(selected.queueUrl) }
-        selected.nodeProject.refreshAwsTree(SqsResources.LIST_QUEUE_URLS)
+        project.refreshAwsTree(SqsResources.LIST_QUEUE_URLS)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/DeleteQueueAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/DeleteQueueAction.kt
@@ -17,7 +17,7 @@ class DeleteQueueAction : DeleteResourceAction<SqsQueueNode>(message("sqs.delete
     override fun performDelete(selected: SqsQueueNode) {
         val project = selected.nodeProject
         val client = project.awsClient<SqsClient>()
-        SqsWindow.getInstance(project)?.closeQueue(selected.queueUrl)
+        SqsWindow.getInstance(project).closeQueue(selected.queueUrl)
         client.deleteQueue { it.queueUrl(selected.queueUrl) }
         project.refreshAwsTree(SqsResources.LIST_QUEUE_URLS)
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/DeleteQueueAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/DeleteQueueAction.kt
@@ -17,7 +17,7 @@ class DeleteQueueAction : DeleteResourceAction<SqsQueueNode>(message("sqs.delete
     override fun performDelete(selected: SqsQueueNode) {
         val project = selected.nodeProject
         val client = project.awsClient<SqsClient>()
-        SqsWindow.getInstance(project).closeQueue(selected.queueUrl)
+        SqsWindow.getInstance(project)?.closeQueue(selected.queueUrl)
         client.deleteQueue { it.queueUrl(selected.queueUrl) }
         project.refreshAwsTree(SqsResources.LIST_QUEUE_URLS)
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/PollMessageAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/PollMessageAction.kt
@@ -12,6 +12,6 @@ import software.aws.toolkits.resources.message
 
 class PollMessageAction : SingleResourceNodeAction<SqsQueueNode>(message("sqs.poll.message")), DumbAware {
     override fun actionPerformed(selected: SqsQueueNode, e: AnActionEvent) {
-        SqsWindow.getInstance(selected.nodeProject)?.pollMessage(selected.queue)
+        SqsWindow.getInstance(selected.nodeProject).pollMessage(selected.queue)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/SendMessageAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/SendMessageAction.kt
@@ -12,6 +12,6 @@ import software.aws.toolkits.resources.message
 
 class SendMessageAction : SingleResourceNodeAction<SqsQueueNode>(message("sqs.send.message")), DumbAware {
     override fun actionPerformed(selected: SqsQueueNode, e: AnActionEvent) {
-        SqsWindow.getInstance(selected.nodeProject)?.sendMessage(selected.queue)
+        SqsWindow.getInstance(selected.nodeProject).sendMessage(selected.queue)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/SubscribeSnsAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/actions/SubscribeSnsAction.kt
@@ -13,9 +13,7 @@ import software.aws.toolkits.resources.message
 class SubscribeSnsAction : SingleResourceNodeAction<SqsQueueNode>(message("sqs.subscribe.sns")), DumbAware {
     override fun update(selected: SqsQueueNode, e: AnActionEvent) {
         // TODO: Amazon SNS isn't currently compatible with FIFO queues.
-        if (selected.queue.isFifo) {
-            e.presentation.isVisible = false
-        }
+        e.presentation.isVisible = !selected.queue.isFifo
     }
 
     override fun actionPerformed(selected: SqsQueueNode, e: AnActionEvent) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.sqs.toolwindow.FifoPanel">
-  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="3" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="1" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="804" height="174"/>
@@ -8,17 +8,9 @@
     <properties/>
     <border type="none"/>
     <children>
-      <component id="39926" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.deduplication_id"/>
-        </properties>
-      </component>
       <component id="e561f" class="com.intellij.ui.components.JBTextField" binding="deduplicationId">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="400" height="-1"/>
             <maximum-size width="400" height="-1"/>
           </grid>
@@ -27,41 +19,17 @@
           <text value=""/>
         </properties>
       </component>
-      <component id="2ace" class="javax.swing.JLabel" binding="deduplicationErrorLabel">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <foreground color="-567206"/>
-          <text value=""/>
-        </properties>
-      </component>
-      <hspacer id="ad108">
-        <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
-            <minimum-size width="50" height="-1"/>
-          </grid>
-        </constraints>
-      </hspacer>
       <component id="d7a32" class="javax.swing.JLabel" binding="deduplicationContextHelp">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>
-        </properties>
-      </component>
-      <component id="a9ef9" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.group_id"/>
         </properties>
       </component>
       <component id="b6b38" class="com.intellij.ui.components.JBTextField" binding="groupId">
         <constraints>
-          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="400" height="-1"/>
             <maximum-size width="400" height="-1"/>
           </grid>
@@ -70,19 +38,26 @@
       </component>
       <component id="5a145" class="javax.swing.JLabel" binding="groupContextHelp">
         <constraints>
-          <grid row="1" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>
         </properties>
       </component>
-      <component id="226d5" class="javax.swing.JLabel" binding="groupErrorLabel">
+      <component id="39926" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <foreground color="-567206"/>
-          <text value=""/>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.deduplication_id"/>
+        </properties>
+      </component>
+      <component id="a9ef9" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.group_id"/>
         </properties>
       </component>
     </children>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
@@ -41,21 +41,28 @@ class FifoPanel {
         groupId.emptyText.text = message("sqs.required.empty.text")
     }
 
-    fun validateFields(): ValidationInfo? = when {
-        deduplicationId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
-            ValidationInfo(message("sqs.message.validation.long.id"), deduplicationId)
+    fun validateFields(): List<ValidationInfo> = listOfNotNull(
+        when {
+            deduplicationId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
+                ValidationInfo(message("sqs.message.validation.long.id"), deduplicationId)
+            }
+            deduplicationId.text.isBlank() -> {
+                ValidationInfo(message("sqs.message.validation.empty.deduplication_id"), deduplicationId)
+            }
+            else -> {
+                null
+            }
+        },
+        when {
+            groupId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
+                ValidationInfo(message("sqs.message.validation.long.id"), groupId)
+            }
+            groupId.text.isBlank() -> {
+                ValidationInfo(message("sqs.message.validation.empty.group_id"), groupId)
+            }
+            else -> {
+                null
+            }
         }
-        groupId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
-            ValidationInfo(message("sqs.message.validation.long.id"), groupId)
-        }
-        deduplicationId.text.isBlank() -> {
-            ValidationInfo(message("sqs.message.validation.empty.deduplication_id"), deduplicationId)
-        }
-        groupId.text.isBlank() -> {
-            ValidationInfo(message("sqs.message.validation.empty.group_id"), groupId)
-        }
-        else -> {
-            null
-        }
-    }
+    )
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
@@ -42,27 +42,31 @@ class FifoPanel {
     }
 
     fun validateFields(): List<ValidationInfo> = listOfNotNull(
-        when {
-            deduplicationId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
-                ValidationInfo(message("sqs.message.validation.long.id"), deduplicationId)
-            }
-            deduplicationId.text.isBlank() -> {
-                ValidationInfo(message("sqs.message.validation.empty.deduplication_id"), deduplicationId)
-            }
-            else -> {
-                null
-            }
-        },
-        when {
-            groupId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
-                ValidationInfo(message("sqs.message.validation.long.id"), groupId)
-            }
-            groupId.text.isBlank() -> {
-                ValidationInfo(message("sqs.message.validation.empty.group_id"), groupId)
-            }
-            else -> {
-                null
-            }
-        }
+        validateDedupeId(),
+        validateGroupId()
     )
+
+    private fun validateDedupeId(): ValidationInfo? = when {
+        deduplicationId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
+            ValidationInfo(message("sqs.message.validation.long.id"), deduplicationId)
+        }
+        deduplicationId.text.isBlank() -> {
+            ValidationInfo(message("sqs.message.validation.empty.deduplication_id"), deduplicationId)
+        }
+        else -> {
+            null
+        }
+    }
+
+    private fun validateGroupId(): ValidationInfo? = when {
+        groupId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
+            ValidationInfo(message("sqs.message.validation.long.id"), groupId)
+        }
+        groupId.text.isBlank() -> {
+            ValidationInfo(message("sqs.message.validation.empty.group_id"), groupId)
+        }
+        else -> {
+            null
+        }
+    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
@@ -9,15 +9,11 @@ import software.aws.toolkits.jetbrains.services.sqs.MAX_LENGTH_OF_FIFO_ID
 import software.aws.toolkits.resources.message
 import javax.swing.JLabel
 import javax.swing.JPanel
-import javax.swing.event.DocumentEvent
-import javax.swing.event.DocumentListener
 
 class FifoPanel {
     lateinit var component: JPanel
     lateinit var deduplicationId: JBTextField
     lateinit var groupId: JBTextField
-    lateinit var deduplicationErrorLabel: JLabel
-    lateinit var groupErrorLabel: JLabel
     lateinit var deduplicationContextHelp: JLabel
     lateinit var groupContextHelp: JLabel
 
@@ -27,9 +23,6 @@ class FifoPanel {
     }
 
     private fun loadComponents() {
-        deduplicationErrorLabel.isVisible = false
-        groupErrorLabel.isVisible = false
-
         deduplicationContextHelp.icon = AllIcons.General.ContextHelp
         HelpTooltip().apply {
             setDescription(message("sqs.message.deduplication_id.tooltip"))
@@ -43,61 +36,18 @@ class FifoPanel {
     }
 
     private fun setFields() {
-        deduplicationId.apply {
-            emptyText.text = message("sqs.required.empty.text")
-            document.addDocumentListener(createListener(this, deduplicationErrorLabel, message("sqs.message.validation.empty.deduplication_id")))
-        }
-
-        groupId.apply {
-            emptyText.text = message("sqs.required.empty.text")
-            document.addDocumentListener(createListener(this, groupErrorLabel, message("sqs.message.validation.empty.group_id")))
-        }
+        deduplicationId.emptyText.text = message("sqs.required.empty.text")
+        groupId.emptyText.text = message("sqs.required.empty.text")
     }
 
-    fun validateFields(): Boolean {
-        var isValid = true
-
-        if (deduplicationId.text.length > MAX_LENGTH_OF_FIFO_ID) {
-            deduplicationErrorLabel.text = message("sqs.message.validation.long.id")
-            deduplicationErrorLabel.isVisible = true
-            isValid = false
+    fun validateFields(): String? =
+        if (deduplicationId.text.length > MAX_LENGTH_OF_FIFO_ID || groupId.text.length > MAX_LENGTH_OF_FIFO_ID) {
+            message("sqs.message.validation.long.id")
         } else if (deduplicationId.text.isBlank()) {
-            deduplicationErrorLabel.text = message("sqs.message.validation.empty.deduplication_id")
-            deduplicationErrorLabel.isVisible = true
-            isValid = false
-        }
-
-        if (groupId.text.length > MAX_LENGTH_OF_FIFO_ID) {
-            groupErrorLabel.text = message("sqs.message.validation.long.id")
-            groupErrorLabel.isVisible = true
-            isValid = false
+            message("sqs.message.validation.empty.deduplication_id")
         } else if (groupId.text.isBlank()) {
-            groupErrorLabel.text = message("sqs.message.validation.empty.group_id")
-            groupErrorLabel.isVisible = true
-            isValid = false
+            message("sqs.message.validation.empty.group_id")
+        } else {
+            null
         }
-
-        return isValid
-    }
-
-    private fun createListener(textField: JBTextField, errorLabel: JLabel, minText: String): DocumentListener = object : DocumentListener {
-        override fun changedUpdate(e: DocumentEvent?) {}
-        override fun insertUpdate(e: DocumentEvent?) {
-            if (textField.text.length > MAX_LENGTH_OF_FIFO_ID) {
-                errorLabel.text = message("sqs.message.validation.long.id")
-                errorLabel.isVisible = true
-            } else {
-                errorLabel.isVisible = false
-            }
-        }
-
-        override fun removeUpdate(e: DocumentEvent?) {
-            if (textField.text.length <= MAX_LENGTH_OF_FIFO_ID && !textField.text.isBlank()) {
-                errorLabel.isVisible = false
-            } else if (textField.text.isBlank()) {
-                errorLabel.text = minText
-                errorLabel.isVisible = true
-            }
-        }
-    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
@@ -45,43 +45,42 @@ class FifoPanel {
     private fun setFields() {
         deduplicationId.apply {
             emptyText.text = message("sqs.required.empty.text")
-            document.addDocumentListener(createListener(this, deduplicationErrorLabel))
+            document.addDocumentListener(createListener(this, deduplicationErrorLabel, message("sqs.message.validation.empty.deduplication_id")))
         }
 
         groupId.apply {
             emptyText.text = message("sqs.required.empty.text")
-            document.addDocumentListener(createListener(this, groupErrorLabel))
+            document.addDocumentListener(createListener(this, groupErrorLabel, message("sqs.message.validation.empty.group_id")))
         }
     }
 
     fun validateFields(): Boolean {
-        var deduplicationIsValid = true
-        var groupIsValid = true
+        var isValid = true
 
         if (deduplicationId.text.length > MAX_LENGTH_OF_FIFO_ID) {
             deduplicationErrorLabel.text = message("sqs.message.validation.long.id")
             deduplicationErrorLabel.isVisible = true
-            deduplicationIsValid = false
-        } else if (deduplicationId.text.isEmpty()) {
+            isValid = false
+        } else if (deduplicationId.text.isBlank()) {
             deduplicationErrorLabel.text = message("sqs.message.validation.empty.deduplication_id")
             deduplicationErrorLabel.isVisible = true
-            deduplicationIsValid = false
+            isValid = false
         }
 
         if (groupId.text.length > MAX_LENGTH_OF_FIFO_ID) {
             groupErrorLabel.text = message("sqs.message.validation.long.id")
             groupErrorLabel.isVisible = true
-            groupIsValid = false
-        } else if (groupId.text.isEmpty()) {
+            isValid = false
+        } else if (groupId.text.isBlank()) {
             groupErrorLabel.text = message("sqs.message.validation.empty.group_id")
             groupErrorLabel.isVisible = true
-            groupIsValid = false
+            isValid = false
         }
 
-        return (deduplicationIsValid && groupIsValid)
+        return isValid
     }
 
-    private fun createListener(textField: JBTextField, errorLabel: JLabel): DocumentListener = object : DocumentListener {
+    private fun createListener(textField: JBTextField, errorLabel: JLabel, minText: String): DocumentListener = object : DocumentListener {
         override fun changedUpdate(e: DocumentEvent?) {}
         override fun insertUpdate(e: DocumentEvent?) {
             if (textField.text.length > MAX_LENGTH_OF_FIFO_ID) {
@@ -93,8 +92,11 @@ class FifoPanel {
         }
 
         override fun removeUpdate(e: DocumentEvent?) {
-            if (textField.text.length <= MAX_LENGTH_OF_FIFO_ID) {
+            if (textField.text.length <= MAX_LENGTH_OF_FIFO_ID && !textField.text.isBlank()) {
                 errorLabel.isVisible = false
+            } else if (textField.text.isBlank()) {
+                errorLabel.text = minText
+                errorLabel.isVisible = true
             }
         }
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
@@ -4,6 +4,7 @@ package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
 import com.intellij.icons.AllIcons
 import com.intellij.ide.HelpTooltip
+import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.components.JBTextField
 import software.aws.toolkits.jetbrains.services.sqs.MAX_LENGTH_OF_FIFO_ID
 import software.aws.toolkits.resources.message
@@ -40,14 +41,21 @@ class FifoPanel {
         groupId.emptyText.text = message("sqs.required.empty.text")
     }
 
-    fun validateFields(): String? =
-        if (deduplicationId.text.length > MAX_LENGTH_OF_FIFO_ID || groupId.text.length > MAX_LENGTH_OF_FIFO_ID) {
-            message("sqs.message.validation.long.id")
-        } else if (deduplicationId.text.isBlank()) {
-            message("sqs.message.validation.empty.deduplication_id")
-        } else if (groupId.text.isBlank()) {
-            message("sqs.message.validation.empty.group_id")
-        } else {
+    fun validateFields(): ValidationInfo? = when {
+        deduplicationId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
+            ValidationInfo(message("sqs.message.validation.long.id"), deduplicationId)
+        }
+        groupId.text.length > MAX_LENGTH_OF_FIFO_ID -> {
+            ValidationInfo(message("sqs.message.validation.long.id"), groupId)
+        }
+        deduplicationId.text.isBlank() -> {
+            ValidationInfo(message("sqs.message.validation.empty.deduplication_id"), deduplicationId)
+        }
+        groupId.text.isBlank() -> {
+            ValidationInfo(message("sqs.message.validation.empty.group_id"), groupId)
+        }
+        else -> {
             null
         }
+    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.kt
@@ -91,6 +91,7 @@ class FifoPanel {
                 errorLabel.isVisible = false
             }
         }
+
         override fun removeUpdate(e: DocumentEvent?) {
             if (textField.text.length <= MAX_LENGTH_OF_FIFO_ID) {
                 errorLabel.isVisible = false

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/MessagesTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/MessagesTable.kt
@@ -28,8 +28,8 @@ class MessagesTable {
     init {
         table = TableView(tableModel).apply {
             autoscrolls = true
-            tableHeader.reorderingAllowed = false
-            tableHeader.resizingAllowed = false
+            // Disable the header so the user cannot sort or resize columns
+            tableHeader.isEnabled = false
             autoResizeMode = JTable.AUTO_RESIZE_LAST_COLUMN
             setPaintBusy(true)
             emptyText.text = message("loading_resource.loading")

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/MessagesTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/MessagesTable.kt
@@ -21,7 +21,8 @@ class MessagesTable {
             MessageBodyColumn(),
             MessageSenderIdColumn(),
             MessageDateColumn()
-        ), mutableListOf<Message>()
+        ),
+        mutableListOf<Message>()
     )
 
     init {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/PollMessagePane.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/PollMessagePane.kt
@@ -1,5 +1,6 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
 import com.intellij.openapi.ui.SimpleToolWindowPanel

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/PollMessageUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/PollMessageUtils.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
 import com.intellij.util.ui.ColumnInfo
-import org.apache.commons.lang.StringUtils
 import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName
 import software.aws.toolkits.jetbrains.services.sqs.MAX_LENGTH_OF_POLLED_MESSAGES
@@ -12,7 +11,6 @@ import software.aws.toolkits.jetbrains.utils.ui.ResizingDateColumnRenderer
 import software.aws.toolkits.jetbrains.utils.ui.ResizingTextColumnRenderer
 import software.aws.toolkits.jetbrains.utils.ui.WrappingCellRenderer
 import software.aws.toolkits.resources.message
-import java.lang.IllegalArgumentException
 import javax.swing.table.TableCellRenderer
 
 class MessageIdColumn : ColumnInfo<Message, String>(message("sqs.message.message_id")) {
@@ -24,8 +22,9 @@ class MessageIdColumn : ColumnInfo<Message, String>(message("sqs.message.message
 
 class MessageBodyColumn : ColumnInfo<Message, String>(message("sqs.message.message_body")) {
     private val renderer = WrappingCellRenderer(wrapOnSelection = true, toggleableWrap = false)
-    // Truncated the message body to show up to 1KB, as it can be up to 256KB in size. Cannot limit the retrieved message size through API.
-    override fun valueOf(item: Message?): String? = StringUtils.abbreviate(item?.body(), MAX_LENGTH_OF_POLLED_MESSAGES)
+
+    // Truncated the message body to show up to 1024 characters, as it can be up to 256KB in size. Cannot limit the retrieved message size through API.
+    override fun valueOf(item: Message?): String? = item?.body()?.take(MAX_LENGTH_OF_POLLED_MESSAGES)
     override fun isCellEditable(item: Message?): Boolean = false
     override fun getRenderer(item: Message?): TableCellRenderer? = renderer
 }
@@ -39,12 +38,7 @@ class MessageSenderIdColumn : ColumnInfo<Message, String>(message("sqs.message.s
 
 class MessageDateColumn : ColumnInfo<Message, String>(message("sqs.message.timestamp")) {
     private val renderer = ResizingDateColumnRenderer(showSeconds = true)
-    override fun valueOf(item: Message): String {
-        if (item !is Message) {
-            throw IllegalArgumentException(message("sqs.failed_to_poll_messages"))
-        }
-        return item.attributes().getValue(MessageSystemAttributeName.SENT_TIMESTAMP)
-    }
+    override fun valueOf(item: Message?): String? = item?.attributes()?.getValue(MessageSystemAttributeName.SENT_TIMESTAMP)
     override fun isCellEditable(item: Message?): Boolean = false
     override fun getRenderer(item: Message?): TableCellRenderer? = renderer
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/PollWarning.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/PollWarning.kt
@@ -1,11 +1,12 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
 import com.intellij.ui.components.JBLabel
+import software.aws.toolkits.resources.message
 import javax.swing.JButton
 import javax.swing.JPanel
-import software.aws.toolkits.resources.message
 
 class PollWarning(private val pane: PollMessagePane) {
     lateinit var content: JPanel

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.sqs.toolwindow.SendMessagePane">
-  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="6" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="4" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
       <xy x="20" y="20" width="910" height="480"/>
@@ -10,31 +10,17 @@
     <children>
       <component id="94dd3" class="javax.swing.JLabel">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="5" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.body"/>
         </properties>
       </component>
-      <vspacer id="96f1e">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </vspacer>
-      <component id="8ca44" class="javax.swing.JLabel" binding="bodyErrorLabel">
-        <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <foreground color="-567206"/>
-          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.message.validation.empty.message.body"/>
-        </properties>
-      </component>
       <scrollpane id="2e16e" binding="scrollPane">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="4" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <minimum-size width="-1" height="100"/>
-            <preferred-size width="-1" height="100"/>
+          <grid row="1" column="0" row-span="1" col-span="5" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <minimum-size width="-1" height="25"/>
+            <preferred-size width="-1" height="80"/>
           </grid>
         </constraints>
         <properties>
@@ -53,48 +39,47 @@
       </scrollpane>
       <nested-form id="a0a90" form-file="software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.form" binding="fifoFields">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
       </nested-form>
-      <hspacer id="81607">
-        <constraints>
-          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </hspacer>
       <component id="7165c" class="javax.swing.JButton" binding="clearButton">
         <constraints>
-          <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="2" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="2" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.clear.button"/>
         </properties>
       </component>
-      <grid id="1f2cf" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="4" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children>
-          <component id="780da" class="javax.swing.JLabel" binding="confirmationLabel">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value=""/>
-            </properties>
-          </component>
-        </children>
-      </grid>
       <component id="3c205" class="com.intellij.ide.plugins.newui.UpdateButton" binding="sendButton">
         <constraints>
-          <grid row="5" column="4" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.send.button"/>
         </properties>
       </component>
+      <component id="8ca44" class="javax.swing.JLabel" binding="errorLabel">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <foreground color="-567206"/>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.message.validation.empty.message.body"/>
+        </properties>
+      </component>
+      <component id="780da" class="javax.swing.JLabel" binding="confirmationLabel">
+        <constraints>
+          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
+      <hspacer id="81607">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
     </children>
   </grid>
 </form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.sqs.toolwindow.SendMessagePane">
-  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="4" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="3" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="20" y="20" width="910" height="480"/>
+      <xy x="20" y="20" width="1071" height="480"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -39,45 +39,36 @@
       </scrollpane>
       <nested-form id="a0a90" form-file="software/aws/toolkits/jetbrains/services/sqs/toolwindow/FifoPanel.form" binding="fifoFields">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
       </nested-form>
-      <component id="7165c" class="javax.swing.JButton" binding="clearButton">
-        <constraints>
-          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="2" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.clear.button"/>
-        </properties>
-      </component>
-      <component id="3c205" class="com.intellij.ide.plugins.newui.UpdateButton" binding="sendButton">
-        <constraints>
-          <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.send.button"/>
-        </properties>
-      </component>
-      <component id="8ca44" class="javax.swing.JLabel" binding="errorLabel">
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <foreground color="-567206"/>
-          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.message.validation.empty.message.body"/>
-        </properties>
-      </component>
       <component id="780da" class="javax.swing.JLabel" binding="confirmationLabel">
         <constraints>
-          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="7" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>
         </properties>
       </component>
-      <hspacer id="81607">
+      <component id="3c205" class="com.intellij.ide.plugins.newui.UpdateButton" binding="sendButton">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="4" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.send.button"/>
+        </properties>
+      </component>
+      <component id="7165c" class="javax.swing.JButton" binding="clearButton">
+        <constraints>
+          <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="sqs.send.message.clear.button"/>
+        </properties>
+      </component>
+      <hspacer id="a108d">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
     </children>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.kt
@@ -67,15 +67,18 @@ class SendMessagePane(
         inputText.apply {
             emptyText.text = message("sqs.send.message.body.empty.text")
             text = messageCache.getValue(queue.queueUrl)
-            addKeyListener(object : KeyListener {
-                override fun keyTyped(e: KeyEvent?) {
-                    if (bodyErrorLabel.isVisible) {
-                        bodyErrorLabel.isVisible = false
+            addKeyListener(
+                object : KeyListener {
+                    override fun keyTyped(e: KeyEvent?) {
+                        if (bodyErrorLabel.isVisible) {
+                            bodyErrorLabel.isVisible = false
+                        }
                     }
+
+                    override fun keyPressed(e: KeyEvent?) {}
+                    override fun keyReleased(e: KeyEvent?) {}
                 }
-                override fun keyPressed(e: KeyEvent?) {}
-                override fun keyReleased(e: KeyEvent?) {}
-            })
+            )
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.kt
@@ -94,15 +94,13 @@ class SendMessagePane(
 
     private fun validateFields(): Boolean {
         val inputIsValid = inputText.text.isNotEmpty()
-        errorLabel.isVisible = !inputIsValid
         if (!inputIsValid) {
+            errorLabel.isVisible = true
             errorLabel.text = message("sqs.message.validation.empty.message.body")
             return false
         }
 
-        return if (!queue.isFifo) {
-            true
-        } else {
+        return if (queue.isFifo) {
             val message = fifoFields.validateFields()
             if (message == null) {
                 errorLabel.isVisible = false
@@ -112,6 +110,9 @@ class SendMessagePane(
                 errorLabel.text = message
                 false
             }
+        } else {
+            errorLabel.isVisible = false
+            true
         }
     }
 
@@ -129,6 +130,7 @@ class SendMessagePane(
                 errorLabel.isVisible = false
             }
         }
+
         override fun keyPressed(e: KeyEvent?) {}
         override fun keyReleased(e: KeyEvent?) {}
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.kt
@@ -1,9 +1,9 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
 import com.intellij.ide.plugins.newui.UpdateButton
-import com.intellij.ide.util.PropertiesComponent
 import com.intellij.ui.IdeBorderFactory
 import com.intellij.ui.components.JBTextArea
 import kotlinx.coroutines.CoroutineScope
@@ -23,8 +23,7 @@ import javax.swing.JScrollPane
 
 class SendMessagePane(
     private val client: SqsClient,
-    private val queue: Queue,
-    private val messageCache: PropertiesComponent
+    private val queue: Queue
 ) : CoroutineScope by ApplicationThreadPoolScope("SendMessagePane") {
     lateinit var component: JPanel
     lateinit var inputText: JBTextArea
@@ -55,7 +54,6 @@ class SendMessagePane(
         }
         clearButton.addActionListener {
             clearFields()
-            messageCache.setValue(queue.queueUrl, "")
             confirmationLabel.isVisible = false
         }
     }
@@ -66,7 +64,6 @@ class SendMessagePane(
         }
         inputText.apply {
             emptyText.text = message("sqs.send.message.body.empty.text")
-            text = messageCache.getValue(queue.queueUrl)
             addKeyListener(
                 object : KeyListener {
                     override fun keyTyped(e: KeyEvent?) {
@@ -96,7 +93,6 @@ class SendMessagePane(
                     }.messageId()
                     confirmationLabel.text = message("sqs.send.message.success", messageId)
                 }
-                messageCache.setValue(queue.queueUrl, inputText.text)
                 clearFields()
             } catch (e: Exception) {
                 confirmationLabel.text = message("sqs.failed_to_send_message")

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePane.kt
@@ -89,35 +89,29 @@ class SendMessagePane(
         }
     }
 
-    private fun validateFields(): Boolean {
-        listOfNotNull(
+    fun validateFields(): Boolean {
+        val validationIssues = mutableListOf<ValidationInfo>().apply {
             if (inputText.text.isEmpty()) {
-                ValidationInfo(message("sqs.message.validation.empty.message.body"), inputText)
-            } else {
-                null
+                add(ValidationInfo(message("sqs.message.validation.empty.message.body"), inputText))
             }
-        ).plus(
             if (queue.isFifo) {
-                fifoFields.validateFields()
-            } else {
-                listOf()
+                addAll(fifoFields.validateFields())
             }
-        ).let {
-            return if (it.isEmpty()) {
-                true
-            } else {
-                it.forEach { validationIssue ->
-                    runInEdt(ModalityState.any()) {
-                        validationIssue.component?.let {
-                            ComponentValidator.createPopupBuilder(validationIssue, null)
-                                .setCancelOnClickOutside(true)
-                                .createPopup()
-                                .showUnderneathOf(it)
-                        }
+        }
+        return if (validationIssues.isEmpty()) {
+            true
+        } else {
+            runInEdt(ModalityState.any()) {
+                validationIssues.forEach { validationIssue ->
+                    validationIssue.component?.let { component ->
+                        ComponentValidator.createPopupBuilder(validationIssue, null)
+                            .setCancelOnClickOutside(true)
+                            .createPopup()
+                            .showUnderneathOf(component)
                     }
                 }
-                false
             }
+            false
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindow.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import icons.AwsIcons
 import kotlinx.coroutines.CoroutineScope
@@ -58,7 +57,7 @@ class SqsWindow(private val project: Project) : CoroutineScope by ApplicationThr
             AwsIcons.Resources.Sqs.SQS_TOOL_WINDOW
         )
 
-        fun getInstance(project: Project): SqsWindow? = ServiceManager.getService(project, SqsWindow::class.java)
+        fun getInstance(project: Project): SqsWindow = project.getService(SqsWindow::class.java)
 
         private val LOG = getLogger<SqsWindow>()
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindow.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import icons.AwsIcons
 import kotlinx.coroutines.CoroutineScope
@@ -57,7 +58,7 @@ class SqsWindow(private val project: Project) : CoroutineScope by ApplicationThr
             AwsIcons.Resources.Sqs.SQS_TOOL_WINDOW
         )
 
-        fun getInstance(project: Project): SqsWindow = project.getService(SqsWindow::class.java)
+        fun getInstance(project: Project): SqsWindow = project.service()
 
         private val LOG = getLogger<SqsWindow>()
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindow.kt
@@ -27,14 +27,14 @@ class SqsWindow(private val project: Project) : CoroutineScope by ApplicationThr
     private val client: SqsClient = project.awsClient()
 
     fun pollMessage(queue: Queue) {
-        showQueue(queue, SqsWindowUI(client, queue).apply { pollMessage() })
+        showQueue(queue, SqsWindowUi(client, queue).apply { pollMessage() })
     }
 
     fun sendMessage(queue: Queue) {
-        showQueue(queue, SqsWindowUI(client, queue).apply { sendMessage() })
+        showQueue(queue, SqsWindowUi(client, queue).apply { sendMessage() })
     }
 
-    private fun showQueue(queue: Queue, component: SqsWindowUI) = launch {
+    private fun showQueue(queue: Queue, component: SqsWindowUi) = launch {
         try {
             withContext(edtContext) {
                 toolWindow.find(queue.queueUrl)?.show() ?: toolWindow.addTab(queue.queueName, component.mainPanel, activate = true, id = queue.queueUrl)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindow.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project
 import icons.AwsIcons
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.aws.toolkits.core.utils.error
@@ -44,10 +45,11 @@ class SqsWindow(private val project: Project) : CoroutineScope by ApplicationThr
         }
     }
 
-    suspend fun closeQueue(queueUrl: String) =
+    fun closeQueue(queueUrl: String) = runBlocking {
         withContext(edtContext) {
             toolWindow.find(queueUrl)?.dispose()
         }
+    }
 
     companion object {
         internal val SQS_TOOL_WINDOW = ToolkitToolWindowType(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindowUI.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindowUI.kt
@@ -3,25 +3,18 @@
 
 package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
-import com.intellij.ide.util.PropertiesComponent
-import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBTabbedPane
 import com.intellij.util.ui.JBUI
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.aws.toolkits.jetbrains.services.sqs.Queue
 import software.aws.toolkits.resources.message
 
-class SqsWindowUI(
-    private val project: Project,
-    private val client: SqsClient,
-    val queue: Queue
-) {
-    val messageCache: PropertiesComponent = PropertiesComponent.getInstance(project)
+class SqsWindowUI(private val client: SqsClient, val queue: Queue) {
     val mainPanel = JBTabbedPane().apply {
         tabComponentInsets = JBUI.emptyInsets()
         border = JBUI.Borders.empty()
         add(message("sqs.queue.polled.messages"), PollMessagePane(client, queue).component)
-        add(message("sqs.send.message"), SendMessagePane(client, queue, messageCache).component)
+        add(message("sqs.send.message"), SendMessagePane(client, queue).component)
     }
 
     fun pollMessage() {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindowUi.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SqsWindowUi.kt
@@ -9,7 +9,7 @@ import software.amazon.awssdk.services.sqs.SqsClient
 import software.aws.toolkits.jetbrains.services.sqs.Queue
 import software.aws.toolkits.resources.message
 
-class SqsWindowUI(private val client: SqsClient, val queue: Queue) {
+class SqsWindowUi(private val client: SqsClient, val queue: Queue) {
     val mainPanel = JBTabbedPane().apply {
         tabComponentInsets = JBUI.emptyInsets()
         border = JBUI.Borders.empty()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/QueueTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/QueueTest.kt
@@ -34,25 +34,35 @@ class QueueTest {
     @Test
     fun `AWS region endpoint parsed`() {
         val queueRegion = AwsRegion("us-west-2", "US West (Oregon)", "aws")
-        val queue = Queue("https://sqs.us-west-2.amazonaws.com/123456789012/test-3", queueRegion)
+        val queue = Queue("https://sqs.us-west-2.amazonaws.com/123456789012/test-_3", queueRegion)
 
-        assertThat(queue.arn).isEqualTo("arn:aws:sqs:us-west-2:123456789012:test-3")
+        assertThat(queue.arn).isEqualTo("arn:aws:sqs:us-west-2:123456789012:test-_3")
         assertThat(queue.accountId).isEqualTo("123456789012")
-        assertThat(queue.queueName).isEqualTo("test-3")
+        assertThat(queue.queueName).isEqualTo("test-_3")
     }
 
     @Test
-    fun `Throw exception with non-url`() {
+    fun `Throws exception with non-url`() {
         assertThatThrownBy { Queue("Not a URL", defaultRegion) }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test
-    fun `Throw exception with no name`() {
+    fun `Throws exception with no name`() {
         assertThatThrownBy { Queue("https://sqs.us-east-1.amazonaws.com/123456789012/", defaultRegion) }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test
-    fun `Throw exception with invalid account ID`() {
+    fun `Throws exception with invalid account ID`() {
         assertThatThrownBy { Queue("https://sqs.us-east-1.amazonaws.com/123/test-4", defaultRegion) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `Throws exception with blank account ID`() {
+        assertThatThrownBy {
+            Queue(
+                "https://sqs.us-east-1.amazonaws.com/            /test_a",
+                defaultRegion
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePaneTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePaneTest.kt
@@ -3,10 +3,12 @@
 
 package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
+import com.intellij.testFramework.ProjectRule
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
 import software.amazon.awssdk.services.sqs.SqsClient
@@ -14,14 +16,22 @@ import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
+import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
 import software.aws.toolkits.jetbrains.services.sqs.MAX_LENGTH_OF_FIFO_ID
 import software.aws.toolkits.jetbrains.services.sqs.Queue
-import software.aws.toolkits.jetbrains.utils.BaseCoroutineTest
 import software.aws.toolkits.jetbrains.utils.waitForTrue
 import software.aws.toolkits.resources.message
 
-class SendMessagePaneTest : BaseCoroutineTest() {
+class SendMessagePaneTest {
+    @Rule
+    @JvmField
+    val projectRule = ProjectRule()
+
+    @JvmField
+    @Rule
+    val mockClientManager = MockClientManagerRule(projectRule)
+
     private lateinit var client: SqsClient
     private lateinit var region: AwsRegion
     private lateinit var standardQueue: Queue
@@ -31,7 +41,7 @@ class SendMessagePaneTest : BaseCoroutineTest() {
 
     @Before
     fun reset() {
-        client = mockClientManagerRule.create()
+        client = mockClientManager.create()
         region = MockRegionProvider.getInstance().defaultRegion()
         standardQueue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/standard", region)
         fifoQueue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/fifo.fifo", region)
@@ -43,10 +53,9 @@ class SendMessagePaneTest : BaseCoroutineTest() {
     fun `No input fails to send for standard`() {
         standardPane.apply {
             inputText.text = ""
-            runBlocking { sendMessage() }
         }
 
-        assertThat(standardPane.errorLabel.isVisible).isTrue()
+        assertThat(standardPane.validateFields()).isFalse()
         assertThat(standardPane.fifoFields.component.isVisible).isFalse()
     }
 
@@ -56,10 +65,9 @@ class SendMessagePaneTest : BaseCoroutineTest() {
             inputText.text = ""
             fifoFields.deduplicationId.text = ""
             fifoFields.groupId.text = ""
-            runBlocking { sendMessage() }
         }
 
-        assertThat(fifoPane.errorLabel.isVisible).isTrue()
+        assertThat(fifoPane.validateFields()).isFalse()
     }
 
     @Test
@@ -68,10 +76,9 @@ class SendMessagePaneTest : BaseCoroutineTest() {
             inputText.text = MESSAGE
             fifoFields.deduplicationId.text = ""
             fifoFields.groupId.text = GROUP_ID
-            runBlocking { sendMessage() }
         }
 
-        assertThat(fifoPane.errorLabel.isVisible).isTrue()
+        assertThat(fifoPane.validateFields()).isFalse()
     }
 
     @Test
@@ -83,7 +90,7 @@ class SendMessagePaneTest : BaseCoroutineTest() {
             runBlocking { sendMessage() }
         }
 
-        assertThat(fifoPane.errorLabel.isVisible).isTrue()
+        assertThat(fifoPane.validateFields()).isFalse()
     }
 
     @Test
@@ -95,8 +102,7 @@ class SendMessagePaneTest : BaseCoroutineTest() {
             runBlocking { sendMessage() }
         }
 
-        assertThat(fifoPane.errorLabel.isVisible).isTrue()
-        assertThat(fifoPane.errorLabel.text).isEqualTo(message("sqs.message.validation.long.id"))
+        assertThat(fifoPane.validateFields()).isFalse()
     }
 
     @Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePaneTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePaneTest.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.sqs.toolwindow
 
-import com.intellij.ide.util.PropertiesComponent
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -29,7 +28,6 @@ class SendMessagePaneTest : BaseCoroutineTest() {
     private lateinit var fifoQueue: Queue
     private lateinit var standardPane: SendMessagePane
     private lateinit var fifoPane: SendMessagePane
-    private lateinit var cache: PropertiesComponent
 
     @Before
     fun reset() {
@@ -37,9 +35,8 @@ class SendMessagePaneTest : BaseCoroutineTest() {
         region = MockRegionProvider.getInstance().defaultRegion()
         standardQueue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/standard", region)
         fifoQueue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/fifo.fifo", region)
-        cache = PropertiesComponent.getInstance(projectRule.project)
-        standardPane = SendMessagePane(client, standardQueue, cache)
-        fifoPane = SendMessagePane(client, fifoQueue, cache)
+        standardPane = SendMessagePane(client, standardQueue)
+        fifoPane = SendMessagePane(client, fifoQueue)
     }
 
     @Test
@@ -49,7 +46,7 @@ class SendMessagePaneTest : BaseCoroutineTest() {
             runBlocking { sendMessage() }
         }
 
-        assertThat(standardPane.bodyErrorLabel.isVisible).isTrue()
+        assertThat(standardPane.errorLabel.isVisible).isTrue()
         assertThat(standardPane.fifoFields.component.isVisible).isFalse()
     }
 
@@ -62,9 +59,7 @@ class SendMessagePaneTest : BaseCoroutineTest() {
             runBlocking { sendMessage() }
         }
 
-        assertThat(fifoPane.bodyErrorLabel.isVisible).isTrue()
-        assertThat(fifoPane.fifoFields.deduplicationErrorLabel.isVisible).isTrue()
-        assertThat(fifoPane.fifoFields.groupErrorLabel.isVisible).isTrue()
+        assertThat(fifoPane.errorLabel.isVisible).isTrue()
     }
 
     @Test
@@ -76,9 +71,7 @@ class SendMessagePaneTest : BaseCoroutineTest() {
             runBlocking { sendMessage() }
         }
 
-        assertThat(fifoPane.bodyErrorLabel.isVisible).isFalse()
-        assertThat(fifoPane.fifoFields.deduplicationErrorLabel.isVisible).isTrue()
-        assertThat(fifoPane.fifoFields.groupErrorLabel.isVisible).isFalse()
+        assertThat(fifoPane.errorLabel.isVisible).isTrue()
     }
 
     @Test
@@ -90,9 +83,7 @@ class SendMessagePaneTest : BaseCoroutineTest() {
             runBlocking { sendMessage() }
         }
 
-        assertThat(fifoPane.bodyErrorLabel.isVisible).isFalse()
-        assertThat(fifoPane.fifoFields.deduplicationErrorLabel.isVisible).isFalse()
-        assertThat(fifoPane.fifoFields.groupErrorLabel.isVisible).isTrue()
+        assertThat(fifoPane.errorLabel.isVisible).isTrue()
     }
 
     @Test
@@ -104,10 +95,8 @@ class SendMessagePaneTest : BaseCoroutineTest() {
             runBlocking { sendMessage() }
         }
 
-        assertThat(fifoPane.bodyErrorLabel.isVisible).isFalse()
-        assertThat(fifoPane.fifoFields.deduplicationErrorLabel.isVisible).isTrue()
-        assertThat(fifoPane.fifoFields.groupErrorLabel.isVisible).isFalse()
-        assertThat(fifoPane.fifoFields.deduplicationErrorLabel.text).isEqualTo(message("sqs.message.validation.long.id"))
+        assertThat(fifoPane.errorLabel.isVisible).isTrue()
+        assertThat(fifoPane.errorLabel.text).isEqualTo(message("sqs.message.validation.long.id"))
     }
 
     @Test

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -775,4 +775,4 @@ sqs.subscribe.sns.success=Subscribed successfully to topic {0}.
 sqs.subscribe.sns.topic=SNS topic:
 sqs.subscribe.sns.validation.empty_topic=Topic must be specified.
 sqs.toolwindow=SQS
-sqs.url.parse_error=Error parsing queue URL
+sqs.url.parse_error=Error parsing SQS queue URL


### PR DESCRIPTION
- A lot of minor code style/formatting cleanups
  - Move `SNSResources` to the `sns` package
  - Cleanup form files
  - Simplify some string parsing
- Remove saving last sent message. While playing with it, it doesn't seem to have a good UX.
- Show open windows on opening them again instead of closing them
- Fixup Send message panel to use less vertical space/have less places where errors show up/not hide the send button when there are errors
## Screenshots
<img width="1374" alt="Screen Shot 2020-09-02 at 2 35 04 PM" src="https://user-images.githubusercontent.com/11964782/92039294-b4253200-ed29-11ea-9360-a6c538aa89f5.png">
<img width="1375" alt="Screen Shot 2020-09-02 at 2 35 10 PM" src="https://user-images.githubusercontent.com/11964782/92039300-b4bdc880-ed29-11ea-869f-216133034b90.png">


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
