### PR TITLE
Improve logging to triage Dotnet debugger failing to attach

### DIFF
--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import software.aws.toolkits.core.utils.getLogger
+import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamDebugSupport
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.SamRunningState
 import software.aws.toolkits.jetbrains.utils.ApplicationThreadPoolScope
@@ -68,15 +69,15 @@ import kotlin.concurrent.schedule
  * 4. Send the command to the worker to attach to the correct PID.
  */
 class DotNetSamDebugSupport : SamDebugSupport {
-    companion object {
-        private val LOG = getLogger<DotNetSamDebugSupport>()
-        private const val DEBUGGER_MODE = "server"
+    private companion object {
+        val LOG = getLogger<DotNetSamDebugSupport>()
+        const val DEBUGGER_MODE = "server"
 
-        private const val REMOTE_DEBUGGER_DIR = "/tmp/lambci_debug_files"
-        private const val REMOTE_NETCORE_CLI_PATH = "/var/lang/bin/dotnet"
-        private const val NUMBER_OF_DEBUG_PORTS = 2
+        const val REMOTE_DEBUGGER_DIR = "/tmp/lambci_debug_files"
+        const val REMOTE_NETCORE_CLI_PATH = "/var/lang/bin/dotnet"
+        const val NUMBER_OF_DEBUG_PORTS = 2
 
-        private const val FIND_PID_SCRIPT =
+        const val FIND_PID_SCRIPT =
             """
                 for i in `ls /proc/*/exe` ; do
                     symlink=`readlink  ${'$'}i 2>/dev/null`;
@@ -217,7 +218,7 @@ class DotNetSamDebugSupport : SamDebugSupport {
                     }
                 }
             } catch (t: Throwable) {
-                LOG.warn("Failed to start debugger", t)
+                LOG.warn(t) { "Failed to start debugger" }
                 debuggerLifetimeDefinition.terminate(true)
                 promise.setError(t)
             }


### PR DESCRIPTION
More logs to help triage #2207

Added more info into the exception due to the stack trace loses the call site due to the `delay` call, and we don't log what we get back from the process.

```
11:08 AM	Error running '[Local] HelloWorldFunction'
				Command did not return expected result within PT30S, last attempt; cmd: 'docker exec -i bdac265895f2 /bin/sh -c faf', exitCode: 127, stdOut: '', stdErr: '/bin/sh: faf: command not found'
```

```
java.lang.IllegalStateException: Command did not return expected result within PT30S, last attempt; cmd: 'docker exec -i bdac265895f2 /bin/sh -c faf', exitCode: 127, stdOut: '', stdErr: '/bin/sh: faf: command not found'
	at software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetSamDebugSupport.runProcessUntil(DotNetSamDebugSupport.kt:283)
	at software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetSamDebugSupport$runProcessUntil$1.invokeSuspend(DotNetSamDebugSupport.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
