### PR TITLE
Fix warning about virtual file pointer leaking when running node tests

### DIFF
--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/NodeJsCodeInsightTestFixtureRule.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/NodeJsCodeInsightTestFixtureRule.kt
@@ -32,13 +32,9 @@ import software.amazon.awssdk.services.lambda.model.Runtime
  *
  * If you wish to have just a [Project], you may use Intellij's [com.intellij.testFramework.ProjectRule]
  */
-class NodeJsCodeInsightTestFixtureRule : CodeInsightTestFixtureRule() {
+class NodeJsCodeInsightTestFixtureRule : CodeInsightTestFixtureRule(NodeJsLightProjectDescriptor()) {
     override fun createTestFixture(): CodeInsightTestFixture {
-        val fixtureFactory = IdeaTestFixtureFactory.getFixtureFactory()
-        val projectFixture = fixtureFactory.createLightFixtureBuilder(NodeJsLightProjectDescriptor())
-        val codeInsightFixture = fixtureFactory.createCodeInsightFixture(projectFixture.fixture)
-        codeInsightFixture.setUp()
-        codeInsightFixture.testDataPath = testDataPath
+        val codeInsightFixture = super.createTestFixture()
         PsiTestUtil.addContentRoot(codeInsightFixture.module, codeInsightFixture.tempDirFixture.getFile(".")!!)
         codeInsightFixture.project.setNodeJsInterpreterVersion(SemVer("v8.10.10", 8, 10, 10))
         codeInsightFixture.project.setJsLanguageLevel(JSLanguageLevel.ES6)


### PR DESCRIPTION
No more of the following when running node tests

```
com.intellij.openapi.util.TraceableDisposable$DisposalException: Virtual pointer 'file:///private/var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/unitTest5625467449441048334' hasn't been disposed: --------------Creation trace: 
java.lang.Throwable
	at com.intellij.openapi.util.TraceableDisposable.<init>(TraceableDisposable.java:31)
	at com.intellij.openapi.vfs.impl.VirtualFilePointerImpl.<init>(VirtualFilePointerImpl.java:38)
	at com.intellij.openapi.vfs.impl.VirtualFilePointerManagerImpl.getOrCreate(VirtualFilePointerManagerImpl.java:358)
	at com.intellij.openapi.vfs.impl.VirtualFilePointerManagerImpl.create(VirtualFilePointerManagerImpl.java:243)
	at com.intellij.openapi.vfs.impl.VirtualFilePointerManagerImpl.create(VirtualFilePointerManagerImpl.java:155)
	at com.intellij.openapi.roots.impl.ContentEntryImpl.<init>(ContentEntryImpl.java:53)
	at com.intellij.openapi.roots.impl.ContentEntryImpl.<init>(ContentEntryImpl.java:48)
	at com.intellij.openapi.roots.impl.RootModelImpl.addContentEntry(RootModelImpl.java:417)
	at com.intellij.testFramework.PsiTestUtil.lambda$addContentRoot$6(PsiTestUtil.java:160)
	at com.intellij.openapi.roots.ModuleRootModificationUtil.updateModel(ModuleRootModificationUtil.java:140)
	at com.intellij.testFramework.PsiTestUtil.addContentRoot(PsiTestUtil.java:160)
	at software.aws.toolkits.jetbrains.utils.rules.NodeJsCodeInsightTestFixtureRule.createTestFixture(NodeJsCodeInsightTestFixtureRule.kt:42)
	at software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule$lazyFixture$1$1.invoke(CodeInsightTestFixtureRule.kt:44)
	at software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule$lazyFixture$1$1.invoke(CodeInsightTestFixtureRule.kt:38)
	at software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRuleKt$invokeAndWait$1.run(CodeInsightTestFixtureRule.kt:143)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:201)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:831)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$invokeAndWait$8(ApplicationImpl.java:480)
	at com.intellij.openapi.application.impl.LaterInvocator$1.run(LaterInvocator.java:124)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:80)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:128)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:46)
	at com.intellij.openapi.application.impl.FlushQueue$FlushNow.run(FlushQueue.java:184)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:974)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:847)
	at com.intellij.ide.IdeEventQueue.lambda$null$8(IdeEventQueue.java:449)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:739)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$9(IdeEventQueue.java:448)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:831)
```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
