### PR TITLE
Stop passing the older AWS env vars

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
@@ -148,14 +148,11 @@ class DefaultCredentialManager : CredentialManager() {
 
 fun AwsCredentials.toEnvironmentVariables(): Map<String, String> {
     val map = mutableMapOf<String, String>()
-    map["AWS_ACCESS_KEY"] = this.accessKeyId()
     map["AWS_ACCESS_KEY_ID"] = this.accessKeyId()
-    map["AWS_SECRET_KEY"] = this.secretAccessKey()
     map["AWS_SECRET_ACCESS_KEY"] = this.secretAccessKey()
 
     if (this is AwsSessionCredentials) {
         map["AWS_SESSION_TOKEN"] = this.sessionToken()
-        map["AWS_SECURITY_TOKEN"] = this.sessionToken()
     }
 
     return map

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
@@ -78,7 +78,7 @@ class ExecutableBackedCacheResourceTest {
         createMockExecutable("validBinary")
 
         executeCacheResource {
-            assertThat(this.environment).containsKey("AWS_ACCESS_KEY").containsKey("AWS_SECRET_KEY")
+            assertThat(this.environment).containsKey("AWS_ACCESS_KEY_ID").containsKey("AWS_SECRET_ACCESS_KEY")
         }
     }
 


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
