### PR TITLE
Fix being unable to use a SSO profile in a source_profile chain

### DIFF
--- a/.changes/next-release/bugfix-f167fb0e-58c8-4493-86fc-a6620ef22a6f.json
+++ b/.changes/next-release/bugfix-f167fb0e-58c8-4493-86fc-a6620ef22a6f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix being unable to use a SSO profile in a credential chain"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/SsoSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/SsoSupport.kt
@@ -56,5 +56,7 @@ interface SsoRequiredInteractiveCredentials : InteractiveCredential {
 
     override val userAction: AnAction get() = RefreshConnectionAction(message("credentials.sso.action"))
 
-    override suspend fun userActionRequired(): Boolean = ssoCache.loadAccessToken(ssoUrl) == null
+    override suspend fun userActionRequired(): Boolean {
+        return ssoCache.loadAccessToken(ssoUrl) == null
+    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/SsoSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/SsoSupport.kt
@@ -56,7 +56,5 @@ interface SsoRequiredInteractiveCredentials : InteractiveCredential {
 
     override val userAction: AnAction get() = RefreshConnectionAction(message("credentials.sso.action"))
 
-    override suspend fun userActionRequired(): Boolean {
-        return ssoCache.loadAccessToken(ssoUrl) == null
-    }
+    override suspend fun userActionRequired(): Boolean = ssoCache.loadAccessToken(ssoUrl) == null
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
@@ -72,7 +72,7 @@ private class ProfileCredentialsIdentifierSso(
 ) : ProfileCredentialsIdentifier(profileName, defaultRegionId, credentialType),
     SsoRequiredInteractiveCredentials
 
-class ProfileCredentialProviderFactory : CredentialProviderFactory {
+class ProfileCredentialProviderFactory(private val ssoCache: SsoCache = diskCache) : CredentialProviderFactory {
     private val profileHolder = ProfileHolder()
 
     override val id = PROFILE_FACTORY_ID
@@ -220,7 +220,7 @@ class ProfileCredentialProviderFactory : CredentialProviderFactory {
             profile.requiredProperty(SSO_URL),
             ssoRegion,
             SsoPrompt,
-            diskCache,
+            ssoCache,
             ssoOidcClient
         )
 
@@ -327,8 +327,8 @@ class ProfileCredentialProviderFactory : CredentialProviderFactory {
             this.requiresSso(profiles) -> ProfileCredentialsIdentifierSso(
                 name,
                 defaultRegion,
-                diskCache,
-                this.requiredProperty(SSO_URL),
+                ssoCache,
+                this.traverseCredentialChain(profiles).map { it.property(SSO_URL) }.first { it.isPresent }.get(),
                 requestedProfileType
             )
             else -> ProfileCredentialsIdentifier(name, defaultRegion, requestedProfileType)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
@@ -23,6 +23,8 @@ import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.stub
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Condition
@@ -42,6 +44,7 @@ import software.amazon.awssdk.http.SdkHttpFullResponse
 import software.aws.toolkits.core.credentials.CredentialIdentifier
 import software.aws.toolkits.core.credentials.CredentialsChangeEvent
 import software.aws.toolkits.core.credentials.CredentialsChangeListener
+import software.aws.toolkits.core.credentials.sso.SsoCache
 import software.aws.toolkits.core.region.ToolkitRegionProvider
 import software.aws.toolkits.core.rules.SystemPropertyHelper
 import software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileCredentialProviderFactory
@@ -648,6 +651,62 @@ class ProfileCredentialProviderFactoryTest {
         }
     }
 
+    @Test
+    fun mfaProfilesAlwaysNeedLogin() {
+        profileFile.writeToFile(
+            """
+            [profile role]
+            role_arn=arn1
+            role_session_name=testSession
+            external_id=externalId
+            mfa_serial=someSerialArn
+            source_profile=source_profile
+
+            [profile source_profile]
+            aws_access_key_id=BarAccessKey
+            aws_secret_access_key=BarSecretKey
+            """.trimIndent()
+        )
+
+        createProviderFactory()
+
+        assertThat(runBlocking { (findCredentialIdentifier("role") as InteractiveCredential).userActionRequired() }).isTrue()
+    }
+
+    @Test
+    fun ssoProfilesCanIdentifyIfTheyNeedLogin() {
+        profileFile.writeToFile(
+            """
+            [profile valid]
+            sso_start_url=ValidUrl
+            sso_region=us-east-2
+            sso_account_id=111222333444
+            sso_role_name=RoleName
+            
+            [profile expired]
+            sso_start_url=ExpiredUrl
+            sso_region=us-east-2
+            sso_account_id=111222333444
+            sso_role_name=RoleName
+            
+            [profile chain]
+            source_profile = valid
+            role_arn = AssumedRoleArn
+            """.trimIndent()
+        )
+
+        val ssoCache = mock<SsoCache> {
+            on { loadAccessToken(("ValidUrl")) }.thenReturn(mock())
+            on { loadAccessToken(("ExpiredUrl")) }.thenReturn(null)
+        }
+
+        createProviderFactory(ssoCache)
+
+        assertThat(runBlocking { (findCredentialIdentifier("valid") as InteractiveCredential).userActionRequired() }).isFalse()
+        assertThat(runBlocking { (findCredentialIdentifier("expired") as InteractiveCredential).userActionRequired() }).isTrue()
+        assertThat(runBlocking { (findCredentialIdentifier("chain") as InteractiveCredential).userActionRequired() }).isFalse()
+    }
+
     private fun File.writeToFile(content: String) {
         WriteCommandAction.runWriteCommandAction(projectRule.project) {
             FileUtil.createIfDoesntExist(this)
@@ -663,8 +722,8 @@ class ProfileCredentialProviderFactoryTest {
             }
         }
 
-    private fun createProviderFactory(): ProfileCredentialProviderFactory {
-        val factory = ProfileCredentialProviderFactory()
+    private fun createProviderFactory(ssoCache: SsoCache = mock()): ProfileCredentialProviderFactory {
+        val factory = ProfileCredentialProviderFactory(ssoCache)
         factory.setUp(profileLoadCallback)
 
         return factory

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
@@ -24,7 +24,6 @@ import com.nhaarman.mockitokotlin2.stub
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Condition


### PR DESCRIPTION
* Added test around InteractiveCredentials

## Related Issue(s)
#2154 

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
