### PR TITLE
Migrate Rider models generator settings from gradle Kts into model Kt class

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -241,7 +241,7 @@ subprojects {
             }
 
             configure<JacocoTaskExtension> {
-                destinationFile = file("$buildDir/jacoco/${Instant.now()}-jacocoUiTests.exec")
+                setDestinationFile(File("$buildDir/jacoco/${Instant.now()}-jacocoUiTests.exec"))
             }
         }
     }

--- a/jetbrains-rider/protocol/model/daemon/LambdaDaemonModel.kt
+++ b/jetbrains-rider/protocol/model/daemon/LambdaDaemonModel.kt
@@ -1,14 +1,41 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package protocol.model.daemon
+package model.daemon
 
-import com.jetbrains.rd.generator.nova.Ext
+import com.jetbrains.rd.generator.nova.csharp.CSharp50Generator
 import com.jetbrains.rd.generator.nova.doc
+import com.jetbrains.rd.generator.nova.Ext
+import com.jetbrains.rd.generator.nova.ExternalGenerator
+import com.jetbrains.rd.generator.nova.FlowTransform
 import com.jetbrains.rd.generator.nova.field
-import com.jetbrains.rd.generator.nova.sink
+import com.jetbrains.rd.generator.nova.GeneratorBase
+import com.jetbrains.rd.generator.nova.kotlin.Kotlin11Generator
 import com.jetbrains.rd.generator.nova.PredefinedType.string
+import com.jetbrains.rd.generator.nova.setting
+import com.jetbrains.rd.generator.nova.sink
+import com.jetbrains.rd.generator.nova.util.syspropertyOrInvalid
+import com.jetbrains.rider.model.nova.ide.IdeRoot
 import com.jetbrains.rider.model.nova.ide.SolutionModel
+import java.io.File
+
+object DaemonKotlinGenerator : ExternalGenerator(
+    Kotlin11Generator(
+        FlowTransform.AsIs,
+        "com.jetbrains.rider.model",
+        File(syspropertyOrInvalid("ktDaemonGeneratedOutput"))
+    ),
+    IdeRoot
+)
+
+object DaemonCSharpGenerator : ExternalGenerator(
+    CSharp50Generator(
+        FlowTransform.Reversed,
+        "JetBrains.Rider.Model",
+        File(syspropertyOrInvalid("csDaemonGeneratedOutput"))
+    ),
+    IdeRoot
+)
 
 @Suppress("unused")
 object LambdaDaemonModel : Ext(SolutionModel.Solution) {
@@ -19,6 +46,11 @@ object LambdaDaemonModel : Ext(SolutionModel.Solution) {
     }
 
     init {
+        setting(GeneratorBase.AcceptsGenerator) { generator ->
+            generator == DaemonKotlinGenerator.generator ||
+                generator == DaemonCSharpGenerator.generator
+        }
+
         sink("runLambda", LambdaRequest)
             .doc("Signal from backend to run lambda on local environment")
 

--- a/jetbrains-rider/protocol/model/project/AwsProjectModel.kt
+++ b/jetbrains-rider/protocol/model/project/AwsProjectModel.kt
@@ -1,14 +1,41 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package protocol.model.project
+package model.project
 
-import com.jetbrains.rd.generator.nova.Ext
+import com.jetbrains.rd.generator.nova.csharp.CSharp50Generator
 import com.jetbrains.rd.generator.nova.call
 import com.jetbrains.rd.generator.nova.doc
+import com.jetbrains.rd.generator.nova.Ext
+import com.jetbrains.rd.generator.nova.ExternalGenerator
+import com.jetbrains.rd.generator.nova.FlowTransform
 import com.jetbrains.rd.generator.nova.field
+import com.jetbrains.rd.generator.nova.GeneratorBase
+import com.jetbrains.rd.generator.nova.kotlin.Kotlin11Generator
 import com.jetbrains.rd.generator.nova.PredefinedType.string
+import com.jetbrains.rd.generator.nova.setting
+import com.jetbrains.rd.generator.nova.util.syspropertyOrInvalid
+import com.jetbrains.rider.model.nova.ide.IdeRoot
 import com.jetbrains.rider.model.nova.ide.SolutionModel
+import java.io.File
+
+object AwsProjectKotlinGenerator : ExternalGenerator(
+    Kotlin11Generator(
+        FlowTransform.AsIs,
+        "com.jetbrains.rider.model",
+        File(syspropertyOrInvalid("ktAwsProjectGeneratedOutput"))
+    ),
+    IdeRoot
+)
+
+object AwsProjectCSharpGenerator : ExternalGenerator(
+    CSharp50Generator(
+        FlowTransform.Reversed,
+        "JetBrains.Rider.Model",
+        File(syspropertyOrInvalid("csAwsProjectGeneratedOutput"))
+    ),
+    IdeRoot
+)
 
 @Suppress("unused")
 object AwsProjectModel : Ext(SolutionModel.Solution) {
@@ -23,6 +50,11 @@ object AwsProjectModel : Ext(SolutionModel.Solution) {
     }
 
     init {
+        setting(GeneratorBase.AcceptsGenerator) { generator ->
+            generator == AwsProjectKotlinGenerator.generator ||
+                generator == AwsProjectCSharpGenerator.generator
+        }
+
         call("getProjectOutput", AwsProjectOutputRequest, AwsProjectOutput)
             .doc("Get AWS project output information")
     }

--- a/jetbrains-rider/protocol/model/psi/LambdaPsiModel.kt
+++ b/jetbrains-rider/protocol/model/psi/LambdaPsiModel.kt
@@ -1,21 +1,48 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package protocol.model.psi
+package model.psi
 
-import com.jetbrains.rd.generator.nova.Ext
 import com.jetbrains.rd.generator.nova.async
+import com.jetbrains.rd.generator.nova.csharp.CSharp50Generator
 import com.jetbrains.rd.generator.nova.call
 import com.jetbrains.rd.generator.nova.doc
+import com.jetbrains.rd.generator.nova.Ext
+import com.jetbrains.rd.generator.nova.ExternalGenerator
+import com.jetbrains.rd.generator.nova.FlowTransform
 import com.jetbrains.rd.generator.nova.field
+import com.jetbrains.rd.generator.nova.GeneratorBase
 import com.jetbrains.rd.generator.nova.immutableList
+import com.jetbrains.rd.generator.nova.kotlin.Kotlin11Generator
 import com.jetbrains.rd.generator.nova.nullable
 import com.jetbrains.rd.generator.nova.PredefinedType.bool
 import com.jetbrains.rd.generator.nova.PredefinedType.int
 import com.jetbrains.rd.generator.nova.PredefinedType.string
 import com.jetbrains.rd.generator.nova.PredefinedType.void
+import com.jetbrains.rd.generator.nova.setting
+import com.jetbrains.rd.generator.nova.util.syspropertyOrInvalid
+import com.jetbrains.rider.model.nova.ide.IdeRoot
 import com.jetbrains.rider.model.nova.ide.ShellModel.IconModel
 import com.jetbrains.rider.model.nova.ide.SolutionModel
+import java.io.File
+
+object PsiKotlinGenerator : ExternalGenerator(
+    Kotlin11Generator(
+        FlowTransform.AsIs,
+        "com.jetbrains.rider.model",
+        File(syspropertyOrInvalid("ktPsiGeneratedOutput"))
+    ),
+    IdeRoot
+)
+
+object PsiCSharpGenerator : ExternalGenerator(
+    CSharp50Generator(
+        FlowTransform.Reversed,
+        "JetBrains.Rider.Model",
+        File(syspropertyOrInvalid("csPsiGeneratedOutput"))
+    ),
+    IdeRoot
+)
 
 @Suppress("unused")
 object LambdaPsiModel : Ext(SolutionModel.Solution) {
@@ -32,6 +59,11 @@ object LambdaPsiModel : Ext(SolutionModel.Solution) {
     }
 
     init {
+        setting(GeneratorBase.AcceptsGenerator) { generator ->
+            generator == PsiKotlinGenerator.generator ||
+                generator == PsiCSharpGenerator.generator
+        }
+
         call("determineHandlers", void, immutableList(HandlerCompletionItem)).async
             .doc("Get collection of HandlerCompletionItems with available handler functions for a solution")
 

--- a/jetbrains-rider/protocol/model/setting/AwsSettingModel.kt
+++ b/jetbrains-rider/protocol/model/setting/AwsSettingModel.kt
@@ -1,19 +1,50 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package protocol.model.setting
+package model.setting
 
+import com.jetbrains.rd.generator.nova.csharp.CSharp50Generator
 import com.jetbrains.rd.generator.nova.doc
+import com.jetbrains.rd.generator.nova.Ext
+import com.jetbrains.rd.generator.nova.ExternalGenerator
+import com.jetbrains.rd.generator.nova.FlowTransform
+import com.jetbrains.rd.generator.nova.GeneratorBase
+import com.jetbrains.rd.generator.nova.kotlin.Kotlin11Generator
+import com.jetbrains.rd.generator.nova.PredefinedType.bool
 import com.jetbrains.rd.generator.nova.setting
 import com.jetbrains.rd.generator.nova.source
-import com.jetbrains.rd.generator.nova.Ext
-import com.jetbrains.rd.generator.nova.PredefinedType.bool
+import com.jetbrains.rd.generator.nova.util.syspropertyOrInvalid
+import com.jetbrains.rider.model.nova.ide.IdeRoot
 import com.jetbrains.rider.model.nova.ide.SolutionModel
+import java.io.File
+
+object AwsSettingsKotlinGenerator : ExternalGenerator(
+    Kotlin11Generator(
+        FlowTransform.AsIs,
+        "com.jetbrains.rider.model",
+        File(syspropertyOrInvalid("ktAwsSettingsGeneratedOutput"))
+    ),
+    IdeRoot
+)
+
+object AwsSettingsCSharpGenerator : ExternalGenerator(
+    CSharp50Generator(
+        FlowTransform.Reversed,
+        "JetBrains.Rider.Model",
+        File(syspropertyOrInvalid("csAwsSettingsGeneratedOutput"))
+    ),
+    IdeRoot
+)
 
 @Suppress("unused")
 object AwsSettingModel : Ext(SolutionModel.Solution) {
 
     init {
+        setting(GeneratorBase.AcceptsGenerator) { generator ->
+            generator == AwsSettingsKotlinGenerator.generator ||
+                generator == AwsSettingsCSharpGenerator.generator
+        }
+
         source("showLambdaGutterMarks", bool)
             .doc("Flag indicating whether Lambda gutter marks should be shown in editor")
     }


### PR DESCRIPTION
Move old way for generator settings from Gradle configuration with model-based configurations.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Move protocol generator configuration from gradle into model class

## Motivation and Context
Move generator configuration logic from gradle into model kt files. Each model can configure generator. This change move from old way of configuring generators to a current one.

## Related Issue(s)
None.

## Testing
Check models are generated and are included in a compiled zip.

## Screenshots (if appropriate)
None.

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
