### PR TITLE
Mark all fork join threads as acceptable leaks until 203 min

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CodeInsightTestFixtureRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CodeInsightTestFixtureRule.kt
@@ -16,6 +16,7 @@ import com.intellij.psi.PsiManager
 import com.intellij.testFramework.ApplicationRule
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.ThreadTracker
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.testFramework.fixtures.impl.LightTempDirTestFixtureImpl
@@ -64,6 +65,12 @@ open class CodeInsightTestFixtureRule(protected val testDescription: LightProjec
             beforeMethod.invoke(appRule)
         }
         this.description = description
+
+        // We can't find fork join pool correctly on JDK 11, we have to match all fork join threads because we can only register by name prefixes unlike the
+        // actual JB logic
+        // https://github.com/JetBrains/intellij-community/commit/0a6c9e16e95983ae0786d7667290c07b420ce705
+        // TODO: Remove this FIX_WHEN_MIN_IS_203
+        ThreadTracker.longRunningThreadCreated(ApplicationManager.getApplication(), "ForkJoinPool.commonPool-worker-")
     }
 
     override fun finished(description: Description?) {


### PR DESCRIPTION
Add a workaround for:

```
software.aws.toolkits.jetbrains.services.clouddebug.python.PythonDebugEndToEndTest

  Test testEndToEnd FAILED (2m 55s)

  java.lang.AssertionError: Thread leaked: Thread[ForkJoinPool.commonPool-worker-13,4,main] (alive) WAITING
  --- its stacktrace:
   at java.base@11.0.9.1/jdk.internal.misc.Unsafe.park(Native Method)
   at java.base@11.0.9.1/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
   at java.base@11.0.9.1/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1628)
   at java.base@11.0.9.1/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
  ---
  stackTrace.length: 4
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
