### PR TITLE
Remove manually adding S3 interceptors

### DIFF
--- a/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
+++ b/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
@@ -125,15 +125,6 @@ abstract class ToolkitClientManager {
                 .region(region)
                 .overrideConfiguration {
                     it.putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX, userAgent)
-                    if (builder is S3ClientBuilder) {
-                        // TODO: Remove after SDK code-gens these instead of uses class loader
-                        it.addExecutionInterceptor(EndpointAddressInterceptor())
-                        it.addExecutionInterceptor(CreateBucketInterceptor())
-                        it.addExecutionInterceptor(PutObjectInterceptor())
-                        it.addExecutionInterceptor(EnableChunkedEncodingInterceptor())
-                        it.addExecutionInterceptor(DisableDoubleUrlEncodingInterceptor())
-                        it.addExecutionInterceptor(DecodeUrlEncodedResponseInterceptor())
-                    }
                 }
                 .also { _ ->
                     endpointOverride?.let {

--- a/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
+++ b/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
@@ -10,13 +10,6 @@ import software.amazon.awssdk.core.SdkClient
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption
 import software.amazon.awssdk.http.SdkHttpClient
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.s3.S3ClientBuilder
-import software.amazon.awssdk.services.s3.internal.handlers.CreateBucketInterceptor
-import software.amazon.awssdk.services.s3.internal.handlers.DecodeUrlEncodedResponseInterceptor
-import software.amazon.awssdk.services.s3.internal.handlers.DisableDoubleUrlEncodingInterceptor
-import software.amazon.awssdk.services.s3.internal.handlers.EnableChunkedEncodingInterceptor
-import software.amazon.awssdk.services.s3.internal.handlers.EndpointAddressInterceptor
-import software.amazon.awssdk.services.s3.internal.handlers.PutObjectInterceptor
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.region.ToolkitRegionProvider


### PR DESCRIPTION
This was causing multiple interceptors to be added to the chain leading to the EndpointAddressInterceptor being ran twice prompting the following:

```
software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request: Certificate for <s3temporarybucketrule-root-43ygfs4u7ytr30l0sgflav7weksis0jfm7ci.s3temporarybucketrule-root-43ygfs4u7ytr30l0sgflav7weksis0jfm7ci.s3.us-west-2.amazonaws.com> doesn't match any of the subject alternative names: [s3-us-west-2.amazonaws.com, *.s3-us-west-2.amazonaws.com, s3.us-west-2.amazonaws.com, *.s3.us-west-2.amazonaws.com, s3.dualstack.us-west-2.amazonaws.com, *.s3.dualstack.us-west-2.amazonaws.com, *.s3.amazonaws.com, *.s3-control.us-west-2.amazonaws.com, s3-control.us-west-2.amazonaws.com, *.s3-control.dualstack.us-west-2.amazonaws.com, s3-control.dualstack.us-west-2.amazonaws.com, *.s3-accesspoint.us-west-2.amazonaws.com, *.s3-accesspoint.dualstack.us-west-2.amazonaws.com, *.s3.us-west-2.vpce.amazonaws.com]
	at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:98)
```

Remote debugging seems to indicate this is working correctly in the IDE and so we do not need to manually add them anymore.

Tested with the S3 browser in 201 and 203

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
