### PR TITLE
Make UI tests pass against 203

### DIFF
--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
@@ -8,6 +8,7 @@ import com.intellij.remoterobot.data.RemoteComponent
 import com.intellij.remoterobot.fixtures.ContainerFixture
 import com.intellij.remoterobot.fixtures.FixtureName
 import com.intellij.remoterobot.stepsProcessing.step
+import com.intellij.remoterobot.utils.keyboard
 import java.nio.file.Path
 import java.time.Duration
 
@@ -38,7 +39,7 @@ class FileBrowserFixture(
         // Wait for file explorer to load
         Thread.sleep(1000)
         step("Fill file explorer with ${path.toAbsolutePath()}") {
-            fillSingleTextField(path.toAbsolutePath().toString())
+            keyboard { enterText(path.toAbsolutePath().toString(), delayBetweenCharsInMs = 0) } // path text box is already focused on open
         }
         val file = path.fileName.toString()
         step("Refresh file explorer to make sure the file $file is loaded") {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeVersionUtils.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeVersionUtils.kt
@@ -1,0 +1,8 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.fixtures
+
+import com.intellij.remoterobot.RemoteRobot
+
+fun RemoteRobot.ideMajorVersion() = callJs<Int>("com.intellij.openapi.application.ApplicationInfo.getInstance().getBuild().getBaselineVersion()")

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -20,7 +20,7 @@ import java.time.Duration
 fun RemoteRobot.idea(function: IdeaFrame.() -> Unit) {
     val frame = find<IdeaFrame>(timeout = Duration.ofSeconds(10))
     // FIX_WHEN_MIN_IS_203 remove this and set the system property "ide.show.tips.on.startup.default.value"
-    frame.apply { tryCloseTips() }
+    frame.apply { dumbAware {  tryCloseTips() } }
     frame.apply(function)
 }
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -18,7 +18,7 @@ import java.awt.event.KeyEvent
 import java.time.Duration
 
 fun RemoteRobot.idea(function: IdeaFrame.() -> Unit) {
-    val frame = find<IdeaFrame>()
+    val frame = find<IdeaFrame>(timeout = Duration.ofSeconds(10))
     // FIX_WHEN_MIN_IS_203 remove this and set the system property "ide.show.tips.on.startup.default.value"
     frame.apply { tryCloseTips() }
     frame.apply(function)
@@ -80,9 +80,14 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : Co
 
     // Tips sometimes open when running, close it if it opens
     fun tryCloseTips() {
-        try {
-            pressClose()
-        } catch (e: Exception) {
+        step("Close Tip of the Day if it appears") {
+            try {
+                val fixture = find<DialogFixture>(DialogFixture.byTitleContains("Tip"))
+                while (fixture.isShowing) {
+                    fixture.pressClose()
+                }
+            } catch (e: Exception) {
+            }
         }
     }
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -20,7 +20,7 @@ import java.time.Duration
 fun RemoteRobot.idea(function: IdeaFrame.() -> Unit) {
     val frame = find<IdeaFrame>(timeout = Duration.ofSeconds(10))
     // FIX_WHEN_MIN_IS_203 remove this and set the system property "ide.show.tips.on.startup.default.value"
-    frame.apply { dumbAware {  tryCloseTips() } }
+    frame.apply { dumbAware { tryCloseTips() } }
     frame.apply(function)
 }
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/WelcomeFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/WelcomeFrame.kt
@@ -25,31 +25,57 @@ fun RemoteRobot.welcomeFrame(function: WelcomeFrame.() -> Unit) {
 @DefaultXpath("type", "//div[@class='FlatWelcomeFrame' and @visible='true']")
 class WelcomeFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : CommonContainerFixture(remoteRobot, remoteComponent) {
     fun openNewProjectWizard() {
-        actionLink(ActionLinkFixture.byTextContains("New Project")).click()
+        // TODO: Remove FIX_WHEN_MIN_IS_203
+        if (remoteRobot.ideMajorVersion() <= 202) {
+            actionLink(ActionLinkFixture.byTextContains("New Project")).click()
+        } else {
+            selectTab("Projects")
+            // This can match two things: If no previous projects, its a SVG icon, else a jbutton
+            findAll<ComponentFixture>(byXpath("//div[@accessiblename='New Project']")).first().click()
+        }
     }
 
     fun openPreferences() = step("Opening preferences dialog") {
-        actionLink("Configure").click()
+        // TODO: Remove FIX_WHEN_MIN_IS_203
+        if (remoteRobot.ideMajorVersion() <= 202) {
+            actionLink("Configure").click()
 
-        // MyList finds both the list of actions and the most recently used file list, so get all candidates
-        val found = findAll(ComponentFixture::class.java, byXpath("//div[@class='MyList']"))
-            .any {
-                try {
-                    it.findText(remoteRobot.preferencesTitle()).click()
-                    true
-                } catch (e: NoSuchElementException) {
-                    false
+            // MyList finds both the list of actions and the most recently used file list, so get all candidates
+            val found = findAll(ComponentFixture::class.java, byXpath("//div[@class='MyList']"))
+                .any {
+                    try {
+                        it.findText(remoteRobot.preferencesTitle()).click()
+                        true
+                    } catch (e: NoSuchElementException) {
+                        false
+                    }
                 }
-            }
 
-        if (!found) {
-            throw IllegalStateException("Unable to find ${remoteRobot.preferencesTitle()} in the configure menu")
+            if (!found) {
+                throw IllegalStateException("Unable to find ${remoteRobot.preferencesTitle()} in the configure menu")
+            }
+        } else {
+            selectTab("Customize")
+            findAndClick("//div[@accessiblename='All settings…']")
         }
+
         log.info("Successfully opened the preferences dialog")
     }
 
+    fun selectTab(tabName: String) {
+        // TODO: Remove FIX_WHEN_MIN_IS_203
+        if (remoteRobot.ideMajorVersion() <= 202) return
+        jList(byXpath("//div[@accessiblename='Welcome screen categories']")).selectItem(tabName)
+    }
+
     fun openFolder(path: Path) {
-        actionLink(ActionLinkFixture.byTextContains("Open")).click()
+        // TODO: Remove FIX_WHEN_MIN_IS_203
+        if (remoteRobot.ideMajorVersion() <= 202) {
+            actionLink(ActionLinkFixture.byTextContains("Open")).click()
+        } else {
+            selectTab("Projects")
+            findAll<ComponentFixture>(byXpath("//div[@accessiblename='Open']")).first().click()
+        }
         fileBrowser("Open") {
             selectFile(path)
         }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/CloudFormationBrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/CloudFormationBrowserTest.kt
@@ -58,8 +58,7 @@ class CloudFormationBrowserTest {
         idea {
             waitForBackgroundTasks()
             showAwsExplorer()
-        }
-        idea {
+
             step("Open stack") {
                 awsExplorer {
                     expandExplorerNode(cloudFormation)

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -97,6 +97,10 @@ class S3BrowserTest {
             // Click on the tree to make sure it's there + we aren't selecting anything else
             s3Tree { click() }
 
+            // If the project starts fast enough we start the test before the tip is shown, but if the tip is showing when we go to start using the file browser
+            // it will fail to find them. So check for it one last time.
+            tryCloseTips()
+
             step("Upload object to top-level") {
                 actionButton(upload).click()
                 fileBrowser("Select") {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -75,8 +75,7 @@ class S3BrowserTest {
         idea {
             waitForBackgroundTasks()
             showAwsExplorer()
-        }
-        idea {
+
             step("Create bucket named $bucket") {
                 awsExplorer {
                     openExplorerActionMenu(S3)

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/SamTemplateProjectWizardTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/SamTemplateProjectWizardTest.kt
@@ -51,6 +51,8 @@ class SamTemplateProjectWizardTest {
 
                         pressOk()
                     }
+
+                    selectTab("Projects")
                 }
             }
         }


### PR DESCRIPTION
* Also make a few changes aimed to make them more stable

203:
```
SUCCESS: Executed 3 tests in 7m 23s


Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 7m 25s
3 actionable tasks: 1 executed, 2 up-to-date
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
