### PR TITLE
Remove version method from LambdaHandlerResolver

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaHandlerResolver.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaHandlerResolver.kt
@@ -17,11 +17,6 @@ import software.amazon.awssdk.services.lambda.model.Runtime
  */
 interface LambdaHandlerResolver {
     /**
-     * The version of this indexer. It should be incremented with the indexing logic has been modified
-     */
-    fun version(): Int
-
-    /**
      * Converts the handler string into PSI elements that represent it. I.e. if the Handler points to a file, return the
      * class, or if a method return the method.
      *

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolver.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaLambdaHandlerResolver.kt
@@ -22,8 +22,6 @@ import com.intellij.psi.search.GlobalSearchScope
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
 
 class JavaLambdaHandlerResolver : LambdaHandlerResolver {
-    override fun version(): Int = 1
-
     override fun findPsiElements(
         project: Project,
         handler: String,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolver.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaHandlerResolver.kt
@@ -21,8 +21,6 @@ import com.jetbrains.python.psi.stubs.PyModuleNameIndex
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
 
 class PythonLambdaHandlerResolver : LambdaHandlerResolver {
-    override fun version(): Int = 1
-
     override fun determineHandlers(element: PsiElement, file: VirtualFile): Set<String> =
         determineHandler(element)?.let { setOf(it) }.orEmpty()
 

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaHandlerResolver.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetLambdaHandlerResolver.kt
@@ -21,9 +21,6 @@ import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
 import software.aws.toolkits.jetbrains.services.lambda.dotnet.element.RiderLambdaHandlerFakePsiElement
 
 class DotNetLambdaHandlerResolver : LambdaHandlerResolver {
-
-    override fun version(): Int = 1
-
     override fun findPsiElements(
         project: Project,
         handler: String,

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolver.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaHandlerResolver.kt
@@ -20,9 +20,6 @@ import com.intellij.psi.search.GlobalSearchScope
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
 
 class NodeJsLambdaHandlerResolver : LambdaHandlerResolver {
-
-    override fun version(): Int = 1
-
     override fun findPsiElements(
         project: Project,
         handler: String,


### PR DESCRIPTION
* Left over from when we built handler indexes

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
