### PR TITLE
Convert ClientManager to app service

### DIFF
--- a/core/tst/software/aws/toolkits/core/region/AwsRegionTest.kt
+++ b/core/tst/software/aws/toolkits/core/region/AwsRegionTest.kt
@@ -46,7 +46,7 @@ fun anAwsRegion(id: String = aRegionId(), name: String = aString(), partitionId:
 
 fun aRegionId(): String {
     val prefix = arrayOf("af", "us", "ca", "eu", "ap", "me", "cn").random()
-    val compass = arrayOf("north", "south", "east", "west", "central")
+    val compass = arrayOf("north", "south", "east", "west", "central").random()
     val count = Random.nextInt(1, 10)
     return "$prefix-$compass-$count"
 }

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -177,7 +177,7 @@
                             serviceImplementation="software.aws.toolkits.jetbrains.core.executables.DefaultExecutableManager"/>
         <applicationService serviceInterface="software.aws.toolkits.jetbrains.core.notification.NoticeManager"
                             serviceImplementation="software.aws.toolkits.jetbrains.core.notification.DefaultNoticeManager"/>
-        <projectService serviceInterface="software.aws.toolkits.core.ToolkitClientManager"
+        <applicationService serviceInterface="software.aws.toolkits.core.ToolkitClientManager"
                         serviceImplementation="software.aws.toolkits.jetbrains.core.AwsClientManager"
                         testServiceImplementation="software.aws.toolkits.jetbrains.core.MockClientManager"/>
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.core.explorer.ExplorerToolWindow"/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsClientManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsClientManager.kt
@@ -7,28 +7,21 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.application.ex.ApplicationInfoEx
-import com.intellij.openapi.components.ServiceManager
-import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import software.amazon.awssdk.core.SdkClient
 import software.amazon.awssdk.http.SdkHttpClient
 import software.aws.toolkits.core.ToolkitClientManager
 import software.aws.toolkits.core.credentials.CredentialIdentifier
-import software.aws.toolkits.core.credentials.CredentialProviderNotFoundException
 import software.aws.toolkits.core.credentials.ToolkitCredentialsChangeListener
-import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
-import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.region.ToolkitRegionProvider
 import software.aws.toolkits.core.utils.tryOrNull
 import software.aws.toolkits.jetbrains.AwsToolkit
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
-import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 
-open class AwsClientManager(project: Project) : ToolkitClientManager(), Disposable {
-
-    private val accountSettingsManager = AwsConnectionManager.getInstance(project)
+open class AwsClientManager : ToolkitClientManager(), Disposable {
     private val regionProvider = AwsRegionProvider.getInstance()
 
     init {
@@ -52,24 +45,11 @@ open class AwsClientManager(project: Project) : ToolkitClientManager(), Disposab
 
     override val userAgent = AwsClientManager.userAgent
 
-    override fun getCredentialsProvider(): ToolkitCredentialsProvider {
-        try {
-            return accountSettingsManager.activeCredentialProvider
-        } catch (e: CredentialProviderNotFoundException) {
-            // TODO: Notify user
-
-            // Throw canceled exception to stop any task relying on this call
-            throw ProcessCanceledException(e)
-        }
-    }
-
-    override fun getRegion(): AwsRegion = accountSettingsManager.activeRegion
-
     override fun getRegionProvider(): ToolkitRegionProvider = regionProvider
 
     companion object {
         @JvmStatic
-        fun getInstance(project: Project): ToolkitClientManager = ServiceManager.getService(project, ToolkitClientManager::class.java)
+        fun getInstance(): ToolkitClientManager = service()
 
         val userAgent: String by lazy {
             val platformName = tryOrNull { ApplicationNamesInfo.getInstance().fullProductNameWithEdition.replace(' ', '-') }
@@ -79,13 +59,10 @@ open class AwsClientManager(project: Project) : ToolkitClientManager(), Disposab
     }
 }
 
-inline fun <reified T : SdkClient> Project.awsClient(
-    credentialsProviderOverride: ToolkitCredentialsProvider? = null,
-    regionOverride: AwsRegion? = null
-): T = AwsClientManager
-    .getInstance(this)
-    .getClient(credentialsProviderOverride = credentialsProviderOverride, regionOverride = regionOverride)
+inline fun <reified T : SdkClient> Project.awsClient(): T {
+    val accountSettingsManager = AwsConnectionManager.getInstance(this)
 
-inline fun <reified T : SdkClient> Project.awsClient(connectionSettings: ConnectionSettings): T = AwsClientManager
-    .getInstance(this)
-    .getClient(connectionSettings.credentials, connectionSettings.region)
+    return AwsClientManager
+        .getInstance()
+        .getClient(accountSettingsManager.activeCredentialProvider, accountSettingsManager.activeRegion)
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
@@ -179,7 +179,7 @@ class ClientBackedCachedResource<ReturnType, ClientType : SdkClient>(
     constructor(sdkClientClass: KClass<ClientType>, id: String, fetchCall: ClientType.() -> ReturnType) : this(sdkClientClass, id, null, fetchCall)
 
     override fun fetch(project: Project, region: AwsRegion, credentials: ToolkitCredentialsProvider): ReturnType {
-        val client = AwsClientManager.getInstance(project).getClient(sdkClientClass, credentials, region)
+        val client = AwsClientManager.getInstance().getClient(sdkClientClass, credentials, region)
         return fetchCall(client)
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/actions/InstrumentDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/actions/InstrumentDialog.kt
@@ -15,7 +15,6 @@ import software.amazon.awssdk.services.iam.IamClient
 import software.amazon.awssdk.services.iam.model.PolicyEvaluationDecisionType
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
-import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.help.HelpIds
@@ -128,7 +127,7 @@ class InstrumentDialog(private val project: Project, val clusterArn: String, val
     // Auto-select task-role (if it exists in the task-definition). Runs on a background thread.
     private fun attemptSelectRole() =
         try {
-            val client: EcsClient = AwsClientManager.getInstance(project).getClient()
+            val client: EcsClient = project.awsClient()
             val service = client.describeServices {
                 it.cluster(clusterArn)
                 it.services(serviceArn)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/actions/DeleteStackAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/actions/DeleteStackAction.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.jetbrains.services.cloudformation.actions
 
 import com.intellij.openapi.application.runInEdt
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
-import software.aws.toolkits.jetbrains.core.AwsClientManager
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.explorer.actions.DeleteResourceAction
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationStackNode
@@ -20,7 +20,7 @@ class DeleteStackAction : DeleteResourceAction<CloudFormationStackNode>(
     TaggingResourceType.CLOUDFORMATION_STACK
 ) {
     override fun performDelete(selected: CloudFormationStackNode) {
-        val client: CloudFormationClient = AwsClientManager.getInstance(selected.nodeProject).getClient()
+        val client: CloudFormationClient = selected.nodeProject.awsClient()
         client.deleteStack { it.stackName(selected.stackName) }
         runInEdt {
             StackWindowManager.getInstance(selected.nodeProject).openStack(selected.stackName, selected.stackId)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
@@ -17,7 +17,7 @@ import com.intellij.uiDesigner.core.GridLayoutManager
 import com.intellij.util.ui.JBUI
 import icons.AwsIcons
 import software.amazon.awssdk.services.cloudformation.model.StackStatus
-import software.aws.toolkits.jetbrains.core.AwsClientManager
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.explorer.actions.SingleResourceNodeAction
 import software.aws.toolkits.jetbrains.core.toolwindow.ToolkitToolWindow
 import software.aws.toolkits.jetbrains.core.toolwindow.ToolkitToolWindowManager
@@ -136,7 +136,7 @@ private class StackUI(private val project: Project, private val stackName: Strin
             stackName = stackName,
             updateEveryMs = UPDATE_STACK_STATUS_INTERVAL,
             listener = this,
-            client = AwsClientManager.getInstance(project).getClient(),
+            client = project.awsClient(),
             setPagesAvailable = pageButtons::setPagesAvailable
         )
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/actions/DeleteGroupAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/actions/DeleteGroupAction.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkits.jetbrains.services.cloudwatch.logs.actions
 
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient
-import software.aws.toolkits.jetbrains.core.AwsClientManager
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.explorer.actions.DeleteResourceAction
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.CloudWatchLogWindow
@@ -15,7 +15,7 @@ import software.aws.toolkits.resources.message
 
 class DeleteGroupAction : DeleteResourceAction<CloudWatchLogsNode>(message("cloudwatch.logs.delete_log_group"), TaggingResourceType.CLOUDWATCHLOGS_GROUP) {
     override fun performDelete(selected: CloudWatchLogsNode) {
-        val client: CloudWatchLogsClient = AwsClientManager.getInstance(selected.nodeProject).getClient()
+        val client: CloudWatchLogsClient = selected.nodeProject.awsClient()
 
         CloudWatchLogWindow.getInstance(selected.nodeProject)?.closeLogGroup(selected.logGroupName)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeleteFunctionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/DeleteFunctionAction.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkits.jetbrains.services.lambda.actions
 
 import software.amazon.awssdk.services.lambda.LambdaClient
-import software.aws.toolkits.jetbrains.core.AwsClientManager
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.explorer.actions.DeleteResourceAction
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunctionNode
@@ -15,8 +15,9 @@ import software.aws.toolkits.resources.message
 class DeleteFunctionAction : DeleteResourceAction<LambdaFunctionNode>(message("lambda.function.delete.action"), TaggingResourceType.LAMBDA_FUNCTION) {
     override fun performDelete(selected: LambdaFunctionNode) {
         val project = selected.nodeProject
-        val client: LambdaClient = AwsClientManager.getInstance(project).getClient()
+
+        val client: LambdaClient = project.awsClient()
         client.deleteFunction { it.functionName(selected.functionName()) }
-        selected.nodeProject.refreshAwsTree(LambdaResources.LIST_FUNCTIONS)
+        project.refreshAwsTree(LambdaResources.LIST_FUNCTIONS)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import software.amazon.awssdk.services.lambda.LambdaClient
-import software.aws.toolkits.jetbrains.core.AwsClientManager
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.explorer.actions.SingleResourceNodeAction
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunctionNode
@@ -27,7 +27,7 @@ abstract class UpdateFunctionAction(private val mode: EditFunctionMode, title: S
         ApplicationManager.getApplication().executeOnPooledThread {
             val selectedFunction = selected.value
 
-            val client: LambdaClient = AwsClientManager.getInstance(project).getClient()
+            val client: LambdaClient = project.awsClient()
 
             // Fetch latest version just in case
             val functionConfiguration = client.getFunction {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaState.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaState.kt
@@ -66,7 +66,7 @@ class RemoteLambdaState(
     }
 
     private fun invokeLambda(lambdaProcess: ProcessHandler) {
-        val client = AwsClientManager.getInstance(environment.project)
+        val client = AwsClientManager.getInstance()
             .getClient<LambdaClient>(settings.credentialProvider, settings.region)
         var result = Result.Succeeded
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamSchemaDownloadPostCreationAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamSchemaDownloadPostCreationAction.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.services.schemas.SchemaCodeLangs
 import software.aws.toolkits.jetbrains.services.schemas.SchemaTemplateParameters
@@ -31,7 +30,7 @@ class SamSchemaDownloadPostCreationAction {
         indicator: ProgressIndicator
     ) {
         // Use sourceCreatingProject instead of rootModel.project because the new project may not have AWS credentials configured yet
-        val codeGenDownloader = SchemaCodeDownloader.create(AwsClientManager.getInstance(sourceCreatingProject))
+        val codeGenDownloader = SchemaCodeDownloader.create(newApplicationProject)
 
         codeGenDownloader.downloadCode(
             SchemaCodeDownloadRequestDetails(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialog.kt
@@ -19,7 +19,6 @@ import software.amazon.awssdk.services.iam.IamClient
 import software.amazon.awssdk.services.lambda.LambdaClient
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.amazon.awssdk.services.s3.S3Client
-import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
@@ -230,7 +229,7 @@ class EditFunctionDialog(
         val s3Bucket = view.sourceBucket.selectedItem as String
 
         val lambdaBuilder = psiFile.language.runtimeGroup?.let { LambdaBuilder.getInstanceOrNull(it) } ?: return
-        val lambdaCreator = LambdaCreatorFactory.create(AwsClientManager.getInstance(project), lambdaBuilder)
+        val lambdaCreator = LambdaCreatorFactory.create(project, lambdaBuilder)
 
         FileDocumentManager.getInstance().saveAllDocuments()
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaCreator.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaCreator.kt
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.lambda.model.FunctionCode
 import software.amazon.awssdk.services.lambda.model.UpdateFunctionCodeRequest
 import software.amazon.awssdk.services.lambda.model.UpdateFunctionConfigurationRequest
 import software.amazon.awssdk.services.s3.S3Client
-import software.aws.toolkits.core.ToolkitClientManager
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilderUtils
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunction
@@ -27,10 +27,10 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
 object LambdaCreatorFactory {
-    fun create(clientManager: ToolkitClientManager, builder: LambdaBuilder): LambdaCreator = LambdaCreator(
+    fun create(project: Project, builder: LambdaBuilder): LambdaCreator = LambdaCreator(
         builder,
-        CodeUploader(clientManager.getClient()),
-        LambdaFunctionCreator(clientManager.getClient())
+        CodeUploader(project.awsClient()),
+        LambdaFunctionCreator(project.awsClient())
     )
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/CreateBucketAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/CreateBucketAction.kt
@@ -7,14 +7,14 @@ import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.project.DumbAwareAction
 import icons.AwsIcons
 import software.amazon.awssdk.services.s3.S3Client
-import software.aws.toolkits.jetbrains.core.AwsClientManager
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.services.s3.CreateS3BucketDialog
 import software.aws.toolkits.resources.message
 
 class CreateBucketAction : DumbAwareAction(message("s3.create.bucket.title"), null, AwsIcons.Resources.S3_BUCKET) {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.getRequiredData(LangDataKeys.PROJECT)
-        val client: S3Client = AwsClientManager.getInstance(project).getClient()
+        val client: S3Client = project.awsClient()
         val dialog = CreateS3BucketDialog(project, client)
         dialog.show()
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/DeleteBucketAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/bucketActions/DeleteBucketAction.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.testFramework.runInEdtAndWait
 import software.amazon.awssdk.services.s3.S3Client
 import software.aws.toolkits.core.s3.deleteBucketAndContents
-import software.aws.toolkits.jetbrains.core.AwsClientManager
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.explorer.actions.DeleteResourceAction
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.s3.S3BucketNode
@@ -18,7 +18,7 @@ import software.aws.toolkits.resources.message
 
 class DeleteBucketAction : DeleteResourceAction<S3BucketNode>(message("s3.delete.bucket.action"), TaggingResourceType.S3_BUCKET) {
     override fun performDelete(selected: S3BucketNode) {
-        val client: S3Client = AwsClientManager.getInstance(selected.nodeProject).getClient()
+        val client: S3Client = selected.nodeProject.awsClient()
 
         val fileEditorManager = FileEditorManager.getInstance(selected.nodeProject)
         fileEditorManager.openFiles.forEach {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/DownloadCodeForSchemaDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/DownloadCodeForSchemaDialog.kt
@@ -18,7 +18,6 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import org.apache.commons.lang.exception.ExceptionUtils
 import software.amazon.awssdk.services.schemas.model.SchemaVersionSummary
-import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.help.HelpIds
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
@@ -249,7 +248,7 @@ class DownloadCodeForSchemaDialog(
             super.doAction(e)
             if (doValidateAll().isNotEmpty()) return
 
-            downloadSchemaCode(SchemaCodeDownloader.create(AwsClientManager.getInstance(project)))
+            downloadSchemaCode(SchemaCodeDownloader.create(project))
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/SchemaCodeDownloader.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/SchemaCodeDownloader.kt
@@ -5,6 +5,7 @@ package software.aws.toolkits.jetbrains.services.schemas.code
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
 import com.intellij.util.io.Decompressor
 import software.amazon.awssdk.services.schemas.SchemasClient
 import software.amazon.awssdk.services.schemas.model.CodeGenerationStatus
@@ -13,8 +14,8 @@ import software.amazon.awssdk.services.schemas.model.DescribeCodeBindingRequest
 import software.amazon.awssdk.services.schemas.model.GetCodeBindingSourceRequest
 import software.amazon.awssdk.services.schemas.model.NotFoundException
 import software.amazon.awssdk.services.schemas.model.PutCodeBindingRequest
-import software.aws.toolkits.core.ToolkitClientManager
 import software.aws.toolkits.core.utils.wait
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.resources.message
 import java.io.File
 import java.io.FileOutputStream
@@ -65,10 +66,10 @@ class SchemaCodeDownloader(
     }
 
     companion object {
-        fun create(clientManager: ToolkitClientManager): SchemaCodeDownloader = SchemaCodeDownloader(
-            CodeGenerator(clientManager.getClient()),
-            CodeGenerationStatusPoller(clientManager.getClient()),
-            CodeDownloader(clientManager.getClient()),
+        fun create(project: Project): SchemaCodeDownloader = SchemaCodeDownloader(
+            CodeGenerator(project.awsClient()),
+            CodeGenerationStatusPoller(project.awsClient()),
+            CodeDownloader(project.awsClient()),
             CodeExtractor(),
             ProgressUpdater()
         )

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/search/SchemaSearchExecutor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/search/SchemaSearchExecutor.kt
@@ -10,13 +10,13 @@ import software.amazon.awssdk.services.schemas.SchemasClient
 import software.amazon.awssdk.services.schemas.model.SearchSchemasRequest
 import software.amazon.awssdk.services.schemas.model.SearchSchemasResponse
 import software.aws.toolkits.core.utils.warn
-import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.AwsResourceCache
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 
 class SchemaSearchExecutor(
     private val project: Project,
-    private val schemasClient: SchemasClient = AwsClientManager.getInstance(project).getClient()
+    private val schemasClient: SchemasClient = project.awsClient()
 ) {
     fun searchSchemasInRegistry(
         registryName: String,

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -178,13 +178,10 @@ class AwsClientManagerTest {
     private fun getClientManager() = AwsClientManager()
 
     // Back-ported from 2020.1 for 2019.3 compat FIX_WHEN_MIN_IS_201
-    private inline fun <T : Disposable, R> T.use(block: (T) -> R): R {
-        try {
-            return block(this)
-        }
-        finally {
-            Disposer.dispose(this)
-        }
+    private inline fun <T : Disposable, R> T.use(block: (T) -> R): R = try {
+        block(this)
+    } finally {
+        Disposer.dispose(this)
     }
 
     class DummyServiceClient(val httpClient: SdkHttpClient) : TestClient() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -4,8 +4,8 @@
 package software.aws.toolkits.jetbrains.core
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.use
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -21,14 +21,14 @@ import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption
 import software.amazon.awssdk.core.client.config.SdkClientOption
 import software.amazon.awssdk.core.signer.Signer
 import software.amazon.awssdk.http.SdkHttpClient
-import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.region.Endpoint
 import software.aws.toolkits.core.region.Service
+import software.aws.toolkits.core.region.anAwsRegion
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
-import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager
+import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager.ProjectAccountSettingsManagerRule
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.credentials.waitUntilConnectionStateIsStable
 import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProvider.RegionProviderRule
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.isAccessible
 
@@ -42,47 +42,54 @@ class AwsClientManagerTest {
     @JvmField
     val temporaryDirectory = TemporaryFolder()
 
+    @Rule
+    @JvmField
+    val regionProviderRule = RegionProviderRule()
+
+    @Rule
+    @JvmField
+    val projectSettingsRule = ProjectAccountSettingsManagerRule(projectRule)
+
     private lateinit var mockCredentialManager: MockCredentialsManager
 
     @Before
     fun setUp() {
         mockCredentialManager = MockCredentialsManager.getInstance()
         mockCredentialManager.reset()
-        MockRegionProvider.getInstance().reset()
-        MockAwsConnectionManager.getInstance(projectRule.project).reset()
     }
 
     @After
     fun tearDown() {
-        MockAwsConnectionManager.getInstance(projectRule.project).reset()
-        MockRegionProvider.getInstance().reset()
         mockCredentialManager.reset()
     }
 
     @Test
     fun canGetAnInstanceOfAClient() {
         val sut = getClientManager()
-        val client = sut.getClient<DummyServiceClient>()
+        val client = sut.getClient<DummyServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion())
         assertThat(client.serviceName()).isEqualTo("dummyClient")
     }
 
     @Test
     fun clientsAreCached() {
         val sut = getClientManager()
-        val fooClient = sut.getClient<DummyServiceClient>()
-        val barClient = sut.getClient<DummyServiceClient>()
+        val credProvider = mockCredentialManager.createCredentialProvider()
+        val region = regionProviderRule.createAwsRegion()
+
+        val fooClient = sut.getClient<DummyServiceClient>(credProvider, region)
+        val barClient = sut.getClient<DummyServiceClient>(credProvider, region)
 
         assertThat(fooClient).isSameAs(barClient)
     }
 
     @Test
-    fun oldClientsAreRemovedWhenProfilesAreRemoved() {
+    fun oldClientsAreRemovedWhenCredentialsAreRemoved() {
         val sut = getClientManager()
 
         val credentialsIdentifier = mockCredentialManager.addCredentials("profile:admin")
         val credentialProvider = mockCredentialManager.getAwsCredentialProvider(credentialsIdentifier, MockRegionProvider.getInstance().defaultRegion())
 
-        sut.getClient<DummyServiceClient>(credentialProvider)
+        sut.getClient<DummyServiceClient>(credentialProvider, anAwsRegion())
 
         assertThat(sut.cachedClients().keys).anySatisfy {
             it.credentialProviderId == "profile:admin"
@@ -96,12 +103,15 @@ class AwsClientManagerTest {
     }
 
     @Test
-    fun clientsAreClosedWhenProjectIsDisposed() {
-        val sut = getClientManager(projectRule.project)
-        val client = sut.getClient<DummyServiceClient>()
+    fun clientsAreClosedWhenParentIsDisposed() {
+        val client = Disposer.newDisposable().use { parent ->
+            val sut = getClientManager()
+            Disposer.register(parent, sut)
 
-        // Frameworks handle this normally but we can't trigger it from tests
-        Disposer.dispose(sut)
+            sut.getClient<DummyServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion()).also {
+                assertThat(it.closed).isFalse()
+            }
+        }
 
         assertThat(client.closed).isTrue()
     }
@@ -109,8 +119,8 @@ class AwsClientManagerTest {
     @Test
     fun httpClientIsSharedAcrossClients() {
         val sut = getClientManager()
-        val dummy = sut.getClient<DummyServiceClient>()
-        val secondDummy = sut.getClient<SecondDummyServiceClient>()
+        val dummy = sut.getClient<DummyServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion())
+        val secondDummy = sut.getClient<SecondDummyServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion())
 
         assertThat(dummy.httpClient.delegate).isSameAs(secondDummy.httpClient.delegate)
     }
@@ -119,7 +129,7 @@ class AwsClientManagerTest {
     fun clientWithoutBuilderFailsDescriptively() {
         val sut = getClientManager()
 
-        assertThatThrownBy { sut.getClient<InvalidServiceClient>() }
+        assertThatThrownBy { sut.getClient<InvalidServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion()) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("builder()")
     }
@@ -128,24 +138,20 @@ class AwsClientManagerTest {
     fun clientInterfaceWithoutNameFieldFailsDescriptively() {
         val sut = getClientManager()
 
-        assertThatThrownBy { sut.getClient<NoServiceNameClient>() }
+        assertThatThrownBy { sut.getClient<NoServiceNameClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion()) }
             .isInstanceOf(NoSuchFieldException::class.java)
             .hasMessageContaining("SERVICE_NAME")
     }
 
     @Test
-    fun newClientCreatedWhenRegionChanges() {
+    fun clientsAreScopedToRegion() {
         val sut = getClientManager()
-        val first = sut.getClient<DummyServiceClient>()
+        val credProvider = mockCredentialManager.createCredentialProvider()
 
-        val testSettings = MockAwsConnectionManager.getInstance(projectRule.project)
-        testSettings.changeRegionAndWait(AwsRegion("us-west-2", "us-west-2", "aws"))
+        val firstRegion = sut.getClient<DummyServiceClient>(credProvider, regionProviderRule.createAwsRegion())
+        val secondRegion = sut.getClient<DummyServiceClient>(credProvider, regionProviderRule.createAwsRegion())
 
-        testSettings.waitUntilConnectionStateIsStable()
-
-        val afterRegionUpdate = sut.getClient<DummyServiceClient>()
-
-        assertThat(afterRegionUpdate).isNotSameAs(first)
+        assertThat(secondRegion).isNotSameAs(firstRegion)
     }
 
     @Test
@@ -159,15 +165,17 @@ class AwsClientManagerTest {
                 partitionEndpoint = "global"
             )
         )
-        val first = sut.getClient<DummyServiceClient>(regionOverride = AwsRegion("us-east-1", "us-east-1", "aws"))
-        val second = sut.getClient<DummyServiceClient>(regionOverride = AwsRegion("us-west-2", "us-west-2", "aws"))
+        val credProvider = mockCredentialManager.createCredentialProvider()
+
+        val first = sut.getClient<DummyServiceClient>(credProvider, regionProviderRule.createAwsRegion(partitionId = "test"))
+        val second = sut.getClient<DummyServiceClient>(credProvider, regionProviderRule.createAwsRegion(partitionId = "test"))
 
         assertThat(first.serviceName()).isEqualTo("dummyClient")
         assertThat(second).isSameAs(first)
     }
 
     // Test against real version so bypass ServiceManager for the client manager
-    private fun getClientManager(project: Project = projectRule.project) = AwsClientManager(project)
+    private fun getClientManager() = AwsClientManager()
 
     class DummyServiceClient(val httpClient: SdkHttpClient) : TestClient() {
         companion object {
@@ -224,7 +232,7 @@ class AwsClientManagerTest {
         }
 
         companion object {
-            @Suppress("unused")
+            @Suppress("unused", "MayBeConstant")
             @JvmField
             val SERVICE_NAME = "DummyService"
         }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -3,9 +3,9 @@
 
 package software.aws.toolkits.jetbrains.core
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Disposer
-import com.intellij.openapi.util.use
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -176,6 +176,16 @@ class AwsClientManagerTest {
 
     // Test against real version so bypass ServiceManager for the client manager
     private fun getClientManager() = AwsClientManager()
+
+    // Back-ported from 2020.1 for 2019.3 compat FIX_WHEN_MIN_IS_201
+    private inline fun <T : Disposable, R> T.use(block: (T) -> R): R {
+        try {
+            return block(this)
+        }
+        finally {
+            Disposer.dispose(this)
+        }
+    }
 
     class DummyServiceClient(val httpClient: SdkHttpClient) : TestClient() {
         companion object {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.core
 
 import com.intellij.openapi.components.service
-import com.intellij.testFramework.ApplicationRule
 import org.junit.rules.ExternalResource
 import software.amazon.awssdk.core.SdkClient
 import software.aws.toolkits.core.ToolkitClientManager

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
@@ -3,19 +3,17 @@
 
 package software.aws.toolkits.jetbrains.core
 
-import com.intellij.openapi.components.ServiceManager
-import com.intellij.openapi.project.Project
-import com.intellij.testFramework.ProjectRule
+import com.intellij.openapi.components.service
+import com.intellij.testFramework.ApplicationRule
 import org.junit.rules.ExternalResource
 import software.amazon.awssdk.core.SdkClient
 import software.aws.toolkits.core.ToolkitClientManager
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.delegateMock
-import software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule
 import kotlin.reflect.KClass
 
-class MockClientManager(project: Project) : AwsClientManager(project) {
+class MockClientManager : AwsClientManager() {
     private data class Key(
         val clazz: KClass<out SdkClient>,
         val region: AwsRegion? = null,
@@ -25,10 +23,10 @@ class MockClientManager(project: Project) : AwsClientManager(project) {
     private val mockClients = mutableMapOf<Key, SdkClient>()
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T : SdkClient> createNewClient(key: AwsClientKey, region: AwsRegion, credProvider: ToolkitCredentialsProvider): T =
-        mockClients[Key(key.serviceClass, region, credProvider.id)] as? T
-            ?: mockClients[Key(key.serviceClass)] as? T
-            ?: throw IllegalStateException("No mock registered for $key")
+    override fun <T : SdkClient> createNewClient(sdkClass: KClass<T>, region: AwsRegion, credProvider: ToolkitCredentialsProvider): T =
+        mockClients[Key(sdkClass, region, credProvider.id)] as? T
+            ?: mockClients[Key(sdkClass)] as? T
+            ?: throw IllegalStateException("No mock registered for $sdkClass")
 
     override fun dispose() {
         super.dispose()
@@ -54,16 +52,13 @@ class MockClientManager(project: Project) : AwsClientManager(project) {
 }
 
 // Scoped to this file only, users should be using MockClientManagerRule to enforce cleanup correctly
-private fun getMockInstance(project: Project): MockClientManager = ServiceManager.getService(project, ToolkitClientManager::class.java) as MockClientManager
+private fun getMockInstance(): MockClientManager = service<ToolkitClientManager>() as MockClientManager
 
-class MockClientManagerRule(private val project: () -> Project) : ExternalResource() {
-    constructor(projectRule: ProjectRule) : this({ projectRule.project })
-    constructor(projectRule: CodeInsightTestFixtureRule) : this({ projectRule.project })
-
+class MockClientManagerRule : ExternalResource() {
     private lateinit var mockClientManager: MockClientManager
 
     override fun before() {
-        mockClientManager = getMockInstance(project())
+        mockClientManager = getMockInstance()
     }
 
     override fun after() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -15,6 +15,8 @@ import software.aws.toolkits.core.credentials.CredentialProviderFactory
 import software.aws.toolkits.core.credentials.CredentialsChangeListener
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.core.utils.test.aString
+import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
 
 class MockCredentialsManager : CredentialManager() {
     init {
@@ -37,6 +39,18 @@ class MockCredentialsManager : CredentialManager() {
         addProvider(credentialIdentifier)
 
         return credentialIdentifier
+    }
+
+    fun createCredentialProvider(
+        id: String = aString(),
+        credentials: AwsCredentials = AwsBasicCredentials.create("Access", "Secret"),
+        region: AwsRegion = MockRegionProvider.getInstance().defaultRegion()
+    ): ToolkitCredentialsProvider {
+        val credentialIdentifier = MockCredentialIdentifier(id, StaticCredentialsProvider.create(credentials), null)
+
+        addProvider(credentialIdentifier)
+
+        return getAwsCredentialProvider(credentialIdentifier, region)
     }
 
     fun removeCredentials(credentialIdentifier: CredentialIdentifier) {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/CreateWaiterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/CreateWaiterTest.kt
@@ -31,7 +31,7 @@ class CreateWaiterTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     private val mockClient by lazy { mockClientManagerRule.create<CloudFormationClient>() }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/DeleteWaiterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/DeleteWaiterTest.kt
@@ -31,7 +31,7 @@ class DeleteWaiterTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     private val mockClient by lazy { mockClientManagerRule.create<CloudFormationClient>() }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/ExecuteChangeSetTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/ExecuteChangeSetTest.kt
@@ -30,7 +30,7 @@ class ExecuteChangeSetTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     private val mockClient by lazy { mockClientManagerRule.create<CloudFormationClient>() }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/UpdateWaiterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/UpdateWaiterTest.kt
@@ -31,7 +31,7 @@ class UpdateWaiterTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     private val mockClient by lazy { mockClientManagerRule.create<CloudFormationClient>() }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsFetcherTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsFetcherTest.kt
@@ -25,7 +25,7 @@ class EventsFetcherTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @Test
     fun onlyNewEvents() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/UpdaterTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/UpdaterTest.kt
@@ -41,7 +41,7 @@ class UpdaterTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     private val treeView = mock(TreeView::class.java)
     private val eventsTable = mock(EventsTable::class.java)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogsTests.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogsTests.kt
@@ -26,7 +26,7 @@ class CloudWatchLogsTests {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @Test
     fun checkIfLogGroupExists() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/DeleteGroupActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/DeleteGroupActionTest.kt
@@ -31,7 +31,7 @@ class DeleteGroupActionTest {
 
     @JvmField
     @Rule
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     private val stream = LogStream.builder().logStreamName("eman").build()
     private lateinit var cloudwatchmock: CloudWatchLogsClient

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/OpenLogStreamInEditorActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/OpenLogStreamInEditorActionTest.kt
@@ -37,7 +37,7 @@ class OpenLogStreamInEditorActionTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @JvmField
     @Rule

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaExecutionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaExecutionTest.kt
@@ -44,7 +44,7 @@ class RemoteLambdaExecutionTest {
 
     @Rule
     @JvmField
-    val mockClientManager = MockClientManagerRule { projectRule.project }
+    val mockClientManager = MockClientManagerRule()
 
     @Before
     fun setUp() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialogTest.kt
@@ -45,7 +45,7 @@ class EditFunctionDialogTest {
 
     @JvmField
     @Rule
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     @JvmField
     @Rule

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaCreatorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaCreatorTest.kt
@@ -44,7 +44,7 @@ abstract class LambdaCreatorTestBase(private val functionDetails: FunctionUpload
 
     @Rule
     @JvmField
-    val mockClientManager = MockClientManagerRule { projectRule.project }
+    val mockClientManager = MockClientManagerRule()
 
     @Test
     fun testCreation() {
@@ -89,7 +89,7 @@ abstract class LambdaCreatorTestBase(private val functionDetails: FunctionUpload
             """
         ).containingFile
 
-        val lambdaCreator = LambdaCreatorFactory.create(mockClientManager.manager(), lambdaBuilder)
+        val lambdaCreator = LambdaCreatorFactory.create(projectRule.project, lambdaBuilder)
         lambdaCreator.createLambda(projectRule.module, psiFile, functionDetails, s3Bucket).toCompletableFuture()
             .get(5, TimeUnit.SECONDS)
 
@@ -157,7 +157,7 @@ abstract class LambdaCreatorTestBase(private val functionDetails: FunctionUpload
             """
         ).containingFile
 
-        val lambdaCreator = LambdaCreatorFactory.create(mockClientManager.manager(), lambdaBuilder)
+        val lambdaCreator = LambdaCreatorFactory.create(projectRule.project, lambdaBuilder)
         lambdaCreator.updateLambda(projectRule.module, psiFile, functionDetails, s3Bucket).toCompletableFuture()
             .get(5, TimeUnit.SECONDS)
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/DeleteBucketTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/DeleteBucketTest.kt
@@ -38,7 +38,7 @@ class DeleteBucketTest {
 
     @JvmField
     @Rule
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     private val bucket = Bucket.builder().name("foo").build()
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3VirtualBucketTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3VirtualBucketTest.kt
@@ -53,7 +53,7 @@ class S3VirtualBucketTest {
 
     @JvmField
     @Rule
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     @Rule
     @JvmField
@@ -209,10 +209,11 @@ class S3VirtualBucketTest {
 
     @Test
     fun getUrl() {
-        settingsManagerRule.settingsManager.changeRegionAndWait(AwsRegion("us-west-2", "US West (Oregon)", "aws"))
+        val awsConnectionManager = settingsManagerRule.settingsManager
+        awsConnectionManager.changeRegionAndWait(AwsRegion("us-west-2", "US West (Oregon)", "aws"))
 
         // Use real manager for this since it can affect the S3Configuration that goes into S3Utilities
-        AwsClientManager(projectRule.project).getClient<S3Client>().use {
+        AwsClientManager().getClient<S3Client>(awsConnectionManager.activeCredentialProvider, awsConnectionManager.activeRegion).use {
             val sut = S3VirtualBucket(Bucket.builder().name("test-bucket").build(), it)
 
             assertThat(sut.generateUrl("prefix/key")).isEqualTo(URL("https://test-bucket.s3.us-west-2.amazonaws.com/prefix/key"))
@@ -221,10 +222,11 @@ class S3VirtualBucketTest {
 
     @Test
     fun getUrlError() {
-        settingsManagerRule.settingsManager.changeRegionAndWait(AwsRegion("us-west-2", "US West (Oregon)", "aws"))
+        val awsConnectionManager = settingsManagerRule.settingsManager
+        awsConnectionManager.changeRegionAndWait(AwsRegion("us-west-2", "US West (Oregon)", "aws"))
 
         // Use real manager for this since it can affect the S3Configuration that goes into S3Utilities
-        AwsClientManager(projectRule.project).getClient<S3Client>().use {
+        AwsClientManager().getClient<S3Client>(awsConnectionManager.activeCredentialProvider, awsConnectionManager.activeRegion).use {
             val sut = S3VirtualBucket(Bucket.builder().name("test-bucket").build(), it)
 
             assertThatThrownBy {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/DownloadObjectActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/DownloadObjectActionTest.kt
@@ -50,7 +50,7 @@ class DownloadObjectActionTest {
 
     @Rule
     @JvmField
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     @Rule
     @JvmField

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemaRegistryNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemaRegistryNodeTest.kt
@@ -23,7 +23,7 @@ class SchemaRegistryNodeTest {
 
     @JvmField
     @Rule
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     @Before
     fun setUp() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasViewerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasViewerTest.kt
@@ -33,7 +33,7 @@ class SchemasViewerTest {
 
     @JvmField
     @Rule
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     private var errorNotification: Notification? = null
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/code/DownloadCodeForSchemaDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/code/DownloadCodeForSchemaDialogTest.kt
@@ -47,7 +47,7 @@ class DownloadCodeForSchemaDialogTest {
 
     @JvmField
     @Rule
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     @Rule
     @JvmField

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/code/SchemaCodeDownloaderTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/code/SchemaCodeDownloaderTest.kt
@@ -71,7 +71,7 @@ class SchemaCodeDownloaderTest {
 
     @JvmField
     @Rule
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     private var errorNotification: Notification? = null
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/ConfigureLambdaDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/ConfigureLambdaDialogTest.kt
@@ -39,7 +39,7 @@ class ConfigureLambdaDialogTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @Before
     fun setup() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/CreateQueueDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/CreateQueueDialogTest.kt
@@ -30,7 +30,7 @@ class CreateQueueDialogTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @Before
     fun setup() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/DeleteQueueActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/DeleteQueueActionTest.kt
@@ -32,7 +32,7 @@ class DeleteQueueActionTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @Before
     fun setup() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/EditAttributesDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/EditAttributesDialogTest.kt
@@ -35,7 +35,7 @@ class EditAttributesDialogTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @Before
     fun setUp() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/SubscribeSnsActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/SubscribeSnsActionTest.kt
@@ -22,7 +22,7 @@ class SubscribeSnsActionTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @Before
     fun setup() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/SubscribeSnsDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/SubscribeSnsDialogTest.kt
@@ -33,7 +33,7 @@ class SubscribeSnsDialogTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @Before
     fun setup() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePaneTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePaneTest.kt
@@ -26,7 +26,7 @@ import software.aws.toolkits.resources.message
 class SendMessagePaneTest : BaseCoroutineTest() {
     @JvmField
     @Rule
-    val mockClientManager = MockClientManagerRule(projectRule)
+    val mockClientManager = MockClientManagerRule()
 
     private lateinit var client: SqsClient
     private lateinit var region: AwsRegion

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/BaseCoroutineTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/BaseCoroutineTest.kt
@@ -24,7 +24,7 @@ abstract class BaseCoroutineTest(timeoutSeconds: Int = 15) {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     @JvmField
     @Rule

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/ResourceOperationAgainstCodePipelineTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/ResourceOperationAgainstCodePipelineTest.kt
@@ -25,7 +25,7 @@ class ResourceOperationAgainstCodePipelineTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     private val mockClient by lazy { mockClientManagerRule.create<ResourceGroupsTaggingApiClient>() }
 

--- a/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/datagrip/DatabaseSecret.kt
+++ b/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/datagrip/DatabaseSecret.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ValidationInfo
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.secretsmanager.model.SecretListEntry
-import software.aws.toolkits.jetbrains.core.AwsClientManager
+import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.datagrip.auth.SecretsManagerDbSecret
 import software.aws.toolkits.jetbrains.services.rds.RdsNode
@@ -25,7 +25,7 @@ object DatabaseSecret {
     fun getSecret(project: Project, secret: SecretListEntry?): Pair<SecretsManagerDbSecret, String>? {
         secret ?: return null
         return try {
-            val value = AwsClientManager.getInstance(project).getClient<SecretsManagerClient>().getSecretValue { it.secretId(secret.arn()) }
+            val value = project.awsClient<SecretsManagerClient>().getSecretValue { it.secretId(secret.arn()) }
             val dbSecret = objectMapper.readValue<SecretsManagerDbSecret>(value.secretString())
             Pair(dbSecret, secret.arn())
         } catch (e: Exception) {

--- a/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/services/redshift/auth/IamAuth.kt
+++ b/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/services/redshift/auth/IamAuth.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.future.future
 import software.amazon.awssdk.services.redshift.RedshiftClient
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
-import software.aws.toolkits.jetbrains.core.awsClient
+import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
 import software.aws.toolkits.jetbrains.datagrip.getAwsConnectionSettings
 import software.aws.toolkits.jetbrains.utils.ApplicationThreadPoolScope
@@ -45,7 +45,10 @@ class IamAuth : DatabaseAuthProvider, CoroutineScope by ApplicationThreadPoolSco
             val project = connection.runConfiguration.project
             try {
                 val auth = validateConnection(connection)
-                val client = project.awsClient<RedshiftClient>(auth.connectionSettings.credentials, auth.connectionSettings.region)
+                val client = AwsClientManager.getInstance().getClient<RedshiftClient>(
+                    auth.connectionSettings.credentials,
+                    auth.connectionSettings.region
+                )
                 val credentials = getCredentials(auth, client)
                 DatabaseCredentialsAuthProvider.applyCredentials(connection, credentials, true)
             } catch (e: Throwable) {

--- a/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/datagrip/DatabaseSecretTest.kt
+++ b/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/datagrip/DatabaseSecretTest.kt
@@ -31,7 +31,7 @@ class DatabaseSecretTest {
 
     @JvmField
     @Rule
-    val mockClientManagerRule = MockClientManagerRule(projectRule)
+    val mockClientManagerRule = MockClientManagerRule()
 
     private val secretName = RuleUtils.randomName()
     private val randomHost = RuleUtils.randomName()

--- a/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthTest.kt
+++ b/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthTest.kt
@@ -41,7 +41,7 @@ class SecretsManagerAuthTest {
 
     @Rule
     @JvmField
-    val clientManager = MockClientManagerRule(projectRule)
+    val clientManager = MockClientManagerRule()
 
     private val objectMapper = jacksonObjectMapper()
 

--- a/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/services/redshift/auth/IamAuthTest.kt
+++ b/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/services/redshift/auth/IamAuthTest.kt
@@ -42,7 +42,7 @@ class IamAuthTest {
 
     @Rule
     @JvmField
-    val mockClientManager = MockClientManagerRule { projectRule.project }
+    val mockClientManager = MockClientManagerRule()
 
     private val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
 


### PR DESCRIPTION
* Remove needing to use it as a project service since it was only used to access defaults
* Project level is now accessed as extension methods on the project

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
