### PR TITLE
Remove mock region usage from CreateFunctionIntegrationTest

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionIntegrationTest.kt
@@ -30,7 +30,7 @@ import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager.ProjectAccountSettingsManagerRule
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.core.credentials.activeRegion
-import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
+import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.services.ecr.resources.EcrResources
 import software.aws.toolkits.jetbrains.services.ecr.resources.Repository
 import software.aws.toolkits.jetbrains.services.iam.Iam.createRoleWithPolicy
@@ -50,7 +50,6 @@ class CreateFunctionIntegrationTest {
     private val projectRule = HeavyJavaCodeInsightTestFixtureRule()
     private val resourceCache = MockResourceCacheRule()
     private val disposableRule = DisposableRule()
-    private val regionProvider = MockRegionProviderRule()
     private val credentialManager = MockCredentialManagerRule()
     private val settingsManager = ProjectAccountSettingsManagerRule(projectRule)
     private val temporaryBucket = S3TemporaryBucketRule { projectRule.project.awsClient() }
@@ -63,7 +62,6 @@ class CreateFunctionIntegrationTest {
         projectRule,
         disposableRule,
         credentialManager,
-        regionProvider,
         settingsManager,
         temporaryBucket
     )
@@ -85,7 +83,7 @@ class CreateFunctionIntegrationTest {
         // TODO: To defend against this we should make a AwsSdkClient that throws telling people to use this method
         MockClientManager.useRealImplementations(disposableRule.disposable)
 
-        val region = regionProvider.addRegion(Region.US_WEST_2)
+        val region = AwsRegionProvider.getInstance()[Region.US_WEST_2.id()]!!
         val credentials = credentialManager.addCredentials("ReadCreds", createIntegrationTestCredentialProvider(), region.id)
 
         settingsManager.settingsManager.changeRegion(region)


### PR DESCRIPTION
Since we use the real one (MockClientManager.useRealImplementations), we should not use the mock region rule. Due to changes in #2300, it is now throwing a class cast exception which revealed the incorrect behavior

Exception:
```
    software.aws.toolkits.jetbrains.services.lambda.upload.CreateFunctionIntegrationTest > zip based lambda can be created FAILED
    java.lang.ClassCastException: class software.aws.toolkits.jetbrains.core.region.AwsRegionProvider cannot be cast to class software.aws.toolkits.jetbrains.core.region.MockRegionProvider (software.aws.toolkits.jetbrains.core.region.AwsRegionProvider and software.aws.toolkits.jetbrains.core.region.MockRegionProvider are in unnamed module of loader 'app')
    at software.aws.toolkits.jetbrains.core.region.MockRegionProvider$Companion.getInstance(MockRegionProvider.kt:64)
    at software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule$lazyRegionProvider$1.invoke(MockRegionProvider.kt:70)
    at software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule$lazyRegionProvider$1.invoke(MockRegionProvider.kt:68)
    at software.aws.toolkits.jetbrains.utils.rules.ClearableLazy.getValue(CodeInsightTestFixtureRule.kt:115)
    at software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule.getRegionManager(MockRegionProvider.kt:74)
    at software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule.addRegion(MockRegionProvider.kt:77)
    at software.aws.toolkits.jetbrains.services.lambda.upload.CreateFunctionIntegrationTest.setUp(CreateFunctionIntegrationTest.kt:88)
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
