### PR TITLE
Fix memory leak in DotNet project wizard

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamProjectGeneratorIntelliJShims.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/wizard/SamProjectGeneratorIntelliJShims.kt
@@ -66,8 +66,7 @@ class SamProjectBuilder(private val generator: SamProjectGenerator) : ModuleBuil
                             try {
                                 samTemplate.postCreationAction(settings, outputDir, model, generator.defaultSourceCreatingProject, indicator)
                             } catch (t: Throwable) {
-                                LOG.error(t) { "Exception thrown during postCreationAction" }
-                                model.dispose()
+                                LOG.error(t) { "Exception thrown during postCreationAction!" }
                             }
                         }
                     }

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/ui/wizard/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/ui/wizard/DotNetSamProjectGenerator.kt
@@ -194,19 +194,24 @@ class DotNetSamProjectGenerator(
             projectToClose = null,
             forceOpenInNewFrame = false,
             solutionFile = solutionFile
-        )
+        ) ?: return
+
         vcsPanel?.initRepository(project)
 
-        project ?: return
         val modifiableModel = ModuleManager.getInstance(project).modules.firstOrNull()?.rootManager?.modifiableModel ?: return
-        val progressIndicator = if (progressManager.hasProgressIndicator()) progressManager.progressIndicator else DumbProgressIndicator()
-        samSettings.template.postCreationAction(
-            settings = samSettings,
-            contentRoot = outDirVf,
-            rootModel = modifiableModel,
-            sourceCreatingProject = generator.defaultSourceCreatingProject,
-            indicator = progressIndicator
-        )
+        try {
+            val progressIndicator = if (progressManager.hasProgressIndicator()) progressManager.progressIndicator else DumbProgressIndicator()
+
+            samSettings.template.postCreationAction(
+                settings = samSettings,
+                contentRoot = outDirVf,
+                rootModel = modifiableModel,
+                sourceCreatingProject = generator.defaultSourceCreatingProject,
+                indicator = progressIndicator
+            )
+        } finally {
+            modifiableModel.dispose()
+        }
     }
 
     override fun refreshUI() {


### PR DESCRIPTION
- Fix memory leak in DotNet project wizard by actually disposing the model
- Remove an unnecessary dispose in the other SAM init paths `ModuleRootModificationUtil#updateModel` handles it. However, it seems `ModuleRootModificationUti#updateModel` does not work for our Rider case since it's a `RootModel` instead of a `Model` (?)

## Related Issue(s)
#1912

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
