### PR TITLE
Fix flaky test caused by concurrent modification of array list

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialsRegionHandlerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialsRegionHandlerTest.kt
@@ -17,7 +17,7 @@ import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.settings.AwsSettings
 import software.aws.toolkits.jetbrains.settings.AwsSettingsRule
 import software.aws.toolkits.jetbrains.settings.UseAwsCredentialRegion
-import software.aws.toolkits.jetbrains.utils.NotificationListenerRule
+import software.aws.toolkits.jetbrains.utils.rules.NotificationListenerRule
 import software.aws.toolkits.resources.message
 
 class CredentialsRegionHandlerTest {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/NotificationUtilsTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/NotificationUtilsTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExternalResource
+import java.util.concurrent.CopyOnWriteArrayList
 
 class NotificationUtilsTest {
 
@@ -34,7 +35,7 @@ class NotificationUtilsTest {
 }
 
 class NotificationListenerRule(private val projectRule: ProjectRule) : ExternalResource() {
-    val notifications = mutableListOf<Notification>()
+    val notifications = CopyOnWriteArrayList<Notification>()
 
     override fun before() {
         with(projectRule.project.messageBus.connect()) {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/NotificationUtilsTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/NotificationUtilsTest.kt
@@ -3,14 +3,11 @@
 
 package software.aws.toolkits.jetbrains.utils
 
-import com.intellij.notification.Notification
-import com.intellij.notification.Notifications
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExternalResource
-import java.util.concurrent.CopyOnWriteArrayList
+import software.aws.toolkits.jetbrains.utils.rules.NotificationListenerRule
 
 class NotificationUtilsTest {
 
@@ -31,19 +28,5 @@ class NotificationUtilsTest {
                 .startsWith("java.lang.NullPointerException")
                 .contains("NotificationUtilsTest.kt")
         }
-    }
-}
-
-class NotificationListenerRule(private val projectRule: ProjectRule) : ExternalResource() {
-    val notifications = CopyOnWriteArrayList<Notification>()
-
-    override fun before() {
-        with(projectRule.project.messageBus.connect()) {
-            setDefaultHandler { _, params ->
-                notifications.add(params[0] as Notification)
-            }
-            subscribe(Notifications.TOPIC)
-        }
-        notifications.clear()
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/NotificationListenerRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/NotificationListenerRule.kt
@@ -1,0 +1,24 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.utils.rules
+
+import com.intellij.notification.Notification
+import com.intellij.notification.Notifications
+import com.intellij.testFramework.ProjectRule
+import org.junit.rules.ExternalResource
+import java.util.concurrent.CopyOnWriteArrayList
+
+class NotificationListenerRule(private val projectRule: ProjectRule) : ExternalResource() {
+    val notifications = CopyOnWriteArrayList<Notification>()
+
+    override fun before() {
+        with(projectRule.project.messageBus.connect()) {
+            setDefaultHandler { _, params ->
+                notifications.add(params[0] as Notification)
+            }
+            subscribe(Notifications.TOPIC)
+        }
+        notifications.clear()
+    }
+}


### PR DESCRIPTION
Fixes:
```
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1043)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:997)
	at software.aws.toolkits.jetbrains.core.credentials.CredentialsRegionHandlerTest.getOnlyNotification(CredentialsRegionHandlerTest.kt:190)
	at software.aws.toolkits.jetbrains.core.credentials.CredentialsRegionHandlerTest.Selecting Never at the prompt sets setting to Never(CredentialsRegionHandlerTest.kt:150)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
