### PR TITLE
Try to stabilize UI tests more

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -240,6 +240,11 @@ subprojects {
                 systemProperty("aws.sharedCredentialsFile", "/tmp/.aws/credentials")
             }
 
+            debugOptions {
+                enabled.set(true)
+                suspend.set(false)
+            }
+
             configure<JacocoTaskExtension> {
                 setDestinationFile(File("$buildDir/jacoco/${Instant.now()}-jacocoUiTests.exec"))
             }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
@@ -49,7 +49,7 @@ class FileBrowserFixture(
         val absolutePath = path.toAbsolutePath()
         step("Select $absolutePath") {
             step("Refresh file explorer to make sure the file ${path.fileName} is loaded") {
-                waitForIgnoringError(duration = Duration.ofSeconds(15)) {
+                waitForIgnoringError(duration = Duration.ofSeconds(30), interval = Duration.ofSeconds(10)) {
                     setFilePath(absolutePath)
                     findAndClick("//div[@accessiblename='Refresh']")
                     tree.requireSelection(*absolutePath.toParts())

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -74,7 +74,7 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : Co
     private fun isDumbMode(): Boolean = callJs(
         """
             var frameHelper = com.intellij.openapi.wm.impl.ProjectFrameHelper.getFrameHelper(component);
-            com.intellij.openapi. project.DumbService.isDumb(frameHelper.project);
+            com.intellij.openapi.project.DumbService.isDumb(frameHelper.project);
         """.trimIndent(),
         runInEdt = true
     )

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -30,13 +30,26 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : Co
     val projectViewTree
         get() = find<ContainerFixture>(byXpath("ProjectViewTree", "//div[@class='ProjectViewTree']"))
 
-    val projectName
-        get() = step("Get project name") { return@step callJs<String>("component.getProject().getName()") }
+    init {
+        waitForProjectToBeAssigned()
+    }
+
+    private fun waitForProjectToBeAssigned() {
+        waitFor(duration = Duration.ofSeconds(30)) {
+            callJs(
+                """
+                var frameHelper = com.intellij.openapi.wm.impl.ProjectFrameHelper.getFrameHelper(component);
+                frameHelper.project != null
+                """.trimIndent(),
+                runInEdt = true
+            )
+        }
+    }
 
     fun dumbAware(timeout: Duration = Duration.ofMinutes(5), function: () -> Unit) {
         step("Wait for smart mode") {
             waitFor(duration = timeout, interval = Duration.ofSeconds(5)) {
-                runCatching { isDumbMode().not() }.getOrDefault(false)
+                isDumbMode().not()
             }
             function()
             step("..wait for smart mode again") {
@@ -58,7 +71,13 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : Co
         }
     }
 
-    private fun isDumbMode(): Boolean = callJs("com.intellij.openapi. project.DumbService.isDumb(component.project);", true)
+    private fun isDumbMode(): Boolean = callJs(
+        """
+            var frameHelper = com.intellij.openapi.wm.impl.ProjectFrameHelper.getFrameHelper(component);
+            com.intellij.openapi. project.DumbService.isDumb(frameHelper.project);
+        """.trimIndent(),
+        runInEdt = true
+    )
 
     fun openProjectStructure() = step("Open Project Structure dialog") {
         if (remoteRobot.isMac()) {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/SQSTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/SQSTest.kt
@@ -180,16 +180,6 @@ class SQSTest {
                         assertThat(it).contains("Started purging queue")
                     }
                 }
-                awsExplorer {
-                    openExplorerActionMenu(sqsNodeLabel, queueName)
-                }
-                actionMenuItem(purgeQueueText).click()
-                pressYes()
-                reattemptAssert {
-                    assertThat(findToastText()).anySatisfy {
-                        assertThat(it).contains("Purge queue request already in progress for queue")
-                    }
-                }
             }
             step("Subscribe queue to sns topic") {
                 awsExplorer {


### PR DESCRIPTION
* Use non-deprecated way to get the project for the isDumb check
* Increase time for it to refresh the file browser
* Do not return the IdeFrame fixture until the project gets assigned to the frame
* Always run the UI test sandbox with the debug port open for ease of debugging

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
