### PR TITLE
Update shared telemetry to normalize metrics better

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ coroutinesVersion=1.3.3
 ideaPluginVersion=0.4.20
 ktlintVersion=0.38.1
 jacksonVersion=2.9.8
-telemetryVersion=0.0.70
+telemetryVersion=0.0.73
 
 assertjVersion=3.15.0
 junitVersion=4.12


### PR DESCRIPTION
Diff between 0.70 and 0.73:
```
425c425
<                     metadata("httpMethod", httpMethod)
---
>                     metadata("httpmethod", httpMethod)
455c455
<                     metadata("httpMethod", httpMethod)
---
>                     metadata("httpmethod", httpMethod)
513c513
<                     metadata("httpMethod", httpMethod)
---
>                     metadata("httpmethod", httpMethod)
537c537
<                     metadata("httpMethod", httpMethod)
---
>                     metadata("httpmethod", httpMethod)
658c658
<                 metadata("serviceType", serviceType.toString())
---
>                 metadata("servicetype", serviceType.toString())
678c678
<                 metadata("serviceType", serviceType.toString())
---
>                 metadata("servicetype", serviceType.toString())
735c735
<                 metadata("serviceType", serviceType.toString())
---
>                 metadata("servicetype", serviceType.toString())
757c757
<                 metadata("serviceType", serviceType.toString())
---
>                 metadata("servicetype", serviceType.toString())
909c909
<                     metadata("runtimeString", runtimeString)
---
>                     metadata("runtimestring", runtimeString)
933c933
<                     metadata("runtimeString", runtimeString)
---
>                     metadata("runtimestring", runtimeString)
982c982
<                 metadata("credentialSourceId", credentialSourceId)
---
>                 metadata("credentialsourceid", credentialSourceId)
1002c1002
<                 metadata("credentialSourceId", credentialSourceId)
---
>                 metadata("credentialsourceid", credentialSourceId)
1160c1160
<                     metadata("credentialType", credentialType.toString())
---
>                     metadata("credentialtype", credentialType.toString())
1182c1182
<                     metadata("credentialType", credentialType.toString())
---
>                     metadata("credentialtype", credentialType.toString())
1203c1203
<                 metadata("partitionId", partitionId)
---
>                 metadata("partitionid", partitionId)
1223c1223
<                 metadata("partitionId", partitionId)
---
>                 metadata("partitionid", partitionId)
1243c1243
<                 metadata("regionId", regionId)
---
>                 metadata("regionid", regionId)
1263c1263
<                 metadata("regionId", regionId)
---
>                 metadata("regionid", regionId)
1322c1322
<                     metadata("credentialType", credentialType.toString())
---
>                     metadata("credentialtype", credentialType.toString())
1346c1346
<                     metadata("credentialType", credentialType.toString())
---
>                     metadata("credentialtype", credentialType.toString())
1404,1405c1404,1405
<                 metadata("regionId", regionId)
<                 metadata("initialDeploy", initialDeploy.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("initialdeploy", initialDeploy.toString())
1413c1413
<                     metadata("xrayEnabled", xrayEnabled.toString())
---
>                     metadata("xrayenabled", xrayEnabled.toString())
1416c1416
<                     metadata("enhancedHealthEnabled", enhancedHealthEnabled.toString())
---
>                     metadata("enhancedhealthenabled", enhancedHealthEnabled.toString())
1444,1445c1444,1445
<                 metadata("regionId", regionId)
<                 metadata("initialDeploy", initialDeploy.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("initialdeploy", initialDeploy.toString())
1453c1453
<                     metadata("xrayEnabled", xrayEnabled.toString())
---
>                     metadata("xrayenabled", xrayEnabled.toString())
1456c1456
<                     metadata("enhancedHealthEnabled", enhancedHealthEnabled.toString())
---
>                     metadata("enhancedhealthenabled", enhancedHealthEnabled.toString())
1650,1651c1650,1651
<                 metadata("workflowToken", workflowToken)
<                 metadata("cloudDebugPlatform", cloudDebugPlatform.toString())
---
>                 metadata("workflowtoken", workflowToken)
>                 metadata("clouddebugplatform", cloudDebugPlatform.toString())
1674,1675c1674,1675
<                 metadata("workflowToken", workflowToken)
<                 metadata("cloudDebugPlatform", cloudDebugPlatform.toString())
---
>                 metadata("workflowtoken", workflowToken)
>                 metadata("clouddebugplatform", cloudDebugPlatform.toString())
1793c1793
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
1815c1815
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
1946c1946
<                     metadata("oldVersion", oldVersion)
---
>                     metadata("oldversion", oldVersion)
1974c1974
<                     metadata("oldVersion", oldVersion)
---
>                     metadata("oldversion", oldVersion)
2032c2032
<                     metadata("workflowToken", workflowToken)
---
>                     metadata("workflowtoken", workflowToken)
2060c2060
<                     metadata("workflowToken", workflowToken)
---
>                     metadata("workflowtoken", workflowToken)
2113c2113
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2135c2135
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2185c2185
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2207c2207
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2331c2331
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2353c2353
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2403c2403
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2425c2425
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2475c2475
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2497c2497
<                 metadata("workflowToken", workflowToken)
---
>                 metadata("workflowtoken", workflowToken)
2614,2615c2614,2615
<                 metadata("regionId", regionId)
<                 metadata("initialDeploy", initialDeploy.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("initialdeploy", initialDeploy.toString())
2638,2639c2638,2639
<                 metadata("regionId", regionId)
<                 metadata("initialDeploy", initialDeploy.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("initialdeploy", initialDeploy.toString())
2958,2959c2958,2959
<                 metadata("insightsQueryTimeType", insightsQueryTimeType.toString())
<                 metadata("insightsQueryStringType", insightsQueryStringType.toString())
---
>                 metadata("insightsquerytimetype", insightsQueryTimeType.toString())
>                 metadata("insightsquerystringtype", insightsQueryStringType.toString())
2982,2983c2982,2983
<                 metadata("insightsQueryTimeType", insightsQueryTimeType.toString())
<                 metadata("insightsQueryStringType", insightsQueryStringType.toString())
---
>                 metadata("insightsquerytimetype", insightsQueryTimeType.toString())
>                 metadata("insightsquerystringtype", insightsQueryStringType.toString())
3099c3099
<                 metadata("insightsDialogOpenSource", insightsDialogOpenSource.toString())
---
>                 metadata("insightsdialogopensource", insightsDialogOpenSource.toString())
3119c3119
<                 metadata("insightsDialogOpenSource", insightsDialogOpenSource.toString())
---
>                 metadata("insightsdialogopensource", insightsDialogOpenSource.toString())
3339c3339
<                     metadata("serviceType", serviceType.toString())
---
>                     metadata("servicetype", serviceType.toString())
3364c3364
<                     metadata("serviceType", serviceType.toString())
---
>                     metadata("servicetype", serviceType.toString())
3419c3419
<                     metadata("serviceType", serviceType.toString())
---
>                     metadata("servicetype", serviceType.toString())
3444c3444
<                     metadata("serviceType", serviceType.toString())
---
>                     metadata("servicetype", serviceType.toString())
4431c4431
<                 metadata("regionId", regionId)
---
>                 metadata("regionid", regionId)
4453c4453
<                 metadata("regionId", regionId)
---
>                 metadata("regionid", regionId)
4489,4566d4488
<      * Called when deploying a scheduled task to an ECS cluster
<      */
<     fun deployScheduledTask(
<         project: Project? = null,
<         result: Result,
<         regionId: String,
<         ecsLaunchType: EcsLaunchType,
<         value: Double = 1.0,
<         createTime: Instant = Instant.now()
<     ) {
<         TelemetryService.getInstance().record(project) {
<             datum("ecs_deployScheduledTask") {
<                 createTime(createTime)
<                 unit(Unit.NONE)
<                 value(value)
<                 passive(false)
<                 metadata("result", result.toString())
<                 metadata("regionId", regionId)
<                 metadata("ecsLaunchType", ecsLaunchType.toString())
<             }
<         }
<     }
<
<     /**
<      * Called when deploying a scheduled task to an ECS cluster
<      */
<     fun deployScheduledTask(
<         metadata: MetricEventMetadata,
<         result: Result,
<         regionId: String,
<         ecsLaunchType: EcsLaunchType,
<         value: Double = 1.0,
<         createTime: Instant = Instant.now()
<     ) {
<         TelemetryService.getInstance().record(metadata) {
<             datum("ecs_deployScheduledTask") {
<                 createTime(createTime)
<                 unit(Unit.NONE)
<                 value(value)
<                 passive(false)
<                 metadata("result", result.toString())
<                 metadata("regionId", regionId)
<                 metadata("ecsLaunchType", ecsLaunchType.toString())
<             }
<         }
<     }
<
<     /**
<      * Called when deploying a scheduled task to an ECS cluster
<      */
<     fun deployScheduledTask(
<         project: Project? = null,
<         success: Boolean,
<         regionId: String,
<         ecsLaunchType: EcsLaunchType,
<         value: Double = 1.0,
<         createTime: Instant = Instant.now()
<     ) {
<         deployScheduledTask(project, if(success) Result.Succeeded else Result.Failed, regionId,
<                 ecsLaunchType, value, createTime)
<     }
<
<     /**
<      * Called when deploying a scheduled task to an ECS cluster
<      */
<     fun deployScheduledTask(
<         metadata: MetricEventMetadata,
<         success: Boolean,
<         regionId: String,
<         ecsLaunchType: EcsLaunchType,
<         value: Double = 1.0,
<         createTime: Instant = Instant.now()
<     ) {
<         deployScheduledTask(metadata, if(success) Result.Succeeded else Result.Failed, regionId,
<                 ecsLaunchType, value, createTime)
<     }
<
<     /**
4584,4585c4506,4507
<                 metadata("regionId", regionId)
<                 metadata("ecsLaunchType", ecsLaunchType.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("ecslaunchtype", ecsLaunchType.toString())
4608,4609c4530,4531
<                 metadata("regionId", regionId)
<                 metadata("ecsLaunchType", ecsLaunchType.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("ecslaunchtype", ecsLaunchType.toString())
4651a4574
>         scheduled: Boolean,
4662,4663c4585,4587
<                 metadata("regionId", regionId)
<                 metadata("ecsLaunchType", ecsLaunchType.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("ecslaunchtype", ecsLaunchType.toString())
>                 metadata("scheduled", scheduled.toString())
4675a4600
>         scheduled: Boolean,
4686,4687c4611,4613
<                 metadata("regionId", regionId)
<                 metadata("ecsLaunchType", ecsLaunchType.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("ecslaunchtype", ecsLaunchType.toString())
>                 metadata("scheduled", scheduled.toString())
4699a4626
>         scheduled: Boolean,
4704c4631
<                 ecsLaunchType, value, createTime)
---
>                 ecsLaunchType, scheduled, value, createTime)
4714a4642
>         scheduled: Boolean,
4719c4647
<                 ecsLaunchType, value, createTime)
---
>                 ecsLaunchType, scheduled, value, createTime)
5308,5309c5236,5237
<                 metadata("regionId", regionId)
<                 metadata("initialDeploy", initialDeploy.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("initialdeploy", initialDeploy.toString())
5340,5341c5268,5269
<                 metadata("regionId", regionId)
<                 metadata("initialDeploy", initialDeploy.toString())
---
>                 metadata("regionid", regionId)
>                 metadata("initialdeploy", initialDeploy.toString())
5857c5785
<                 metadata("databaseCredentials", databaseCredentials.toString())
---
>                 metadata("databasecredentials", databaseCredentials.toString())
5859c5787
<                     metadata("databaseEngine", databaseEngine)
---
>                     metadata("databaseengine", databaseEngine)
5885c5813
<                 metadata("databaseCredentials", databaseCredentials.toString())
---
>                 metadata("databasecredentials", databaseCredentials.toString())
5887c5815
<                     metadata("databaseEngine", databaseEngine)
---
>                     metadata("databaseengine", databaseEngine)
5946,5947c5874,5875
<                 metadata("databaseCredentials", databaseCredentials.toString())
<                 metadata("databaseEngine", databaseEngine)
---
>                 metadata("databasecredentials", databaseCredentials.toString())
>                 metadata("databaseengine", databaseEngine)
5971,5972c5899,5900
<                 metadata("databaseCredentials", databaseCredentials.toString())
<                 metadata("databaseEngine", databaseEngine)
---
>                 metadata("databasecredentials", databaseCredentials.toString())
>                 metadata("databaseengine", databaseEngine)
6223c6151
<                 metadata("databaseCredentials", databaseCredentials.toString())
---
>                 metadata("databasecredentials", databaseCredentials.toString())
6246c6174
<                 metadata("databaseCredentials", databaseCredentials.toString())
---
>                 metadata("databasecredentials", databaseCredentials.toString())
6299c6227
<                 metadata("databaseCredentials", databaseCredentials.toString())
---
>                 metadata("databasecredentials", databaseCredentials.toString())
6322c6250
<                 metadata("databaseCredentials", databaseCredentials.toString())
---
>                 metadata("databasecredentials", databaseCredentials.toString())
7382c7310
<                     metadata("templateName", templateName)
---
>                     metadata("templatename", templateName)
7391c7319
<                     metadata("eventBridgeSchema", eventBridgeSchema)
---
>                     metadata("eventbridgeschema", eventBridgeSchema)
7426c7354
<                     metadata("templateName", templateName)
---
>                     metadata("templatename", templateName)
7435c7363
<                     metadata("eventBridgeSchema", eventBridgeSchema)
---
>                     metadata("eventbridgeschema", eventBridgeSchema)
7499c7427
<                     metadata("schemaLanguage", schemaLanguage.toString())
---
>                     metadata("schemalanguage", schemaLanguage.toString())
7523c7451
<                     metadata("schemaLanguage", schemaLanguage.toString())
---
>                     metadata("schemalanguage", schemaLanguage.toString())
7910c7838
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
7932c7860
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
7983c7911
<                     metadata("sqsQueueType", sqsQueueType.toString())
---
>                     metadata("sqsqueuetype", sqsQueueType.toString())
8007c7935
<                     metadata("sqsQueueType", sqsQueueType.toString())
---
>                     metadata("sqsqueuetype", sqsQueueType.toString())
8059c7987
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8082c8010
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8134c8062
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8156c8084
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8204c8132
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8224c8152
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8246c8174
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8268c8196
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8318c8246
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8340c8268
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8390c8318
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
8412c8340
<                 metadata("sqsQueueType", sqsQueueType.toString())
---
>                 metadata("sqsqueuetype", sqsQueueType.toString())
```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
