### PR TITLE
Add deprecation message for 2019.3

### DIFF
--- a/.changes/next-release/deprecation-407a34ef-c785-45eb-b3f1-20c394878d8c.json
+++ b/.changes/next-release/deprecation-407a34ef-c785-45eb-b3f1-20c394878d8c.json
@@ -1,0 +1,4 @@
+{
+  "type" : "deprecation",
+  "description" : "2019.3 support will be removed in the next release"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/JetBrainsMinimumVersionChange.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/JetBrainsMinimumVersionChange.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.notification
 
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationNamesInfo
 import software.aws.toolkits.resources.message
@@ -40,4 +41,5 @@ class JetBrainsMinimumVersionChange : NoticeType {
     }
 
     override fun getNoticeContents(): NoticeContents = noticeContents
+    override fun getNoticeType(): NotificationType = NotificationType.WARNING
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/JetBrainsMinimumVersionChange.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/JetBrainsMinimumVersionChange.kt
@@ -8,14 +8,14 @@ import com.intellij.openapi.application.ApplicationNamesInfo
 import software.aws.toolkits.resources.message
 
 class JetBrainsMinimumVersionChange : NoticeType {
-    override val id: String = "JetBrainsMinimumVersion_193"
+    override val id: String = "JetBrainsMinimumVersion_201"
     private val noticeContents = NoticeContents(
         message("notice.title.jetbrains.minimum.version"),
         message(
             "notice.message.jetbrains.minimum.version",
             ApplicationInfo.getInstance().fullVersion,
             ApplicationNamesInfo.getInstance().fullProductName,
-            "2019.3"
+            "2020.1"
         )
     )
 
@@ -31,12 +31,9 @@ class JetBrainsMinimumVersionChange : NoticeType {
     override fun isNotificationRequired(): Boolean {
         val appInfo = ApplicationInfo.getInstance()
         val majorVersion = appInfo.majorVersion.toIntOrNull()
-        val minorVersion = appInfo.minorVersion.toFloatOrNull()
 
         majorVersion?.let {
-            minorVersion?.let {
-                return majorVersion < 2019 || (majorVersion == 2019 && minorVersion < 3)
-            }
+            return majorVersion < 2020
         }
 
         return true

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/NoticeManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/NoticeManager.kt
@@ -7,13 +7,14 @@ import com.intellij.notification.NotificationDisplayType
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
+import org.jetbrains.annotations.TestOnly
 import software.aws.toolkits.resources.message
 
 interface NoticeManager {
@@ -71,7 +72,7 @@ class DefaultNoticeManager :
         )
 
         notification.addAction(
-            object : AnAction(message("notice.suppress")) {
+            object : DumbAwareAction(message("notice.suppress")) {
                 override fun actionPerformed(e: AnActionEvent) {
                     suppressNotification(notice)
                     notification.hideBalloon()
@@ -86,6 +87,7 @@ class DefaultNoticeManager :
         internalState[notice.id] = NoticeState(notice.id, notice.getSuppressNotificationValue())
     }
 
+    @TestOnly
     fun resetAllNotifications() {
         internalState.clear()
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/NoticeStartupActivity.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/NoticeStartupActivity.kt
@@ -10,8 +10,7 @@ import com.intellij.openapi.startup.StartupActivity
 
 class NoticeStartupActivity : StartupActivity, DumbAware {
     override fun runActivity(project: Project) {
-        val noticeManager =
-            ServiceManager.getService(NoticeManager::class.java)
+        val noticeManager = ServiceManager.getService(NoticeManager::class.java)
 
         val notices = noticeManager.getRequiredNotices(NoticeType.notices(), project)
         noticeManager.notify(notices, project)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/NoticeType.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/NoticeType.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.notification
 
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.extensions.ExtensionPointName
 
 interface NoticeType {
@@ -18,6 +19,11 @@ interface NoticeType {
 
     // Notification Title/Message
     fun getNoticeContents(): NoticeContents
+
+    /*
+     * Allow setting different warning levels depending on the type of notification
+     */
+    open fun getNoticeType(): NotificationType = NotificationType.INFORMATION
 
     companion object {
         val EP_NAME = ExtensionPointName<NoticeType>("aws.toolkit.notice")


### PR DESCRIPTION
- Add message
- Fix notification action to be dumb aware
- Make the deprecation message a `warning` instead of an `info`

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
