### PR TITLE
Switch cloud debug integration tests to use the public ECR repository

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/python/PythonDebugEndToEndTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/python/PythonDebugEndToEndTest.kt
@@ -27,8 +27,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CountDownLatch
 
-// We use the corretto image for Python too, that is why we use the Java Task Def
-class PythonDebugEndToEndTest : CloudDebugTestCase("CloudDebugTestECSClusterTaskDefinitionWithJava") {
+class PythonDebugEndToEndTest : CloudDebugTestCase("CloudDebugTestECSClusterTaskDefinitionWithPython") {
     @JvmField
     @Rule
     val projectRule = PythonCodeInsightTestFixtureRule()

--- a/testdata/testFiles/cloudDebugTestCluster.yaml
+++ b/testdata/testFiles/cloudDebugTestCluster.yaml
@@ -21,7 +21,36 @@ Resources:
       TaskRoleArn: !Ref TaskRole
       ContainerDefinitions:
         - Name: 'ContainerName'
-          Image: "amazoncorretto"
+          Image: "public.ecr.aws/bitnami/java:14"
+          Command:
+            - 'tail -f /dev/null'
+          EntryPoint:
+            - 'sh'
+            - '-c'
+          PortMappings:
+            - ContainerPort: 80
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: ecs
+  TaskDefinitionWithPython:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn: LogGroup
+    Properties:
+      Family: !Join [ '', [ !Ref Cluster, TaskDefinitionWithJava ] ]
+      # awsvpc is required for Fargate
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 1024
+      Memory: 2GB
+      ExecutionRoleArn: !Ref ExecutionRole
+      TaskRoleArn: !Ref TaskRole
+      ContainerDefinitions:
+        - Name: 'ContainerName'
+          Image: "public.ecr.aws/bitnami/python:2"
           Command:
             - 'tail -f /dev/null'
           EntryPoint:
@@ -50,7 +79,7 @@ Resources:
       TaskRoleArn: !Ref TaskRole
       ContainerDefinitions:
         - Name: 'ContainerName'
-          Image: "node"
+          Image: "public.ecr.aws/bitnami/node:14"
           Command:
             - 'tail -f /dev/null'
           EntryPoint:

--- a/testdata/testFiles/cloudDebugTestCluster.yaml
+++ b/testdata/testFiles/cloudDebugTestCluster.yaml
@@ -39,7 +39,7 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     DependsOn: LogGroup
     Properties:
-      Family: !Join [ '', [ !Ref Cluster, TaskDefinitionWithJava ] ]
+      Family: !Join [ '', [ !Ref Cluster, TaskDefinitionWithPython ] ]
       # awsvpc is required for Fargate
       NetworkMode: awsvpc
       RequiresCompatibilities:
@@ -50,7 +50,7 @@ Resources:
       TaskRoleArn: !Ref TaskRole
       ContainerDefinitions:
         - Name: 'ContainerName'
-          Image: "public.ecr.aws/bitnami/python:2"
+          Image: "public.ecr.aws/bitnami/python:3.9"
           Command:
             - 'tail -f /dev/null'
           EntryPoint:


### PR DESCRIPTION

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
