### PR TITLE
Fix deployment for image based lambdas in sam cli 1.14+

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamExecutable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamExecutable.kt
@@ -141,7 +141,8 @@ fun GeneralCommandLine.samDeployCommand(
     templatePath: Path,
     parameters: Map<String, String>,
     capabilities: List<CreateCapabilities>,
-    s3Bucket: String
+    s3Bucket: String,
+    ecrRepo: String? = null
 ) = this.apply {
     withEnvironment(environmentVariables)
     withWorkDirectory(templatePath.parent.toAbsolutePath().toString())
@@ -153,6 +154,10 @@ fun GeneralCommandLine.samDeployCommand(
     addParameter(stackName)
     addParameter("--s3-bucket")
     addParameter(s3Bucket)
+    ecrRepo?.let {
+        addParameter("--image-repository")
+        addParameter(ecrRepo)
+    }
 
     if (capabilities.isNotEmpty()) {
         addParameter("--capabilities")

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/steps/DeployLambda.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/steps/DeployLambda.kt
@@ -17,6 +17,7 @@ class DeployLambda(
     private val packagedTemplateFile: Path,
     private val stackName: String,
     private val s3Bucket: String,
+    private val ecrRepo: String?,
     private val capabilities: List<CreateCapabilities>,
     private val parameters: Map<String, String>,
     private val envVars: Map<String, String>,
@@ -30,6 +31,7 @@ class DeployLambda(
         templatePath = packagedTemplateFile,
         stackName = stackName,
         s3Bucket = s3Bucket,
+        ecrRepo = ecrRepo,
         capabilities = capabilities,
         parameters = parameters
     )

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/steps/LambdaWorkflows.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/steps/LambdaWorkflows.kt
@@ -130,7 +130,7 @@ fun createDeployWorkflow(
     return StepWorkflow(
         BuildLambda(templatePath, buildDir, envVars, SamOptions(buildInContainer = useContainer)),
         PackageLambda(builtTemplate, packagedTemplate, null, envVars, s3Bucket, ecrRepo),
-        DeployLambda(packagedTemplate, stackName, s3Bucket, capabilities, parameters, envVars, region)
+        DeployLambda(packagedTemplate, stackName, s3Bucket, ecrRepo, capabilities, parameters, envVars, region)
     )
 }
 


### PR DESCRIPTION
- 1.14.0 made the `sam deploy` option `--image-repository` required for image based lambdas
- Tested against 1.14.0 and 1.13.2

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
