### PR TITLE
Upgrade Rider .net reference assemblies

### DIFF
--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Daemon/AWS.Daemon.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Daemon/AWS.Daemon.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-preview.2" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Localization/AWS.Localization.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Localization/AWS.Localization.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-preview.2" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Project/AWS.Project.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Project/AWS.Project.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-preview.2" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0" />
     </ItemGroup>
 
 </Project>

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Psi/AWS.Psi.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Psi/AWS.Psi.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
       <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-preview.2" />
+      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0" />
     </ItemGroup>
 
 </Project>

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Settings/AWS.Settings.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Settings/AWS.Settings.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-preview.2" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This should fix the mac builds

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
