### PR TITLE
Break Update Function Code into its own dedicated UI

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
@@ -6,15 +6,18 @@ package software.aws.toolkits.jetbrains.services.lambda.actions
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
 import software.amazon.awssdk.services.lambda.LambdaClient
 import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.explorer.actions.SingleResourceNodeAction
 import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
+import software.aws.toolkits.jetbrains.services.lambda.LambdaFunction
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunctionNode
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.toDataClass
 import software.aws.toolkits.jetbrains.services.lambda.upload.EditFunctionDialog
 import software.aws.toolkits.jetbrains.services.lambda.upload.EditFunctionMode
+import software.aws.toolkits.jetbrains.services.lambda.upload.UpdateFunctionCodeDialog
 import software.aws.toolkits.jetbrains.utils.Operation
 import software.aws.toolkits.jetbrains.utils.TaggingResourceType
 import software.aws.toolkits.jetbrains.utils.warnResourceOperationAgainstCodePipeline
@@ -43,9 +46,13 @@ abstract class UpdateFunctionAction(private val mode: EditFunctionMode, title: S
                 TaggingResourceType.LAMBDA_FUNCTION,
                 Operation.UPDATE
             ) {
-                EditFunctionDialog(project, lambdaFunction, mode = mode).show()
+                updateLambda(project, lambdaFunction)
             }
         }
+    }
+
+    protected open fun updateLambda(project: Project, lambdaFunction: LambdaFunction) {
+        EditFunctionDialog(project, lambdaFunction, mode = mode).show()
     }
 }
 
@@ -57,5 +64,9 @@ class UpdateFunctionCodeAction : UpdateFunctionAction(EditFunctionMode.UPDATE_CO
             return
         }
         e.presentation.isVisible = false
+    }
+
+    override fun updateLambda(project: Project, lambdaFunction: LambdaFunction) {
+        UpdateFunctionCodeDialog(project, lambdaFunction).show()
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/BuildSettingsPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/BuildSettingsPanel.form
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.lambda.upload.BuildSettingsPanel">
+  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="864" height="49"/>
+    </constraints>
+    <properties>
+      <preferredSize width="750" height="-1"/>
+    </properties>
+    <border type="none"/>
+    <children>
+      <vspacer id="bcf26">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="ce59b" class="javax.swing.JCheckBox" binding="buildInContainerCheckbox">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <selected value="false"/>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="serverless.application.deploy.use_container"/>
+          <toolTipText resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.sam.buildInContainer.tooltip"/>
+        </properties>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/BuildSettingsPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/BuildSettingsPanel.kt
@@ -1,0 +1,19 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.aws.toolkits.jetbrains.services.lambda.upload
+
+import com.intellij.ui.IdeBorderFactory
+import software.aws.toolkits.resources.message
+import java.awt.BorderLayout
+import javax.swing.JCheckBox
+import javax.swing.JPanel
+
+class BuildSettingsPanel : JPanel(BorderLayout()) {
+    lateinit var content: JPanel
+    lateinit var buildInContainerCheckbox: JCheckBox
+
+    init {
+        content.border = IdeBorderFactory.createTitledBorder(message("lambda.upload.build_settings"), false)
+        add(content, BorderLayout.CENTER)
+    }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CodeStoragePanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CodeStoragePanel.form
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.lambda.upload.CodeStoragePanel">
+  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="883" height="113"/>
+    </constraints>
+    <properties>
+      <preferredSize width="750" height="-1"/>
+    </properties>
+    <border type="none"/>
+    <children>
+      <vspacer id="bcf26">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="435ad" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.create.source_bucket.label"/>
+          <toolTipText resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.function.sourceBucket.tooltip"/>
+        </properties>
+      </component>
+      <component id="84d36" class="javax.swing.JButton" binding="createBucketButton">
+        <constraints>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="general.create_button"/>
+        </properties>
+      </component>
+      <component id="89882" class="software.aws.toolkits.jetbrains.ui.ResourceSelector" binding="sourceBucket" custom-create="true">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <toolTipText resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.function.sourceBucket.tooltip"/>
+        </properties>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CodeStoragePanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CodeStoragePanel.kt
@@ -45,6 +45,10 @@ class CodeStoragePanel(private val project: Project) : JPanel(BorderLayout()) {
     }
 
     fun validatePanel(): ValidationInfo? {
+        if (sourceBucket.isLoading) {
+            return sourceBucket.validationInfo(message("serverless.application.deploy.validation.s3.bucket.loading"))
+        }
+
         if (sourceBucket.selected() == null) {
             return sourceBucket.validationInfo(message("lambda.upload_validation.source_bucket"))
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CodeStoragePanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CodeStoragePanel.kt
@@ -1,0 +1,54 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.aws.toolkits.jetbrains.services.lambda.upload
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.IdeBorderFactory
+import software.aws.toolkits.jetbrains.core.awsClient
+import software.aws.toolkits.jetbrains.services.s3.CreateS3BucketDialog
+import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources.listBucketNamesByActiveRegion
+import software.aws.toolkits.jetbrains.ui.ResourceSelector
+import software.aws.toolkits.jetbrains.utils.ui.validationInfo
+import software.aws.toolkits.resources.message
+import java.awt.BorderLayout
+import javax.swing.JButton
+import javax.swing.JPanel
+
+class CodeStoragePanel(private val project: Project) : JPanel(BorderLayout()) {
+    lateinit var content: JPanel
+    lateinit var sourceBucket: ResourceSelector<String>
+    lateinit var createBucketButton: JButton
+
+    init {
+        createBucketButton.addActionListener {
+            val bucketDialog = CreateS3BucketDialog(
+                project = project,
+                s3Client = project.awsClient(),
+                parent = content
+            )
+
+            if (bucketDialog.showAndGet()) {
+                bucketDialog.bucketName().let {
+                    sourceBucket.reload(forceFetch = true)
+                    sourceBucket.selectedItem = it
+                }
+            }
+        }
+
+        content.border = IdeBorderFactory.createTitledBorder(message("lambda.upload.deployment_settings"), false)
+        add(content, BorderLayout.CENTER)
+    }
+
+    private fun createUIComponents() {
+        sourceBucket = ResourceSelector.builder().resource(listBucketNamesByActiveRegion(project)).awsConnection(project).build()
+    }
+
+    fun validatePanel(): ValidationInfo? {
+        if (sourceBucket.selected() == null) {
+            return sourceBucket.validationInfo(message("lambda.upload_validation.source_bucket"))
+        }
+
+        return null
+    }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodeDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodeDialog.kt
@@ -30,7 +30,11 @@ class UpdateFunctionCodeDialog(private val project: Project, private val initial
     private val view = UpdateFunctionCodePanel(project)
     private val updateSettings = UpdateLambdaSettings.getInstance(initialSettings.arn)
 
-    private val action: OkAction = UpdateFunctionOkAction()
+    private val action: OkAction = object : OkAction() {
+        init {
+            putValue(Action.NAME, message("lambda.upload.update_settings_button.title"))
+        }
+    }
 
     init {
         super.init()
@@ -113,13 +117,6 @@ class UpdateFunctionCodeDialog(private val project: Project, private val initial
                     LambdaTelemetry.editFunction(project, update = false, result = Result.Failed)
                 }
             }
-        }
-    }
-
-    // Using an OkAction to force the validation logic to trigger as well
-    private inner class UpdateFunctionOkAction : OkAction() {
-        init {
-            putValue(Action.NAME, message("lambda.upload.update_settings_button.title"))
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodeDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodeDialog.kt
@@ -1,0 +1,138 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.upload
+
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.module.ModuleUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import org.jetbrains.annotations.TestOnly
+import software.aws.toolkits.jetbrains.core.help.HelpIds
+import software.aws.toolkits.jetbrains.services.lambda.Lambda.findPsiElementsForHandler
+import software.aws.toolkits.jetbrains.services.lambda.LambdaBuilder
+import software.aws.toolkits.jetbrains.services.lambda.LambdaFunction
+import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
+import software.aws.toolkits.jetbrains.settings.UpdateLambdaSettings
+import software.aws.toolkits.jetbrains.utils.notifyError
+import software.aws.toolkits.jetbrains.utils.notifyInfo
+import software.aws.toolkits.resources.message
+import software.aws.toolkits.telemetry.LambdaTelemetry
+import software.aws.toolkits.telemetry.Result
+import javax.swing.Action
+import javax.swing.JComponent
+
+private val NOTIFICATION_TITLE = message("lambda.service_name")
+
+class UpdateFunctionCodeDialog(private val project: Project, private val initialSettings: LambdaFunction) : DialogWrapper(project) {
+    private val view = UpdateFunctionCodePanel(project)
+    private val updateSettings = UpdateLambdaSettings.getInstance(initialSettings.arn)
+
+    private val action: OkAction = UpdateFunctionOkAction()
+
+    init {
+        super.init()
+        title = message("lambda.upload.updateCode.title", initialSettings.name)
+
+        view.handlerPanel.handler.text = initialSettings.handler
+        view.handlerPanel.setRuntime(initialSettings.runtime)
+
+        loadSettings()
+    }
+
+    private fun configurationChanged(): Boolean = initialSettings.handler != view.handlerPanel.handler.text
+
+    override fun createCenterPanel(): JComponent? = view.content
+
+    override fun getPreferredFocusedComponent(): JComponent? = view.handlerPanel.handler
+
+    override fun doValidate(): ValidationInfo? = view.validatePanel()
+
+    override fun getOKAction(): Action = action
+
+    override fun doCancelAction() {
+        LambdaTelemetry.editFunction(project, result = Result.Cancelled)
+        super.doCancelAction()
+    }
+
+    override fun doOKAction() {
+        saveSettings()
+        upsertLambdaCode()
+        close(OK_EXIT_CODE)
+    }
+
+    override fun getHelpId(): String? = HelpIds.UPDATE_FUNCTION_CODE_DIALOG.id
+
+    private fun upsertLambdaCode() {
+        if (!okAction.isEnabled) {
+            return
+        }
+        FileDocumentManager.getInstance().saveAllDocuments()
+
+        val functionDetails = FunctionUploadDetails(
+            name = initialSettings.name,
+            handler = view.handlerPanel.handler.text,
+            iamRole = initialSettings.role,
+            runtime = initialSettings.runtime,
+            description = initialSettings.description,
+            envVars = initialSettings.envVariables ?: emptyMap(),
+            timeout = initialSettings.timeout,
+            memorySize = initialSettings.memorySize,
+            xrayEnabled = initialSettings.xrayEnabled,
+            samOptions = SamOptions(
+                buildInContainer = view.buildSettings.buildInContainerCheckbox.isSelected
+            )
+        )
+
+        val element = findPsiElementsForHandler(project, functionDetails.runtime, functionDetails.handler).first()
+        val psiFile = element.containingFile
+        val module = ModuleUtil.findModuleForFile(psiFile)
+            ?: throw IllegalStateException("Failed to locate module for $psiFile")
+        val lambdaBuilder = initialSettings.runtime.runtimeGroup?.let { LambdaBuilder.getInstanceOrNull(it) }
+            ?: throw IllegalStateException("LambdaBuilder for ${initialSettings.runtime} not found")
+
+        val s3Bucket = view.codeStorage.sourceBucket.selected() as String
+
+        val lambdaCreator = LambdaCreatorFactory.create(project, lambdaBuilder)
+
+        val future = lambdaCreator.updateLambda(module, element, functionDetails, s3Bucket, configurationChanged())
+        future.whenComplete { _, error ->
+            when (error) {
+                null -> {
+                    notifyInfo(
+                        project = project,
+                        title = NOTIFICATION_TITLE,
+                        content = message("lambda.function.code_updated.notification", functionDetails.name)
+                    )
+                    LambdaTelemetry.editFunction(project, update = false, result = Result.Succeeded)
+                }
+                is Exception -> {
+                    error.notifyError(project = project, title = NOTIFICATION_TITLE)
+                    LambdaTelemetry.editFunction(project, update = false, result = Result.Failed)
+                }
+            }
+        }
+    }
+
+    // Using an OkAction to force the validation logic to trigger as well
+    private inner class UpdateFunctionOkAction : OkAction() {
+        init {
+            putValue(Action.NAME, message("lambda.upload.update_settings_button.title"))
+        }
+    }
+
+    private fun loadSettings() {
+        view.codeStorage.sourceBucket.selectedItem = updateSettings.bucketName
+        view.buildSettings.buildInContainerCheckbox.isSelected = updateSettings.useContainer ?: false
+    }
+
+    private fun saveSettings() {
+        updateSettings.bucketName = view.codeStorage.sourceBucket.selectedItem?.toString()
+        updateSettings.useContainer = view.buildSettings.buildInContainerCheckbox.isSelected
+    }
+
+    @TestOnly
+    fun getViewForTestAssertions() = view
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodePanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodePanel.form
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="software.aws.toolkits.jetbrains.services.lambda.upload.UpdateFunctionCodePanel">
+  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="864" height="285"/>
+    </constraints>
+    <properties>
+      <preferredSize width="750" height="-1"/>
+    </properties>
+    <border type="none"/>
+    <children>
+      <vspacer id="bcf26">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <nested-form id="92326" form-file="software/aws/toolkits/jetbrains/services/lambda/upload/BuildSettingsPanel.form" binding="buildSettings">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </nested-form>
+      <nested-form id="603ab" form-file="software/aws/toolkits/jetbrains/services/lambda/upload/CodeStoragePanel.form" binding="codeStorage" custom-create="true">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </nested-form>
+      <grid id="38f04" binding="lambdaConfigurationPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="fc780" class="javax.swing.JLabel" binding="handlerLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.handler.label"/>
+              <toolTipText resource-bundle="software/aws/toolkits/resources/localized_messages" key="lambda.function.handler.tooltip"/>
+            </properties>
+          </component>
+          <component id="26fa3" class="software.aws.toolkits.jetbrains.ui.HandlerPanel" binding="handlerPanel" custom-create="true">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodePanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodePanel.kt
@@ -1,0 +1,32 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.aws.toolkits.jetbrains.services.lambda.upload
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.IdeBorderFactory
+import software.aws.toolkits.jetbrains.ui.HandlerPanel
+import software.aws.toolkits.resources.message
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+class UpdateFunctionCodePanel internal constructor(private val project: Project) {
+    lateinit var content: JPanel
+    lateinit var buildSettings: BuildSettingsPanel
+    lateinit var codeStorage: CodeStoragePanel
+    lateinit var handlerLabel: JLabel
+    lateinit var handlerPanel: HandlerPanel
+    private lateinit var lambdaConfigurationPanel: JPanel
+
+    init {
+        lambdaConfigurationPanel.border = IdeBorderFactory.createTitledBorder(message("lambda.upload.configuration_settings"), false)
+    }
+
+    private fun createUIComponents() {
+        codeStorage = CodeStoragePanel(project)
+        handlerPanel = HandlerPanel(project)
+    }
+
+    fun validatePanel(): ValidationInfo? = handlerPanel.validateHandler()
+        ?: codeStorage.validatePanel()
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/EditFunctionDialogTest.kt
@@ -25,14 +25,12 @@ import software.amazon.awssdk.services.lambda.model.Runtime
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.Bucket
 import software.aws.toolkits.core.region.AwsRegion
-import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
-import software.aws.toolkits.jetbrains.settings.UpdateLambdaSettings
 import software.aws.toolkits.jetbrains.ui.ResourceSelector
 import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.waitForFalse
@@ -78,48 +76,6 @@ class EditFunctionDialogTest {
         }
         assertThat(dialog.getViewForTestAssertions().runtime.model.size).isEqualTo(LambdaHandlerResolver.supportedRuntimeGroups().flatMap { it.runtimes }.size)
         assertThat(dialog.getViewForTestAssertions().runtime.model.size).isNotEqualTo(Runtime.knownValues().size)
-
-        val dialog2 = runInEdtAndGet {
-            EditFunctionDialog(project = projectRule.project, mode = EditFunctionMode.UPDATE_CODE)
-        }
-        assertThat(dialog2.getViewForTestAssertions().runtime.model.size).isEqualTo(LambdaHandlerResolver.supportedRuntimeGroups().flatMap { it.runtimes }.size)
-        assertThat(dialog2.getViewForTestAssertions().runtime.model.size).isNotEqualTo(Runtime.knownValues().size)
-    }
-
-    @Test
-    fun `Loads saved settings if function name matches`() {
-        mockBuckets()
-
-        val arn = RuleUtils.randomName()
-        val settings = UpdateLambdaSettings.getInstance(arn)
-
-        settings.bucketName = "hello2"
-        settings.useContainer = true
-
-        val dialog = runInEdtAndGet {
-            EditFunctionDialog(project = projectRule.project, mode = EditFunctionMode.UPDATE_CODE, arn = arn)
-        }
-        dialog.getViewForTestAssertions().sourceBucket.waitToLoad()
-        assertThat(dialog.getViewForTestAssertions().buildInContainer.isSelected).isEqualTo(true)
-        assertThat(dialog.getViewForTestAssertions().sourceBucket.selectedItem?.toString()).isEqualTo("hello2")
-    }
-
-    @Test
-    fun `Does not load saved settings if function name does not match`() {
-        mockBuckets()
-
-        val arn = RuleUtils.randomName()
-        val settings = UpdateLambdaSettings.getInstance(arn)
-
-        settings.bucketName = "hello2"
-        settings.useContainer = true
-
-        val dialog = runInEdtAndGet {
-            EditFunctionDialog(project = projectRule.project, mode = EditFunctionMode.UPDATE_CODE, arn = "not$arn")
-        }
-        dialog.getViewForTestAssertions().sourceBucket.waitToLoad()
-        assertThat(dialog.getViewForTestAssertions().buildInContainer.isSelected).isEqualTo(false)
-        assertThat(dialog.getViewForTestAssertions().sourceBucket.selectedItem).isNull()
     }
 
     @Test
@@ -157,30 +113,6 @@ class EditFunctionDialogTest {
         assertThat(dialog.getViewForTestAssertions().configurationSettings.isVisible).isTrue()
         assertThat(dialog.getViewForTestAssertions().deploySettings.isVisible).isFalse()
         assertThat(dialog.getViewForTestAssertions().buildSettings.isVisible).isFalse()
-    }
-
-    @Test
-    fun updateCodeShowsOnlyDeploymentSettingsHandlerAndBuild() {
-        mockRoles()
-
-        val dialog = runInEdtAndGet {
-            EditFunctionDialog(project = projectRule.project, mode = EditFunctionMode.UPDATE_CODE)
-        }
-
-        assertThat(dialog.getViewForTestAssertions().deploySettings.isVisible).isTrue()
-        assertThat(dialog.getViewForTestAssertions().buildSettings.isVisible).isTrue()
-        assertThat(dialog.getViewForTestAssertions().handlerPanel.handler.isVisible).isTrue()
-
-        assertThat(dialog.getViewForTestAssertions().buildInContainer.isVisible).isTrue()
-
-        assertThat(dialog.getViewForTestAssertions().name.isVisible).isFalse()
-        assertThat(dialog.getViewForTestAssertions().description.isVisible).isFalse()
-        assertThat(dialog.getViewForTestAssertions().iamRole.isVisible).isFalse()
-        assertThat(dialog.getViewForTestAssertions().createRole.isVisible).isFalse()
-        assertThat(dialog.getViewForTestAssertions().runtime.isVisible).isFalse()
-        assertThat(dialog.getViewForTestAssertions().envVars.isVisible).isFalse()
-        assertThat(dialog.getViewForTestAssertions().timeoutSlider.isVisible).isFalse()
-        assertThat(dialog.getViewForTestAssertions().memorySlider.isVisible).isFalse()
     }
 
     private fun mockBuckets() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodeDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodeDialogTest.kt
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.lambda.model.Runtime
 import software.amazon.awssdk.services.s3.model.Bucket
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.core.utils.test.aString
+import software.aws.toolkits.core.utils.test.retryableAssert
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.activeRegion
@@ -48,8 +49,11 @@ class UpdateFunctionCodeDialogTest {
             UpdateFunctionCodeDialog(project = projectRule.project, initialSettings = aLambdaFunction().copy(arn = arn))
         }
         dialog.getViewForTestAssertions().codeStorage.sourceBucket.waitToLoad()
-        assertThat(dialog.getViewForTestAssertions().buildSettings.buildInContainerCheckbox.isSelected).isEqualTo(true)
-        assertThat(dialog.getViewForTestAssertions().codeStorage.sourceBucket.selectedItem?.toString()).isEqualTo("hello2")
+
+        retryableAssert {
+            assertThat(dialog.getViewForTestAssertions().buildSettings.buildInContainerCheckbox.isSelected).isEqualTo(true)
+            assertThat(dialog.getViewForTestAssertions().codeStorage.sourceBucket.selectedItem?.toString()).isEqualTo("hello2")
+        }
     }
 
     @Test
@@ -66,8 +70,11 @@ class UpdateFunctionCodeDialogTest {
             UpdateFunctionCodeDialog(project = projectRule.project, initialSettings = aLambdaFunction().copy(arn = "not$arn"))
         }
         dialog.getViewForTestAssertions().codeStorage.sourceBucket.waitToLoad()
-        assertThat(dialog.getViewForTestAssertions().buildSettings.buildInContainerCheckbox.isSelected).isEqualTo(false)
-        assertThat(dialog.getViewForTestAssertions().codeStorage.sourceBucket.selectedItem?.toString()).isNull()
+
+        retryableAssert {
+            assertThat(dialog.getViewForTestAssertions().buildSettings.buildInContainerCheckbox.isSelected).isEqualTo(false)
+            assertThat(dialog.getViewForTestAssertions().codeStorage.sourceBucket.selectedItem?.toString()).isNull()
+        }
     }
 
     private fun mockBuckets() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodeDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionCodeDialogTest.kt
@@ -1,0 +1,99 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.upload
+
+import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.runInEdtAndGet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.awssdk.services.lambda.model.Runtime
+import software.amazon.awssdk.services.s3.model.Bucket
+import software.aws.toolkits.core.utils.RuleUtils
+import software.aws.toolkits.core.utils.test.aString
+import software.aws.toolkits.jetbrains.core.MockClientManagerRule
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
+import software.aws.toolkits.jetbrains.core.credentials.activeRegion
+import software.aws.toolkits.jetbrains.services.iam.IamRole
+import software.aws.toolkits.jetbrains.services.lambda.LambdaFunction
+import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
+import software.aws.toolkits.jetbrains.settings.UpdateLambdaSettings
+import software.aws.toolkits.jetbrains.utils.waitToLoad
+
+class UpdateFunctionCodeDialogTest {
+    @JvmField
+    @Rule
+    val projectRule = ProjectRule()
+
+    @JvmField
+    @Rule
+    val mockClientManager = MockClientManagerRule()
+
+    @JvmField
+    @Rule
+    val mockResourceCache = MockResourceCacheRule()
+
+    @Test
+    fun `Loads saved settings if function arn matches`() {
+        mockBuckets()
+
+        val arn = aString()
+        val settings = UpdateLambdaSettings.getInstance(arn)
+
+        settings.bucketName = "hello2"
+        settings.useContainer = true
+
+        val dialog = runInEdtAndGet {
+            UpdateFunctionCodeDialog(project = projectRule.project, initialSettings = aLambdaFunction().copy(arn = arn))
+        }
+        dialog.getViewForTestAssertions().codeStorage.sourceBucket.waitToLoad()
+        assertThat(dialog.getViewForTestAssertions().buildSettings.buildInContainerCheckbox.isSelected).isEqualTo(true)
+        assertThat(dialog.getViewForTestAssertions().codeStorage.sourceBucket.selectedItem?.toString()).isEqualTo("hello2")
+    }
+
+    @Test
+    fun `Does not load saved settings if function arn does not match`() {
+        mockBuckets()
+
+        val arn = RuleUtils.randomName()
+        val settings = UpdateLambdaSettings.getInstance(arn)
+
+        settings.bucketName = "hello2"
+        settings.useContainer = true
+
+        val dialog = runInEdtAndGet {
+            UpdateFunctionCodeDialog(project = projectRule.project, initialSettings = aLambdaFunction().copy(arn = "not$arn"))
+        }
+        dialog.getViewForTestAssertions().codeStorage.sourceBucket.waitToLoad()
+        assertThat(dialog.getViewForTestAssertions().buildSettings.buildInContainerCheckbox.isSelected).isEqualTo(false)
+        assertThat(dialog.getViewForTestAssertions().codeStorage.sourceBucket.selectedItem?.toString()).isNull()
+    }
+
+    private fun mockBuckets() {
+        val region = projectRule.project.activeRegion()
+
+        mockResourceCache.addEntry(
+            projectRule.project,
+            S3Resources.LIST_REGIONALIZED_BUCKETS,
+            listOf(
+                S3Resources.RegionalizedBucket(Bucket.builder().name("hello").build(), region),
+                S3Resources.RegionalizedBucket(Bucket.builder().name("hello2").build(), region)
+            )
+        )
+    }
+
+    private fun aLambdaFunction() = LambdaFunction(
+        name = aString(),
+        description = aString(),
+        arn = aString(),
+        lastModified = "",
+        handler = aString(),
+        runtime = Runtime.UNKNOWN_TO_SDK_VERSION,
+        timeout = 1,
+        memorySize = 1,
+        xrayEnabled = false,
+        role = IamRole(aString()),
+        envVariables = emptyMap()
+    )
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateLambdaCodePanelTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateLambdaCodePanelTest.kt
@@ -1,0 +1,101 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.upload
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.testFramework.IdeaTestUtil
+import com.intellij.testFramework.runInEdtAndWait
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.awssdk.services.lambda.model.Runtime
+import software.amazon.awssdk.services.s3.model.Bucket
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
+import software.aws.toolkits.jetbrains.core.credentials.activeRegion
+import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
+import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
+import software.aws.toolkits.jetbrains.utils.rules.openClass
+import software.aws.toolkits.jetbrains.utils.waitToLoad
+
+class UpdateLambdaCodePanelTest {
+    @Rule
+    @JvmField
+    val projectRule = JavaCodeInsightTestFixtureRule()
+
+    @Rule
+    @JvmField
+    val resourceCache = MockResourceCacheRule()
+
+    private lateinit var sut: UpdateFunctionCodePanel
+
+    @Before
+    fun wireMocksTogetherWithValidOptions() {
+        val project = projectRule.project
+        val bucketName = "sourceBucket"
+
+        resourceCache.addEntry(
+            project,
+            S3Resources.LIST_REGIONALIZED_BUCKETS,
+            listOf(S3Resources.RegionalizedBucket(Bucket.builder().name(bucketName).build(), project.activeRegion()))
+        )
+
+        val sdk = IdeaTestUtil.getMockJdk18()
+        runInEdtAndWait {
+            runWriteAction {
+                ProjectJdkTable.getInstance().addJdk(sdk, projectRule.fixture.projectDisposable)
+                ProjectRootManager.getInstance(project).projectSdk = sdk
+            }
+            sut = UpdateFunctionCodePanel(project)
+            sut.handlerPanel.setRuntime(Runtime.JAVA8)
+            sut.handlerPanel.handler.text = "com.example.LambdaHandler::handleRequest"
+            sut.codeStorage.sourceBucket.selectedItem = bucketName
+        }
+
+        projectRule.fixture.openClass(
+            """
+            package com.example;
+
+            public class LambdaHandler {
+                public static void handleRequest(InputStream input, OutputStream output) { }
+            }
+            """
+        )
+
+        sut.codeStorage.sourceBucket.waitToLoad()
+    }
+
+    @Test
+    fun validFunctionReturnsNull() {
+        runInEdtAndWait {
+            assertThat(sut.validatePanel()).isNull()
+        }
+    }
+
+    @Test
+    fun sourceBucketMustBeSelectedToDeploy() {
+        runInEdtAndWait {
+            sut.codeStorage.sourceBucket.selectedItem = null
+            assertThat(sut.validatePanel()?.message).contains("Bucket must be specified")
+        }
+    }
+
+    @Test
+    fun handlerCannotBeBlank() {
+        runInEdtAndWait {
+            sut.handlerPanel.handler.text = ""
+            assertThat(sut.validatePanel()?.message).contains("Handler must be specified")
+        }
+    }
+
+    @Test
+    fun handlerMustBeInProjectToDeploy() {
+        runInEdtAndWait {
+            sut.handlerPanel.handler.text = "Foo"
+            assertThat(sut.validatePanel()?.message).contains("Must be able to locate the handler")
+        }
+    }
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/CoroutineTestUtils.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/CoroutineTestUtils.kt
@@ -5,6 +5,14 @@ package software.aws.toolkits.jetbrains.utils
 
 import com.intellij.util.ui.ListTableModel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import software.aws.toolkits.jetbrains.ui.ResourceSelector
+
+fun ResourceSelector<*>.waitToLoad() {
+    runBlocking {
+        waitForFalse { isLoading }
+    }
+}
 
 suspend fun ListTableModel<*>.waitForModelToBeAtLeast(size: Int) {
     waitForFalse { items.size < size }

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -522,6 +522,7 @@ lambda.upload_validation.handler=Handler must be specified
 lambda.upload_validation.handler_not_found=Must be able to locate the handler in the project in order to deploy to Lambda
 lambda.upload_validation.iam_role=IAM role must be specified
 lambda.upload_validation.iam_role.loading=Still loading IAM role...
+lambda.upload_validation.module_not_found=Failed to locate module for {0}
 lambda.upload_validation.runtime=Runtime must be specified
 lambda.upload_validation.source_bucket=Bucket must be specified in order to deploy to Lambda
 lambda.upload_validation.source_bucket.loading=Still loading S3 bucket...


### PR DESCRIPTION
* Make Update Function Code have its own UI instead of bunch of hidden elements since it can lead to hidden errors
* Break up our panels
* Move validation logic closer to the UI

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
