### PR TITLE
Convert resource cache to an app service

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -178,17 +178,19 @@
         <applicationService serviceInterface="software.aws.toolkits.jetbrains.core.notification.NoticeManager"
                             serviceImplementation="software.aws.toolkits.jetbrains.core.notification.DefaultNoticeManager"/>
         <applicationService serviceInterface="software.aws.toolkits.core.ToolkitClientManager"
-                        serviceImplementation="software.aws.toolkits.jetbrains.core.AwsClientManager"
-                        testServiceImplementation="software.aws.toolkits.jetbrains.core.MockClientManager"/>
+                            serviceImplementation="software.aws.toolkits.jetbrains.core.AwsClientManager"
+                            testServiceImplementation="software.aws.toolkits.jetbrains.core.MockClientManager"/>
+        <applicationService serviceInterface="software.aws.toolkits.jetbrains.core.AwsResourceCache"
+                            serviceImplementation="software.aws.toolkits.jetbrains.core.DefaultAwsResourceCache"
+                            testServiceImplementation="software.aws.toolkits.jetbrains.core.MockResourceCache"/>
+
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.core.explorer.ExplorerToolWindow"/>
-        <projectService serviceInterface="software.aws.toolkits.jetbrains.core.AwsResourceCache"
-                        serviceImplementation="software.aws.toolkits.jetbrains.core.DefaultAwsResourceCache"
-                        testServiceImplementation="software.aws.toolkits.jetbrains.core.MockResourceCache"/>
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.services.cloudformation.stack.StackWindowManager"/>
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.services.lambda.validation.LambdaHandlerValidator" />
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.core.toolwindow.ToolkitToolWindowManager" />
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.services.cloudwatch.logs.CloudWatchLogWindow" />
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.services.sqs.toolwindow.SqsWindow" />
+
         <toolWindow id="aws.explorer" anchor="left" secondary="true"
                     factoryClass="software.aws.toolkits.jetbrains.core.explorer.AwsExplorerFactory"
                     icon="AwsIcons.Logos.AWS"/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
@@ -6,7 +6,7 @@ package software.aws.toolkits.jetbrains.core
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.util.Alarm
 import com.intellij.util.AlarmFactory
@@ -18,6 +18,7 @@ import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
+import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.toEnvironmentVariables
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
@@ -34,22 +35,16 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
+// Getting resources can take a long time on a slow connection or if there are a lot of resources. This call should
+// always be done in an async context so it should be OK to take multiple seconds.
+private val DEFAULT_TIMEOUT = Duration.ofSeconds(30)
+
 /**
  * Intended to prevent repeated unnecessary calls to AWS to understand resource state.
  *
  * Will cache responses from AWS by [AwsRegion]/[ToolkitCredentialsProvider] - generically applicable to any AWS call.
  */
 interface AwsResourceCache {
-
-    /**
-     * Get a [resource] either by making a call or returning it from the cache if present and unexpired. Uses the currently [AwsRegion]
-     * & [ToolkitCredentialsProvider] active in [AwsConnectionManager].
-     *
-     * @param[useStale] if an exception occurs attempting to refresh the resource return a cached version if it exists (even if it's expired). Default: true
-     * @param[forceFetch] force the resource to refresh (and update cache) even if a valid cache version exists. Default: false
-     */
-    fun <T> getResource(resource: Resource<T>, useStale: Boolean = true, forceFetch: Boolean = false): CompletionStage<T>
-
     /**
      * @see [getResource]
      *
@@ -66,12 +61,13 @@ interface AwsResourceCache {
 
     /**
      * Blocking version of [getResource]
-     *
-     * @param[useStale] if an exception occurs attempting to refresh the resource return a cached version if it exists (even if it's expired). Default: true
-     * @param[forceFetch] force the resource to refresh (and update cache) even if a valid cache version exists. Default: false
      */
-    fun <T> getResourceNow(resource: Resource<T>, timeout: Duration = DEFAULT_TIMEOUT, useStale: Boolean = true, forceFetch: Boolean = false): T =
-        wait(timeout) { getResource(resource, useStale, forceFetch) }
+    fun <T> getResource(
+        resource: Resource<T>,
+        connectionSettings: ConnectionSettings,
+        useStale: Boolean = true,
+        forceFetch: Boolean = false
+    ): CompletionStage<T> = getResource(resource, connectionSettings.region, connectionSettings.credentials, useStale, forceFetch)
 
     /**
      * Blocking version of [getResource]
@@ -89,11 +85,15 @@ interface AwsResourceCache {
     ): T = wait(timeout) { getResource(resource, region, credentialProvider, useStale, forceFetch) }
 
     /**
-     * Gets the [resource] if it exists in the cache.
-     *
-     * @param[useStale] return a cached version if it exists (even if it's expired). Default: true
+     * Blocking version of [getResource]
      */
-    fun <T> getResourceIfPresent(resource: Resource<T>, useStale: Boolean = true): T?
+    fun <T> getResourceNow(
+        resource: Resource<T>,
+        connectionSettings: ConnectionSettings,
+        timeout: Duration = DEFAULT_TIMEOUT,
+        useStale: Boolean = true,
+        forceFetch: Boolean = false
+    ): T = getResourceNow(resource, connectionSettings.region, connectionSettings.credentials, timeout, useStale, forceFetch)
 
     /**
      * Gets the [resource] if it exists in the cache.
@@ -104,14 +104,26 @@ interface AwsResourceCache {
     fun <T> getResourceIfPresent(resource: Resource<T>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider, useStale: Boolean = true): T?
 
     /**
+     * Gets the [resource] if it exists in the cache.
+     */
+    fun <T> getResourceIfPresent(resource: Resource<T>, connectionSettings: ConnectionSettings, useStale: Boolean = true): T? =
+        getResourceIfPresent(resource, connectionSettings.region, connectionSettings.credentials, useStale)
+
+    /**
      * Clears the contents of the cache across all regions, credentials and resource types.
      */
     fun clear()
 
     /**
-     * Clears the contents of the cache for the specific [resource] type, in the currently active [AwsRegion] & [ToolkitCredentialsProvider]
+     * Clears the contents of the cache for the specific [ConnectionSettings]
      */
-    fun clear(resource: Resource<*>)
+    fun clear(connectionSettings: ConnectionSettings)
+
+    /**
+     * Clears the contents of the cache for the specific [resource] type] & [ConnectionSettings]
+     */
+    fun clear(resource: Resource<*>, connectionSettings: ConnectionSettings) =
+        clear(resource, connectionSettings.region, connectionSettings.credentials)
 
     /**
      * Clears the contents of the cache for the specific [resource] type, [AwsRegion] & [ToolkitCredentialsProvider]
@@ -120,11 +132,7 @@ interface AwsResourceCache {
 
     companion object {
         @JvmStatic
-        fun getInstance(project: Project): AwsResourceCache = ServiceManager.getService(project, AwsResourceCache::class.java)
-
-        // Getting resources can take a long time on a slow connection or if there are a lot of resources. This call should
-        // always be done in an async context so it should be OK to take multiple seconds.
-        private val DEFAULT_TIMEOUT = Duration.ofSeconds(30)
+        fun getInstance(): AwsResourceCache = service()
 
         private fun <T> wait(timeout: Duration, call: () -> CompletionStage<T>) = try {
             call().toCompletableFuture().get(timeout.toMillis(), TimeUnit.MILLISECONDS)
@@ -134,8 +142,47 @@ interface AwsResourceCache {
     }
 }
 
-fun <T> Project.getResource(resource: Resource<T>, useStale: Boolean = true, forceFetch: Boolean = false) =
-    AwsResourceCache.getInstance(this).getResource(resource, useStale, forceFetch)
+/**
+ * Get a [resource] either by making a call or returning it from the cache if present and unexpired. Uses the currently [AwsRegion]
+ * & [ToolkitCredentialsProvider] active in [AwsConnectionManager].
+ *
+ * @param[useStale] if an exception occurs attempting to refresh the resource return a cached version if it exists (even if it's expired). Default: true
+ * @param[forceFetch] force the resource to refresh (and update cache) even if a valid cache version exists. Default: false
+ */
+fun <T> Project.getResource(resource: Resource<T>, useStale: Boolean = true, forceFetch: Boolean = false): CompletionStage<T> =
+    AwsResourceCache.getInstance().getResource(resource, this.getConnectionSettings(), useStale, forceFetch)
+
+/**
+ * Blocking version of [getResource]
+ *
+ * @param[useStale] if an exception occurs attempting to refresh the resource return a cached version if it exists (even if it's expired). Default: true
+ * @param[forceFetch] force the resource to refresh (and update cache) even if a valid cache version exists. Default: false
+ */
+fun <T> Project.getResourceNow(resource: Resource<T>, timeout: Duration = DEFAULT_TIMEOUT, useStale: Boolean = true, forceFetch: Boolean = false): T =
+    AwsResourceCache.getInstance().getResourceNow(resource, this.getConnectionSettings(), timeout, useStale, forceFetch)
+
+/**
+ * Gets the [resource] if it exists in the cache.
+ *
+ * @param[useStale] return a cached version if it exists (even if it's expired). Default: true
+ */
+fun <T> Project.getResourceIfPresent(resource: Resource<T>, useStale: Boolean = true): T? =
+    AwsResourceCache.getInstance().getResourceIfPresent(resource, this.getConnectionSettings(), useStale)
+
+/**
+ * Clears the contents of the cache for the specific [resource] type, in the currently active [ConnectionSettings]
+ */
+fun Project.clearResourceCache(resource: Resource<*>) =
+    AwsResourceCache.getInstance().clear(resource, this.getConnectionSettings())
+
+/**
+ * Clears the contents of the cache of all resource types for the currently active [ConnectionSettings]
+ */
+fun Project.clearResourceCache() =
+    AwsResourceCache.getInstance().clear(this.getConnectionSettings())
+
+private fun Project.getConnectionSettings(): ConnectionSettings = AwsConnectionManager.getInstance(this).connectionSettings()
+    ?: throw IllegalStateException("Bug: ResourceCache was accessed with invalid ConnectionSettings")
 
 sealed class Resource<T> {
 
@@ -143,7 +190,7 @@ sealed class Resource<T> {
      * A [Cached] resource is one whose fetch is potentially expensive, the result of which should be memoized for a period of time ([expiry]).
      */
     abstract class Cached<T> : Resource<T>() {
-        abstract fun fetch(project: Project, region: AwsRegion, credentials: ToolkitCredentialsProvider): T
+        abstract fun fetch(region: AwsRegion, credentials: ToolkitCredentialsProvider): T
         open fun expiry(): Duration = DEFAULT_EXPIRY
         abstract val id: String
 
@@ -178,7 +225,7 @@ class ClientBackedCachedResource<ReturnType, ClientType : SdkClient>(
 
     constructor(sdkClientClass: KClass<ClientType>, id: String, fetchCall: ClientType.() -> ReturnType) : this(sdkClientClass, id, null, fetchCall)
 
-    override fun fetch(project: Project, region: AwsRegion, credentials: ToolkitCredentialsProvider): ReturnType {
+    override fun fetch(region: AwsRegion, credentials: ToolkitCredentialsProvider): ReturnType {
         val client = AwsClientManager.getInstance().getClient(sdkClientClass, credentials, region)
         return fetchCall(client)
     }
@@ -194,7 +241,7 @@ class ExecutableBackedCacheResource<ReturnType, ExecType : ExecutableType<*>>(
     private val fetchCall: GeneralCommandLine.() -> ReturnType
 ) : Resource.Cached<ReturnType>() {
 
-    override fun fetch(project: Project, region: AwsRegion, credentials: ToolkitCredentialsProvider): ReturnType {
+    override fun fetch(region: AwsRegion, credentials: ToolkitCredentialsProvider): ReturnType {
         val executableType = ExecutableType.getExecutable(executableTypeClass.java)
 
         val executable = ExecutableManager.getInstance().getExecutableIfPresent(executableType).let {
@@ -234,9 +281,6 @@ class DefaultAwsResourceCache(
         ApplicationManager.getApplication().messageBus.connect(this).subscribe(CredentialManager.CREDENTIALS_CHANGED, this)
         scheduleCacheMaintenance()
     }
-
-    override fun <T> getResource(resource: Resource<T>, useStale: Boolean, forceFetch: Boolean) =
-        getResource(resource, accountSettings.activeRegion, accountSettings.activeCredentialProvider, useStale, forceFetch)
 
     override fun <T> getResource(
         resource: Resource<T>,
@@ -286,9 +330,6 @@ class DefaultAwsResourceCache(
         }
     }
 
-    override fun <T> getResourceIfPresent(resource: Resource<T>, useStale: Boolean): T? =
-        getResourceIfPresent(resource, accountSettings.activeRegion, accountSettings.activeCredentialProvider, useStale)
-
     override fun <T> getResourceIfPresent(resource: Resource<T>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider, useStale: Boolean): T? =
         when (resource) {
             is Resource.Cached<T> -> {
@@ -301,10 +342,6 @@ class DefaultAwsResourceCache(
             is Resource.View<*, T> -> getResourceIfPresent(resource.underlying, region, credentialProvider, useStale)?.let { resource.doMap(it) }
         }
 
-    override fun clear(resource: Resource<*>) {
-        clear(resource, accountSettings.activeRegion, accountSettings.activeCredentialProvider)
-    }
-
     override fun clear(resource: Resource<*>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider) {
         when (resource) {
             is Resource.Cached<*> -> cache.remove(CacheKey(resource.id, region.id, credentialProvider.id))
@@ -314,6 +351,10 @@ class DefaultAwsResourceCache(
 
     override fun clear() {
         cache.clear()
+    }
+
+    override fun clear(connectionSettings: ConnectionSettings) {
+        cache.keys.removeIf { it.credentialsId == connectionSettings.credentials.id && it.regionId == connectionSettings.region.id }
     }
 
     override fun dispose() {
@@ -343,7 +384,7 @@ class DefaultAwsResourceCache(
     }
 
     private fun <T> fetch(context: Context<T>): Entry<T> {
-        val value = context.resource.fetch(project, context.region, context.credentials)
+        val value = context.resource.fetch(context.region, context.credentials)
         return Entry(clock.instant().plus(context.resource.expiry()), value)
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
@@ -166,13 +166,13 @@ fun <T> Project.getResourceIfPresent(resource: Resource<T>, useStale: Boolean = 
 /**
  * Clears the contents of the cache for the specific [resource] type, in the currently active [ConnectionSettings]
  */
-fun Project.clearResourceCache(resource: Resource<*>) =
+fun Project.clearResourceForCurrentConnection(resource: Resource<*>) =
     AwsResourceCache.getInstance().clear(resource, this.getConnectionSettings())
 
 /**
  * Clears the contents of the cache of all resource types for the currently active [ConnectionSettings]
  */
-fun Project.clearResourceCache() =
+fun Project.clearResourceForCurrentConnection() =
     AwsResourceCache.getInstance().clear(this.getConnectionSettings())
 
 private fun Project.getConnectionSettings(): ConnectionSettings = AwsConnectionManager.getInstance(this).connectionSettings()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
@@ -34,7 +34,7 @@ import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
 
 abstract class AwsConnectionManager(private val project: Project) : SimpleModificationTracker(), Disposable {
-    private val resourceCache = AwsResourceCache.getInstance(project)
+    private val resourceCache = AwsResourceCache.getInstance()
     private val regionProvider = AwsRegionProvider.getInstance()
     private val credentialsRegionHandler = CredentialsRegionHandler.getInstance(project)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/RefreshConnectionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/RefreshConnectionAction.kt
@@ -22,7 +22,8 @@ class RefreshConnectionAction(text: String = message("settings.refresh.descripti
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        AwsResourceCache.getInstance(project).clear()
+
+        AwsResourceCache.getInstance().clear()
         AwsConnectionManager.getInstance(project).refreshConnectionState()
 
         AwsTelemetry.refreshExplorer(project)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/RefreshAwsTree.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/RefreshAwsTree.kt
@@ -7,13 +7,14 @@ import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.Project
 import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.Resource
+import software.aws.toolkits.jetbrains.core.clearResourceCache
 
 fun Project.refreshAwsTree(resource: Resource<*>? = null) {
-    val cache = AwsResourceCache.getInstance(this)
+    val cache = AwsResourceCache.getInstance()
     if (resource == null) {
-        cache.clear()
+        this.clearResourceCache()
     } else {
-        cache.clear(resource)
+        this.clearResourceCache(resource)
     }
     runInEdt {
         // redraw explorer

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/RefreshAwsTree.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/RefreshAwsTree.kt
@@ -7,14 +7,14 @@ import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.Project
 import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.Resource
-import software.aws.toolkits.jetbrains.core.clearResourceCache
+import software.aws.toolkits.jetbrains.core.clearResourceForCurrentConnection
 
 fun Project.refreshAwsTree(resource: Resource<*>? = null) {
     val cache = AwsResourceCache.getInstance()
     if (resource == null) {
-        this.clearResourceCache()
+        this.clearResourceForCurrentConnection()
     } else {
-        this.clearResourceCache(resource)
+        this.clearResourceForCurrentConnection(resource)
     }
     runInEdt {
         // redraw explorer

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/nodes/AwsExplorerServiceRootNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/nodes/AwsExplorerServiceRootNode.kt
@@ -4,8 +4,8 @@
 package software.aws.toolkits.jetbrains.core.explorer.nodes
 
 import com.intellij.openapi.project.Project
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.Resource
+import software.aws.toolkits.jetbrains.core.getResourceNow
 
 /**
  * Top level node for any AWS service node
@@ -25,7 +25,7 @@ abstract class AwsExplorerServiceRootNode(project: Project, private val service:
 abstract class CacheBackedAwsExplorerServiceRootNode<T>(project: Project, service: AwsExplorerServiceNode, private val resource: Resource<out Collection<T>>) :
     AwsExplorerServiceRootNode(project, service) {
 
-    final override fun getChildrenInternal(): List<AwsExplorerNode<*>> = AwsResourceCache.getInstance(nodeProject).getResourceNow(resource).map(this::toNode)
+    final override fun getChildrenInternal(): List<AwsExplorerNode<*>> = nodeProject.getResourceNow(resource).map(this::toNode)
 
     abstract fun toNode(child: T): AwsExplorerNode<*>
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/actions/PseCliAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/actions/PseCliAction.kt
@@ -29,7 +29,7 @@ import org.slf4j.event.Level
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
+import software.aws.toolkits.jetbrains.core.clearResourceCache
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.toEnvironmentVariables
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
@@ -161,7 +161,7 @@ abstract class PseCliAction(val project: Project, val actionName: String, privat
                             project
                         )
                         // reset the cache
-                        AwsResourceCache.getInstance(project).clear(CloudDebuggingResources.LIST_INSTRUMENTED_RESOURCES)
+                        project.clearResourceCache(CloudDebuggingResources.LIST_INSTRUMENTED_RESOURCES)
                         callback?.invoke(true)
                     } else {
                         notifyError(
@@ -177,8 +177,8 @@ abstract class PseCliAction(val project: Project, val actionName: String, privat
                         val parent = selectedNode.parent
                         if (parent is EcsClusterNode) {
                             // dump cached values relating to altered service
-                            AwsResourceCache.getInstance(project).clear(describeService(parent.resourceArn(), selectedNode.resourceArn()))
-                            AwsResourceCache.getInstance(project).clear(listServiceArns(parent.resourceArn()))
+                            project.clearResourceCache(describeService(parent.resourceArn(), selectedNode.resourceArn()))
+                            project.clearResourceCache(listServiceArns(parent.resourceArn()))
                             runInEdt {
                                 // redraw explorer from the cluster downwards
                                 val explorer = ExplorerToolWindow.getInstance(project)
@@ -188,7 +188,7 @@ abstract class PseCliAction(val project: Project, val actionName: String, privat
                         // If this wasn't run through a node, just redraw the whole tree
                         // Open to suggestions to making this smarter.
                     } else {
-                        AwsResourceCache.getInstance(project).clear()
+                        project.clearResourceCache()
                         runInEdt {
                             // redraw explorer from the cluster downwards
                             val explorer = ExplorerToolWindow.getInstance(project)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/actions/PseCliAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/actions/PseCliAction.kt
@@ -29,7 +29,7 @@ import org.slf4j.event.Level
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
-import software.aws.toolkits.jetbrains.core.clearResourceCache
+import software.aws.toolkits.jetbrains.core.clearResourceForCurrentConnection
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.toEnvironmentVariables
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
@@ -161,7 +161,7 @@ abstract class PseCliAction(val project: Project, val actionName: String, privat
                             project
                         )
                         // reset the cache
-                        project.clearResourceCache(CloudDebuggingResources.LIST_INSTRUMENTED_RESOURCES)
+                        project.clearResourceForCurrentConnection(CloudDebuggingResources.LIST_INSTRUMENTED_RESOURCES)
                         callback?.invoke(true)
                     } else {
                         notifyError(
@@ -177,8 +177,8 @@ abstract class PseCliAction(val project: Project, val actionName: String, privat
                         val parent = selectedNode.parent
                         if (parent is EcsClusterNode) {
                             // dump cached values relating to altered service
-                            project.clearResourceCache(describeService(parent.resourceArn(), selectedNode.resourceArn()))
-                            project.clearResourceCache(listServiceArns(parent.resourceArn()))
+                            project.clearResourceForCurrentConnection(describeService(parent.resourceArn(), selectedNode.resourceArn()))
+                            project.clearResourceForCurrentConnection(listServiceArns(parent.resourceArn()))
                             runInEdt {
                                 // redraw explorer from the cluster downwards
                                 val explorer = ExplorerToolWindow.getInstance(project)
@@ -188,7 +188,7 @@ abstract class PseCliAction(val project: Project, val actionName: String, privat
                         // If this wasn't run through a node, just redraw the whole tree
                         // Open to suggestions to making this smarter.
                     } else {
-                        project.clearResourceCache()
+                        project.clearResourceForCurrentConnection()
                         runInEdt {
                             // redraw explorer from the cluster downwards
                             val explorer = ExplorerToolWindow.getInstance(project)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/ContainerActions.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/ContainerActions.kt
@@ -13,9 +13,10 @@ import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient
 import software.amazon.awssdk.services.ecs.model.ContainerDefinition
 import software.amazon.awssdk.services.ecs.model.LogDriver
 import software.amazon.awssdk.services.ecs.model.Service
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.explorer.actions.SingleExplorerNodeActionGroup
+import software.aws.toolkits.jetbrains.core.getResource
+import software.aws.toolkits.jetbrains.core.getResourceNow
 import software.aws.toolkits.jetbrains.services.clouddebug.actions.StartRemoteShellAction
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.CloudWatchLogWindow
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.checkIfLogStreamExists
@@ -43,7 +44,7 @@ data class ContainerDetails(val service: Service, val containerDefinition: Conta
 class ServiceContainerActions : SingleExplorerNodeActionGroup<EcsServiceNode>("Containers") {
     override fun getChildren(selected: EcsServiceNode, e: AnActionEvent): List<AnAction> {
         val containers = try {
-            AwsResourceCache.getInstance(selected.nodeProject).getResourceNow(EcsResources.listContainers(selected.value.taskDefinition()))
+            selected.nodeProject.getResourceNow(EcsResources.listContainers(selected.value.taskDefinition()))
         } catch (e: Exception) {
             e.notifyError(message("cloud_debug.ecs.run_config.container.loading.error", e.localizedMessage), selected.nodeProject)
             return emptyList()
@@ -84,8 +85,7 @@ class ContainerLogsAction(
 
         val window = CloudWatchLogWindow.getInstance(project)
 
-        AwsResourceCache.getInstance(project)
-            .getResource(EcsResources.listTaskIds(container.service.clusterArn(), container.service.serviceArn()))
+        project.getResource(EcsResources.listTaskIds(container.service.clusterArn(), container.service.serviceArn()))
             .thenAccept { tasks ->
                 when {
                     tasks.isEmpty() -> notifyInfo(message("ecs.service.logs.no_running_tasks"))

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/execution/EcsCloudDebugRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/execution/EcsCloudDebugRunConfiguration.kt
@@ -257,8 +257,7 @@ class EcsCloudDebugRunConfiguration(project: Project, private val configFactory:
             }
         }.filterNotNull().toMutableSet()
 
-        val resourceCache = AwsResourceCache.getInstance(project)
-
+        val resourceCache = AwsResourceCache.getInstance()
         val validContainerNames = if (deepCheck) {
             try {
                 val service = resourceCache.getResourceNow(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/execution/EcsCloudDebugSettingsEditorPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/execution/EcsCloudDebugSettingsEditorPanel.kt
@@ -192,7 +192,7 @@ class EcsCloudDebugSettingsEditorPanel(private val project: Project) : Disposabl
 
         val (awsRegion, credentialProvider) = credentialSettings.get()
 
-        val resourceCache = AwsResourceCache.getInstance(project)
+        val resourceCache = AwsResourceCache.getInstance()
         resourceCache.getResource(
             EcsResources.describeService(clusterArn, serviceArn),
             awsRegion,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/SamInvokeRunner.kt
@@ -117,7 +117,7 @@ class SamInvokeRunner : AsyncProgramRunner<RunnerSettings>() {
                 buildingPromise.setError(it)
                 throw it
             }.whenComplete { _, exception ->
-                val account = AwsResourceCache.getInstance(state.environment.project)
+                val account = AwsResourceCache.getInstance()
                     .getResourceIfPresent(StsResources.ACCOUNT, lambdaSettings.region, lambdaSettings.credentials)
                 LambdaTelemetry.invokeLocal(
                     metadata = MetricEventMetadata(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/LambdaLineMarker.kt
@@ -19,8 +19,9 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPointerManager
 import icons.AwsIcons
 import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
+import software.aws.toolkits.jetbrains.core.getResource
+import software.aws.toolkits.jetbrains.core.getResourceIfPresent
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationTemplateIndex.Companion.listFunctions
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
@@ -93,11 +94,9 @@ class LambdaLineMarker : LineMarkerProviderDescriptor() {
             return false
         }
 
-        val cache = AwsResourceCache.getInstance(psiFile.project)
-
-        return when (val functions = cache.getResourceIfPresent(LambdaResources.LIST_FUNCTIONS)) {
+        return when (val functions = psiFile.project.getResourceIfPresent(LambdaResources.LIST_FUNCTIONS)) {
             null -> {
-                cache.getResource(LambdaResources.LIST_FUNCTIONS).whenComplete { _, _ ->
+                psiFile.project.getResource(LambdaResources.LIST_FUNCTIONS).whenComplete { _, _ ->
                     runReadAction {
                         DaemonCodeAnalyzer.getInstance(psiFile.project).restart(psiFile)
                     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/S3ExplorerNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/S3ExplorerNode.kt
@@ -7,17 +7,17 @@ import com.intellij.openapi.project.Project
 import icons.AwsIcons
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.Bucket
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.credentials.activeRegion
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceRootNode
+import software.aws.toolkits.jetbrains.core.getResourceNow
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
 
 class S3ServiceNode(project: Project, service: AwsExplorerServiceNode) : AwsExplorerServiceRootNode(project, service) {
     override fun getChildrenInternal(): List<AwsExplorerNode<*>> =
-        AwsResourceCache.getInstance(nodeProject).getResourceNow(S3Resources.listBucketsByActiveRegion(nodeProject)).map { S3BucketNode(nodeProject, it) }
+        nodeProject.getResourceNow(S3Resources.listBucketsByActiveRegion(nodeProject)).map { S3BucketNode(nodeProject, it) }
 }
 
 class S3BucketNode(project: Project, val bucket: Bucket) :

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/SchemaViewer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/SchemaViewer.kt
@@ -17,9 +17,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.ExceptionUtil
 import software.amazon.awssdk.services.schemas.model.DescribeSchemaResponse
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.credentials.activeCredentialProvider
 import software.aws.toolkits.jetbrains.core.credentials.activeRegion
+import software.aws.toolkits.jetbrains.core.getResource
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
@@ -74,7 +74,7 @@ class SchemaViewer(
 class SchemaDownloader() {
     fun getSchemaContent(registryName: String, schemaName: String, version: String? = null, project: Project): CompletionStage<DescribeSchemaResponse> {
         val resource = SchemasResources.getSchema(registryName, schemaName, version)
-        return AwsResourceCache.getInstance(project).getResource(resource)
+        return project.getResource(resource)
     }
 
     fun getSchemaContentAsJson(schemaContent: DescribeSchemaResponse): JsonNode = mapper.readTree(schemaContent.content())

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/SchemasExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/SchemasExplorerNodes.kt
@@ -7,13 +7,13 @@ import com.intellij.openapi.project.Project
 import icons.AwsIcons
 import software.amazon.awssdk.services.schemas.SchemasClient
 import software.amazon.awssdk.services.schemas.model.RegistrySummary
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceParentNode
+import software.aws.toolkits.jetbrains.core.getResourceNow
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 import software.aws.toolkits.resources.message
 
@@ -47,9 +47,8 @@ open class SchemaRegistryNode(
     override fun getChildren(): List<AwsExplorerNode<*>> = super<ResourceParentNode>.getChildren()
 
     override fun getChildrenInternal(): List<AwsExplorerNode<*>> {
-        val resourceCache = AwsResourceCache.getInstance(nodeProject)
         val registryName = value.registryName()
-        return resourceCache
+        return nodeProject
             .getResourceNow(SchemasResources.listSchemas(registryName))
             .map { schema -> SchemaNode(nodeProject, schema.toDataClass(registryName)) }
             .toList()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/DownloadCodeForSchemaDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/DownloadCodeForSchemaDialog.kt
@@ -18,7 +18,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import org.apache.commons.lang.exception.ExceptionUtils
 import software.amazon.awssdk.services.schemas.model.SchemaVersionSummary
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
+import software.aws.toolkits.jetbrains.core.getResourceNow
 import software.aws.toolkits.jetbrains.core.help.HelpIds
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.schemas.Schema
@@ -102,11 +102,10 @@ class DownloadCodeForSchemaDialog(
         return null
     }
 
-    private fun loadSchemaVersions(): List<String> =
-        AwsResourceCache.getInstance(project)
-            .getResourceNow(SchemasResources.getSchemaVersions(registryName, schemaName))
-            .map(SchemaVersionSummary::schemaVersion)
-            .sortedByDescending { s -> s.toIntOrNull() }
+    private fun loadSchemaVersions(): List<String> = project
+        .getResourceNow(SchemasResources.getSchemaVersions(registryName, schemaName))
+        .map(SchemaVersionSummary::schemaVersion)
+        .sortedByDescending { s -> s.toIntOrNull() }
 
     private fun getLanguageForCurrentRuntime(): SchemaCodeLangs? {
         val currentRuntimeGroup = RuntimeGroup.determineRuntimeGroup(project) ?: return null

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/search/SchemaSearchExecutor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/search/SchemaSearchExecutor.kt
@@ -10,8 +10,8 @@ import software.amazon.awssdk.services.schemas.SchemasClient
 import software.amazon.awssdk.services.schemas.model.SearchSchemasRequest
 import software.amazon.awssdk.services.schemas.model.SearchSchemasResponse
 import software.aws.toolkits.core.utils.warn
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.awsClient
+import software.aws.toolkits.jetbrains.core.getResource
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 
 class SchemaSearchExecutor(
@@ -40,7 +40,7 @@ class SchemaSearchExecutor(
         incrementalResultsCallback: OnSearchResultReturned,
         registrySearchErrorCallback: OnSearchResultError
     ) {
-        AwsResourceCache.getInstance(project).getResource(SchemasResources.LIST_REGISTRIES)
+        project.getResource(SchemasResources.LIST_REGISTRIES)
             .thenApply {
                 it.forEach { registry ->
                     val registryName = registry.registryName()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
@@ -15,8 +15,8 @@ import software.aws.toolkits.core.telemetry.MetricEvent
 import software.aws.toolkits.core.telemetry.TelemetryBatcher
 import software.aws.toolkits.core.telemetry.TelemetryPublisher
 import software.aws.toolkits.core.utils.tryOrNull
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.credentials.activeRegion
+import software.aws.toolkits.jetbrains.core.getResourceIfPresent
 import software.aws.toolkits.jetbrains.services.sts.StsResources
 import software.aws.toolkits.jetbrains.settings.AwsSettings
 import java.util.concurrent.atomic.AtomicBoolean
@@ -42,7 +42,7 @@ abstract class TelemetryService(private val publisher: TelemetryPublisher, priva
         record(metricEventMetadata, buildEvent)
     }
 
-    private fun Project.activeAwsAccountIfKnown(): String? = tryOrNull { AwsResourceCache.getInstance(this).getResourceIfPresent(StsResources.ACCOUNT) }
+    private fun Project.activeAwsAccountIfKnown(): String? = tryOrNull { this.getResourceIfPresent(StsResources.ACCOUNT) }
 
     @Synchronized
     fun setTelemetryEnabled(isEnabled: Boolean) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ResourceSelector.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ResourceSelector.kt
@@ -43,8 +43,6 @@ class ResourceSelector<T> private constructor(
     private val sortOnLoad: Boolean,
     private val awsConnection: LazyAwsConnectionEvaluator
 ) : ComboBox<T>(comboBoxModel) {
-
-    private val resourceCache = AwsResourceCache.getInstance(project)
     @Volatile
     private var loadingStatus: Status = Status.NOT_LOADED
     private var shouldBeEnabled: Boolean = isEnabled
@@ -83,7 +81,7 @@ class ResourceSelector<T> private constructor(
                 processSuccess(emptyList(), null)
             } else {
                 val (region, credentials) = awsConnection()
-                val resultFuture = resourceCache.getResource(resource, region, credentials, forceFetch = forceFetch).toCompletableFuture()
+                val resultFuture = AwsResourceCache.getInstance().getResource(resource, region, credentials, forceFetch = forceFetch).toCompletableFuture()
                 loadingFuture = resultFuture
                 resultFuture.whenComplete { value, error ->
                     when {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -78,7 +78,7 @@ class AwsResourceCacheTest {
 
         connectionSettings = ConnectionSettings(credentialsManager.createCredentialProvider(), regionProviderRule.createAwsRegion())
 
-        sut = DefaultAwsResourceCache(projectRule.project, mockClock, 1000, Duration.ofMinutes(1))
+        sut = DefaultAwsResourceCache(mockClock, 1000, Duration.ofMinutes(1))
         sut.clear()
 
         reset(mockClock, mockResource)
@@ -200,7 +200,7 @@ class AwsResourceCacheTest {
         val usw2Cred1 = sut.getResource(mockResource, US_WEST_2, cred1Provider).value
         val usw2Cred2 = sut.getResource(mockResource, US_WEST_2, cred2Provider).value
 
-        sut.clear(mockResource, region = US_WEST_1, credentialProvider = cred1Provider)
+        sut.clear(mockResource, ConnectionSettings(cred1Provider, US_WEST_1))
 
         assertThat(sut.getResource(mockResource, US_WEST_1, cred1Provider)).wait().isCompletedWithValueMatching { it != usw1Cred1 }
         assertThat(sut.getResource(mockResource, US_WEST_1, cred2Provider)).hasValue(usw1Cred2)
@@ -262,7 +262,7 @@ class AwsResourceCacheTest {
 
     @Test
     fun cacheIsRegularlyPrunedToEnsureItDoesntGrowTooLarge() {
-        val localSut = DefaultAwsResourceCache(projectRule.project, mockClock, 5, Duration.ofMillis(50))
+        val localSut = DefaultAwsResourceCache(mockClock, 5, Duration.ofMillis(50))
 
         val now = Instant.now()
         whenever(mockClock.instant()).thenReturn(now)
@@ -284,7 +284,7 @@ class AwsResourceCacheTest {
 
     @Test
     fun pruningConsidersCollectionEntriesBasedOnTheirSize() {
-        val localSut = DefaultAwsResourceCache(projectRule.project, mockClock, 5, Duration.ofMillis(50))
+        val localSut = DefaultAwsResourceCache(mockClock, 5, Duration.ofMillis(50))
 
         val listResource = DummyResource("list", listOf("a", "b", "c", "d"))
         val now = Instant.now()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.core
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.project.Project
 import com.intellij.testFramework.ProjectRule
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.atLeastOnce
@@ -25,11 +24,14 @@ import org.junit.Test
 import software.aws.toolkits.core.credentials.CredentialIdentifier
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.core.region.aRegionId
 import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.core.utils.test.retryableAssert
+import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
 import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProvider.RegionProviderRule
 import software.aws.toolkits.jetbrains.utils.hasException
 import software.aws.toolkits.jetbrains.utils.hasValue
 import software.aws.toolkits.jetbrains.utils.value
@@ -48,14 +50,20 @@ class AwsResourceCacheTest {
     @JvmField
     val projectRule = ProjectRule()
 
+    @Rule
+    @JvmField
+    val regionProviderRule = RegionProviderRule()
+
     private val mockClock = mock<Clock>()
     private val mockResource = mock<Resource.Cached<String>>()
 
     private lateinit var sut: AwsResourceCache
+
     private lateinit var cred1Identifier: CredentialIdentifier
     private lateinit var cred1Provider: ToolkitCredentialsProvider
     private lateinit var cred2Identifier: CredentialIdentifier
     private lateinit var cred2Provider: ToolkitCredentialsProvider
+    private lateinit var connectionSettings: ConnectionSettings
 
     @Before
     fun setUp() {
@@ -67,6 +75,8 @@ class AwsResourceCacheTest {
 
         cred2Identifier = credentialsManager.addCredentials("Cred2")
         cred2Provider = credentialsManager.getAwsCredentialProvider(cred2Identifier, MockRegionProvider.getInstance().defaultRegion())
+
+        connectionSettings = ConnectionSettings(credentialsManager.createCredentialProvider(), regionProviderRule.createAwsRegion())
 
         sut = DefaultAwsResourceCache(projectRule.project, mockClock, 1000, Duration.ofMinutes(1))
         sut.clear()
@@ -84,52 +94,56 @@ class AwsResourceCacheTest {
 
     @Test
     fun basicCachingWorks() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
 
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
+
         verifyResourceCalled(times = 1)
     }
 
     @Test
     fun expirationWorks() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
 
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
         whenever(mockClock.instant()).thenReturn(Instant.now().plus(DEFAULT_EXPIRY))
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
+
         verifyResourceCalled(times = 2)
     }
 
     @Test
     fun exceptionsAreBubbledWhenNoEntry() {
-        doAnswer { throw Throwable("Bang!") }.whenever(mockResource).fetch(any(), any(), any())
-        assertThat(sut.getResource(mockResource)).hasException.withFailMessage("Bang!")
+        doAnswer { throw Throwable("Bang!") }.whenever(mockResource).fetch(any(), any())
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasException.withFailMessage("Bang!")
     }
 
     @Test
     fun exceptionsAreLoggedButStaleEntryReturnedByDefault() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello").doThrow(RuntimeException("BOOM"))
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello").doThrow(RuntimeException("BOOM"))
 
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
         whenever(mockClock.instant()).thenReturn(Instant.now().plus(DEFAULT_EXPIRY))
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
     }
 
     @Test
     fun exceptionsAreBubbledWhenExistingEntryExpiredAndUseStaleIsFalse() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello").doThrow(RuntimeException("BOOM"))
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello").doThrow(RuntimeException("BOOM"))
 
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
         whenever(mockClock.instant()).thenReturn(Instant.now().plus(DEFAULT_EXPIRY))
-        assertThat(sut.getResource(mockResource, useStale = false)).hasException
+        assertThat(sut.getResource(mockResource, connectionSettings, useStale = false)).hasException
     }
 
     @Test
     fun cacheEntriesAreSeparatedByRegionAndCredentials() {
-        whenever(mockResource.fetch(any(), any(), any())).thenAnswer {
-            val region = it.getArgument<AwsRegion>(1)
-            val cred = it.getArgument<ToolkitCredentialsProvider>(2)
+        val region1 = aRegionId()
+
+        whenever(mockResource.fetch(any(), any())).thenAnswer {
+            val region = it.getArgument<AwsRegion>(0)
+            val cred = it.getArgument<ToolkitCredentialsProvider>(1)
             "${region.id}-${cred.id}"
         }
 
@@ -144,31 +158,40 @@ class AwsResourceCacheTest {
 
     @Test
     fun cacheCanBeCleared() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello").thenReturn("goodbye")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello").thenReturn("goodbye")
 
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
+
         sut.clear()
-        assertThat(sut.getResource(mockResource)).hasValue("goodbye")
-        assertThat(sut.getResource(mockResource)).hasValue("goodbye")
+
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("goodbye")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("goodbye")
+
         verifyResourceCalled(times = 2)
     }
 
     @Test
     fun cacheCanBeClearedByKey() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello").thenReturn("goodbye")
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
-        sut.clear(mockResource)
-        assertThat(sut.getResource(mockResource)).hasValue("goodbye")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello").thenReturn("goodbye")
+
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
+
+        sut.clear(mockResource, connectionSettings)
+
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("goodbye")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("goodbye")
+
         verifyResourceCalled(times = 2)
     }
 
     @Test
     fun cacheCanBeClearedByKeyAndConnection() {
         val incrementer = AtomicInteger(0)
-        whenever(mockResource.fetch(any(), any(), any())).thenAnswer {
-            val region = it.getArgument<AwsRegion>(1)
-            val cred = it.getArgument<ToolkitCredentialsProvider>(2)
+        whenever(mockResource.fetch(any(), any())).thenAnswer {
+            val region = it.getArgument<AwsRegion>(0)
+            val cred = it.getArgument<ToolkitCredentialsProvider>(1)
             "${region.id}-${cred.id}-${incrementer.getAndIncrement()}"
         }
 
@@ -188,10 +211,12 @@ class AwsResourceCacheTest {
 
     @Test
     fun canForceCacheRefresh() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello").thenReturn("goodbye")
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
-        assertThat(sut.getResource(mockResource, forceFetch = true)).hasValue("goodbye")
-        assertThat(sut.getResource(mockResource)).hasValue("goodbye")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello").thenReturn("goodbye")
+
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings, forceFetch = true)).hasValue("goodbye")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("goodbye")
+
         verifyResourceCalled(times = 2)
     }
 
@@ -204,33 +229,33 @@ class AwsResourceCacheTest {
 
     @Test
     fun viewsCanBeCreatedOnTopOfOtherCachedItems() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
         val viewResource = Resource.View(mockResource) { toList() }
 
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
-        assertThat(sut.getResource(viewResource)).hasValue(listOf('h', 'e', 'l', 'l', 'o'))
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
+        assertThat(sut.getResource(viewResource, connectionSettings)).hasValue(listOf('h', 'e', 'l', 'l', 'o'))
         verifyResourceCalled(times = 1)
     }
 
     @Test
     fun mapFilterAndFindExtensionsToEasilyCreateViews() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
         val viewResource = Resource.View(mockResource) { toList() }
 
         val filteredAndMapped = viewResource.filter { it != 'l' }.map { it.toUpperCase() }
-        assertThat(sut.getResource(filteredAndMapped)).hasValue(listOf('H', 'E', 'O'))
+        assertThat(sut.getResource(filteredAndMapped, connectionSettings)).hasValue(listOf('H', 'E', 'O'))
 
         val find = viewResource.find { it == 'l' }
-        assertThat(sut.getResource(find)).hasValue('l')
+        assertThat(sut.getResource(find, connectionSettings)).hasValue('l')
     }
 
     @Test
     fun clearingViewsClearTheUnderlyingCachedResource() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
         val viewResource = Resource.View(mockResource) { toList() }
-        sut.getResource(viewResource).value
-        sut.clear(viewResource)
-        sut.getResource(viewResource).value
+        sut.getResource(viewResource, connectionSettings).value
+        sut.clear(viewResource, connectionSettings)
+        sut.getResource(viewResource, connectionSettings).value
 
         verifyResourceCalled(times = 2)
     }
@@ -241,16 +266,19 @@ class AwsResourceCacheTest {
 
         val now = Instant.now()
         whenever(mockClock.instant()).thenReturn(now)
-        localSut.getResource(StringResource("1")).value
+
+        localSut.getResource(StringResource("1"), connectionSettings).value
+
         whenever(mockClock.instant()).thenReturn(now.plusMillis(10))
-        localSut.getResource(StringResource("2")).value
-        localSut.getResource(StringResource("3")).value
-        localSut.getResource(StringResource("4")).value
-        localSut.getResource(StringResource("5")).value
-        localSut.getResource(StringResource("6")).value
+
+        localSut.getResource(StringResource("2"), connectionSettings).value
+        localSut.getResource(StringResource("3"), connectionSettings).value
+        localSut.getResource(StringResource("4"), connectionSettings).value
+        localSut.getResource(StringResource("5"), connectionSettings).value
+        localSut.getResource(StringResource("6"), connectionSettings).value
 
         retryableAssert {
-            assertThat(localSut.getResourceIfPresent(StringResource("1"))).isNull()
+            assertThat(localSut.getResourceIfPresent(StringResource("1"), connectionSettings)).isNull()
         }
     }
 
@@ -261,21 +289,24 @@ class AwsResourceCacheTest {
         val listResource = DummyResource("list", listOf("a", "b", "c", "d"))
         val now = Instant.now()
         whenever(mockClock.instant()).thenReturn(now)
-        localSut.getResource(listResource).value
+
+        localSut.getResource(listResource, connectionSettings).value
+
         whenever(mockClock.instant()).thenReturn(now.plusMillis(10))
-        localSut.getResource(StringResource("1")).value
-        localSut.getResource(StringResource("2")).value
+
+        localSut.getResource(StringResource("1"), connectionSettings).value
+        localSut.getResource(StringResource("2"), connectionSettings).value
 
         retryableAssert {
-            assertThat(localSut.getResourceIfPresent(listResource)).isNull()
-            assertThat(localSut.getResourceIfPresent(StringResource("1"))).isNotEmpty()
-            assertThat(localSut.getResourceIfPresent(StringResource("2"))).isNotEmpty()
+            assertThat(localSut.getResourceIfPresent(listResource, connectionSettings)).isNull()
+            assertThat(localSut.getResourceIfPresent(StringResource("1"), connectionSettings)).isNotEmpty()
+            assertThat(localSut.getResourceIfPresent(StringResource("2"), connectionSettings)).isNotEmpty()
         }
     }
 
     @Test
     fun multipleCallsInDifferentThreadsStillOnlyCallTheUnderlyingResourceOnce() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
         val concurrency = 200
 
         val latch = CountDownLatch(1)
@@ -285,7 +316,7 @@ class AwsResourceCacheTest {
                 val future = CompletableFuture<String>()
                 executor.submit {
                     latch.await()
-                    sut.getResource(mockResource).whenComplete { result, error ->
+                    sut.getResource(mockResource, connectionSettings).whenComplete { result, error ->
                         when {
                             result != null -> future.complete(result)
                             error != null -> future.completeExceptionally(error)
@@ -304,79 +335,80 @@ class AwsResourceCacheTest {
     }
 
     @Test
-    fun cachingShouldBeBasedOnId() {
+    fun cachingShouldBeBasedOnResourceId() {
         val first = StringResource("first")
         val anotherFirst = StringResource("first")
 
-        sut.getResource(first).value
-        sut.getResource(anotherFirst).value
+        sut.getResource(first, connectionSettings).value
+        sut.getResource(anotherFirst, connectionSettings).value
+
         assertThat(first.callCount).hasValue(1)
         assertThat(anotherFirst.callCount).hasValue(0)
     }
 
     @Test
     fun whenACredentialIdIsRemovedItsEntriesAreRemovedFromTheCache() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
         getAllRegionAndCredPermutations()
 
         ApplicationManager.getApplication().messageBus.syncPublisher(CredentialManager.CREDENTIALS_CHANGED).providerRemoved(cred1Identifier)
 
         getAllRegionAndCredPermutations()
 
-        verify(mockResource, times(2)).fetch(projectRule.project, US_WEST_1, cred1Provider)
-        verify(mockResource, times(2)).fetch(projectRule.project, US_WEST_2, cred1Provider)
-        verify(mockResource, times(1)).fetch(projectRule.project, US_WEST_1, cred2Provider)
-        verify(mockResource, times(1)).fetch(projectRule.project, US_WEST_2, cred2Provider)
+        verify(mockResource, times(2)).fetch(US_WEST_1, cred1Provider)
+        verify(mockResource, times(2)).fetch(US_WEST_2, cred1Provider)
+        verify(mockResource, times(1)).fetch(US_WEST_1, cred2Provider)
+        verify(mockResource, times(1)).fetch(US_WEST_2, cred2Provider)
     }
 
     @Test
     fun whenACredentialIdIsModifiedItsEntriesAreRemovedFromTheCache() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
         getAllRegionAndCredPermutations()
 
         ApplicationManager.getApplication().messageBus.syncPublisher(CredentialManager.CREDENTIALS_CHANGED).providerModified(cred1Identifier)
 
         getAllRegionAndCredPermutations()
 
-        verify(mockResource, times(2)).fetch(projectRule.project, US_WEST_1, cred1Provider)
-        verify(mockResource, times(2)).fetch(projectRule.project, US_WEST_2, cred1Provider)
-        verify(mockResource, times(1)).fetch(projectRule.project, US_WEST_1, cred2Provider)
-        verify(mockResource, times(1)).fetch(projectRule.project, US_WEST_2, cred2Provider)
+        verify(mockResource, times(2)).fetch(US_WEST_1, cred1Provider)
+        verify(mockResource, times(2)).fetch(US_WEST_2, cred1Provider)
+        verify(mockResource, times(1)).fetch(US_WEST_1, cred2Provider)
+        verify(mockResource, times(1)).fetch(US_WEST_2, cred2Provider)
     }
 
     @Test
     fun cacheExposesBlockingApi() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
-        assertThat(sut.getResourceNow(mockResource)).isEqualTo("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
+        assertThat(sut.getResourceNow(mockResource, connectionSettings)).isEqualTo("hello")
     }
 
     @Test
     fun cacheExposesBlockingApiWithRegionAndCred() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
         assertThat(sut.getResourceNow(mockResource, US_WEST_1, cred1Provider)).isEqualTo("hello")
-        verify(mockResource).fetch(projectRule.project, US_WEST_1, cred1Provider)
+        verify(mockResource).fetch(US_WEST_1, cred1Provider)
     }
 
     @Test
     fun cacheExposesBlockingApiWhereExecutionExceptionIsUnwrapped() {
-        whenever(mockResource.fetch(any(), any(), any())).thenThrow(RuntimeException("boom"))
-        assertThatThrownBy { sut.getResourceNow(mockResource, timeout = Duration.ofMillis(5)) }
+        whenever(mockResource.fetch(any(), any())).thenThrow(RuntimeException("boom"))
+        assertThatThrownBy { sut.getResourceNow(mockResource, connectionSettings, timeout = Duration.ofMillis(5)) }
             .isInstanceOf(RuntimeException::class.java)
             .withFailMessage("boom")
     }
 
     @Test
     fun cacheExposesBlockingApiWithTimeout() {
-        whenever(mockResource.fetch(any(), any(), any())).thenAnswer {
+        whenever(mockResource.fetch(any(), any())).thenAnswer {
             Thread.sleep(50)
             "hello"
         }
-        assertThatThrownBy { sut.getResourceNow(mockResource, timeout = Duration.ofMillis(5)) }.isInstanceOf(TimeoutException::class.java)
+        assertThatThrownBy { sut.getResourceNow(mockResource, connectionSettings, timeout = Duration.ofMillis(5)) }.isInstanceOf(TimeoutException::class.java)
     }
 
     @Test
     fun canConditionallyFetchOnlyIfAvailableInCache() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
 
         assertThat(sut.getResourceIfPresent(mockResource, US_WEST_1, cred1Provider)).isNull()
         sut.getResource(mockResource, US_WEST_1, cred1Provider).value
@@ -385,7 +417,7 @@ class AwsResourceCacheTest {
 
     @Test
     fun canConditionallyFetchOnlyIfAvailableInCacheAndRespectExpiry() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
 
         val now = Instant.now()
         whenever(mockClock.instant()).thenReturn(now)
@@ -397,7 +429,7 @@ class AwsResourceCacheTest {
 
     @Test
     fun canConditionallyFetchViewOnlyIfAvailableInCache() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
         val viewResource = Resource.View(mockResource) { reversed() }
 
         assertThat(sut.getResourceIfPresent(viewResource, US_WEST_1, cred1Provider)).isNull()
@@ -407,10 +439,10 @@ class AwsResourceCacheTest {
 
     @Test
     fun canConditionallyFetchOnlyIfAvailableWithoutExplicitCredentialsRegion() {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello")
-        sut.getResource(mockResource).value
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello")
+        sut.getResource(mockResource, connectionSettings).value
 
-        assertThat(sut.getResourceIfPresent(mockResource)).isEqualTo("hello")
+        assertThat(sut.getResourceIfPresent(mockResource, connectionSettings)).isEqualTo("hello")
     }
 
     private fun getAllRegionAndCredPermutations() {
@@ -421,24 +453,24 @@ class AwsResourceCacheTest {
     }
 
     private fun assertExpectedExpiryFunctions(expiryFunction: Instant.() -> Instant, shouldExpire: Boolean) {
-        whenever(mockResource.fetch(any(), any(), any())).thenReturn("hello", "goodbye")
+        whenever(mockResource.fetch(any(), any())).thenReturn("hello", "goodbye")
         whenever(mockResource.expiry()).thenReturn(Duration.ofSeconds(1))
         val now = Instant.now()
         val expiry = now.plus(Duration.ofSeconds(1))
         whenever(mockClock.instant()).thenReturn(now)
-        assertThat(sut.getResource(mockResource)).hasValue("hello")
+        assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
 
         whenever(mockClock.instant()).thenReturn(expiryFunction(expiry))
         when (shouldExpire) {
-            true -> assertThat(sut.getResource(mockResource)).hasValue("goodbye")
-            false -> assertThat(sut.getResource(mockResource)).hasValue("hello")
+            true -> assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("goodbye")
+            false -> assertThat(sut.getResource(mockResource, connectionSettings)).hasValue("hello")
         }
 
         sut.clear()
     }
 
     private fun verifyResourceCalled(times: Int, resource: Resource.Cached<*> = mockResource) {
-        verify(resource, times(times)).fetch(any(), any(), any())
+        verify(resource, times(times)).fetch(any(), any())
         verify(resource, times(times)).expiry()
         verify(resource, atLeastOnce()).id
         verifyNoMoreInteractions(resource)
@@ -453,7 +485,7 @@ class AwsResourceCacheTest {
         private open class DummyResource<T>(override val id: String, private val value: T) : Resource.Cached<T>() {
             val callCount = AtomicInteger(0)
 
-            override fun fetch(project: Project, region: AwsRegion, credentials: ToolkitCredentialsProvider): T {
+            override fun fetch(region: AwsRegion, credentials: ToolkitCredentialsProvider): T {
                 callCount.getAndIncrement()
                 return value
             }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
@@ -103,7 +103,7 @@ class ExecutableBackedCacheResourceTest {
             assertionBlock.invoke(this)
         }
 
-        return cacheResource.fetch(projectRule.project, MockRegionProvider.getInstance().defaultRegion(), mockCredentials())
+        return cacheResource.fetch(MockRegionProvider.getInstance().defaultRegion(), mockCredentials())
     }
 
     private fun mockCredentials(): ToolkitCredentialsProvider {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
@@ -4,27 +4,21 @@
 package software.aws.toolkits.jetbrains.core
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.intellij.testFramework.ProjectRule
-import org.junit.rules.ExternalResource
+import com.intellij.testFramework.ApplicationRule
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
-import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
-import software.aws.toolkits.jetbrains.services.sts.StsResources
-import software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule
+import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
+import software.aws.toolkits.jetbrains.core.credentials.activeCredentialProvider
+import software.aws.toolkits.jetbrains.core.credentials.activeRegion
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.ConcurrentHashMap
 
 @Suppress("UNCHECKED_CAST")
-class MockResourceCache(private val project: Project) : AwsResourceCache {
-
+class MockResourceCache : AwsResourceCache {
     private val map = ConcurrentHashMap<CacheKey, Any>()
-    private val accountSettings by lazy { AwsConnectionManager.getInstance(project) }
-
-    override fun <T> getResourceIfPresent(resource: Resource<T>, useStale: Boolean): T? =
-        getResourceIfPresent(resource, accountSettings.activeRegion, accountSettings.activeCredentialProvider, useStale)
 
     override fun <T> getResourceIfPresent(
         resource: Resource<T>,
@@ -35,9 +29,6 @@ class MockResourceCache(private val project: Project) : AwsResourceCache {
         is Resource.View<*, T> -> getResourceIfPresent(resource.underlying, region, credentialProvider)?.let { resource.doMap(it) }
         is Resource.Cached<T> -> mockResourceIfPresent(resource, region, credentialProvider)
     }
-
-    override fun <T> getResource(resource: Resource<T>, useStale: Boolean, forceFetch: Boolean): CompletionStage<T> =
-        getResource(resource, accountSettings.activeRegion, accountSettings.activeCredentialProvider, useStale, forceFetch)
 
     override fun <T> getResource(
         resource: Resource<T>,
@@ -77,10 +68,6 @@ class MockResourceCache(private val project: Project) : AwsResourceCache {
         }
     }
 
-    override fun clear(resource: Resource<*>) {
-        clear(resource, accountSettings.activeRegion, accountSettings.activeCredentialProvider)
-    }
-
     override fun clear(resource: Resource<*>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider) {
         when (resource) {
             is Resource.Cached<*> -> map.remove(CacheKey(resource.id, region.id, credentialProvider.id))
@@ -88,17 +75,15 @@ class MockResourceCache(private val project: Project) : AwsResourceCache {
         }
     }
 
+    override fun clear(connectionSettings: ConnectionSettings) {
+        map.keys.removeIf { it.credentialsId == connectionSettings.credentials.id && it.regionId == connectionSettings.region.id }
+    }
+
     override fun clear() {
         map.clear()
     }
 
     fun entryCount() = map.size
-
-    fun <T> addEntry(resource: Resource.Cached<T>, value: T) =
-        addEntry(resource, accountSettings.activeRegion.id, accountSettings.activeCredentialProvider.id, value)
-
-    fun <T> addEntry(resource: Resource.Cached<T>, value: CompletableFuture<T>) =
-        addEntry(resource, accountSettings.activeRegion.id, accountSettings.activeCredentialProvider.id, value)
 
     fun <T> addEntry(resource: Resource.Cached<T>, regionId: String, credentialsId: String, value: T) {
         map[CacheKey(resource.id, regionId, credentialsId)] = value as Any
@@ -108,39 +93,34 @@ class MockResourceCache(private val project: Project) : AwsResourceCache {
         map[CacheKey(resource.id, regionId, credentialsId)] = value as Any
     }
 
-    fun addValidAwsCredential(regionId: String, credentialsId: String, awsAccountId: String) {
-        map[CacheKey(StsResources.ACCOUNT.id, regionId, credentialsId)] = awsAccountId as Any
-    }
-
-    fun addInvalidAwsCredential(regionId: String, credentialsId: String) {
-        val future = CompletableFuture<String>()
-        ApplicationManager.getApplication().executeOnPooledThread {
-            future.completeExceptionally(IllegalStateException("Invalid AWS credentials $credentialsId"))
-        }
-        map[CacheKey(StsResources.ACCOUNT.id, regionId, credentialsId)] = future
-    }
-
     companion object {
         @JvmStatic
-        fun getInstance(project: Project): MockResourceCache = ServiceManager.getService(project, AwsResourceCache::class.java) as MockResourceCache
+        fun getInstance(): MockResourceCache = service<AwsResourceCache>() as MockResourceCache
 
         private data class CacheKey(val resourceId: String, val regionId: String, val credentialsId: String)
     }
 }
 
-class MockResourceCacheRule(private val project: () -> Project) : ExternalResource() {
-    constructor(projectRule: ProjectRule) : this({ projectRule.project })
-    constructor(projectRule: CodeInsightTestFixtureRule) : this({ projectRule.project })
-
-    private lateinit var cache: MockResourceCache
-
-    override fun before() {
-        cache = MockResourceCache.getInstance(project())
-    }
+class MockResourceCacheRule : ApplicationRule() {
+    private val cache by lazy { MockResourceCache.getInstance() }
 
     override fun after() {
         cache.clear()
     }
 
-    fun get() = cache
+    fun <T> addEntry(project: Project, resource: Resource.Cached<T>, value: T) =
+        cache.addEntry(resource, project.activeRegion().id, project.activeCredentialProvider().id, value)
+
+    fun <T> addEntry(project: Project, resource: Resource.Cached<T>, value: CompletableFuture<T>) =
+        cache.addEntry(resource, project.activeRegion().id, project.activeCredentialProvider().id, value)
+
+    fun <T> addEntry(resource: Resource.Cached<T>, regionId: String, credentialsId: String, value: T) {
+        cache.addEntry(resource, regionId, credentialsId, value)
+    }
+
+    fun <T> addEntry(resource: Resource.Cached<T>, regionId: String, credentialsId: String, value: CompletableFuture<T>) {
+        cache.addEntry(resource, regionId, credentialsId, value)
+    }
+
+    fun size() = cache.entryCount()
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
@@ -68,10 +68,10 @@ class MockResourceCache : AwsResourceCache {
         }
     }
 
-    override fun clear(resource: Resource<*>, region: AwsRegion, credentialProvider: ToolkitCredentialsProvider) {
+    override fun clear(resource: Resource<*>, connectionSettings: ConnectionSettings) {
         when (resource) {
-            is Resource.Cached<*> -> map.remove(CacheKey(resource.id, region.id, credentialProvider.id))
-            is Resource.View<*, *> -> clear(resource.underlying, region, credentialProvider)
+            is Resource.Cached<*> -> map.remove(CacheKey(resource.id, connectionSettings.region.id, connectionSettings.credentials.id))
+            is Resource.View<*, *> -> clear(resource.underlying, connectionSettings)
         }
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/TestUtils.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/TestUtils.kt
@@ -3,35 +3,39 @@
 
 package software.aws.toolkits.jetbrains.core
 
+import com.intellij.openapi.project.Project
 import com.nhaarman.mockitokotlin2.mock
 import software.amazon.awssdk.services.s3.model.Bucket
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.services.ecs.resources.EcsResources
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
 
-fun fillResourceCache(resourceCache: MockResourceCache) {
-    resourceCache.addEntry(
+fun MockResourceCacheRule.fillResourceCache(project: Project) {
+    this.addEntry(
+        project,
         EcsResources.LIST_CLUSTER_ARNS,
         listOf("arn2", "arn3")
     )
 
-    resourceCache.addEntry(
+    this.addEntry(
+        project,
         S3Resources.LIST_REGIONALIZED_BUCKETS,
         listOf(S3Resources.RegionalizedBucket(Bucket.builder().name("abc").build(), AwsRegion.GLOBAL))
     )
 
-    resourceCache.addEntry(
+    this.addEntry(
+        project,
         makeMockList("arn2"),
         listOf("service1", "service2")
     )
 
-    resourceCache.addEntry(
+    this.addEntry(
+        project,
         makeMockList("arn3"),
         listOf("service1", "service2")
     )
 }
 
-fun makeMockList(clusterArn: String): Resource.Cached<List<String>> =
-    mock {
-        on { id }.thenReturn("ecs.list_services.$clusterArn")
-    }
+fun makeMockList(clusterArn: String): Resource.Cached<List<String>> = mock {
+    on { id }.thenReturn("ecs.list_services.$clusterArn")
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/RefreshConnectionActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/RefreshConnectionActionTest.kt
@@ -13,21 +13,23 @@ import software.aws.toolkits.core.credentials.aToolkitCredentialsProvider
 import software.aws.toolkits.core.region.anAwsRegion
 import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.jetbrains.core.AwsResourceCacheTest.Companion.dummyResource
-import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import java.util.concurrent.ConcurrentHashMap
 
-internal class RefreshConnectionActionTest {
-
+class RefreshConnectionActionTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
+
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
 
     private val sut = RefreshConnectionAction()
 
     @Test
     fun refreshActionClearsCacheAndUpdatesConnectionState() {
-        val mockResourceCache = MockResourceCache.getInstance(projectRule.project)
-        mockResourceCache.addEntry(dummyResource(), aString())
+        resourceCache.addEntry(projectRule.project, dummyResource(), aString())
 
         val states = ConcurrentHashMap.newKeySet<ConnectionState>()
         projectRule.project.messageBus.connect()
@@ -42,7 +44,7 @@ internal class RefreshConnectionActionTest {
 
         sut.actionPerformed(testAction())
 
-        assertThat(mockResourceCache.entryCount()).isZero()
+        assertThat(resourceCache.size()).isZero()
         assertThat(states).hasAtLeastOneElementOfType(ConnectionState.ValidatingConnection::class.java)
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerNodeProcessorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerNodeProcessorTest.kt
@@ -20,7 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.fillResourceCache
 import software.aws.toolkits.jetbrains.ui.tree.AsyncTreeModel
@@ -38,9 +38,13 @@ class AwsExplorerNodeProcessorTest {
     @JvmField
     val disposableRule = DisposableRule()
 
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
+
     @Before
     fun setUp() {
-        fillResourceCache(resourceCache())
+        resourceCache.fillResourceCache(projectRule.project)
     }
 
     @Test
@@ -99,6 +103,4 @@ class AwsExplorerNodeProcessorTest {
         val structureTreeModel = StructureTreeModel(awsTreeModel, disposableRule.disposable)
         return AsyncTreeModel(structureTreeModel, true, disposableRule.disposable)
     }
-
-    private fun resourceCache() = MockResourceCache.getInstance(projectRule.project)
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerTreeStructureProviderTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerTreeStructureProviderTest.kt
@@ -17,7 +17,7 @@ import com.nhaarman.mockitokotlin2.verify
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.fillResourceCache
 import software.aws.toolkits.jetbrains.ui.tree.AsyncTreeModel
 import software.aws.toolkits.jetbrains.ui.tree.StructureTreeModel
@@ -34,9 +34,13 @@ class AwsExplorerTreeStructureProviderTest {
     @JvmField
     val disposableRule = DisposableRule()
 
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
+
     @Before
     fun setUp() {
-        fillResourceCache(resourceCache())
+        resourceCache.fillResourceCache(projectRule.project)
     }
 
     @Test
@@ -68,6 +72,4 @@ class AwsExplorerTreeStructureProviderTest {
         val structureTreeModel = StructureTreeModel(awsTreeModel, disposableRule.disposable)
         return AsyncTreeModel(structureTreeModel, false, disposableRule.disposable)
     }
-
-    private fun resourceCache() = MockResourceCache.getInstance(projectRule.project)
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationServiceNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationServiceNodeTest.kt
@@ -5,12 +5,11 @@ package software.aws.toolkits.jetbrains.services.cloudformation
 
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.cloudformation.model.StackStatus
 import software.amazon.awssdk.services.cloudformation.model.StackSummary
-import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CloudFormationExplorerRootNode
 import software.aws.toolkits.jetbrains.services.cloudformation.resources.CloudFormationResources
@@ -22,14 +21,13 @@ class CloudFormationServiceNodeTest {
     @Rule
     val projectRule = ProjectRule()
 
-    @Before
-    fun setUp() {
-        resourceCache().clear()
-    }
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
 
     @Test
     fun completedStacksAreShown() {
-        resourceCache().stacksWithNames(listOf("Stack" to StackStatus.CREATE_COMPLETE))
+        stacksWithNames(listOf("Stack" to StackStatus.CREATE_COMPLETE))
 
         val node = CloudFormationServiceNode(projectRule.project, CF_EXPLORER_NODE)
 
@@ -38,7 +36,7 @@ class CloudFormationServiceNodeTest {
 
     @Test
     fun deletedStacksAreNotShown() {
-        resourceCache().stacksWithNames(listOf("Stack" to StackStatus.DELETE_COMPLETE))
+        stacksWithNames(listOf("Stack" to StackStatus.DELETE_COMPLETE))
 
         val node = CloudFormationServiceNode(projectRule.project, CF_EXPLORER_NODE)
 
@@ -47,17 +45,16 @@ class CloudFormationServiceNodeTest {
 
     @Test
     fun noStacksShowsEmptyNode() {
-        resourceCache().stacksWithNames(emptyList())
+        stacksWithNames(emptyList())
 
         val node = CloudFormationServiceNode(projectRule.project, CF_EXPLORER_NODE)
 
         assertThat(node.children).hasOnlyElementsOfType(AwsExplorerEmptyNode::class.java)
     }
 
-    private fun resourceCache() = MockResourceCache.getInstance(projectRule.project)
-
-    private fun MockResourceCache.stacksWithNames(names: List<Pair<String, StackStatus>>) {
-        this.addEntry(
+    private fun stacksWithNames(names: List<Pair<String, StackStatus>>) {
+        resourceCache.addEntry(
+            projectRule.project,
             CloudFormationResources.LIST_STACKS,
             CompletableFuture.completedFuture(
                 names.map {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/ecs/execution/EcsCloudDebugRunConfigurationProducerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/ecs/execution/EcsCloudDebugRunConfigurationProducerTest.kt
@@ -12,21 +12,14 @@ import com.intellij.testFramework.MapDataContext
 import com.intellij.testFramework.ProjectRule
 import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.ecs.model.Service
-import software.aws.toolkits.jetbrains.core.MockResourceCache
 
 class EcsCloudDebugRunConfigurationProducerTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
-
-    @Before
-    fun setUp() {
-        resourceCache().clear()
-    }
 
     @Test
     fun validRunConfigurationIsCreated() {
@@ -59,6 +52,4 @@ class EcsCloudDebugRunConfigurationProducerTest {
         dataContext.put(Location.DATA_KEY, EcsCloudDebugLocation(projectRule.project, service))
         return ConfigurationContext.getFromContext(dataContext)
     }
-
-    private fun resourceCache() = MockResourceCache.getInstance(projectRule.project)
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaLineMarkerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaLineMarkerTest.kt
@@ -14,7 +14,7 @@ import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.FunctionConfiguration
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.amazon.awssdk.services.lambda.model.TracingMode
-import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager
 import software.aws.toolkits.jetbrains.services.lambda.resources.LambdaResources
 import software.aws.toolkits.jetbrains.services.lambda.upload.LambdaLineMarker
@@ -28,6 +28,10 @@ class JavaLambdaLineMarkerTest {
     @Rule
     @JvmField
     val projectRule = JavaCodeInsightTestFixtureRule()
+
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
 
     @Before
     fun setUp() {
@@ -521,7 +525,7 @@ Resources:
 
         val fixture = projectRule.fixture
         val future = CompletableFuture<List<FunctionConfiguration>>()
-        MockResourceCache.getInstance(fixture.project).addEntry(LambdaResources.LIST_FUNCTIONS, future)
+        resourceCache.addEntry(projectRule.project, LambdaResources.LIST_FUNCTIONS, future)
 
         fixture.openClass(
             """

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialogTest.kt
@@ -49,7 +49,7 @@ class EditFunctionDialogTest {
 
     @JvmField
     @Rule
-    val mockResourceCache = MockResourceCacheRule(projectRule)
+    val mockResourceCache = MockResourceCacheRule()
 
     private val mockSettingsManager by lazy { AwsConnectionManager.getInstance(projectRule.project) as MockAwsConnectionManager }
 
@@ -184,7 +184,8 @@ class EditFunctionDialogTest {
     }
 
     private fun mockBuckets() {
-        mockResourceCache.get().addEntry(
+        mockResourceCache.addEntry(
+            projectRule.project,
             S3Resources.LIST_REGIONALIZED_BUCKETS,
             listOf(
                 S3Resources.RegionalizedBucket(Bucket.builder().name("hello").build(), mockSettingsManager.activeRegion),

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/wizard/SchemaSelectionPanelTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/wizard/SchemaSelectionPanelTest.kt
@@ -14,7 +14,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.schemas.model.DescribeSchemaResponse
-import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.Resource
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SchemaSelectionPanelBase.Companion.DEFAULT_EVENT_DETAIL_TYPE
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SchemaSelectionPanelBase.Companion.DEFAULT_EVENT_SOURCE
@@ -32,6 +32,10 @@ class SchemaSelectionPanelTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
+
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
 
     private val AWSToolkitUserAgent = "AWSToolkit"
 
@@ -89,7 +93,8 @@ class SchemaSelectionPanelTest {
     }
 
     private fun initMockResourceCache() {
-        getMockResourceCache().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             SchemasResources.getSchema(REGISTRY_NAME, AWS_SCHEMA_NAME),
             DescribeSchemaResponse.builder()
                 .schemaName(AWS_SCHEMA_NAME)
@@ -97,7 +102,8 @@ class SchemaSelectionPanelTest {
                 .schemaVersion(SCHEMA_VERSION)
                 .build()
         )
-        getMockResourceCache().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             SchemasResources.getSchema(REGISTRY_NAME, PARTNER_SCHEMA_NAME),
             DescribeSchemaResponse.builder()
                 .schemaName(PARTNER_SCHEMA_NAME)
@@ -105,7 +111,8 @@ class SchemaSelectionPanelTest {
                 .schemaVersion(SCHEMA_VERSION)
                 .build()
         )
-        getMockResourceCache().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             SchemasResources.getSchema(REGISTRY_NAME, CUSTOMER_UPLOADED_SCHEMA_NAME),
             DescribeSchemaResponse.builder()
                 .schemaName(CUSTOMER_UPLOADED_SCHEMA_NAME)
@@ -113,7 +120,8 @@ class SchemaSelectionPanelTest {
                 .schemaVersion(SCHEMA_VERSION)
                 .build()
         )
-        getMockResourceCache().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             SchemasResources.getSchema(REGISTRY_NAME, CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES_NAME),
             DescribeSchemaResponse.builder()
                 .schemaName(CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES_NAME)
@@ -121,11 +129,11 @@ class SchemaSelectionPanelTest {
                 .schemaVersion(SCHEMA_VERSION)
                 .build()
         )
-        getMockResourceCache()
-            .addEntry(
-                LIST_REGISTRIES_AND_SCHEMAS,
-                listOf(REGISTRY_ITEM, AWS_SCHEMA_ITEM, PARTNER_SCHEMA_ITEM, CUSTOMER_UPLOADED_SCHEMA_ITEM, CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES_ITEM)
-            )
+        resourceCache.addEntry(
+            projectRule.project,
+            LIST_REGISTRIES_AND_SCHEMAS,
+            listOf(REGISTRY_ITEM, AWS_SCHEMA_ITEM, PARTNER_SCHEMA_ITEM, CUSTOMER_UPLOADED_SCHEMA_ITEM, CUSTOMER_UPLOADED_SCHEMA_MULTIPLE_TYPES_ITEM)
+        )
     }
 
     private fun initMockResourceSelector() {
@@ -266,6 +274,4 @@ class SchemaSelectionPanelTest {
         assertThat(schemaTemplateParameters?.templateExtraContext?.detailType).isEqualTo(DEFAULT_EVENT_DETAIL_TYPE)
         assertThat(schemaTemplateParameters?.templateExtraContext?.userAgent).isEqualTo(AWSToolkitUserAgent)
     }
-
-    private fun getMockResourceCache() = MockResourceCache.getInstance(projectRule.project)
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3ServiceNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3ServiceNodeTest.kt
@@ -4,12 +4,10 @@ package software.aws.toolkits.jetbrains.services.s3
 
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.s3.model.Bucket
-import software.aws.toolkits.jetbrains.core.MockResourceCache
-import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerErrorNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.S3ExplorerRootNode
@@ -24,16 +22,14 @@ class S3ServiceNodeTest {
     @Rule
     val projectRule = ProjectRule()
 
-    @Before
-    fun setUp() {
-        resourceCache().clear()
-        MockAwsConnectionManager.getInstance(projectRule.project).reset()
-    }
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
 
     @Test
     fun s3BucketsAreListed() {
         val bucketList = listOf("bcd", "abc", "AEF", "ZZZ")
-        resourceCache().s3buckets(bucketList)
+        s3buckets(bucketList)
         val children = S3ServiceNode(projectRule.project, S3_EXPLORER_NODE).children
 
         assertThat(children).allMatch { it is S3BucketNode }
@@ -47,15 +43,15 @@ class S3ServiceNodeTest {
 
     @Test
     fun noBucketsInTheRegion() {
-        val bucketList = emptyList<String>()
-        resourceCache().s3buckets(bucketList)
+        s3buckets(emptyList())
         val children = S3ServiceNode(projectRule.project, S3_EXPLORER_NODE).children
         assertThat(children).allMatch { it is AwsExplorerEmptyNode }
     }
 
     @Test
     fun errorLoadingBuckets() {
-        resourceCache().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             S3Resources.LIST_REGIONALIZED_BUCKETS,
             CompletableFuture<List<S3Resources.RegionalizedBucket>>().also {
                 it.completeExceptionally(RuntimeException("Simulated error"))
@@ -65,16 +61,14 @@ class S3ServiceNodeTest {
         assertThat(children).allMatch { it is AwsExplorerErrorNode }
     }
 
-    private fun bucketData(bucketName: String) =
-        Bucket.builder()
-            .creationDate(Instant.parse("1995-10-23T10:12:35Z"))
-            .name(bucketName)
-            .build()
+    private fun bucketData(bucketName: String) = Bucket.builder()
+        .creationDate(Instant.parse("1995-10-23T10:12:35Z"))
+        .name(bucketName)
+        .build()
 
-    private fun resourceCache() = MockResourceCache.getInstance(projectRule.project)
-
-    private fun MockResourceCache.s3buckets(names: List<String>) {
-        this.addEntry(
+    private fun s3buckets(names: List<String>) {
+        resourceCache.addEntry(
+            projectRule.project,
             S3Resources.LIST_REGIONALIZED_BUCKETS,
             CompletableFuture.completedFuture(names.map { S3Resources.RegionalizedBucket(bucketData(it), MockRegionProvider.getInstance().defaultRegion()) })
         )

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemaRegistryNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemaRegistryNodeTest.kt
@@ -5,13 +5,12 @@ package software.aws.toolkits.jetbrains.services.schemas
 
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.schemas.model.RegistrySummary
 import software.amazon.awssdk.services.schemas.model.SchemaSummary
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
-import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 import java.util.concurrent.CompletableFuture
 
@@ -25,10 +24,9 @@ class SchemaRegistryNodeTest {
     @Rule
     val mockClientManager = MockClientManagerRule()
 
-    @Before
-    fun setUp() {
-        resourceCache().clear()
-    }
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
 
     @Test
     fun showRegistrySchemas() {
@@ -37,7 +35,7 @@ class SchemaRegistryNodeTest {
 
         val schema1 = "schema1"
         val schema2 = "schema2"
-        resourceCache().registryWithSchemas(
+        registryWithSchemas(
             registry,
             listOf(
                 schema1,
@@ -53,10 +51,9 @@ class SchemaRegistryNodeTest {
 
     private fun aSchemaRegistryNode(registry: String) = SchemaRegistryNode(projectRule.project, RegistrySummary.builder().registryName(registry).build())
 
-    private fun resourceCache() = MockResourceCache.getInstance(projectRule.project)
-
-    private fun MockResourceCache.registryWithSchemas(registryName: String, schemas: List<String>) {
-        this.addEntry(
+    private fun registryWithSchemas(registryName: String, schemas: List<String>) {
+        resourceCache.addEntry(
+            projectRule.project,
             SchemasResources.listSchemas(registryName),
             CompletableFuture.completedFuture(
                 schemas.map {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasServiceNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasServiceNodeTest.kt
@@ -5,11 +5,10 @@ package software.aws.toolkits.jetbrains.services.schemas
 
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.schemas.model.RegistrySummary
-import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.SchemasExplorerRootNode
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
@@ -21,16 +20,15 @@ class SchemasServiceNodeTest {
     @Rule
     val projectRule = ProjectRule()
 
-    @Before
-    fun setUp() {
-        resourceCache().clear()
-    }
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
 
     @Test
     fun registriesAreShown() {
         val registry1 = "Registry1"
         val registry2 = "aws.events"
-        resourceCache().registries(listOf(registry1, registry2))
+        registries(listOf(registry1, registry2))
 
         val node = SchemasServiceNode(projectRule.project, SCHEMAS_EXPLORER_NODE)
 
@@ -41,17 +39,16 @@ class SchemasServiceNodeTest {
 
     @Test
     fun noRegistriesShowsEmptyNode() {
-        resourceCache().registries(emptyList())
+        registries(emptyList())
 
         val node = SchemasServiceNode(projectRule.project, SCHEMAS_EXPLORER_NODE)
 
         assertThat(node.children).hasOnlyElementsOfType(AwsExplorerEmptyNode::class.java)
     }
 
-    private fun resourceCache() = MockResourceCache.getInstance(projectRule.project)
-
-    private fun MockResourceCache.registries(names: List<String>) {
-        this.addEntry(
+    private fun registries(names: List<String>) {
+        resourceCache.addEntry(
+            projectRule.project,
             SchemasResources.LIST_REGISTRIES,
             CompletableFuture.completedFuture(
                 names.map {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/code/DownloadCodeForSchemaDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/code/DownloadCodeForSchemaDialogTest.kt
@@ -26,7 +26,7 @@ import org.junit.rules.TemporaryFolder
 import software.amazon.awssdk.services.schemas.model.SchemaVersionSummary
 import software.aws.toolkits.core.utils.failedFuture
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
-import software.aws.toolkits.jetbrains.core.MockResourceCache
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager
 import software.aws.toolkits.jetbrains.services.schemas.Schema
@@ -53,6 +53,10 @@ class DownloadCodeForSchemaDialogTest {
     @JvmField
     val tempFolder = TemporaryFolder()
 
+    @JvmField
+    @Rule
+    val resourceCache = MockResourceCacheRule()
+
     private lateinit var fileEditorManager: FileEditorManager
     private lateinit var mockSettingsManager: MockAwsConnectionManager
 
@@ -74,7 +78,7 @@ class DownloadCodeForSchemaDialogTest {
         fileEditorManager = FileEditorManager.getInstance(projectRule.project)
         mockSettingsManager = AwsConnectionManager.getInstance(projectRule.project) as MockAwsConnectionManager
 
-        resourceCache().mockSchemaVersions(
+        mockSchemaVersions(
             REGISTRY,
             SCHEMA_NAME,
             VERSIONS
@@ -233,10 +237,9 @@ class DownloadCodeForSchemaDialogTest {
         messageBus.subscribe(Notifications.TOPIC)
     }
 
-    private fun resourceCache() = MockResourceCache.getInstance(projectRule.project)
-
-    private fun MockResourceCache.mockSchemaVersions(registryName: String, schemaName: String, schemaVersions: List<String>) {
-        this.addEntry(
+    private fun mockSchemaVersions(registryName: String, schemaName: String, schemaVersions: List<String>) {
+        resourceCache.addEntry(
+            projectRule.project,
             SchemasResources.getSchemaVersions(registryName, schemaName),
             completedFuture(
                 schemaVersions.map { v ->

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/SqsServiceNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/SqsServiceNodeTest.kt
@@ -21,11 +21,12 @@ class SqsServiceNodeTest {
 
     @JvmField
     @Rule
-    val resourceCache = MockResourceCacheRule(projectRule)
+    val resourceCache = MockResourceCacheRule()
 
     @Test
     fun `Sqs queues are listed`() {
-        resourceCache.get().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             SqsResources.LIST_QUEUE_URLS,
             listOf(
                 "https://sqs.us-east-1.amazonaws.com/123456789012/test2",
@@ -49,14 +50,14 @@ class SqsServiceNodeTest {
 
     @Test
     fun `No queues listed`() {
-        resourceCache.get().addEntry(SqsResources.LIST_QUEUE_URLS, listOf())
+        resourceCache.addEntry(projectRule.project, SqsResources.LIST_QUEUE_URLS, listOf())
         val children = SqsServiceNode(projectRule.project, SQS_EXPLORER_NODE).children
         assertThat(children).hasOnlyOneElementSatisfying { it is AwsExplorerEmptyNode }
     }
 
     @Test
     fun `Error loading queues`() {
-        resourceCache.get().addEntry(SqsResources.LIST_QUEUE_URLS, CompletableFutureUtils.failedFuture(RuntimeException("Simulated error")))
+        resourceCache.addEntry(projectRule.project, SqsResources.LIST_QUEUE_URLS, CompletableFutureUtils.failedFuture(RuntimeException("Simulated error")))
         val children = SqsServiceNode(projectRule.project, SQS_EXPLORER_NODE).children
         assertThat(children).hasOnlyOneElementSatisfying { it is AwsExplorerErrorNode }
     }

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/ecs/execution/DotNetEcsCloudDebugRunConfigurationTest.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/ecs/execution/DotNetEcsCloudDebugRunConfigurationTest.kt
@@ -79,7 +79,7 @@ class DotNetEcsCloudDebugRunConfigurationTest : AwsReuseSolutionTestBase() {
         regionId: String = defaultRegion,
         credentialsIdentifier: CredentialIdentifier = mockCredentials
     ) {
-        val resourceCache = MockResourceCache.getInstance(project)
+        val resourceCache = MockResourceCache.getInstance()
         val taskDefinitionName = "taskDefinition"
         val fakeService = Service.builder()
             .clusterArn(clusterArn)

--- a/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodes.kt
+++ b/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodes.kt
@@ -7,13 +7,13 @@ import com.intellij.openapi.project.Project
 import icons.AwsIcons
 import software.amazon.awssdk.services.rds.RdsClient
 import software.amazon.awssdk.services.rds.model.DBInstance
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.Resource
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceRootNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceParentNode
+import software.aws.toolkits.jetbrains.core.getResourceNow
 import software.aws.toolkits.resources.message
 import javax.swing.Icon
 
@@ -46,7 +46,7 @@ class RdsParentNode(
 ) : AwsExplorerNode<String>(project, type, null), ResourceParentNode {
     override fun isAlwaysShowPlus(): Boolean = true
     override fun getChildren(): List<AwsExplorerNode<*>> = super.getChildren()
-    override fun getChildrenInternal(): List<AwsExplorerNode<*>> = AwsResourceCache.getInstance(nodeProject)
+    override fun getChildrenInternal(): List<AwsExplorerNode<*>> = nodeProject
         .getResourceNow(method)
         .map {
             RdsNode(

--- a/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/services/rds/actions/CreateIamDataSourceAction.kt
+++ b/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/services/rds/actions/CreateIamDataSourceAction.kt
@@ -13,10 +13,10 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.DumbAware
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.credentials.activeCredentialProvider
 import software.aws.toolkits.jetbrains.core.credentials.activeRegion
 import software.aws.toolkits.jetbrains.core.explorer.actions.SingleExplorerNodeAction
+import software.aws.toolkits.jetbrains.core.getResourceNow
 import software.aws.toolkits.jetbrains.core.help.HelpIds
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
@@ -92,7 +92,7 @@ class CreateIamDataSourceAction : SingleExplorerNodeAction<RdsNode>(message("rds
     internal fun createDatasource(node: RdsNode, registry: DataSourceRegistry) {
         val username = try {
             // use current STS user as username. Split on : because it comes back id:username
-            AwsResourceCache.getInstance(node.nodeProject).getResourceNow(StsResources.USER).substringAfter(':')
+            node.nodeProject.getResourceNow(StsResources.USER).substringAfter(':')
         } catch (e: Exception) {
             LOG.warn(e) { "Getting username from STS failed, falling back to master username" }
             node.dbInstance.masterUsername()

--- a/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/services/redshift/RedshiftUtils.kt
+++ b/jetbrains-ultimate/src-201+/software/aws/toolkits/jetbrains/services/redshift/RedshiftUtils.kt
@@ -8,8 +8,8 @@ import com.intellij.openapi.project.Project
 import software.amazon.awssdk.services.redshift.model.Cluster
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.tryOrNull
-import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
+import software.aws.toolkits.jetbrains.core.getResourceIfPresent
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.FullSslValidation
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
@@ -29,7 +29,7 @@ object RedshiftUtils {
 
 fun Project.clusterArn(cluster: Cluster, region: AwsRegion): String {
     // Attempt to get account out of the cache. If not, it's empty so, it is still a valid arn
-    val account = tryOrNull { AwsResourceCache.getInstance(this).getResourceIfPresent(StsResources.ACCOUNT) } ?: ""
+    val account = tryOrNull { this.getResourceIfPresent(StsResources.ACCOUNT) } ?: ""
     return "arn:${region.partitionId}:redshift:${region.id}:$account:cluster:${cluster.clusterIdentifier()}"
 }
 

--- a/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodeTest.kt
+++ b/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodeTest.kt
@@ -8,13 +8,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.rds.model.DBInstance
-import software.amazon.awssdk.utils.CompletableFutureUtils
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerErrorNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.RdsExplorerRootNode
 import software.aws.toolkits.resources.message
+import java.util.concurrent.CompletableFuture
 
 class RdsExplorerNodeTest {
     @JvmField
@@ -23,13 +23,14 @@ class RdsExplorerNodeTest {
 
     @JvmField
     @Rule
-    val resourceCache = MockResourceCacheRule(projectRule)
+    val resourceCache = MockResourceCacheRule()
 
     @Test
     fun `MySQL resources are listed`() {
         val name = RuleUtils.randomName()
         val name2 = RuleUtils.randomName()
-        resourceCache.get().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             RdsResources.LIST_INSTANCES_MYSQL,
             listOf(
                 DBInstance.builder().engine(mysqlEngineType).dbName(name).dbInstanceArn("").build(),
@@ -52,7 +53,8 @@ class RdsExplorerNodeTest {
     fun `Aurora MySQL resources are listed`() {
         val name = RuleUtils.randomName()
         val name2 = RuleUtils.randomName()
-        resourceCache.get().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             RdsResources.LIST_INSTANCES_AURORA_MYSQL,
             listOf(
                 DBInstance.builder().engine(auroraMysqlEngineType).dbName(name).dbInstanceArn("").build(),
@@ -74,7 +76,8 @@ class RdsExplorerNodeTest {
     fun `PostgreSQL resources are listed`() {
         val name = RuleUtils.randomName()
         val name2 = RuleUtils.randomName()
-        resourceCache.get().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             RdsResources.LIST_INSTANCES_POSTGRES,
             listOf(
                 DBInstance.builder().engine(postgresEngineType).dbName(name).dbInstanceArn("").build(),
@@ -93,7 +96,8 @@ class RdsExplorerNodeTest {
     fun `Aurora PostgreSQL resources are listed`() {
         val name = RuleUtils.randomName()
         val name2 = RuleUtils.randomName()
-        resourceCache.get().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             RdsResources.LIST_INSTANCES_AURORA_POSTGRES,
             listOf(
                 DBInstance.builder().engine(auroraPostgresEngineType).dbName(name).dbInstanceArn("").build(),
@@ -113,10 +117,10 @@ class RdsExplorerNodeTest {
 
     @Test
     fun `No resources leads to empty nodes`() {
-        resourceCache.get().addEntry(RdsResources.LIST_INSTANCES_MYSQL, listOf())
-        resourceCache.get().addEntry(RdsResources.LIST_INSTANCES_POSTGRES, listOf())
-        resourceCache.get().addEntry(RdsResources.LIST_INSTANCES_AURORA_MYSQL, listOf())
-        resourceCache.get().addEntry(RdsResources.LIST_INSTANCES_AURORA_POSTGRES, listOf())
+        resourceCache.addEntry(projectRule.project, RdsResources.LIST_INSTANCES_MYSQL, listOf())
+        resourceCache.addEntry(projectRule.project, RdsResources.LIST_INSTANCES_POSTGRES, listOf())
+        resourceCache.addEntry(projectRule.project, RdsResources.LIST_INSTANCES_AURORA_MYSQL, listOf())
+        resourceCache.addEntry(projectRule.project, RdsResources.LIST_INSTANCES_AURORA_POSTGRES, listOf())
         val serviceRootNode = sut.buildServiceRootNode(projectRule.project)
         assertThat(serviceRootNode.children).isNotEmpty
         serviceRootNode.children.forEach { node ->
@@ -132,10 +136,26 @@ class RdsExplorerNodeTest {
 
     @Test
     fun `Exception makes error nodes`() {
-        resourceCache.get().addEntry(RdsResources.LIST_INSTANCES_MYSQL, CompletableFutureUtils.failedFuture(RuntimeException("Simulated error")))
-        resourceCache.get().addEntry(RdsResources.LIST_INSTANCES_POSTGRES, CompletableFutureUtils.failedFuture(RuntimeException("Simulated error")))
-        resourceCache.get().addEntry(RdsResources.LIST_INSTANCES_AURORA_MYSQL, CompletableFutureUtils.failedFuture(RuntimeException("Simulated error")))
-        resourceCache.get().addEntry(RdsResources.LIST_INSTANCES_AURORA_POSTGRES, CompletableFutureUtils.failedFuture(RuntimeException("Simulated error")))
+        resourceCache.addEntry(
+            projectRule.project,
+            RdsResources.LIST_INSTANCES_MYSQL,
+            CompletableFuture.failedFuture(RuntimeException("Simulated error"))
+        )
+        resourceCache.addEntry(
+            projectRule.project,
+            RdsResources.LIST_INSTANCES_POSTGRES,
+            CompletableFuture.failedFuture(RuntimeException("Simulated error"))
+        )
+        resourceCache.addEntry(
+            projectRule.project,
+            RdsResources.LIST_INSTANCES_AURORA_MYSQL,
+            CompletableFuture.failedFuture(RuntimeException("Simulated error"))
+        )
+        resourceCache.addEntry(
+            projectRule.project,
+            RdsResources.LIST_INSTANCES_AURORA_POSTGRES,
+            CompletableFuture.failedFuture(RuntimeException("Simulated error"))
+        )
         val serviceRootNode = sut.buildServiceRootNode(projectRule.project)
         assertThat(serviceRootNode.children).isNotEmpty
         serviceRootNode.children.forEach { node ->

--- a/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/services/rds/actions/CreateConfigurationActionTest.kt
+++ b/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/services/rds/actions/CreateConfigurationActionTest.kt
@@ -38,7 +38,7 @@ class CreateConfigurationActionTest {
 
     @Rule
     @JvmField
-    val resourceCache = MockResourceCacheRule(projectRule)
+    val resourceCache = MockResourceCacheRule()
 
     private val port = RuleUtils.randomNumber()
     private val address = RuleUtils.randomName()
@@ -59,7 +59,7 @@ class CreateConfigurationActionTest {
 
     @Test
     fun `Create data source gets user`() {
-        resourceCache.get().addEntry(StsResources.USER, username)
+        resourceCache.addEntry(projectRule.project, StsResources.USER, username)
         val node = createNode()
         val registry = DataSourceRegistry(projectRule.project)
         CreateIamDataSourceAction().createDatasource(node, registry)
@@ -71,7 +71,8 @@ class CreateConfigurationActionTest {
 
     @Test
     fun `Create data source falls back to master username`() {
-        resourceCache.get().addEntry(
+        resourceCache.addEntry(
+            projectRule.project,
             StsResources.USER,
             CompletableFuture<String>().also {
                 it.completeExceptionally(RuntimeException("Failed to get current user"))

--- a/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/services/redshift/RedshiftUtilsTest.kt
+++ b/jetbrains-ultimate/tst-201+/software/aws/toolkits/jetbrains/services/redshift/RedshiftUtilsTest.kt
@@ -22,7 +22,7 @@ class RedshiftUtilsTest {
 
     @JvmField
     @Rule
-    val resourceCache = MockResourceCacheRule(projectRule)
+    val resourceCache = MockResourceCacheRule()
 
     private val defaultRegion = RuleUtils.randomName()
     private val region = AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName())
@@ -34,7 +34,7 @@ class RedshiftUtilsTest {
 
     @Test
     fun `Account ID ARN`() {
-        resourceCache.get().addEntry(StsResources.ACCOUNT, accountId)
+        resourceCache.addEntry(projectRule.project, StsResources.ACCOUNT, accountId)
         val arn = projectRule.project.clusterArn(mockCluster, region)
         assertThat(arn).isEqualTo("arn:${region.partitionId}:redshift:${region.id}:$accountId:cluster:$clusterId")
     }


### PR DESCRIPTION
* Remove project from the resource cache
* Project utils are now extension methods
* Add clear() method for connection settings
* Clean up a bunch of tests to make sure they clean up properly

Note: 
This does mean if you do a list in one project, it will be cached IDE wide

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
