### PR TITLE
Migrate off deprecated constructor in LocalFileSystemFileFinder

### DIFF
--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamDebugSupport.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamDebugSupport.kt
@@ -32,7 +32,7 @@ class NodeJsSamDebugSupport : SamDebugSupport {
     ): XDebugProcessStarter? = object : XDebugProcessStarter() {
         override fun start(session: XDebugSession): XDebugProcess {
             val mappings = createBiMapMappings(state.builtLambda.mappings)
-            val fileFinder = RemoteDebuggingFileFinder(mappings, LocalFileSystemFileFinder(false))
+            val fileFinder = RemoteDebuggingFileFinder(mappings, LocalFileSystemFileFinder())
 
             val connection = WipLocalVmConnection()
             val executionResult = state.execute(environment.executor, environment.runner)


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
