### PR TITLE
Harden UI tests, fix bug in 203 welcome screen

### DIFF
--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
@@ -7,8 +7,11 @@ import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.data.RemoteComponent
 import com.intellij.remoterobot.fixtures.ContainerFixture
 import com.intellij.remoterobot.fixtures.FixtureName
+import com.intellij.remoterobot.fixtures.JTextFieldFixture
+import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.stepsProcessing.step
-import com.intellij.remoterobot.utils.keyboard
+import com.intellij.remoterobot.utils.waitForIgnoringError
+import java.io.File
 import java.nio.file.Path
 import java.time.Duration
 
@@ -35,16 +38,42 @@ class FileBrowserFixture(
     remoteRobot: RemoteRobot,
     remoteComponent: RemoteComponent
 ) : DialogFixture(remoteRobot, remoteComponent) {
-    fun selectFile(path: Path) = step("Select ${path.toAbsolutePath()}") {
-        // Wait for file explorer to load
-        Thread.sleep(1000)
-        step("Fill file explorer with ${path.toAbsolutePath()}") {
-            keyboard { enterText(path.toAbsolutePath().toString(), delayBetweenCharsInMs = 0) } // path text box is already focused on open
+    private val tree by lazy {
+        find<JTreeFixture>(byXpath("//div[@class='Tree']"), Duration.ofSeconds(10)).also {
+            it.separator = "|" // switch out the separator since tree has path "/" as the root
         }
-        val file = path.fileName.toString()
-        step("Refresh file explorer to make sure the file $file is loaded") {
-            findAndClick("//div[@accessiblename='Refresh']")
+    }
+
+    fun selectFile(path: Path) {
+        val absolutePath = path.toAbsolutePath()
+        step("Select $absolutePath") {
+            step("Fill file explorer with $absolutePath") {
+                val pathBox: JTextFieldFixture = if (remoteRobot.ideMajorVersion() <= 202) {
+                    find(byXpath("//div[@class='JTextField']"), Duration.ofSeconds(5))
+                } else {
+                    find(byXpath("//div[@class='BorderlessTextField']"), Duration.ofSeconds(5))
+                }
+                pathBox.text = absolutePath.toString()
+            }
+
+            step("Refresh file explorer to make sure the file ${path.fileName} is loaded") {
+                waitForIgnoringError {
+                    findAndClick("//div[@accessiblename='Refresh']")
+                    tree.requireSelection(*absolutePath.toParts())
+                    true
+                }
+            }
+
+            pressOk()
         }
-        pressOk()
+    }
+
+    private fun Path.toParts(): Array<String> {
+        val parts = this.toString().split(File.separatorChar).toMutableList()
+        // Need to re-add "/" on linux
+        if (this.toString().startsWith(File.separatorChar)) {
+            parts[0] = File.separator
+        }
+        return parts.toTypedArray()
     }
 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -104,4 +104,5 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : Co
     }
 
     fun findToast(timeout: Duration = Duration.ofSeconds(5)): ComponentFixture = find(byXpath("//div[@class='StatusPanel']"), timeout)
+    fun findToastText(timeout: Duration = Duration.ofSeconds(5)): List<String> = findToast(timeout).findAllText().map { it.text }
 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
@@ -12,10 +12,26 @@ class JTreeFixture(
     remoteRobot: RemoteRobot,
     remoteComponent: RemoteComponent
 ) : ComponentFixture(remoteRobot, remoteComponent) {
+    var separator: String = "/"
+
     fun clickPath(vararg paths: String) = runJsPathMethod("clickPath", *paths)
     fun expandPath(vararg paths: String) = runJsPathMethod("expandPath", *paths)
     fun rightClickPath(vararg paths: String) = runJsPathMethod("rightClickPath", *paths)
     fun doubleClickPath(vararg paths: String) = runJsPathMethod("doubleClickPath", *paths)
+
+    fun requireSelection(vararg paths: String) {
+        val path = paths.joinToString(separator)
+        step("requireSelection $path") {
+            runJs(
+                """
+                const jTreeFixture = JTreeFixture(robot, component);
+                jTreeFixture.replaceSeparator('$separator')
+                // Have to disambiguate int[] vs string[]
+                jTreeFixture['requireSelection(java.lang.String[])'](['$path']) 
+                """.trimIndent()
+            )
+        }
+    }
 
     fun clickRow(row: Int) = runJsRowMethod("clickRow", row)
     fun expandRow(row: Int) = runJsRowMethod("expandRow", row)
@@ -26,6 +42,7 @@ class JTreeFixture(
             runJs(
                 """
                 const jTreeFixture = JTreeFixture(robot, component);
+                jTreeFixture.replaceSeparator('$separator')
                 jTreeFixture.$name('$path') 
                 """.trimIndent()
             )
@@ -37,6 +54,7 @@ class JTreeFixture(
             runJs(
                 """
                 const jTreeFixture = JTreeFixture(robot, component);
+                jTreeFixture.replaceSeparator('$separator')
                 jTreeFixture.$name($row) 
                 """.trimIndent()
             )

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/WelcomeFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/WelcomeFrame.kt
@@ -31,7 +31,7 @@ class WelcomeFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
         } else {
             selectTab("Projects")
             // This can match two things: If no previous projects, its a SVG icon, else a jbutton
-            findAll<ComponentFixture>(byXpath("//div[contains(@accessiblename, 'New Project') and (@class='MainButton 'or @class='JButton')]")).first().click()
+            findAll<ComponentFixture>(byXpath("//div[contains(@accessiblename, 'New Project') and (@class='MainButton' or @class='JButton')]")).first().click()
         }
     }
 
@@ -74,7 +74,7 @@ class WelcomeFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
             actionLink(ActionLinkFixture.byTextContains("Open")).click()
         } else {
             selectTab("Projects")
-            findAll<ComponentFixture>(byXpath("//div[contains(@accessiblename, 'Open') and (@class='MainButton 'or @class='JButton')]")).first().click()
+            findAll<ComponentFixture>(byXpath("//div[contains(@accessiblename, 'Open') and (@class='MainButton' or @class='JButton')]")).first().click()
         }
         fileBrowser("Open") {
             selectFile(path)

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/utils/retryableAssert.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/utils/retryableAssert.kt
@@ -3,23 +3,25 @@
 
 package software.aws.toolkits.jetbrains.uitests.utils
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import java.time.Duration
-import java.time.Instant
 
 fun recheckAssert(
     timeout: Duration = Duration.ofSeconds(1),
     interval: Duration = Duration.ofMillis(100),
     assertion: () -> Unit
 ) {
-    val expiry = Instant.now().plus(timeout)
-    while (true) {
-        try {
-            assertion()
-            return
-        } catch (e: AssertionError) { // deliberately narrowed to an AssertionError - this is intended to be used in a test assertion
-            when {
-                Instant.now().isAfter(expiry) -> throw e
-                else -> Thread.sleep(interval.toMillis())
+    runBlocking {
+        withTimeout(timeout.toMillis()) {
+            while (true) {
+                try {
+                    assertion()
+                    return@withTimeout
+                } catch (e: AssertionError) { // deliberately narrowed to an AssertionError - this is intended to be used in a test assertion
+                    delay(interval.toMillis())
+                }
             }
         }
     }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/utils/retryableAssert.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/utils/retryableAssert.kt
@@ -1,0 +1,45 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.utils
+
+import java.time.Duration
+import java.time.Instant
+
+fun recheckAssert(
+    timeout: Duration = Duration.ofSeconds(1),
+    interval: Duration = Duration.ofMillis(100),
+    assertion: () -> Unit
+) {
+    val expiry = Instant.now().plus(timeout)
+    while (true) {
+        try {
+            assertion()
+            return
+        } catch (e: AssertionError) { // deliberately narrowed to an AssertionError - this is intended to be used in a test assertion
+            when {
+                Instant.now().isAfter(expiry) -> throw e
+                else -> Thread.sleep(interval.toMillis())
+            }
+        }
+    }
+}
+
+fun reattemptAssert(
+    maxAttempts: Int = 5,
+    interval: Duration = Duration.ofMillis(100),
+    assertion: () -> Unit
+) {
+    var attempts = 0
+    while (true) {
+        try {
+            assertion()
+            return
+        } catch (e: AssertionError) { // deliberately narrowed to an AssertionError - this is intended to be used in a test assertion
+            when {
+                ++attempts >= maxAttempts -> throw e
+                else -> Thread.sleep(interval.toMillis())
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Fix welcome screen not finding button in 203
* Speed up file browser path entering
* Harden file browser by making sure the selected path gets selected after refresh
* Fix SQS tests not asserting the status messages
* Use actionMenuItem since it has built in waitFor to handle slow loading context menu
* Give more attempts for the SQS polling table to have the value show up

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
