### PR TITLE
Tear down maven server on dispose if we create a maven project

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
@@ -33,6 +33,7 @@ import com.intellij.util.io.readBytes
 import com.intellij.util.io.write
 import com.intellij.xdebugger.XDebuggerUtil
 import org.jetbrains.idea.maven.project.MavenProjectsManager
+import org.jetbrains.idea.maven.server.MavenServerManager
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
 import org.jetbrains.plugins.gradle.util.GradleConstants
 import org.junit.Assert.fail
@@ -52,12 +53,7 @@ fun HeavyJavaCodeInsightTestFixtureRule.setUpJdk(jdkName: String = "Real JDK"): 
             val jdkHomeDir = LocalFileSystem.getInstance().refreshAndFindFileByPath(jdkHome)!!
             val jdk = SdkConfigurationUtil.setupSdk(emptyArray(), jdkHomeDir, JavaSdk.getInstance(), false, null, jdkName)!!
 
-            ProjectJdkTable.getInstance().addJdk(jdk)
-            Disposer.register(
-                this.fixture.testRootDisposable,
-                Disposable { runWriteAction { ProjectJdkTable.getInstance().removeJdk(jdk) } }
-            )
-
+            ProjectJdkTable.getInstance().addJdk(jdk, this.fixture.testRootDisposable)
             ModuleRootModificationUtil.setModuleSdk(this.module, jdk)
         }
     }
@@ -266,6 +262,10 @@ internal fun HeavyJavaCodeInsightTestFixtureRule.setUpMavenProject(): PsiClass {
             }
         """.trimIndent()
     )
+
+    Disposer.register(this.fixture.testRootDisposable, Disposable {
+        MavenServerManager.getInstance().shutdown(true)
+    })
 
     val projectsManager = MavenProjectsManager.getInstance(project)
     projectsManager.addManagedFilesOrUnignore(listOf(pomFile))

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
@@ -263,9 +263,10 @@ internal fun HeavyJavaCodeInsightTestFixtureRule.setUpMavenProject(): PsiClass {
         """.trimIndent()
     )
 
-    Disposer.register(this.fixture.testRootDisposable, Disposable {
-        MavenServerManager.getInstance().shutdown(true)
-    })
+    Disposer.register(
+        this.fixture.testRootDisposable,
+        Disposable { MavenServerManager.getInstance().shutdown(true) }
+    )
 
     val projectsManager = MavenProjectsManager.getInstance(project)
     projectsManager.addManagedFilesOrUnignore(listOf(pomFile))


### PR DESCRIPTION
Fixes:

```
2020-12-21 12:50:55 WARN  CodeInsightTestFixtureRule:91 - Exception during tear-down
CompositeException (2 nested):
------------------------------
[0]: java.lang.AssertionError: Thread leaked: Thread[BaseDataReader: error stream of /Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Home/b...IC/2020.1/cbeeb1f1aebd4c9ea8fb5ab990c5904a676fc41a/ideaIC-2020.1/plugins/maven/lib/maven3/boot/plexus-classworlds-2.6.0.jar org.jetbrains.idea.maven.server.RemoteMavenServer36,4,main] (alive) RUNNABLE
--- its stacktrace:
 at java.base@11.0.8/java.io.FileInputStream.readBytes(Native Method)
 at java.base@11.0.8/java.io.FileInputStream.read(FileInputStream.java:279)
 at java.base@11.0.8/java.io.BufferedInputStream.read1(BufferedInputStream.java:290)
 at java.base@11.0.8/java.io.BufferedInputStream.read(BufferedInputStream.java:351)
 at java.base@11.0.8/sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
 at java.base@11.0.8/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
 at java.base@11.0.8/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
 at java.base@11.0.8/java.io.InputStreamReader.read(InputStreamReader.java:185)
 at java.base@11.0.8/java.io.Reader.read(Reader.java:229)
 at app//com.intellij.util.io.BaseOutputReader.readAvailableBlocking(BaseOutputReader.java:134)
 at app//com.intellij.util.io.BaseDataReader.readAvailable(BaseDataReader.java:67)
 at app//com.intellij.util.io.BaseDataReader.doRun(BaseDataReader.java:160)
 at app//com.intellij.util.io.BaseDataReader$$Lambda$401/0x0000000800492040.run(Unknown Source)
 at app//com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:210)
 at app//com.intellij.util.io.BaseDataReader.lambda$start$0(BaseDataReader.java:50)
 at app//com.intellij.util.io.BaseDataReader$$Lambda$400/0x0000000800492c40.run(Unknown Source)
 at java.base@11.0.8/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
 at java.base@11.0.8/java.util.concurrent.FutureTask.run(FutureTask.java:264)
 at java.base@11.0.8/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
 at java.base@11.0.8/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
 at java.base@11.0.8/java.lang.Thread.run(Thread.java:834)
---
(diagnostic: 0: java.io.FileInputStream : false . readBytes : false 2: java.io.BufferedInputStream : false . read1 : false)

```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
