### PR TITLE
Allow version ranges in source/test

### DIFF
--- a/buildSrc/src/software/aws/toolkits/gradle/SourcesUtils.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/SourcesUtils.kt
@@ -34,6 +34,7 @@ fun findFolders(project: Project, type: String, ideProfile: Profile): Set<File> 
  *  - tst-201
  *  - tst-201+
  *  - tst-192+
+ *  - tst-201-202
  *
  * The following with *not* match:
  *  - tst-resources
@@ -44,8 +45,12 @@ fun findFolders(project: Project, type: String, ideProfile: Profile): Set<File> 
  */
 internal fun includeFolder(type: String, ideVersion: String, folderName: String): Boolean {
     val ideVersionAsInt = ideVersion.toInt()
-    val match = "$type(-(\\d{3}))?(\\+)?".toRegex().matchEntire(folderName) ?: return false
-    val (_, version, plus) = match.destructured
+    // Check version range first
+    "$type-(\\d{3})-(\\d{3})".toRegex().matchEntire(folderName)?.destructured?.let { (minVersion, maxVersion) ->
+        return ideVersionAsInt in minVersion.toInt()..maxVersion.toInt()
+    }
+    // Then check singular versions/min+
+    val (_, version, plus) = "$type(-(\\d{3}))?(\\+)?".toRegex().matchEntire(folderName)?.destructured ?: return false
     return when {
         version.isBlank() -> true
         plus.isBlank() -> version.toInt() == ideVersionAsInt

--- a/buildSrc/tst/software/aws/toolkits/gradle/SourceUtilsTest.kt
+++ b/buildSrc/tst/software/aws/toolkits/gradle/SourceUtilsTest.kt
@@ -19,14 +19,19 @@ class SourceUtilsTest(private val folderName: String, private val expected: Bool
             arrayOf("tst-201", true),
             arrayOf("tst-190+", true),
             arrayOf("tst-201+", true),
+            arrayOf("tst-201-202", true),
+            arrayOf("tst-193-201", true),
+            arrayOf("tst-193-202", true),
 
             arrayOf("tst-resources", false),
             arrayOf("tst-resources-201", false),
             arrayOf("tst-192", false),
             arrayOf("tst-202", false),
             arrayOf("tst-202+", false),
+            arrayOf("src-201", false),
             arrayOf("random", false),
-            arrayOf("src-tst", false)
+            arrayOf("src-tst", false),
+            arrayOf("tst-192-193", false)
         )
     }
 


### PR DESCRIPTION
- Allow version ranges (like `tst-201-202`) to prevent having to duplicate code for 203
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
