### PR TITLE
Upgrade Wiremock, remove direct dependency on jetty proxy

### DIFF
--- a/jetbrains-core/build.gradle.kts
+++ b/jetbrains-core/build.gradle.kts
@@ -97,10 +97,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
 
     testImplementation(project(path = ":core", configuration = "testArtifacts"))
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.26.0")
+    testImplementation("com.github.tomakehurst:wiremock:2.27.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutinesVersion")
-
-    integrationTestImplementation("org.eclipse.jetty:jetty-servlet:9.4.15.v20190215")
-    integrationTestImplementation("org.eclipse.jetty:jetty-proxy:9.4.15.v20190215")
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsSdkClientTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsSdkClientTest.kt
@@ -78,6 +78,7 @@ class AwsSdkClientTest {
                 .dynamicHttpsPort()
                 .keystorePath(selfSignedJks.toString())
                 .keystorePassword("changeit")
+                .keyManagerPassword("changeit")
                 .keystoreType("jks")
         )
     }


### PR DESCRIPTION
Jetty proxy gets pulled in through wiremock so use that so we do not have to manage versions manually

This replaces PRs #2298, #2299

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
