### PR TITLE
Fixup some places where we didn't refresh the explorer on create

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
@@ -25,7 +25,6 @@ import software.aws.toolkits.jetbrains.core.executables.getExecutable
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.cloudformation.describeStack
 import software.aws.toolkits.jetbrains.services.cloudformation.executeChangeSetAndWait
-import software.aws.toolkits.jetbrains.services.cloudformation.resources.CloudFormationResources
 import software.aws.toolkits.jetbrains.services.cloudformation.stack.StackWindowManager
 import software.aws.toolkits.jetbrains.services.cloudformation.validateSamTemplateHasResources
 import software.aws.toolkits.jetbrains.services.cloudformation.validateSamTemplateLambdaRuntimes
@@ -144,8 +143,8 @@ class DeployServerlessApplicationAction : AnAction(
                     project
                 )
                 SamTelemetry.deploy(project, Result.Succeeded)
-                // We do not know if it is a create or not, so refresh every time
-                project.refreshAwsTree(CloudFormationResources.LIST_STACKS)
+                // Since we could update anything, do a full refresh of the resource cache and explorer
+                project.refreshAwsTree()
             } catch (e: Exception) {
                 e.notifyError(message("cloudformation.execute_change_set.failed", stackName), project)
                 SamTelemetry.deploy(project, Result.Failed)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeployServerlessApplicationAction.kt
@@ -22,8 +22,10 @@ import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutable
+import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.cloudformation.describeStack
 import software.aws.toolkits.jetbrains.services.cloudformation.executeChangeSetAndWait
+import software.aws.toolkits.jetbrains.services.cloudformation.resources.CloudFormationResources
 import software.aws.toolkits.jetbrains.services.cloudformation.stack.StackWindowManager
 import software.aws.toolkits.jetbrains.services.cloudformation.validateSamTemplateHasResources
 import software.aws.toolkits.jetbrains.services.cloudformation.validateSamTemplateLambdaRuntimes
@@ -142,6 +144,8 @@ class DeployServerlessApplicationAction : AnAction(
                     project
                 )
                 SamTelemetry.deploy(project, Result.Succeeded)
+                // We do not know if it is a create or not, so refresh every time
+                project.refreshAwsTree(CloudFormationResources.LIST_STACKS)
             } catch (e: Exception) {
                 e.notifyError(message("cloudformation.execute_change_set.failed", stackName), project)
                 SamTelemetry.deploy(project, Result.Failed)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/SamDeployDialog.kt
@@ -165,12 +165,6 @@ class SamDeployDialog(
                 doOKAction()
             }
         }
-
-        SamTelemetry.deploy(
-            project = project,
-            success = true,
-            version = SamCommon.getVersionString()
-        )
     }
 
     private fun handleError(error: Throwable): String {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialog.kt
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
+import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.core.help.HelpIds
 import software.aws.toolkits.jetbrains.services.iam.CreateIamRoleDialog
 import software.aws.toolkits.jetbrains.services.iam.IamRole
@@ -31,6 +32,7 @@ import software.aws.toolkits.jetbrains.services.lambda.LambdaFunction
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
 import software.aws.toolkits.jetbrains.services.lambda.LambdaLimits.DEFAULT_MEMORY_SIZE
 import software.aws.toolkits.jetbrains.services.lambda.LambdaLimits.DEFAULT_TIMEOUT
+import software.aws.toolkits.jetbrains.services.lambda.resources.LambdaResources
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.jetbrains.services.lambda.upload.EditFunctionMode.NEW
@@ -245,6 +247,10 @@ class EditFunctionDialog(
                 null -> {
                     notifyInfo(title = NOTIFICATION_TITLE, content = message, project = project)
                     LambdaTelemetry.editFunction(project, update = false, result = Result.Succeeded)
+                    // If we created a new lambda, clear the resource cache for LIST_FUNCTIONS
+                    if (mode == NEW) {
+                        project.refreshAwsTree(LambdaResources.LIST_FUNCTIONS)
+                    }
                 }
                 is Exception -> {
                     error.notifyError(title = NOTIFICATION_TITLE)


### PR DESCRIPTION
- Refresh on Lambda create
- Refresh on CFN deploy (we don't know if it is a create or not, so refresh every time, this is probably better since while actively working with CFN the most updated view would be more useful)
- Remove duplicate `SamTelemetry.deploy`. We need failure in `SamDeployDialog` but not success as it goes on to `DeployServerlessApplicationAction` to finish deploying
## Related Issue(s)
#2073

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
