### PR TITLE
Improve file browser fixture for UI tests

### DIFF
--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
@@ -47,24 +47,27 @@ class FileBrowserFixture(
     fun selectFile(path: Path) {
         val absolutePath = path.toAbsolutePath()
         step("Select $absolutePath") {
-            step("Fill file explorer with $absolutePath") {
-                val pathBox: JTextFieldFixture = if (remoteRobot.ideMajorVersion() <= 202) {
-                    find(byXpath("//div[@class='JTextField']"), Duration.ofSeconds(5))
-                } else {
-                    find(byXpath("//div[@class='BorderlessTextField']"), Duration.ofSeconds(5))
-                }
-                pathBox.text = absolutePath.toString()
-            }
-
             step("Refresh file explorer to make sure the file ${path.fileName} is loaded") {
-                waitForIgnoringError {
-                    findAndClick("//div[@accessiblename='Refresh']")
+                findAndClick("//div[@accessiblename='Refresh']")
+                waitForIgnoringError(duration = Duration.ofSeconds(15)) {
+                    setFilePath(absolutePath)
                     tree.requireSelection(*absolutePath.toParts())
                     true
                 }
             }
 
             pressOk()
+        }
+    }
+
+    private fun setFilePath(path: Path) {
+        step("Set file path to $path") {
+            val pathBox: JTextFieldFixture = if (remoteRobot.ideMajorVersion() <= 202) {
+                find(byXpath("//div[@class='JTextField']"), Duration.ofSeconds(5))
+            } else {
+                find(byXpath("//div[@class='BorderlessTextField']"), Duration.ofSeconds(5))
+            }
+            pathBox.text = path.toString()
         }
     }
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -213,7 +213,10 @@ class S3BrowserTest {
     }
 
     private fun waitForS3BucketDeletion() {
-        s3Client.waiter().waitUntilBucketNotExists { it.bucket(bucket) }
+        s3Client.waiter().waitUntilBucketNotExists(
+            { it.bucket(bucket) },
+            { it.maxAttempts(30) }
+        )
     }
 
     private fun waitForS3BucketCreation() {


### PR DESCRIPTION
* Only call refresh once
* Set the path each time we look for it instead of before hitting refresh
* Also increase the time we look for it if refresh takes longer than expected

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
