### PR TITLE
Fix S3 Tree table name rendering

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeCellRenderer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeCellRenderer.kt
@@ -42,4 +42,6 @@ class S3TreeCellRenderer(private val speedSearchTarget: JComponent) : ColoredTre
 
         SpeedSearchUtil.applySpeedSearchHighlighting(speedSearchTarget, this, true, selected)
     }
+
+    override fun calcFocusedState(): Boolean = speedSearchTarget.hasFocus()
 }


### PR DESCRIPTION
This does not fix the date and size unfocused colors, not sure whats causing that yet.

Before:
<img width="887" alt="Screen Shot 2020-11-17 at 10 48 42 AM" src="https://user-images.githubusercontent.com/8992246/99433544-7cf30580-28c2-11eb-8b38-d4daf51aa9bf.png">
<img width="861" alt="Screen Shot 2020-11-17 at 10 48 46 AM" src="https://user-images.githubusercontent.com/8992246/99433555-80868c80-28c2-11eb-92b4-de376e563699.png">

After:
<img width="732" alt="Screen Shot 2020-11-17 at 10 29 13 AM" src="https://user-images.githubusercontent.com/8992246/99433404-5208b180-28c2-11eb-9a17-f5aef6b72483.png">
<img width="777" alt="Screen Shot 2020-11-17 at 10 47 52 AM" src="https://user-images.githubusercontent.com/8992246/99433438-5d5bdd00-28c2-11eb-8d93-220ff04919ce.png">

## Related Issues
#2100 

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
