### PR TITLE
Move almost all remaining MockRegionProvider and MockCredentialManager to rules

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTestCase.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebugTestCase.kt
@@ -22,7 +22,7 @@ import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.Resource
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.runUnderRealCredentials
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.services.clouddebug.actions.DeinstrumentResourceFromExplorerAction
 import software.aws.toolkits.jetbrains.services.clouddebug.actions.InstrumentResourceAction
 import software.aws.toolkits.jetbrains.services.ecs.EcsUtils
@@ -56,11 +56,15 @@ abstract class CloudDebugTestCase(private val taskDefName: String) {
     @JvmField
     val resourceCache = MockResourceCacheRule()
 
+    @Rule
+    @JvmField
+    val mockRegionProvider = MockRegionProviderRule()
+
     @Before
     open fun setUp() {
         // does not validate that a SSM session is successfully created
         val region = AwsRegion("us-west-2", "US West 2", "aws")
-        MockRegionProvider.getInstance().addRegion(region)
+        mockRegionProvider.addRegion(region)
         AwsConnectionManager.getInstance(getProject()).changeRegion(region)
         instrumentationRole = cfnRule.outputs["TaskRole"] ?: throw RuntimeException("Could not find instrumentation role in CloudFormation outputs")
         service = createService()

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
@@ -20,7 +20,7 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.createHandlerBasedRunConfiguration
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.createTemplateRunConfiguration
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
@@ -171,7 +171,7 @@ class PythonLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runt
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(jsonToMap(executeLambda.stdout))
-            .containsEntry("AWS_REGION", MockRegionProvider.getInstance().defaultRegion().id)
+            .containsEntry("AWS_REGION", getDefaultRegion().id)
     }
 
     @Test

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionIntegrationTest.kt
@@ -86,7 +86,7 @@ class CreateFunctionIntegrationTest {
         MockClientManager.useRealImplementations(disposableRule.disposable)
 
         val region = regionProvider.addRegion(Region.US_WEST_2)
-        val credentials = credentialManager.addCredentials("ReadCreds", createIntegrationTestCredentialProvider(), region)
+        val credentials = credentialManager.addCredentials("ReadCreds", createIntegrationTestCredentialProvider(), region.id)
 
         settingsManager.settingsManager.changeRegion(region)
         settingsManager.settingsManager.changeCredentialProviderAndWait(credentials)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -134,7 +134,7 @@ class AwsClientManagerTest {
     @Test
     fun clientsAreScopedToRegion() {
         val sut = getClientManager()
-        val credProvider = mockCredentialManager.createCredentialProvider()
+        val credProvider = credentialManager.createCredentialProvider()
 
         val firstRegion = sut.getClient<DummyServiceClient>(credProvider, regionProvider.createAwsRegion())
         val secondRegion = sut.getClient<DummyServiceClient>(credProvider, regionProvider.createAwsRegion())

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.use
 import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RuleChain
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Rule
@@ -30,26 +31,21 @@ import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.isAccessible
 
 class AwsClientManagerTest {
+    private val projectRule = ProjectRule()
+    private val temporaryDirectory = TemporaryFolder()
+    private val regionProvider = MockRegionProviderRule()
+    private val credentialManager = MockCredentialManagerRule()
+    private val projectSettingsRule = ProjectAccountSettingsManagerRule(projectRule)
 
     @Rule
     @JvmField
-    val projectRule = ProjectRule()
-
-    @Rule
-    @JvmField
-    val temporaryDirectory = TemporaryFolder()
-
-    @Rule
-    @JvmField
-    val regionProvider = MockRegionProviderRule()
-
-    @Rule
-    @JvmField
-    val credentialManager = MockCredentialManagerRule()
-
-    @Rule
-    @JvmField
-    val projectSettingsRule = ProjectAccountSettingsManagerRule(projectRule)
+    val ruleChain = RuleChain(
+        projectRule,
+        temporaryDirectory,
+        credentialManager,
+        regionProvider,
+        projectSettingsRule
+    )
 
     @Test
     fun canGetAnInstanceOfAClient() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -26,9 +26,8 @@ import software.aws.toolkits.core.region.Service
 import software.aws.toolkits.core.region.anAwsRegion
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager.ProjectAccountSettingsManagerRule
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider.RegionProviderRule
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.isAccessible
 
@@ -44,37 +43,28 @@ class AwsClientManagerTest {
 
     @Rule
     @JvmField
-    val regionProviderRule = RegionProviderRule()
+    val regionProvider = MockRegionProviderRule()
+
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
 
     @Rule
     @JvmField
     val projectSettingsRule = ProjectAccountSettingsManagerRule(projectRule)
 
-    private lateinit var mockCredentialManager: MockCredentialsManager
-
-    @Before
-    fun setUp() {
-        mockCredentialManager = MockCredentialsManager.getInstance()
-        mockCredentialManager.reset()
-    }
-
-    @After
-    fun tearDown() {
-        mockCredentialManager.reset()
-    }
-
     @Test
     fun canGetAnInstanceOfAClient() {
         val sut = getClientManager()
-        val client = sut.getClient<DummyServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion())
+        val client = sut.getClient<DummyServiceClient>(credentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion())
         assertThat(client.serviceName()).isEqualTo("dummyClient")
     }
 
     @Test
     fun clientsAreCached() {
         val sut = getClientManager()
-        val credProvider = mockCredentialManager.createCredentialProvider()
-        val region = regionProviderRule.createAwsRegion()
+        val credProvider = credentialManager.createCredentialProvider()
+        val region = regionProvider.createAwsRegion()
 
         val fooClient = sut.getClient<DummyServiceClient>(credProvider, region)
         val barClient = sut.getClient<DummyServiceClient>(credProvider, region)
@@ -86,8 +76,8 @@ class AwsClientManagerTest {
     fun oldClientsAreRemovedWhenCredentialsAreRemoved() {
         val sut = getClientManager()
 
-        val credentialsIdentifier = mockCredentialManager.addCredentials("profile:admin")
-        val credentialProvider = mockCredentialManager.getAwsCredentialProvider(credentialsIdentifier, MockRegionProvider.getInstance().defaultRegion())
+        val credentialsIdentifier = credentialManager.addCredentials("profile:admin")
+        val credentialProvider = credentialManager.getAwsCredentialProvider(credentialsIdentifier, MockRegionProvider.getInstance().defaultRegion())
 
         sut.getClient<DummyServiceClient>(credentialProvider, anAwsRegion())
 
@@ -108,7 +98,7 @@ class AwsClientManagerTest {
             val sut = getClientManager()
             Disposer.register(parent, sut)
 
-            sut.getClient<DummyServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion()).also {
+            sut.getClient<DummyServiceClient>(credentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion()).also {
                 assertThat(it.closed).isFalse()
             }
         }
@@ -119,8 +109,8 @@ class AwsClientManagerTest {
     @Test
     fun httpClientIsSharedAcrossClients() {
         val sut = getClientManager()
-        val dummy = sut.getClient<DummyServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion())
-        val secondDummy = sut.getClient<SecondDummyServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion())
+        val dummy = sut.getClient<DummyServiceClient>(credentialManager.createCredentialProvider(), regionProvider.createAwsRegion())
+        val secondDummy = sut.getClient<SecondDummyServiceClient>(credentialManager.createCredentialProvider(), regionProvider.createAwsRegion())
 
         assertThat(dummy.httpClient.delegate).isSameAs(secondDummy.httpClient.delegate)
     }
@@ -129,7 +119,7 @@ class AwsClientManagerTest {
     fun clientWithoutBuilderFailsDescriptively() {
         val sut = getClientManager()
 
-        assertThatThrownBy { sut.getClient<InvalidServiceClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion()) }
+        assertThatThrownBy { sut.getClient<InvalidServiceClient>(credentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion()) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("builder()")
     }
@@ -138,7 +128,7 @@ class AwsClientManagerTest {
     fun clientInterfaceWithoutNameFieldFailsDescriptively() {
         val sut = getClientManager()
 
-        assertThatThrownBy { sut.getClient<NoServiceNameClient>(mockCredentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion()) }
+        assertThatThrownBy { sut.getClient<NoServiceNameClient>(credentialManager.createCredentialProvider(), regionProviderRule.createAwsRegion()) }
             .isInstanceOf(NoSuchFieldException::class.java)
             .hasMessageContaining("SERVICE_NAME")
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -18,7 +18,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -5,6 +5,7 @@ package software.aws.toolkits.jetbrains.core
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RuleChain
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.doAnswer
@@ -45,17 +46,19 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 
 class AwsResourceCacheTest {
-    @Rule
-    @JvmField
-    val projectRule = ProjectRule()
+    private val projectRule = ProjectRule()
+    private val credentialsManager = MockCredentialManagerRule()
+    private val regionProvider = MockRegionProviderRule()
 
+    // If we don't control the order manually, regionProvider can run its before
+    // before projectRule which causes a NPE
     @Rule
     @JvmField
-    val regionProvider = MockRegionProviderRule()
-
-    @Rule
-    @JvmField
-    val credentialsManager = MockCredentialManagerRule()
+    val ruleChain = RuleChain(
+        projectRule,
+        credentialsManager,
+        regionProvider
+    )
 
     private val mockClock = mock<Clock>()
     private val mockResource = mock<Resource.Cached<String>>()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
@@ -9,17 +9,16 @@ import com.intellij.testFramework.ExtensionTestUtil
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.ExecutableType
 import software.aws.toolkits.jetbrains.core.executables.Validatable
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
@@ -36,14 +35,13 @@ class ExecutableBackedCacheResourceTest {
     @JvmField
     val disposableRule = DisposableRule()
 
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
     @Before
     fun setUp() {
         ExtensionTestUtil.maskExtensions(ExecutableType.EP_NAME, listOf(MockExecutable), disposableRule.disposable)
-    }
-
-    @After
-    fun testDown() {
-        MockCredentialsManager.getInstance().reset()
     }
 
     @Test
@@ -103,12 +101,11 @@ class ExecutableBackedCacheResourceTest {
             assertionBlock.invoke(this)
         }
 
-        return cacheResource.fetch(MockRegionProvider.getInstance().defaultRegion(), mockCredentials())
+        return cacheResource.fetch(getDefaultRegion(), mockCredentials())
     }
 
     private fun mockCredentials(): ToolkitCredentialsProvider {
-        val credentialsManager = MockCredentialsManager.getInstance()
-        return credentialsManager.getAwsCredentialProvider(credentialsManager.addCredentials("Cred2"), MockRegionProvider.getInstance().defaultRegion())
+        return credentialManager.getAwsCredentialProvider(credentialManager.addCredentials("Cred2"), getDefaultRegion())
     }
 
     private object MockExecutable : ExecutableType<String>, Validatable {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/ExecutableBackedCacheResourceTest.kt
@@ -104,9 +104,8 @@ class ExecutableBackedCacheResourceTest {
         return cacheResource.fetch(getDefaultRegion(), mockCredentials())
     }
 
-    private fun mockCredentials(): ToolkitCredentialsProvider {
-        return credentialManager.getAwsCredentialProvider(credentialManager.addCredentials("Cred2"), getDefaultRegion())
-    }
+    private fun mockCredentials(): ToolkitCredentialsProvider =
+        credentialManager.getAwsCredentialProvider(credentialManager.addCredentials("Cred2"), getDefaultRegion())
 
     private object MockExecutable : ExecutableType<String>, Validatable {
         override val id: String = "Mock"

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ChangeAccountSettingsActionGroupTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ChangeAccountSettingsActionGroupTest.kt
@@ -7,7 +7,8 @@ import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider.RegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 
 class ChangeAccountSettingsActionGroupTest {
 
@@ -17,7 +18,7 @@ class ChangeAccountSettingsActionGroupTest {
 
     @Rule
     @JvmField
-    val regionProviderRule = RegionProviderRule()
+    val regionProviderRule = MockRegionProviderRule()
 
     @Rule
     @JvmField
@@ -81,7 +82,7 @@ class ChangeAccountSettingsActionGroupTest {
 
     @Test
     fun `Don't show partition selector if there is only one partition`() {
-        val selectedRegion = regionProviderRule.regionProvider.defaultRegion()
+        val selectedRegion = getDefaultRegion()
 
         settingsManagerRule.settingsManager.changeRegionAndWait(selectedRegion)
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialManagerTest.kt
@@ -21,7 +21,8 @@ import software.aws.toolkits.core.credentials.CredentialProviderNotFoundExceptio
 import software.aws.toolkits.core.credentials.CredentialsChangeEvent
 import software.aws.toolkits.core.credentials.CredentialsChangeListener
 import software.aws.toolkits.core.region.AwsRegion
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import kotlin.test.assertNotNull
 
 class CredentialManagerTest {
@@ -33,9 +34,13 @@ class CredentialManagerTest {
     @JvmField
     val application = ApplicationRule()
 
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
+
     @Test
     fun testCredentialsCanLoadFromExtensions() {
-        val region = MockRegionProvider.getInstance().defaultRegion()
+        val region = getDefaultRegion()
 
         addFactories(
             createTestCredentialFactory(
@@ -97,7 +102,7 @@ class CredentialManagerTest {
 
     @Test
     fun testCredentialUpdatingDoesNotBreakExisting() {
-        val region = MockRegionProvider.getInstance().defaultRegion()
+        val region = getDefaultRegion()
         val credentialFactory = createTestCredentialFactory(
             "testFactory1",
             listOf("testFoo1")
@@ -139,7 +144,7 @@ class CredentialManagerTest {
 
     @Test
     fun testRemovedCredentialsCeaseWorkingAfter() {
-        val region = MockRegionProvider.getInstance().defaultRegion()
+        val region = getDefaultRegion()
         val credentialFactory = createTestCredentialFactory(
             "testFactory1",
             listOf("testFoo1")
@@ -177,7 +182,7 @@ class CredentialManagerTest {
 
     @Test
     fun testUpdatedCredentialIdentifierIsApplied() {
-        val region = MockRegionProvider.getInstance().defaultRegion()
+        val region = getDefaultRegion()
         val credentialFactory = createTestCredentialFactory(
             "testFactory1",
             listOf("testFoo1")
@@ -189,7 +194,7 @@ class CredentialManagerTest {
 
         assertThat(credentialManager.getCredentialIdentifierById("testFoo1")?.defaultRegionId).isEqualTo(region.id)
 
-        val newRegion = MockRegionProvider.getInstance().addRegion(AwsRegion("test", "test", "test"))
+        val newRegion = regionProvider.addRegion(AwsRegion("test", "test", "test"))
 
         credentialFactory.updateCredentials(
             "testFoo1",
@@ -219,7 +224,7 @@ class CredentialManagerTest {
             callback = credentialLoadCallback
 
             initialProviderIds.forEach {
-                credentialsMapping[it] = TestCredentialProviderIdentifier(it, id, MockRegionProvider.getInstance().defaultRegion().id)
+                credentialsMapping[it] = TestCredentialProviderIdentifier(it, id, getDefaultRegion().id)
             }
 
             callback(

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialsRegionHandlerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialsRegionHandlerTest.kt
@@ -13,7 +13,7 @@ import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.credentials.aCredentialsIdentifier
 import software.aws.toolkits.core.region.anAwsRegion
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider.RegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.settings.AwsSettings
 import software.aws.toolkits.jetbrains.settings.AwsSettingsRule
 import software.aws.toolkits.jetbrains.settings.UseAwsCredentialRegion
@@ -28,7 +28,7 @@ class CredentialsRegionHandlerTest {
 
     @Rule
     @JvmField
-    val regionProviderRule = RegionProviderRule()
+    val regionProviderRule = MockRegionProviderRule()
 
     @Rule
     @JvmField

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockAwsConnectionManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockAwsConnectionManager.kt
@@ -25,7 +25,8 @@ class MockAwsConnectionManager(project: Project) : AwsConnectionManager(project)
         recentlyUsedRegions.clear()
         recentlyUsedProfiles.clear()
         val regionProvider = AwsRegionProvider.getInstance()
-        changeConnectionSettings(MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER, regionProvider.defaultRegion())
+        val credentialProvider = CredentialManager.getInstance().getCredentialIdentifiers().first()
+        changeConnectionSettings(credentialProvider, regionProvider.defaultRegion())
 
         waitUntilConnectionStateIsStable()
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockAwsConnectionManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockAwsConnectionManager.kt
@@ -25,8 +25,7 @@ class MockAwsConnectionManager(project: Project) : AwsConnectionManager(project)
         recentlyUsedRegions.clear()
         recentlyUsedProfiles.clear()
         val regionProvider = AwsRegionProvider.getInstance()
-        val credentialProvider = CredentialManager.getInstance().getCredentialIdentifiers().first()
-        changeConnectionSettings(credentialProvider, regionProvider.defaultRegion())
+        changeConnectionSettings(DUMMY_PROVIDER_IDENTIFIER, regionProvider.defaultRegion())
 
         waitUntilConnectionStateIsStable()
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -18,6 +18,7 @@ import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.region.ToolkitRegionProvider
 import software.aws.toolkits.core.utils.test.aString
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 
 private class MockCredentialsManager : CredentialManager() {
     init {
@@ -115,7 +116,7 @@ class MockCredentialManagerRule : ExternalResource() {
         id: String = aString(),
         credentials: AwsCredentials = AwsBasicCredentials.create("Access", "Secret"),
         // Do not store this value as we should be able to dynamically change it
-        region: AwsRegion = ServiceManager.getService(ToolkitRegionProvider::class.java).defaultRegion()
+        region: AwsRegion = getDefaultRegion()
     ): ToolkitCredentialsProvider = credentialManager.createCredentialProvider(id, credentials, region)
 
     fun getAwsCredentialProvider(providerId: CredentialIdentifier, region: AwsRegion): ToolkitCredentialsProvider =

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -129,7 +129,6 @@ class MockCredentialManagerRule : ExternalResource() {
     }
 
     fun reset() {
-        @Suppress("DEPRECATION")
         credentialManager.reset()
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -19,6 +19,7 @@ import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 
+@Deprecated("Use MockCredentialManagerRule")
 class MockCredentialsManager : CredentialManager() {
     init {
         reset()
@@ -86,6 +87,7 @@ class MockCredentialsManager : CredentialManager() {
     }
 }
 
+@Suppress("DEPRECATION")
 class MockCredentialManagerRule : ExternalResource() {
     private lateinit var credentialManager: MockCredentialsManager
 
@@ -98,6 +100,12 @@ class MockCredentialManagerRule : ExternalResource() {
         credentials: AwsCredentials = AwsBasicCredentials.create("Access", "Secret"),
         region: AwsRegion? = null
     ): CredentialIdentifier = credentialManager.addCredentials(id, credentials, region?.id)
+
+    fun addCredentials(
+        id: String,
+        credentials: AwsCredentialsProvider,
+        regionId: String? = null
+    ): MockCredentialsManager.MockCredentialIdentifier = credentialManager.addCredentials(id, credentials, regionId)
 
     fun createCredentialProvider(
         id: String = aString(),
@@ -120,6 +128,11 @@ class MockCredentialManagerRule : ExternalResource() {
     }
 }
 
+@Deprecated(
+    "DUMMY_PROVIDER_IDENTIFIER should not be used outside of the MockCredentialsManager, if you " +
+        "need mock credentials set them up in the test instead of relying on the global one"
+)
+@Suppress("DEPRECATION")
 val DUMMY_PROVIDER_IDENTIFIER: CredentialIdentifier = MockCredentialsManager.MockCredentialIdentifier(
     "DUMMY_CREDENTIALS",
     StaticCredentialsProvider.create(AwsBasicCredentials.create("DummyAccess", "DummySecret")),

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -16,11 +16,10 @@ import software.aws.toolkits.core.credentials.CredentialProviderFactory
 import software.aws.toolkits.core.credentials.CredentialsChangeListener
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
-import software.aws.toolkits.core.region.ToolkitRegionProvider
 import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 
-private class MockCredentialsManager : CredentialManager() {
+class MockCredentialsManager : CredentialManager() {
     init {
         reset()
     }
@@ -66,12 +65,6 @@ private class MockCredentialsManager : CredentialManager() {
 
     companion object {
         fun getInstance(): MockCredentialsManager = ServiceManager.getService(CredentialManager::class.java) as MockCredentialsManager
-
-        val DUMMY_PROVIDER_IDENTIFIER: CredentialIdentifier = MockCredentialIdentifier(
-            "DUMMY_CREDENTIALS",
-            StaticCredentialsProvider.create(AwsBasicCredentials.create("DummyAccess", "DummySecret")),
-            null
-        )
     }
 
     class MockCredentialIdentifier(override val displayName: String, val credentials: AwsCredentialsProvider, override val defaultRegionId: String?) :
@@ -106,12 +99,6 @@ class MockCredentialManagerRule : ExternalResource() {
         region: AwsRegion? = null
     ): CredentialIdentifier = credentialManager.addCredentials(id, credentials, region?.id)
 
-    fun addCredentials(
-        id: String,
-        credentials: AwsCredentialsProvider,
-        region: AwsRegion? = null
-    ): CredentialIdentifier = credentialManager.addCredentials(id, credentials, region?.id)
-
     fun createCredentialProvider(
         id: String = aString(),
         credentials: AwsCredentials = AwsBasicCredentials.create("Access", "Secret"),
@@ -132,3 +119,9 @@ class MockCredentialManagerRule : ExternalResource() {
         credentialManager.reset()
     }
 }
+
+val DUMMY_PROVIDER_IDENTIFIER: CredentialIdentifier = MockCredentialsManager.MockCredentialIdentifier(
+    "DUMMY_CREDENTIALS",
+    StaticCredentialsProvider.create(AwsBasicCredentials.create("DummyAccess", "DummySecret")),
+    null
+)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
@@ -47,7 +47,7 @@ import software.aws.toolkits.core.region.ToolkitRegionProvider
 import software.aws.toolkits.core.rules.SystemPropertyHelper
 import software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileCredentialProviderFactory
 import software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileWatcher
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.ui.TestDialogService
 import java.io.File
 import java.time.ZonedDateTime
@@ -768,7 +768,7 @@ class ProfileCredentialProviderFactoryTest {
 
     private fun ProfileCredentialProviderFactory.createProvider(validProfile: CredentialIdentifier) = this.createAwsCredentialProvider(
         validProfile,
-        MockRegionProvider.getInstance().defaultRegion(),
+        getDefaultRegion(),
         sdkHttpClientSupplier = { mockSdkHttpClient }
     )
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.jetbrains.core.region
 
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.service
-import com.intellij.testFramework.ApplicationRule
+import org.jetbrains.annotations.TestOnly
 import org.junit.rules.ExternalResource
 import software.amazon.awssdk.regions.Region
 import software.aws.toolkits.core.region.AwsPartition
@@ -110,4 +110,5 @@ class MockRegionProviderRule : ExternalResource() {
 }
 
 // dynamically get the default region from whatever is currently registered
+@TestOnly
 fun getDefaultRegion() = ServiceManager.getService(ToolkitRegionProvider::class.java).defaultRegion()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -62,27 +62,6 @@ private class MockRegionProvider : ToolkitRegionProvider() {
         private val regions = mapOf(US_EAST_1.id to US_EAST_1)
         fun getInstance(): MockRegionProvider = ServiceManager.getService(ToolkitRegionProvider::class.java) as MockRegionProvider
     }
-
-    class RegionProviderRule : ApplicationRule() {
-        val regionProvider by lazy { getInstance() }
-
-        override fun after() {
-            regionProvider.reset()
-        }
-
-        fun createAwsRegion(id: String = uniqueRegionId(), partitionId: String = aString()): AwsRegion =
-            anAwsRegion(id = id, partitionId = partitionId).also { regionProvider.addRegion(it) }
-
-        private fun uniqueRegionId(): String {
-            repeat(10) {
-                val generatedId = aRegionId()
-                if (regionProvider[generatedId] == null) {
-                    return generatedId
-                }
-            }
-            throw IllegalStateException("Failed to generate a unique region ID")
-        }
-    }
 }
 
 class MockRegionProviderRule : ExternalResource() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -129,3 +129,6 @@ class MockRegionProviderRule : ExternalResource() {
         regionManager.reset()
     }
 }
+
+// dynamically get the default region from whatever is currently registered
+fun getDefaultRegion() = ServiceManager.getService(ToolkitRegionProvider::class.java).defaultRegion()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -110,5 +110,4 @@ class MockRegionProviderRule : ExternalResource() {
 }
 
 // dynamically get the default region from whatever is currently registered
-@TestOnly
 fun getDefaultRegion() = ServiceManager.getService(ToolkitRegionProvider::class.java).defaultRegion()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -5,7 +5,6 @@ package software.aws.toolkits.jetbrains.core.region
 
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.service
-import org.jetbrains.annotations.TestOnly
 import org.junit.rules.ExternalResource
 import software.amazon.awssdk.regions.Region
 import software.aws.toolkits.core.region.AwsPartition
@@ -110,4 +109,4 @@ class MockRegionProviderRule : ExternalResource() {
 }
 
 // dynamically get the default region from whatever is currently registered
-fun getDefaultRegion() = ServiceManager.getService(ToolkitRegionProvider::class.java).defaultRegion()
+fun getDefaultRegion() = service<ToolkitRegionProvider>().defaultRegion()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/ecs/execution/EcsCloudDebugRunConfigurationTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/ecs/execution/EcsCloudDebugRunConfigurationTest.kt
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.ecs.model.ServiceNotFoundException
 import software.amazon.awssdk.services.ecs.model.TaskDefinition
 import software.aws.toolkits.core.credentials.CredentialIdentifier
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.services.clouddebug.CloudDebugConstants
 import software.aws.toolkits.jetbrains.services.clouddebug.CloudDebuggingPlatform
 import software.aws.toolkits.jetbrains.services.clouddebug.execution.CloudDebugRunState
@@ -45,6 +45,10 @@ class EcsCloudDebugRunConfigurationTest {
     @JvmField
     @Rule
     val resourceCache = MockResourceCacheRule()
+
+    @JvmField
+    @Rule
+    val credentialManager = MockCredentialManagerRule()
 
     @Test
     fun happyPath() {
@@ -488,7 +492,7 @@ class EcsCloudDebugRunConfigurationTest {
         resourceCache.addEntry(EcsResources.describeTaskDefinition(taskDefinitionName), regionId, credentialsIdentifier.id, fakeTaskDefinition)
     }
 
-    private fun getMockCredentials(): CredentialIdentifier = MockCredentialsManager.getInstance().addCredentials(
+    private fun getMockCredentials(): CredentialIdentifier = credentialManager.addCredentials(
         "mockCreds",
         AwsBasicCredentials.create("foo", "bar")
     )

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/CreateRunConfiguration.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/CreateRunConfiguration.kt
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.setExecutablePath
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfigurationType
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
@@ -32,7 +32,7 @@ fun createTemplateRunConfiguration(
     logicalId: String? = null,
     inputIsFile: Boolean = false,
     credentialsProviderId: String? = null,
-    region: AwsRegion? = MockRegionProvider.getInstance().defaultRegion(),
+    region: AwsRegion? = getDefaultRegion(),
     samOptions: SamOptions = SamOptions()
 ): LocalLambdaRunConfiguration {
     val runConfiguration = samRunConfiguration(project)
@@ -60,7 +60,7 @@ fun createHandlerBasedRunConfiguration(
     input: String? = "inputText",
     inputIsFile: Boolean = false,
     credentialsProviderId: String? = null,
-    region: AwsRegion? = MockRegionProvider.getInstance().defaultRegion(),
+    region: AwsRegion? = getDefaultRegion(),
     environmentVariables: MutableMap<String, String> = mutableMapOf(),
     samOptions: SamOptions = SamOptions()
 ): LocalLambdaRunConfiguration {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationTest.kt
@@ -24,7 +24,7 @@ import org.junit.rules.TemporaryFolder
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.rules.EnvironmentVariableHelper
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunningState
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
@@ -52,6 +52,10 @@ class LocalLambdaRunConfigurationTest {
     @JvmField
     val tempDir = TemporaryFolder()
 
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
     private val mockId = "MockCredsId"
     private val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
     private val runtime = Runtime.JAVA8
@@ -63,7 +67,7 @@ class LocalLambdaRunConfigurationTest {
         preWarmSamVersionCache(validSam.toString())
         ExecutableManager.getInstance().setExecutablePath(SamExecutable(), validSam).value
 
-        MockCredentialsManager.getInstance().addCredentials(mockId, mockCreds)
+        credentialManager.addCredentials(mockId, mockCreds)
 
         val fixture = projectRule.fixture
         val module = fixture.addModule("main")
@@ -83,7 +87,6 @@ class LocalLambdaRunConfigurationTest {
 
     @After
     fun tearDown() {
-        MockCredentialsManager.getInstance().reset()
         ExecutableManager.getInstance().removeExecutable(SamExecutable())
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/CreateRunConfiguration.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/CreateRunConfiguration.kt
@@ -6,14 +6,14 @@ package software.aws.toolkits.jetbrains.services.lambda.execution.remote
 import com.intellij.execution.RunManager
 import com.intellij.openapi.project.Project
 import software.aws.toolkits.core.region.AwsRegion
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfigurationType
 
 fun createRunConfiguration(
     project: Project,
     input: String? = "",
     inputIsFile: Boolean = false,
-    regionId: AwsRegion? = MockRegionProvider.getInstance().defaultRegion(),
+    regionId: AwsRegion? = getDefaultRegion(),
     credentialId: String? = "MockCredentials",
     functionName: String? = "DummyFunction"
 ): RemoteLambdaRunConfiguration {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaExecutionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaExecutionTest.kt
@@ -29,8 +29,8 @@ import software.amazon.awssdk.services.lambda.model.InvokeResponse
 import software.amazon.awssdk.services.lambda.model.LambdaException
 import software.amazon.awssdk.services.lambda.model.LogType
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 import java.util.concurrent.CompletableFuture
@@ -46,10 +46,13 @@ class RemoteLambdaExecutionTest {
     @JvmField
     val mockClientManager = MockClientManagerRule()
 
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
     @Before
     fun setUp() {
-        MockCredentialsManager.getInstance()
-            .addCredentials(CREDENTIAL_ID, AwsBasicCredentials.create("Access", "Secret"))
+        credentialManager.addCredentials(CREDENTIAL_ID, AwsBasicCredentials.create("Access", "Secret"))
     }
 
     @Test
@@ -128,7 +131,7 @@ class RemoteLambdaExecutionTest {
             inputIsFile = inputFile,
             credentialId = CREDENTIAL_ID,
             functionName = FUNCTION_NAME,
-            regionId = MockRegionProvider.getInstance().defaultRegion()
+            regionId = getDefaultRegion()
         )
 
         val executor = ExecutorRegistry.getInstance().getExecutorById(DefaultRunExecutor.EXECUTOR_ID)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationTest.kt
@@ -19,7 +19,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
 import software.aws.toolkits.resources.message
 import kotlin.test.assertNotNull
@@ -33,16 +33,15 @@ class RemoteLambdaRunConfigurationTest {
     @JvmField
     val tempDir = TemporaryFolder()
 
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
     private val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
 
     @Before
     fun setUp() {
-        MockCredentialsManager.getInstance().addCredentials("MockCredentials", mockCreds)
-    }
-
-    @After
-    fun tearDown() {
-        MockCredentialsManager.getInstance().reset()
+        credentialManager.addCredentials("MockCredentials", mockCreds)
     }
 
     @Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunConfigurationTest.kt
@@ -13,7 +13,6 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3ServiceNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3ServiceNodeTest.kt
@@ -11,7 +11,7 @@ import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerErrorNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.S3ExplorerRootNode
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
@@ -25,6 +25,10 @@ class S3ServiceNodeTest {
     @JvmField
     @Rule
     val resourceCache = MockResourceCacheRule()
+
+    @JvmField
+    @Rule
+    val regionProvider = MockRegionProviderRule()
 
     @Test
     fun s3BucketsAreListed() {
@@ -70,7 +74,7 @@ class S3ServiceNodeTest {
         resourceCache.addEntry(
             projectRule.project,
             S3Resources.LIST_REGIONALIZED_BUCKETS,
-            CompletableFuture.completedFuture(names.map { S3Resources.RegionalizedBucket(bucketData(it), MockRegionProvider.getInstance().defaultRegion()) })
+            CompletableFuture.completedFuture(names.map { S3Resources.RegionalizedBucket(bucketData(it), regionProvider.defaultRegion()) })
         )
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasViewerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasViewerTest.kt
@@ -21,7 +21,6 @@ import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 import java.io.File
 import java.util.concurrent.CompletableFuture.completedFuture

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasViewerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasViewerTest.kt
@@ -21,7 +21,7 @@ import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 import java.io.File
 import java.util.concurrent.CompletableFuture.completedFuture
@@ -44,7 +44,7 @@ class SchemasViewerTest {
 
     private val fileEditorManager = FileEditorManager.getInstance(projectRule.project)
 
-    private val CREDENTIAL_IDENTIFIER = MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.displayName
+    private val CREDENTIAL_IDENTIFIER = MockAwsConnectionManager.getInstance(projectRule.project).activeCredentialProvider.displayName
     private val REGION = MockAwsConnectionManager.getInstance(projectRule.project).activeRegion.id
     private val REGISTRY = "registry"
     private val SCHEMA = "schema"

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/ConfigureLambdaDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/ConfigureLambdaDialogTest.kt
@@ -24,7 +24,7 @@ import software.amazon.awssdk.services.lambda.model.ResourceConflictException
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 
 class ConfigureLambdaDialogTest {
     lateinit var sqsClient: SqsClient
@@ -46,8 +46,7 @@ class ConfigureLambdaDialogTest {
         sqsClient = mockClientManagerRule.create()
         lambdaClient = mockClientManagerRule.create()
         iamClient = mockClientManagerRule.create()
-        region = MockRegionProvider.getInstance().defaultRegion()
-        queue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/test", region)
+        queue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/test", getDefaultRegion())
     }
 
     @Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/EditAttributesDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/EditAttributesDialogTest.kt
@@ -20,13 +20,12 @@ import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest
 import software.amazon.awssdk.services.sqs.model.SetQueueAttributesResponse
-import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 
 class EditAttributesDialogTest {
     lateinit var client: SqsClient
-    lateinit var region: AwsRegion
     lateinit var queue: Queue
 
     @Rule
@@ -40,8 +39,7 @@ class EditAttributesDialogTest {
     @Before
     fun setUp() {
         client = mockClientManagerRule.create()
-        region = MockRegionProvider.getInstance().defaultRegion()
-        queue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/test", region)
+        queue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/test", getDefaultRegion())
     }
 
     @Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/EditAttributesDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/EditAttributesDialogTest.kt
@@ -21,7 +21,6 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest
 import software.amazon.awssdk.services.sqs.model.SetQueueAttributesResponse
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
-import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 
 class EditAttributesDialogTest {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/SubscribeSnsDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/SubscribeSnsDialogTest.kt
@@ -26,7 +26,7 @@ import software.amazon.awssdk.services.sqs.model.GetQueueAttributesResponse
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 
 class SubscribeSnsDialogTest {
     lateinit var snsClient: SnsClient
@@ -43,6 +43,10 @@ class SubscribeSnsDialogTest {
     @Rule
     val mockClientManagerRule = MockClientManagerRule()
 
+    @JvmField
+    @Rule
+    val regionProvider = MockRegionProviderRule()
+
     @Before
     fun setup() {
         snsClient = mockClientManagerRule.create()
@@ -56,7 +60,7 @@ class SubscribeSnsDialogTest {
             ).build()
         }
 
-        region = MockRegionProvider.getInstance().defaultRegion()
+        region = regionProvider.defaultRegion()
         queue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/test", region)
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePaneTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/sqs/toolwindow/SendMessagePaneTest.kt
@@ -16,7 +16,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.services.sqs.MAX_LENGTH_OF_FIFO_ID
 import software.aws.toolkits.jetbrains.services.sqs.Queue
 import software.aws.toolkits.jetbrains.utils.BaseCoroutineTest
@@ -28,6 +28,10 @@ class SendMessagePaneTest : BaseCoroutineTest() {
     @Rule
     val mockClientManager = MockClientManagerRule()
 
+    @JvmField
+    @Rule
+    val regionProvider = MockRegionProviderRule()
+
     private lateinit var client: SqsClient
     private lateinit var region: AwsRegion
     private lateinit var standardQueue: Queue
@@ -38,7 +42,7 @@ class SendMessagePaneTest : BaseCoroutineTest() {
     @Before
     fun reset() {
         client = mockClientManager.create()
-        region = MockRegionProvider.getInstance().defaultRegion()
+        region = regionProvider.defaultRegion()
         standardQueue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/standard", region)
         fifoQueue = Queue("https://sqs.us-east-1.amazonaws.com/123456789012/fifo.fifo", region)
         standardPane = SendMessagePane(projectRule.project, client, standardQueue)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
@@ -23,10 +23,9 @@ import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.ConnectionState
 import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager.ProjectAccountSettingsManagerRule
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.core.credentials.waitUntilConnectionStateIsStable
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider.RegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.services.sts.StsResources
 import software.aws.toolkits.jetbrains.settings.AwsSettings
 import java.util.concurrent.CountDownLatch
@@ -45,7 +44,11 @@ class TelemetryServiceTest {
 
     @JvmField
     @Rule
-    val regionProvider = RegionProviderRule()
+    val regionProvider = MockRegionProviderRule()
+
+    @JvmField
+    @Rule
+    val credentialManager = MockCredentialManagerRule()
 
     @JvmField
     @Rule
@@ -54,8 +57,6 @@ class TelemetryServiceTest {
     @After
     fun tearDown() {
         AwsSettings.getInstance().isTelemetryEnabled = false
-
-        MockCredentialsManager.getInstance().reset()
     }
 
     @Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
@@ -134,7 +134,7 @@ class TelemetryServiceTest {
 
     @Test
     fun metricEventMetadataIsSet() {
-        val credentials = MockCredentialsManager.getInstance().addCredentials("profile:admin")
+        val credentials = credentialManager.addCredentials("profile:admin")
         val mockRegion = regionProvider.createAwsRegion()
 
         markConnectionSettingsAsValid(credentials, mockRegion)
@@ -162,13 +162,13 @@ class TelemetryServiceTest {
     @Test
     fun metricEventMetadataIsOverridden() {
         val accountSettings = MockAwsConnectionManager.getInstance(projectRule.project)
-        val credentials = MockCredentialsManager.getInstance().addCredentials("profile:admin")
+        val credentials = credentialManager.addCredentials("profile:admin")
 
         markConnectionSettingsAsValid(credentials, accountSettings.activeRegion)
         accountSettings.changeCredentialProvider(credentials)
 
         val mockRegion = AwsRegion("foo-region", "foo-region", "aws")
-        MockRegionProvider.getInstance().addRegion(mockRegion)
+        regionProvider.addRegion(mockRegion)
         accountSettings.changeRegion(mockRegion)
 
         val eventCaptor = argumentCaptor<MetricEvent>()

--- a/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetLocalLambdaRunConfigurationIntegrationTest.kt
@@ -13,7 +13,7 @@ import org.testng.annotations.Test
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.createHandlerBasedRunConfiguration
 import software.aws.toolkits.jetbrains.utils.executeRunConfiguration
 import software.aws.toolkits.jetbrains.utils.setSamExecutableFromEnvironment
@@ -91,7 +91,7 @@ abstract class DotnetLocalLambdaRunConfigurationIntegrationTestBase(private val 
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(jsonToMap(executeLambda.stdout))
-            .containsEntry("AWS_REGION", MockRegionProvider.getInstance().defaultRegion().id)
+            .containsEntry("AWS_REGION", getDefaultRegion().id)
     }
 
     @Test

--- a/jetbrains-ultimate/tst-202+/software/aws/toolkits/jetbrains/rds/actions/CreateConfigurationActionTest202.kt
+++ b/jetbrains-ultimate/tst-202+/software/aws/toolkits/jetbrains/rds/actions/CreateConfigurationActionTest202.kt
@@ -16,10 +16,8 @@ import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.DUMMY_PROVIDER_IDENTIFIER
 import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.services.rds.RdsDatasourceConfiguration
-import software.aws.toolkits.jetbrains.services.rds.RdsNode
 import software.aws.toolkits.jetbrains.services.rds.actions.createRdsDatasource
 import software.aws.toolkits.jetbrains.services.rds.jdbcMysqlAurora
-import software.aws.toolkits.jetbrains.services.rds.mysqlEngineType
 import software.aws.toolkits.jetbrains.services.rds.postgresEngineType
 
 // FIX_WHEN_MIN_IS_202 merge this with the normal one

--- a/jetbrains-ultimate/tst-202+/software/aws/toolkits/jetbrains/rds/actions/CreateConfigurationActionTest202.kt
+++ b/jetbrains-ultimate/tst-202+/software/aws/toolkits/jetbrains/rds/actions/CreateConfigurationActionTest202.kt
@@ -13,8 +13,8 @@ import software.amazon.awssdk.services.rds.model.DBInstance
 import software.amazon.awssdk.services.rds.model.Endpoint
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.DUMMY_PROVIDER_IDENTIFIER
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.services.rds.RdsDatasourceConfiguration
 import software.aws.toolkits.jetbrains.services.rds.RdsNode
 import software.aws.toolkits.jetbrains.services.rds.actions.createRdsDatasource
@@ -44,8 +44,8 @@ class CreateConfigurationActionTest202 {
         registry.createRdsDatasource(
             RdsDatasourceConfiguration(
                 username = username,
-                credentialId = MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = MockRegionProvider.getInstance().defaultRegion().id,
+                credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
+                regionId = getDefaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -64,8 +64,8 @@ class CreateConfigurationActionTest202 {
         registry.createRdsDatasource(
             RdsDatasourceConfiguration(
                 username = username,
-                credentialId = MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = MockRegionProvider.getInstance().defaultRegion().id,
+                credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
+                regionId = getDefaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -74,19 +74,6 @@ class CreateConfigurationActionTest202 {
             assertThat(it.driverClass).contains("mariadb")
             assertThat(it.url).contains(jdbcMysqlAurora)
             assertThat(it.sslCfg?.myMode).isEqualTo(SslMode.REQUIRE)
-        }
-    }
-
-    private fun createNode(
-        address: String = RuleUtils.randomName(),
-        port: Int = RuleUtils.randomNumber(),
-        dbName: String = RuleUtils.randomName(),
-        iamAuthEnabled: Boolean = true,
-        engineType: String = mysqlEngineType
-    ): RdsNode = mock {
-        on { nodeProject } doAnswer { projectRule.project }
-        on { dbInstance } doAnswer {
-            createDbInstance(address, port, dbName, iamAuthEnabled, engineType)
         }
     }
 

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/DatagripUtilsTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/DatagripUtilsTest.kt
@@ -14,8 +14,8 @@ import org.junit.Test
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 
 class DatagripUtilsTest {
     @Rule
@@ -27,10 +27,18 @@ class DatagripUtilsTest {
 
     private val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
 
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
+
     @Before
     fun setUp() {
-        MockCredentialsManager.getInstance().addCredentials(credentialId, mockCreds)
-        MockRegionProvider.getInstance().addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
+        credentialManager.addCredentials(credentialId, mockCreds)
+        regionProvider.addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnectionTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnectionTest.kt
@@ -10,10 +10,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
-import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.auth.SECRET_ID_PROPERTY
@@ -27,10 +26,6 @@ class AddSecretsManagerConnectionTest {
 
     @Rule
     @JvmField
-    val regionProvider = MockRegionProviderRule()
-
-    @Rule
-    @JvmField
     val credentialManager = MockCredentialManagerRule()
 
     private val credentialId = RuleUtils.randomName()
@@ -40,7 +35,6 @@ class AddSecretsManagerConnectionTest {
     @Before
     fun setUp() {
         credentialManager.addCredentials(credentialId, mockCreds)
-        regionProvider.addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
     }
 
     @Test
@@ -63,7 +57,7 @@ class AddSecretsManagerConnectionTest {
             assertThat(it.sslCfg?.myEnabled).isTrue()
             assertThat(it.url).isEqualTo("jdbc:adapter://$address:$port")
             assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(credentialId)
-            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(defaultRegion)
+            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(getDefaultRegion().id)
             assertThat(it.additionalJdbcProperties[SECRET_ID_PROPERTY]).isEqualTo(secretArn)
             assertThat(it.authProviderId).isEqualTo(SecretsManagerAuth.providerId)
         }

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnectionTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnectionTest.kt
@@ -9,7 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.utils.RuleUtils
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.credentials.DUMMY_PROVIDER_IDENTIFIER
 import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
@@ -25,10 +25,6 @@ class AddSecretsManagerConnectionTest {
     @Rule
     @JvmField
     val regionProvider = MockRegionProviderRule()
-
-    @Rule
-    @JvmField
-    val credentialManager = MockCredentialManagerRule()
 
     @Test
     fun `Add data source`() {
@@ -49,7 +45,7 @@ class AddSecretsManagerConnectionTest {
             assertThat(it.isTemporary).isFalse()
             assertThat(it.sslCfg?.myEnabled).isTrue()
             assertThat(it.url).isEqualTo("jdbc:adapter://$address:$port")
-            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(credentialManager.MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.displayName)
+            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(DUMMY_PROVIDER_IDENTIFIER)
             assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(regionProvider.defaultRegion().id)
             assertThat(it.additionalJdbcProperties[SECRET_ID_PROPERTY]).isEqualTo(secretArn)
             assertThat(it.authProviderId).isEqualTo(SecretsManagerAuth.providerId)

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnectionTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnectionTest.kt
@@ -9,8 +9,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.utils.RuleUtils
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.auth.SECRET_ID_PROPERTY
@@ -21,6 +21,14 @@ class AddSecretsManagerConnectionTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
+
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
 
     @Test
     fun `Add data source`() {
@@ -41,8 +49,8 @@ class AddSecretsManagerConnectionTest {
             assertThat(it.isTemporary).isFalse()
             assertThat(it.sslCfg?.myEnabled).isTrue()
             assertThat(it.url).isEqualTo("jdbc:adapter://$address:$port")
-            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.displayName)
-            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(MockRegionProvider.getInstance().defaultRegion().id)
+            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(credentialManager.MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.displayName)
+            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(regionProvider.defaultRegion().id)
             assertThat(it.additionalJdbcProperties[SECRET_ID_PROPERTY]).isEqualTo(secretArn)
             assertThat(it.authProviderId).isEqualTo(SecretsManagerAuth.providerId)
         }

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnectionTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnectionTest.kt
@@ -6,12 +6,10 @@ package software.aws.toolkits.jetbrains.datagrip.actions
 import com.intellij.database.autoconfig.DataSourceRegistry
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.aws.toolkits.core.utils.RuleUtils
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.credentials.DUMMY_PROVIDER_IDENTIFIER
 import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
@@ -23,19 +21,6 @@ class AddSecretsManagerConnectionTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
-
-    @Rule
-    @JvmField
-    val credentialManager = MockCredentialManagerRule()
-
-    private val credentialId = RuleUtils.randomName()
-    private val defaultRegion = RuleUtils.randomName()
-    private val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
-
-    @Before
-    fun setUp() {
-        credentialManager.addCredentials(credentialId, mockCreds)
-    }
 
     @Test
     fun `Add data source`() {
@@ -56,7 +41,7 @@ class AddSecretsManagerConnectionTest {
             assertThat(it.isTemporary).isFalse()
             assertThat(it.sslCfg?.myEnabled).isTrue()
             assertThat(it.url).isEqualTo("jdbc:adapter://$address:$port")
-            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(credentialId)
+            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(DUMMY_PROVIDER_IDENTIFIER.id)
             assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(getDefaultRegion().id)
             assertThat(it.additionalJdbcProperties[SECRET_ID_PROPERTY]).isEqualTo(secretArn)
             assertThat(it.authProviderId).isEqualTo(SecretsManagerAuth.providerId)

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthTest.kt
@@ -28,8 +28,8 @@ import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.core.utils.unwrap
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 import kotlin.test.assertNotNull
@@ -42,6 +42,14 @@ class SecretsManagerAuthTest {
     @Rule
     @JvmField
     val clientManager = MockClientManagerRule()
+
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
 
     private val objectMapper = jacksonObjectMapper()
 
@@ -60,8 +68,8 @@ class SecretsManagerAuthTest {
 
     @Before
     fun setUp() {
-        MockCredentialsManager.getInstance().addCredentials(credentialId, mockCreds)
-        MockRegionProvider.getInstance().addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
+        credentialManager.addCredentials(credentialId, mockCreds)
+        regionProvider.addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
     }
 
     @Test

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthWidgetTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthWidgetTest.kt
@@ -16,8 +16,8 @@ import org.junit.Test
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 
@@ -25,6 +25,14 @@ class SecretsManagerAuthWidgetTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
+
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
 
     private lateinit var widget: SecretsManagerAuthWidget
     private val credentialId = RuleUtils.randomName()
@@ -35,8 +43,8 @@ class SecretsManagerAuthWidgetTest {
     @Before
     fun setUp() {
         widget = SecretsManagerAuthWidget()
-        MockCredentialsManager.getInstance().addCredentials(credentialId, mockCreds)
-        MockRegionProvider.getInstance().addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
+        credentialManager.addCredentials(credentialId, mockCreds)
+        regionProvider.addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
     }
 
     @Test

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthWidgetTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthWidgetTest.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.datagrip.auth
 import com.intellij.database.dataSource.LocalDataSource
 import com.intellij.database.dataSource.url.template.UrlEditorModel
 import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RuleChain
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -22,17 +23,19 @@ import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 
 class SecretsManagerAuthWidgetTest {
-    @Rule
-    @JvmField
-    val projectRule = ProjectRule()
+    private val projectRule = ProjectRule()
+    private val credentialManager = MockCredentialManagerRule()
+    private val regionProvider = MockRegionProviderRule()
 
+    // If we don't control the order manually, regionProvider can run its before
+    // before projectRule which causes a NPE
     @Rule
     @JvmField
-    val credentialManager = MockCredentialManagerRule()
-
-    @Rule
-    @JvmField
-    val regionProvider = MockRegionProviderRule()
+    val ruleChain = RuleChain(
+        projectRule,
+        credentialManager,
+        regionProvider
+    )
 
     private lateinit var widget: SecretsManagerAuthWidget
     private val credentialId = RuleUtils.randomName()

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodeTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodeTest.kt
@@ -5,17 +5,13 @@ package software.aws.toolkits.jetbrains.services.rds
 
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.rds.model.DBInstance
-import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.core.utils.test.hasOnlyElementsOfType
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.core.explorer.nodes.RdsExplorerRootNode
-import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.services.rds.resources.LIST_SUPPORTED_INSTANCES
 
 class RdsExplorerNodeTest {
@@ -26,23 +22,6 @@ class RdsExplorerNodeTest {
     @JvmField
     @Rule
     val resourceCache = MockResourceCacheRule()
-
-    private val credentialId = RuleUtils.randomName()
-    private val defaultRegion = RuleUtils.randomName()
-
-    @Rule
-    @JvmField
-    val credentialManager = MockCredentialManagerRule()
-
-    @Rule
-    @JvmField
-    val regionProvider = MockRegionProviderRule()
-
-    @Before
-    fun setUp() {
-        credentialManager.addCredentials(credentialId)
-        regionProvider.addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
-    }
 
     @Test
     fun `database resources are listed`() {

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodeTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodeTest.kt
@@ -5,13 +5,17 @@ package software.aws.toolkits.jetbrains.services.rds
 
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.rds.model.DBInstance
+import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.core.utils.test.hasOnlyElementsOfType
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.core.explorer.nodes.RdsExplorerRootNode
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.services.rds.resources.LIST_SUPPORTED_INSTANCES
 
 class RdsExplorerNodeTest {
@@ -22,6 +26,23 @@ class RdsExplorerNodeTest {
     @JvmField
     @Rule
     val resourceCache = MockResourceCacheRule()
+
+    private val credentialId = RuleUtils.randomName()
+    private val defaultRegion = RuleUtils.randomName()
+
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
+
+    @Before
+    fun setUp() {
+        credentialManager.addCredentials(credentialId)
+        regionProvider.addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
+    }
 
     @Test
     fun `database resources are listed`() {

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/actions/CreateConfigurationActionTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/actions/CreateConfigurationActionTest.kt
@@ -5,6 +5,7 @@ package software.aws.toolkits.jetbrains.services.rds.actions
 
 import com.intellij.database.autoconfig.DataSourceRegistry
 import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RuleChain
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
@@ -15,6 +16,7 @@ import software.amazon.awssdk.services.rds.model.Endpoint
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.DUMMY_PROVIDER_IDENTIFIER
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
@@ -29,13 +31,17 @@ import software.aws.toolkits.jetbrains.services.sts.StsResources
 import java.util.concurrent.CompletableFuture
 
 class CreateConfigurationActionTest {
-    @Rule
-    @JvmField
-    val projectRule = ProjectRule()
+    private val projectRule = ProjectRule()
+    private val resourceCache = MockResourceCacheRule()
+    private val credentialManager = MockCredentialManagerRule()
 
     @Rule
     @JvmField
-    val resourceCache = MockResourceCacheRule()
+    val ruleChain = RuleChain(
+        projectRule,
+        credentialManager,
+        resourceCache
+    )
 
     private val port = RuleUtils.randomNumber()
     private val address = RuleUtils.randomName()

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/actions/CreateConfigurationActionTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/actions/CreateConfigurationActionTest.kt
@@ -14,8 +14,8 @@ import software.amazon.awssdk.services.rds.model.DBInstance
 import software.amazon.awssdk.services.rds.model.Endpoint
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.DUMMY_PROVIDER_IDENTIFIER
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 import software.aws.toolkits.jetbrains.services.rds.RdsDatasourceConfiguration
@@ -36,6 +36,10 @@ class CreateConfigurationActionTest {
     @Rule
     @JvmField
     val resourceCache = MockResourceCacheRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
 
     private val port = RuleUtils.randomNumber()
     private val address = RuleUtils.randomName()
@@ -92,8 +96,8 @@ class CreateConfigurationActionTest {
         registry.createRdsDatasource(
             RdsDatasourceConfiguration(
                 username = username,
-                credentialId = MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = MockRegionProvider.getInstance().defaultRegion().id,
+                credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
+                regionId = regionProvider.defaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -101,8 +105,8 @@ class CreateConfigurationActionTest {
             assertThat(it.isTemporary).isFalse()
             assertThat(it.url).contains(port.toString())
             assertThat(it.url).contains(address)
-            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.displayName)
-            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(MockRegionProvider.getInstance().defaultRegion().id)
+            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(DUMMY_PROVIDER_IDENTIFIER.displayName)
+            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(regionProvider.defaultRegion().id)
             assertThat(it.authProviderId).isEqualTo(IamAuth.providerId)
         }
     }
@@ -114,8 +118,8 @@ class CreateConfigurationActionTest {
         registry.createRdsDatasource(
             RdsDatasourceConfiguration(
                 username = username,
-                credentialId = MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = MockRegionProvider.getInstance().defaultRegion().id,
+                credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
+                regionId = regionProvider.defaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -133,8 +137,8 @@ class CreateConfigurationActionTest {
         registry.createRdsDatasource(
             RdsDatasourceConfiguration(
                 username = username,
-                credentialId = MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = MockRegionProvider.getInstance().defaultRegion().id,
+                credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
+                regionId = regionProvider.defaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -152,8 +156,8 @@ class CreateConfigurationActionTest {
         registry.createRdsDatasource(
             RdsDatasourceConfiguration(
                 username = username,
-                credentialId = MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = MockRegionProvider.getInstance().defaultRegion().id,
+                credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
+                regionId = regionProvider.defaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -172,8 +176,8 @@ class CreateConfigurationActionTest {
         registry.createRdsDatasource(
             RdsDatasourceConfiguration(
                 username = username,
-                credentialId = MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = MockRegionProvider.getInstance().defaultRegion().id,
+                credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
+                regionId = regionProvider.defaultRegion().id,
                 dbInstance = instance
             )
         )

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/actions/CreateConfigurationActionTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/actions/CreateConfigurationActionTest.kt
@@ -15,7 +15,7 @@ import software.amazon.awssdk.services.rds.model.Endpoint
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.credentials.DUMMY_PROVIDER_IDENTIFIER
-import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 import software.aws.toolkits.jetbrains.services.rds.RdsDatasourceConfiguration
@@ -36,10 +36,6 @@ class CreateConfigurationActionTest {
     @Rule
     @JvmField
     val resourceCache = MockResourceCacheRule()
-
-    @Rule
-    @JvmField
-    val regionProvider = MockRegionProviderRule()
 
     private val port = RuleUtils.randomNumber()
     private val address = RuleUtils.randomName()
@@ -97,7 +93,7 @@ class CreateConfigurationActionTest {
             RdsDatasourceConfiguration(
                 username = username,
                 credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = regionProvider.defaultRegion().id,
+                regionId = getDefaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -106,7 +102,7 @@ class CreateConfigurationActionTest {
             assertThat(it.url).contains(port.toString())
             assertThat(it.url).contains(address)
             assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(DUMMY_PROVIDER_IDENTIFIER.displayName)
-            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(regionProvider.defaultRegion().id)
+            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(getDefaultRegion().id)
             assertThat(it.authProviderId).isEqualTo(IamAuth.providerId)
         }
     }
@@ -119,7 +115,7 @@ class CreateConfigurationActionTest {
             RdsDatasourceConfiguration(
                 username = username,
                 credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = regionProvider.defaultRegion().id,
+                regionId = getDefaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -138,7 +134,7 @@ class CreateConfigurationActionTest {
             RdsDatasourceConfiguration(
                 username = username,
                 credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = regionProvider.defaultRegion().id,
+                regionId = getDefaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -157,7 +153,7 @@ class CreateConfigurationActionTest {
             RdsDatasourceConfiguration(
                 username = username,
                 credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = regionProvider.defaultRegion().id,
+                regionId = getDefaultRegion().id,
                 dbInstance = instance
             )
         )
@@ -177,7 +173,7 @@ class CreateConfigurationActionTest {
             RdsDatasourceConfiguration(
                 username = username,
                 credentialId = DUMMY_PROVIDER_IDENTIFIER.id,
-                regionId = regionProvider.defaultRegion().id,
+                regionId = getDefaultRegion().id,
                 dbInstance = instance
             )
         )

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/auth/IamAuthTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/auth/IamAuthTest.kt
@@ -20,8 +20,8 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.core.utils.unwrap
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.RequireSsl
@@ -42,10 +42,18 @@ class IamAuthTest {
 
     private val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
 
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
+
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
     @Before
     fun setUp() {
-        MockCredentialsManager.getInstance().addCredentials(credentialId, mockCreds)
-        MockRegionProvider.getInstance().addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
+        credentialManager.addCredentials(credentialId, mockCreds)
+        regionProvider.addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
     }
 
     @Test

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/auth/IamAuthWidgetTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/rds/auth/IamAuthWidgetTest.kt
@@ -16,8 +16,8 @@ import org.junit.Test
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 
@@ -25,6 +25,14 @@ class IamAuthWidgetTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
+
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
 
     private lateinit var widget: IamAuthWidget
     private val credentialId = RuleUtils.randomName()
@@ -34,8 +42,8 @@ class IamAuthWidgetTest {
     @Before
     fun setUp() {
         widget = IamAuthWidget()
-        MockCredentialsManager.getInstance().addCredentials(credentialId, mockCreds)
-        MockRegionProvider.getInstance().addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
+        credentialManager.addCredentials(credentialId, mockCreds)
+        regionProvider.addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
     }
 
     @Test

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/RedshiftUtilsTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/RedshiftUtilsTest.kt
@@ -10,9 +10,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.redshift.model.Cluster
-import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.services.sts.StsResources
 
 class RedshiftUtilsTest {
@@ -24,8 +24,6 @@ class RedshiftUtilsTest {
     @Rule
     val resourceCache = MockResourceCacheRule()
 
-    private val defaultRegion = RuleUtils.randomName()
-    private val region = AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName())
     private val clusterId = RuleUtils.randomName()
     private val accountId = RuleUtils.randomName()
     private val mockCluster = mock<Cluster> {
@@ -34,6 +32,7 @@ class RedshiftUtilsTest {
 
     @Test
     fun `Account ID ARN`() {
+        val region = getDefaultRegion()
         resourceCache.addEntry(projectRule.project, StsResources.ACCOUNT, accountId)
         val arn = projectRule.project.clusterArn(mockCluster, region)
         assertThat(arn).isEqualTo("arn:${region.partitionId}:redshift:${region.id}:$accountId:cluster:$clusterId")
@@ -41,6 +40,7 @@ class RedshiftUtilsTest {
 
     @Test
     fun `No account ID ARN`() {
+        val region = getDefaultRegion()
         val arn = projectRule.project.clusterArn(mockCluster, region)
         assertThat(arn).isEqualTo("arn:${region.partitionId}:redshift:${region.id}::cluster:$clusterId")
     }

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/actions/CreateDataSourceActionTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/actions/CreateDataSourceActionTest.kt
@@ -10,8 +10,8 @@ import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.redshift.model.Cluster
 import software.aws.toolkits.core.utils.RuleUtils
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.DUMMY_PROVIDER_IDENTIFIER
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 import software.aws.toolkits.jetbrains.services.redshift.auth.CLUSTER_ID_PROPERTY
@@ -22,6 +22,10 @@ class CreateDataSourceActionTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
 
     @Test
     fun `Add data source`() {
@@ -43,8 +47,8 @@ class CreateDataSourceActionTest {
             assertThat(it.isTemporary).isFalse()
             assertThat(it.sslCfg?.myEnabled).isTrue()
             assertThat(it.url).isEqualTo("jdbc:redshift://$address:$port/$dbName")
-            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(MockCredentialsManager.DUMMY_PROVIDER_IDENTIFIER.displayName)
-            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(MockRegionProvider.getInstance().defaultRegion().id)
+            assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(DUMMY_PROVIDER_IDENTIFIER.displayName)
+            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(regionProvider.defaultRegion().id)
             assertThat(it.additionalJdbcProperties[CLUSTER_ID_PROPERTY]).isEqualTo(address)
             assertThat(it.authProviderId).isEqualTo(IamAuth.providerId)
         }

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/actions/CreateDataSourceActionTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/actions/CreateDataSourceActionTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 import software.amazon.awssdk.services.redshift.model.Cluster
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.credentials.DUMMY_PROVIDER_IDENTIFIER
-import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 import software.aws.toolkits.jetbrains.services.redshift.auth.CLUSTER_ID_PROPERTY
@@ -22,10 +22,6 @@ class CreateDataSourceActionTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
-
-    @Rule
-    @JvmField
-    val regionProvider = MockRegionProviderRule()
 
     @Test
     fun `Add data source`() {
@@ -48,7 +44,7 @@ class CreateDataSourceActionTest {
             assertThat(it.sslCfg?.myEnabled).isTrue()
             assertThat(it.url).isEqualTo("jdbc:redshift://$address:$port/$dbName")
             assertThat(it.additionalJdbcProperties[CREDENTIAL_ID_PROPERTY]).isEqualTo(DUMMY_PROVIDER_IDENTIFIER.displayName)
-            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(regionProvider.defaultRegion().id)
+            assertThat(it.additionalJdbcProperties[REGION_ID_PROPERTY]).isEqualTo(getDefaultRegion().id)
             assertThat(it.additionalJdbcProperties[CLUSTER_ID_PROPERTY]).isEqualTo(address)
             assertThat(it.authProviderId).isEqualTo(IamAuth.providerId)
         }

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/auth/IamAuthTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/auth/IamAuthTest.kt
@@ -30,8 +30,8 @@ import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
-import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 
@@ -43,6 +43,14 @@ class IamAuthTest {
     @Rule
     @JvmField
     val mockClientManager = MockClientManagerRule()
+
+    @Rule
+    @JvmField
+    val credentialManager = MockCredentialManagerRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
 
     private val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
 
@@ -61,8 +69,8 @@ class IamAuthTest {
 
     @Before
     fun setUp() {
-        MockCredentialsManager.getInstance().addCredentials(credentialId, mockCreds)
-        MockRegionProvider.getInstance().addRegion(region)
+        credentialManager.addCredentials(credentialId, mockCreds)
+        regionProvider.addRegion(region)
     }
 
     @Test

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/auth/IamAuthWidgetTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/redshift/auth/IamAuthWidgetTest.kt
@@ -14,10 +14,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
-import software.aws.toolkits.jetbrains.core.region.MockRegionProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.datagrip.CREDENTIAL_ID_PROPERTY
 import software.aws.toolkits.jetbrains.datagrip.REGION_ID_PROPERTY
 
@@ -25,6 +24,10 @@ class IamAuthWidgetTest {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
+
+    @JvmField
+    @Rule
+    val regionProvider = MockRegionProviderRule()
 
     private lateinit var widget: IamAuthWidget
     private val credentialId = RuleUtils.randomName()
@@ -36,7 +39,7 @@ class IamAuthWidgetTest {
     fun setUp() {
         widget = IamAuthWidget()
         MockCredentialsManager.getInstance().addCredentials(credentialId, mockCreds)
-        MockRegionProvider.getInstance().addRegion(AwsRegion(defaultRegion, RuleUtils.randomName(), RuleUtils.randomName()))
+        regionProvider.addRegion(regionProvider.createAwsRegion(defaultRegion))
     }
 
     @Test


### PR DESCRIPTION
- Move to rules for test isolation
- Still remaining are a few usages of MockCredentialManager and DUMMY_PROVIDER_IDENTIFIER, we should tackle those later

## Testing
Unit tests passed locally on my mac, we'll see how it goes

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
