### PR TITLE
Setup the explorer tool window correctly using the content manager

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerFactory.kt
@@ -20,7 +20,10 @@ import software.aws.toolkits.resources.message
 class AwsExplorerFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val explorer = ExplorerToolWindow.getInstance(project)
-        toolWindow.component.parent.add(explorer)
+        val contentManager = toolWindow.contentManager
+        val content = contentManager.factory.createContent(explorer, null, false)
+        contentManager.addContent(content)
+
         toolWindow.helpId = HelpIds.EXPLORER_WINDOW.id
         if (toolWindow is ToolWindowEx) {
             val actionManager = ActionManager.getInstance()


### PR DESCRIPTION
Fixes the explorer being frozen in 203

Before:
<img width="354" alt="Screen Shot 2020-11-16 at 11 12 18 AM" src="https://user-images.githubusercontent.com/8992246/99306180-a8fe8000-2809-11eb-93ef-5ec305ad97fd.png">

After:
<img width="440" alt="Screen Shot 2020-11-16 at 12 45 45 PM" src="https://user-images.githubusercontent.com/8992246/99306192-adc33400-2809-11eb-8180-ae146f53b34e.png">


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
