### PR TITLE
Start SAM Init before indexing is done

### DIFF
--- a/.changes/next-release/bugfix-44d2c717-92aa-4552-92da-c494d6b246b1.json
+++ b/.changes/next-release/bugfix-44d2c717-92aa-4552-92da-c494d6b246b1.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Start generating SAM project before the IDE is done indexing"
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,12 +84,14 @@ allprojects {
     tasks.withType(RunIdeTask::class.java) {
         val alternativeIde = System.getenv("ALTERNATIVE_IDE")
         if (alternativeIde != null) {
-            if (File(alternativeIde).exists()) {
+            // remove the trailing slash if there is one or else it will not work
+            val path = alternativeIde.trimEnd('/')
+            if (File(path).exists()) {
                 intellij {
-                    alternativeIdePath = System.getenv("ALTERNATIVE_IDE")
+                    alternativeIdePath = path
                 }
             } else {
-                throw GradleException("ALTERNATIVE_IDE path not found $alternativeIde ${if (alternativeIde.endsWith("/")) "remove the trailing slash" else ""}")
+                throw GradleException("ALTERNATIVE_IDE path not found $alternativeIde")
             }
         }
     }


### PR DESCRIPTION
- Start `SAM Init` before indexing is done. Where we start it, we have enough information to start immediately. So, we don't have to wait for the IDE to index. 
- Switching to StartupManager#registerStartupActivity had timing issues where it would run after "startup" sometimes making it not generate, but it seems like we don't need to wait at all.
- Tested generating in PyCharm/Rider/Intellij 

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
