### PR TITLE
Make UI tests retry if error nodes show up, try to harden file browse…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ publishToken=
 publishChannel=
 
 # Common dependencies
-ideProfileName=2020.3
+ideProfileName=2020.1
 kotlinVersion=1.3.70
 awsSdkVersion=2.15.38
 coroutinesVersion=1.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ mockitoKotlinVersion=2.2.0
 mockitoVersion=3.4.0
 
 remoteRobotPort=8080
-remoteRobotVersion=0.10.1
+remoteRobotVersion=0.9.35
 uiTestFixturesVersion=1.1.18
 
 # Code style

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ publishToken=
 publishChannel=
 
 # Common dependencies
-ideProfileName=2020.1
+ideProfileName=2020.3
 kotlinVersion=1.3.70
 awsSdkVersion=2.15.38
 coroutinesVersion=1.3.3
@@ -25,7 +25,7 @@ mockitoKotlinVersion=2.2.0
 mockitoVersion=3.4.0
 
 remoteRobotPort=8080
-remoteRobotVersion=0.9.35
+remoteRobotVersion=0.10.1
 uiTestFixturesVersion=1.1.18
 
 # Code style

--- a/ui-tests/build.gradle.kts
+++ b/ui-tests/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 
 dependencies {
     testImplementation(gradleApi())
+    testImplementation(project(":core"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit5Version")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ActionMenu.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ActionMenu.kt
@@ -10,7 +10,7 @@ import com.intellij.remoterobot.fixtures.FixtureName
 import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.utils.waitFor
 
-fun RemoteRobot.actionMenu(text: String): ActionMenuFixture {
+fun IdeaFrame.actionMenu(text: String): ActionMenuFixture {
     val xpath = byXpath("text '$text'", "//div[@class='ActionMenu' and @text='$text']")
     waitFor {
         findAll<ActionMenuFixture>(xpath).isNotEmpty()
@@ -18,7 +18,7 @@ fun RemoteRobot.actionMenu(text: String): ActionMenuFixture {
     return findAll<ActionMenuFixture>(xpath).first()
 }
 
-fun RemoteRobot.actionMenuItem(text: String): ActionMenuItemFixture {
+fun IdeaFrame.actionMenuItem(text: String): ActionMenuItemFixture {
     val xpath = byXpath("text '$text'", "//div[@class='ActionMenuItem' and @text='$text']")
     waitFor {
         findAll<ActionMenuItemFixture>(xpath).isNotEmpty()

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -17,7 +17,7 @@ fun IdeaFrame.awsExplorer(
     timeout: Duration = Duration.ofSeconds(20),
     function: AwsExplorer.() -> Unit
 ) {
-    private val locator = byXpath("//div[@accessiblename='AWS Explorer Tool Window' and @class='InternalDecorator']")
+    val locator = byXpath("//div[@accessiblename='AWS Explorer Tool Window' and @class='InternalDecorator']")
 
     step("AWS explorer") {
         val explorer = try {
@@ -78,5 +78,9 @@ open class AwsExplorer(
 
     fun doubleClickExplorer(vararg nodeElements: String) {
         explorerTree.doubleClickPath(*nodeElements)
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 5
     }
 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -13,12 +13,12 @@ import com.intellij.remoterobot.stepsProcessing.step
 import org.assertj.swing.timing.Pause
 import java.time.Duration
 
-private val locator = byXpath("//div[@accessiblename='AWS Explorer Tool Window' and @class='InternalDecorator']")
-
 fun IdeaFrame.awsExplorer(
     timeout: Duration = Duration.ofSeconds(20),
     function: AwsExplorer.() -> Unit
 ) {
+    private val locator = byXpath("//div[@accessiblename='AWS Explorer Tool Window' and @class='InternalDecorator']")
+
     step("AWS explorer") {
         val explorer = try {
             find<AwsExplorer>(locator, timeout)
@@ -49,14 +49,14 @@ open class AwsExplorer(
         expandServiceNode(path.first())
 
         explorerTree.expandPath(*path)
-        waitForLoading()
+        explorerTree.waitUntilLoaded()
     }
 
     private fun expandServiceNode(serviceName: String) {
         repeat(MAX_ATTEMPTS) {
             val attempt = it + 1
             explorerTree.expandPath(serviceName)
-            waitForLoading()
+            explorerTree.waitUntilLoaded()
 
             if (explorerTree.hasText { remoteText -> remoteText.text.startsWith("Error Loading Resources") }) {
                 val pauseTime = Duration.ofSeconds(2 * attempt.toLong())
@@ -76,23 +76,7 @@ open class AwsExplorer(
         }
     }
 
-    private fun waitForLoading() {
-        step("waiting for loading text to go away...") {
-            try {
-                while (true) {
-                    explorerTree.findText("loading...")
-                    Thread.sleep(100)
-                }
-            } catch (e: Exception) {
-            }
-        }
-    }
-
     fun doubleClickExplorer(vararg nodeElements: String) {
         explorerTree.doubleClickPath(*nodeElements)
-    }
-
-    private companion object {
-        const val MAX_ATTEMPTS = 5
     }
 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -23,9 +23,11 @@ fun IdeaFrame.awsExplorer(
         val explorer = try {
             find<AwsExplorer>(locator, timeout)
         } catch (e: Exception) {
-            // Click the tool window stripe
-            find(ComponentFixture::class.java, byXpath("//div[@accessiblename='AWS Explorer' and @class='StripeButton' and @text='AWS Explorer']")).click()
-            find<AwsExplorer>(locator, timeout)
+            step("Open tool window" ) {
+                // Click the tool window stripe
+                find(ComponentFixture::class.java, byXpath("//div[@accessiblename='AWS Explorer' and @class='StripeButton' and @text='AWS Explorer']")).click()
+                find<AwsExplorer>(locator, timeout)
+            }
         }
 
         explorer.apply(function)
@@ -57,6 +59,8 @@ open class AwsExplorer(
             val attempt = it + 1
             explorerTree.expandPath(serviceName)
             explorerTree.waitUntilLoaded()
+
+            step("DEBUG: ${explorerTree.findAllText().joinToString()}") {}
 
             if (explorerTree.hasText { remoteText -> remoteText.text.startsWith("Error Loading Resources") }) {
                 val pauseTime = Duration.ofSeconds(2 * attempt.toLong())

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -41,32 +41,30 @@ open class AwsExplorer(
     remoteRobot: RemoteRobot,
     remoteComponent: RemoteComponent
 ) : CommonContainerFixture(remoteRobot, remoteComponent) {
-    private val explorerTree by lazy {
-        find<JTreeFixture>(byXpath("//div[@class='Tree']"))
-    }
+    private fun explorerTree() = find<JTreeFixture>(byXpath("//div[@class='Tree']"))
 
     fun openExplorerActionMenu(vararg path: String) {
-        explorerTree.rightClickPath(*path)
+        explorerTree().rightClickPath(*path)
     }
 
     fun expandExplorerNode(vararg path: String) {
         expandServiceNode(path.first())
 
-        explorerTree.expandPath(*path)
-        explorerTree.waitUntilLoaded()
+        explorerTree().expandPath(*path)
+        explorerTree().waitUntilLoaded()
     }
 
     private fun expandServiceNode(serviceName: String) {
         step("Expand service node '$serviceName'") {
-            waitFor { explorerTree.hasPath(serviceName) }
+            waitFor { explorerTree().hasPath(serviceName) }
 
             for (attempt in 1..MAX_ATTEMPTS) {
-                explorerTree.expandPath(serviceName)
-                explorerTree.waitUntilLoaded()
+                explorerTree().expandPath(serviceName)
+                explorerTree().waitUntilLoaded()
 
-                step("DEBUG: ${explorerTree.findAllText().joinToString { it.text }}") {}
+                step("DEBUG: ${explorerTree().findAllText().joinToString { it.text }}") {}
 
-                if (explorerTree.hasText { remoteText -> remoteText.text.startsWith("Error Loading Resources") }) {
+                if (explorerTree().findAllText().any { remoteText -> remoteText.text.startsWith("Error Loading Resources") }) {
                     if (attempt < MAX_ATTEMPTS) {
                         val pauseTime = Duration.ofSeconds(30 * attempt.toLong() + Random.nextInt(30))
                         step("Error node was returned, will wait and try again in $pauseTime . Attempt $attempt of $MAX_ATTEMPTS") {
@@ -90,7 +88,7 @@ open class AwsExplorer(
     }
 
     fun doubleClickExplorer(vararg nodeElements: String) {
-        explorerTree.doubleClickPath(*nodeElements)
+        explorerTree().doubleClickPath(*nodeElements)
     }
 
     private companion object {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -12,6 +12,7 @@ import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.stepsProcessing.step
 import org.assertj.swing.timing.Pause
 import java.time.Duration
+import kotlin.random.Random
 
 fun IdeaFrame.awsExplorer(
     timeout: Duration = Duration.ofSeconds(20),
@@ -23,7 +24,7 @@ fun IdeaFrame.awsExplorer(
         val explorer = try {
             find<AwsExplorer>(locator, timeout)
         } catch (e: Exception) {
-            step("Open tool window" ) {
+            step("Open tool window") {
                 // Click the tool window stripe
                 find(ComponentFixture::class.java, byXpath("//div[@accessiblename='AWS Explorer' and @class='StripeButton' and @text='AWS Explorer']")).click()
                 find<AwsExplorer>(locator, timeout)
@@ -60,10 +61,10 @@ open class AwsExplorer(
             explorerTree.expandPath(serviceName)
             explorerTree.waitUntilLoaded()
 
-            step("DEBUG: ${explorerTree.findAllText().joinToString()}") {}
+            step("DEBUG: ${explorerTree.findAllText().joinToString { it.text }}") {}
 
             if (explorerTree.hasText { remoteText -> remoteText.text.startsWith("Error Loading Resources") }) {
-                val pauseTime = Duration.ofSeconds(2 * attempt.toLong())
+                val pauseTime = Duration.ofSeconds(30 * attempt.toLong() + Random.nextInt(30))
                 step("Error node was returned, will wait and try again in $pauseTime . Attempt $attempt of $MAX_ATTEMPTS") {
                     Pause.pause(pauseTime.toMillis())
                     refresh()

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -57,13 +57,15 @@ open class AwsExplorer(
     private fun expandServiceNode(serviceName: String) {
         step("Expand service node '$serviceName'") {
             for (attempt in 1..MAX_ATTEMPTS) {
-                waitFor { explorerTree().hasPath(serviceName) }
-                explorerTree().expandPath(serviceName)
-                explorerTree().waitUntilLoaded()
+                val explorerTree = explorerTree()
 
-                step("DEBUG: ${explorerTree().findAllText().joinToString { it.text }}") {}
+                waitFor { explorerTree.hasPath(serviceName) }
+                explorerTree.expandPath(serviceName)
+                explorerTree.waitUntilLoaded()
 
-                if (explorerTree().findAllText().any { remoteText -> remoteText.text.startsWith("Error Loading Resources") }) {
+                step("DEBUG: ${explorerTree.findAllText().joinToString { it.text }}") {}
+
+                if (explorerTree.findAllText().any { remoteText -> remoteText.text.startsWith("Error Loading Resources") }) {
                     if (attempt < MAX_ATTEMPTS) {
                         val pauseTime = Duration.ofSeconds(30 * attempt.toLong() + Random.nextInt(30))
                         step("Error node was returned, will wait and try again in $pauseTime . Attempt $attempt of $MAX_ATTEMPTS") {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -10,6 +10,7 @@ import com.intellij.remoterobot.fixtures.ComponentFixture
 import com.intellij.remoterobot.fixtures.FixtureName
 import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.stepsProcessing.step
+import com.intellij.remoterobot.utils.waitFor
 import org.assertj.swing.timing.Pause
 import java.time.Duration
 import kotlin.random.Random
@@ -56,6 +57,8 @@ open class AwsExplorer(
     }
 
     private fun expandServiceNode(serviceName: String) {
+        waitFor { explorerTree.hasPath(serviceName) }
+
         repeat(MAX_ATTEMPTS) {
             val attempt = it + 1
             explorerTree.expandPath(serviceName)

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -56,9 +56,8 @@ open class AwsExplorer(
 
     private fun expandServiceNode(serviceName: String) {
         step("Expand service node '$serviceName'") {
-            waitFor { explorerTree().hasPath(serviceName) }
-
             for (attempt in 1..MAX_ATTEMPTS) {
+                waitFor { explorerTree().hasPath(serviceName) }
                 explorerTree().expandPath(serviceName)
                 explorerTree().waitUntilLoaded()
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -10,10 +10,7 @@ import com.intellij.remoterobot.fixtures.ComponentFixture
 import com.intellij.remoterobot.fixtures.FixtureName
 import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.stepsProcessing.step
-import com.intellij.remoterobot.utils.waitFor
-import org.assertj.swing.timing.Pause
 import java.time.Duration
-import kotlin.random.Random
 
 fun IdeaFrame.awsExplorer(
     timeout: Duration = Duration.ofSeconds(20),
@@ -48,36 +45,8 @@ open class AwsExplorer(
     }
 
     fun expandExplorerNode(vararg path: String) {
-        expandServiceNode(path.first())
-
         explorerTree().expandPath(*path)
         explorerTree().waitUntilLoaded()
-    }
-
-    private fun expandServiceNode(serviceName: String) {
-        step("Expand service node '$serviceName'") {
-            for (attempt in 1..MAX_ATTEMPTS) {
-                val explorerTree = explorerTree()
-
-                waitFor { explorerTree.hasPath(serviceName) }
-                explorerTree.expandPath(serviceName)
-                explorerTree.waitUntilLoaded()
-
-                if (explorerTree.findAllText().any { remoteText -> remoteText.text.startsWith("Error Loading Resources") }) {
-                    if (attempt < MAX_ATTEMPTS) {
-                        val pauseTime = Duration.ofSeconds(30 * attempt.toLong() + Random.nextInt(30))
-                        step("Error node was returned, will wait and try again in $pauseTime . Attempt $attempt of $MAX_ATTEMPTS") {
-                            Pause.pause(pauseTime.toMillis())
-                            refresh()
-                        }
-                    } else {
-                        throw IllegalStateException("Max attempts reached")
-                    }
-                } else {
-                    break
-                }
-            }
-        }
     }
 
     private fun refresh() {
@@ -88,9 +57,5 @@ open class AwsExplorer(
 
     fun doubleClickExplorer(vararg nodeElements: String) {
         explorerTree().doubleClickPath(*nodeElements)
-    }
-
-    private companion object {
-        const val MAX_ATTEMPTS = 5
     }
 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -41,7 +41,7 @@ open class AwsExplorer(
     remoteRobot: RemoteRobot,
     remoteComponent: RemoteComponent
 ) : CommonContainerFixture(remoteRobot, remoteComponent) {
-    private fun explorerTree() = find<JTreeFixture>(byXpath("//div[@class='Tree']"))
+    private fun explorerTree() = find<JTreeFixture>(byXpath("//div[@class='Tree']")).also { it.waitUntilLoaded() }
 
     fun openExplorerActionMenu(vararg path: String) {
         explorerTree().rightClickPath(*path)

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -49,12 +49,6 @@ open class AwsExplorer(
         explorerTree().waitUntilLoaded()
     }
 
-    private fun refresh() {
-        step("Pressing Refresh...") {
-            findAndClick("//div[@accessiblename='Refresh AWS Connection']")
-        }
-    }
-
     fun doubleClickExplorer(vararg nodeElements: String) {
         explorerTree().doubleClickPath(*nodeElements)
     }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -20,7 +20,7 @@ fun IdeaFrame.awsExplorer(
 
     step("AWS explorer") {
         val explorer = try {
-            find<AwsExplorer>(locator, timeout)
+            find<AwsExplorer>(locator)
         } catch (e: Exception) {
             step("Open tool window") {
                 // Click the tool window stripe

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -63,8 +63,6 @@ open class AwsExplorer(
                 explorerTree.expandPath(serviceName)
                 explorerTree.waitUntilLoaded()
 
-                step("DEBUG: ${explorerTree.findAllText().joinToString { it.text }}") {}
-
                 if (explorerTree.findAllText().any { remoteText -> remoteText.text.startsWith("Error Loading Resources") }) {
                     if (attempt < MAX_ATTEMPTS) {
                         val pauseTime = Duration.ofSeconds(30 * attempt.toLong() + Random.nextInt(30))

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/FileBrowserFixture.kt
@@ -10,8 +10,8 @@ import com.intellij.remoterobot.fixtures.FixtureName
 import com.intellij.remoterobot.fixtures.JTextFieldFixture
 import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.stepsProcessing.step
-import com.intellij.remoterobot.utils.keyboard
 import com.intellij.remoterobot.utils.waitForIgnoringError
+import org.assertj.swing.timing.Pause
 import java.io.File
 import java.nio.file.Path
 import java.time.Duration
@@ -68,11 +68,17 @@ class FileBrowserFixture(
             } else {
                 find(byXpath("//div[@class='BorderlessTextField']"), Duration.ofSeconds(5))
             }
-            // clear the path box then type in the path. needs to be typed not set because sometimes it will fail
-            // to load properly if just set (and fail the tests)
+            // clear the path box then type in the path. needs to be set slowly and not typed due to the tree can steal focus when loading.
+            // so break the path up and set it in segments
             pathBox.text = ""
-            pathBox.click()
-            keyboard { this.enterText(path.toString()) }
+            step("Type path '$path'") {
+                val pathSoFar = mutableListOf<String>()
+                path.toParts().forEach {
+                    pathSoFar += it
+                    pathBox.text = pathSoFar.joinToString(separator = "/").replace("//", "/")
+                    Pause.pause(100)
+                }
+            }
         }
     }
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -7,14 +7,11 @@ import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.data.RemoteComponent
 import com.intellij.remoterobot.fixtures.CommonContainerFixture
 import com.intellij.remoterobot.fixtures.ComponentFixture
-import com.intellij.remoterobot.fixtures.ContainerFixture
 import com.intellij.remoterobot.fixtures.DefaultXpath
 import com.intellij.remoterobot.fixtures.FixtureName
 import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.stepsProcessing.step
-import com.intellij.remoterobot.utils.keyboard
 import com.intellij.remoterobot.utils.waitFor
-import java.awt.event.KeyEvent
 import java.time.Duration
 
 fun RemoteRobot.idea(function: IdeaFrame.() -> Unit) {
@@ -27,9 +24,6 @@ fun RemoteRobot.idea(function: IdeaFrame.() -> Unit) {
 @FixtureName("Idea frame")
 @DefaultXpath("IdeFrameImpl type", "//div[@class='IdeFrameImpl']")
 class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : CommonContainerFixture(remoteRobot, remoteComponent) {
-    val projectViewTree
-        get() = find<ContainerFixture>(byXpath("ProjectViewTree", "//div[@class='ProjectViewTree']"))
-
     init {
         waitForProjectToBeAssigned()
     }
@@ -79,24 +73,6 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : Co
         runInEdt = true
     )
 
-    fun openProjectStructure() = step("Open Project Structure dialog") {
-        if (remoteRobot.isMac()) {
-            keyboard { hotKey(KeyEvent.VK_META, KeyEvent.VK_SEMICOLON) }
-        } else {
-            keyboard { hotKey(KeyEvent.VK_CONTROL, KeyEvent.VK_ALT, KeyEvent.VK_SHIFT, KeyEvent.VK_S) }
-        }
-        find(ComponentFixture::class.java, byXpath("//div[@accessiblename='Project Structure']")).click()
-    }
-
-    // Show AWS Explorer, or leave it open if it is already open
-    fun showAwsExplorer() {
-        try {
-            find<AwsExplorer>(byXpath("//div[@class='ExplorerToolWindow']"))
-        } catch (e: Exception) {
-            find(ComponentFixture::class.java, byXpath("//div[@accessiblename='AWS Explorer' and @class='StripeButton' and @text='AWS Explorer']")).click()
-        }
-    }
-
     // Tips sometimes open when running, close it if it opens
     fun tryCloseTips() {
         step("Close Tip of the Day if it appears") {
@@ -104,18 +80,6 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : Co
                 find<DialogFixture>(DialogFixture.byTitleContains("Tip")).close()
             } catch (e: Exception) {
             }
-        }
-    }
-
-    fun refreshExplorer() {
-        findAndClick("//div[@accessiblename='Refresh AWS Connection' and @class='ActionButton']")
-        // wait for loading to disappear
-        try {
-            while (true) {
-                findText("loading...")
-                Thread.sleep(100)
-            }
-        } catch (e: Exception) {
         }
     }
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
@@ -75,7 +75,7 @@ fun JTreeFixture.waitUntilLoaded() {
         try {
             while (true) {
                 Pause.pause(100)
-                findText("loading...")
+                findAllText().any { it.text.equals("loading...", ignoreCase = true) }
             }
         } catch (e: Exception) {
         }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
@@ -37,7 +37,7 @@ class JTreeFixture(
     fun expandRow(row: Int) = runJsRowMethod("expandRow", row)
 
     private fun runJsPathMethod(name: String, vararg paths: String) {
-        val path = paths.joinToString("/")
+        val path = paths.joinToString(separator)
         step("$name $path") {
             runJs(
                 """

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
@@ -61,3 +61,15 @@ class JTreeFixture(
         }
     }
 }
+
+fun JTreeFixture.waitUntilLoaded() {
+    step("waiting for loading text to go away...") {
+        try {
+            while (true) {
+                findText("loading...")
+                Thread.sleep(100)
+            }
+        } catch (e: Exception) {
+        }
+    }
+}

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
@@ -7,6 +7,7 @@ import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.data.RemoteComponent
 import com.intellij.remoterobot.fixtures.ComponentFixture
 import com.intellij.remoterobot.stepsProcessing.step
+import org.assertj.swing.timing.Pause
 
 class JTreeFixture(
     remoteRobot: RemoteRobot,
@@ -73,10 +74,12 @@ fun JTreeFixture.waitUntilLoaded() {
     step("waiting for loading text to go away...") {
         try {
             while (true) {
+                Pause.pause(100)
                 findText("loading...")
-                Thread.sleep(100)
             }
         } catch (e: Exception) {
         }
+
+        Pause.pause(100)
     }
 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
@@ -14,6 +14,13 @@ class JTreeFixture(
 ) : ComponentFixture(remoteRobot, remoteComponent) {
     var separator: String = "/"
 
+    fun hasPath(vararg paths: String) = try {
+        runJsPathMethod("node", *paths)
+        true
+    } catch (e: Exception) {
+        false
+    }
+
     fun clickPath(vararg paths: String) = runJsPathMethod("clickPath", *paths)
     fun expandPath(vararg paths: String) = runJsPathMethod("expandPath", *paths)
     fun rightClickPath(vararg paths: String) = runJsPathMethod("rightClickPath", *paths)

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
@@ -8,6 +8,7 @@ import com.intellij.remoterobot.data.RemoteComponent
 import com.intellij.remoterobot.fixtures.ComponentFixture
 import com.intellij.remoterobot.stepsProcessing.step
 import com.intellij.remoterobot.utils.waitFor
+import org.assertj.swing.timing.Pause
 import java.time.Duration
 
 class JTreeFixture(
@@ -58,9 +59,11 @@ class JTreeFixture(
 
 fun JTreeFixture.waitUntilLoaded() {
     step("waiting for loading text to go away...") {
+        Pause.pause(100)
         waitFor(duration = Duration.ofMinutes(1)) {
             // Do not use hasText(String) https://github.com/JetBrains/intellij-ui-test-robot/issues/10
             !hasText { txt -> txt.text == "loading..." }
         }
+        Pause.pause(100)
     }
 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
@@ -7,7 +7,8 @@ import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.data.RemoteComponent
 import com.intellij.remoterobot.fixtures.ComponentFixture
 import com.intellij.remoterobot.stepsProcessing.step
-import org.assertj.swing.timing.Pause
+import com.intellij.remoterobot.utils.waitFor
+import java.time.Duration
 
 class JTreeFixture(
     remoteRobot: RemoteRobot,
@@ -72,14 +73,9 @@ class JTreeFixture(
 
 fun JTreeFixture.waitUntilLoaded() {
     step("waiting for loading text to go away...") {
-        try {
-            while (true) {
-                Pause.pause(100)
-                findAllText().any { it.text.equals("loading...", ignoreCase = true) }
-            }
-        } catch (e: Exception) {
+        waitFor(duration = Duration.ofMinutes(1)) {
+            // Do not use hasText(String) https://github.com/JetBrains/intellij-ui-test-robot/issues/10
+            !hasText { txt -> txt.text == "loading..." }
         }
-
-        Pause.pause(100)
     }
 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/JTreeFixture.kt
@@ -42,9 +42,6 @@ class JTreeFixture(
         }
     }
 
-    fun clickRow(row: Int) = runJsRowMethod("clickRow", row)
-    fun expandRow(row: Int) = runJsRowMethod("expandRow", row)
-
     private fun runJsPathMethod(name: String, vararg paths: String) {
         val path = paths.joinToString(separator)
         step("$name $path") {
@@ -53,18 +50,6 @@ class JTreeFixture(
                 const jTreeFixture = JTreeFixture(robot, component);
                 jTreeFixture.replaceSeparator('$separator')
                 jTreeFixture.$name('$path') 
-                """.trimIndent()
-            )
-        }
-    }
-
-    private fun runJsRowMethod(name: String, row: Int) {
-        step("$name $row") {
-            runJs(
-                """
-                const jTreeFixture = JTreeFixture(robot, component);
-                jTreeFixture.replaceSeparator('$separator')
-                jTreeFixture.$name($row) 
                 """.trimIndent()
             )
         }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
@@ -8,14 +8,22 @@ import com.intellij.remoterobot.data.RemoteComponent
 import com.intellij.remoterobot.fixtures.FixtureName
 import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.stepsProcessing.step
+import com.intellij.remoterobot.utils.keyboard
+import java.awt.event.KeyEvent
 import java.time.Duration
 
-fun RemoteRobot.projectStructureDialog(
+fun IdeaFrame.projectStructureDialog(
     timeout: Duration = Duration.ofSeconds(20),
     function: ProjectStructureDialog.() -> Unit
 ) {
-    step("Search for Project Structure dialog") {
-        val dialog = find<ProjectStructureDialog>(byXpath("//div[@accessiblename='Project Structure']"), timeout)
+    step("Project Structure dialog") {
+        if (remoteRobot.isMac()) {
+            keyboard { hotKey(KeyEvent.VK_META, KeyEvent.VK_SEMICOLON) }
+        } else {
+            keyboard { hotKey(KeyEvent.VK_CONTROL, KeyEvent.VK_ALT, KeyEvent.VK_SHIFT, KeyEvent.VK_S) }
+        }
+
+        val dialog = remoteRobot.find<ProjectStructureDialog>(byXpath("//div[@accessiblename='Project Structure']"), timeout)
 
         dialog.apply(function)
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
@@ -17,13 +17,13 @@ fun IdeaFrame.projectStructureDialog(
     function: ProjectStructureDialog.() -> Unit
 ) {
     step("Project Structure dialog") {
-        if (remoteRobot.isMac()) {
-            keyboard { hotKey(KeyEvent.VK_META, KeyEvent.VK_SEMICOLON) }
-        } else {
-            keyboard { hotKey(KeyEvent.VK_CONTROL, KeyEvent.VK_ALT, KeyEvent.VK_SHIFT, KeyEvent.VK_S) }
+        keyboard {
+            double(KeyEvent.VK_SHIFT)
+            enterText("Project Structure")
+            enter()
         }
 
-        val dialog = remoteRobot.find<ProjectStructureDialog>(byXpath("//div[@accessiblename='Project Structure']"), timeout)
+        val dialog = find<ProjectStructureDialog>(byXpath("//div[@accessiblename='Project Structure']"), timeout)
 
         dialog.apply(function)
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
@@ -17,10 +17,10 @@ fun IdeaFrame.projectStructureDialog(
     function: ProjectStructureDialog.() -> Unit
 ) {
     step("Project Structure dialog") {
-        keyboard {
-            double(KeyEvent.VK_SHIFT)
-            enterText("Project Structure")
-            enter()
+        if (remoteRobot.isMac()) {
+            keyboard { hotKey(KeyEvent.VK_META, KeyEvent.VK_SEMICOLON) }
+        } else {
+            keyboard { hotKey(KeyEvent.VK_CONTROL, KeyEvent.VK_ALT, KeyEvent.VK_SHIFT, KeyEvent.VK_S) }
         }
 
         val dialog = find<ProjectStructureDialog>(byXpath("//div[@accessiblename='Project Structure']"), timeout)

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/CloudFormationBrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/CloudFormationBrowserTest.kt
@@ -76,7 +76,6 @@ class CloudFormationBrowserTest {
         }
         idea {
             waitForBackgroundTasks()
-            showAwsExplorer()
 
             step("Open stack") {
                 awsExplorer {
@@ -107,7 +106,6 @@ class CloudFormationBrowserTest {
                 }
             }
             step("Delete stack $stack") {
-                showAwsExplorer()
                 awsExplorer {
                     openExplorerActionMenu(cloudFormation, stack)
                 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/InsightsQueryTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/InsightsQueryTest.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.uitests.tests
 
-import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.fixtures.ComboBoxFixture
 import com.intellij.remoterobot.fixtures.ComponentFixture
 import com.intellij.remoterobot.fixtures.ContainerFixture
@@ -26,6 +25,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.QueryStatus
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException
 import software.aws.toolkits.jetbrains.uitests.CoreTest
 import software.aws.toolkits.jetbrains.uitests.extensions.uiTest
+import software.aws.toolkits.jetbrains.uitests.fixtures.IdeaFrame
 import software.aws.toolkits.jetbrains.uitests.fixtures.JTreeFixture
 import software.aws.toolkits.jetbrains.uitests.fixtures.awsExplorer
 import software.aws.toolkits.jetbrains.uitests.fixtures.findAndClick
@@ -115,7 +115,6 @@ class InsightsQueryTest {
         }
         idea {
             waitForBackgroundTasks()
-            showAwsExplorer()
             step("Expand log groups node") {
                 awsExplorer {
                     expandExplorerNode(cloudWatchExplorerLabel)
@@ -189,7 +188,7 @@ class InsightsQueryTest {
         }
     }
 
-    private fun RemoteRobot.openInsightsQueryDialogFromExplorer(groupName: String) = step("Open insights query dialog") {
+    private fun IdeaFrame.openInsightsQueryDialogFromExplorer(groupName: String) = step("Open insights query dialog") {
         awsExplorer {
             openExplorerActionMenu(cloudWatchExplorerLabel, groupName)
         }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/InsightsQueryTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/InsightsQueryTest.kt
@@ -31,6 +31,7 @@ import software.aws.toolkits.jetbrains.uitests.fixtures.awsExplorer
 import software.aws.toolkits.jetbrains.uitests.fixtures.findAndClick
 import software.aws.toolkits.jetbrains.uitests.fixtures.idea
 import software.aws.toolkits.jetbrains.uitests.fixtures.rightClick
+import software.aws.toolkits.jetbrains.uitests.fixtures.waitUntilLoaded
 import software.aws.toolkits.jetbrains.uitests.fixtures.welcomeFrame
 import java.nio.file.Path
 import java.time.Duration
@@ -120,18 +121,24 @@ class InsightsQueryTest {
                     expandExplorerNode(cloudWatchExplorerLabel)
                 }
             }
+
             step("Query with default settings returns results") {
                 openInsightsQueryDialogFromExplorer(logGroupName)
                 step("Execute") {
                     findAndClick("//div[@text='$executeButtonText']")
                 }
-                assertThat(find<JTreeFixture>(byXpath("//div[@class='TableView']"), Duration.ofSeconds(5)).findAllText()).anySatisfy {
+
+                val logResults = find<JTreeFixture>(byXpath("//div[@class='TableView']"), Duration.ofSeconds(5))
+                logResults.waitUntilLoaded()
+
+                assertThat(logResults.findAllText()).anySatisfy {
                     assertThat(it.text).contains("group1")
                 }
                 assertThat(find<JTreeFixture>(byXpath("//div[@class='TableView']")).findAllText()).anySatisfy {
                     assertThat(it.text).contains("group2")
                 }
             }
+
             step("Revising query from current results") {
                 // Find query ID. Query ID is a GUID with dashes, which makes it 36 characters long.
                 val currentQueryId = findAll<JLabelFixture>(byXpath("//div[@class='ContentTabLabel']"))
@@ -147,14 +154,17 @@ class InsightsQueryTest {
                     .text
                 val currentTab = find<JLabelFixture>(byXpath("//div[@class='ContentTabLabel' and contains(@accessiblename, '$currentQueryId')]"))
                 openInsightsQueryDialogFromResults()
+
                 step("Change relative time values") {
                     find<JTextFieldFixture>(byXpath("//div[@class='JFormattedTextField' and @visible_text='$defaultRelativeTimeAmount']")).text =
                         testRelativeTimeAmount
                     find<ComboBoxFixture>(byXpath("//div[@class='ComboBox']")).selectItem("Hours")
                 }
+
                 step("Execute") {
                     findAndClick("//div[@text='$executeButtonText']")
                 }
+
                 step("Verify new result tab selected") {
                     // close the old one
                     currentTab.rightClick()
@@ -162,7 +172,11 @@ class InsightsQueryTest {
 
                     find<JLabelFixture>(byXpath("//div[@class='ContentTabLabel' and @visible_text!='$currentQueryId']")).click()
                 }
-                assertThat(find<JTreeFixture>(byXpath("//div[@class='TableView']"), Duration.ofSeconds(5)).findAllText()).anySatisfy {
+
+                val logResults = find<JTreeFixture>(byXpath("//div[@class='TableView']"), Duration.ofSeconds(5))
+                logResults.waitUntilLoaded()
+
+                assertThat(logResults.findAllText()).anySatisfy {
                     assertThat(it.text).contains("group1")
                 }
                 assertThat(find<JTreeFixture>(byXpath("//div[@class='TableView']")).findAllText()).anySatisfy {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.uitests.tests
 
-import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.fixtures.ComponentFixture
 import com.intellij.remoterobot.fixtures.JTextFieldFixture
 import com.intellij.remoterobot.search.locators.byXpath
@@ -20,6 +19,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException
 import software.aws.toolkits.jetbrains.uitests.CoreTest
 import software.aws.toolkits.jetbrains.uitests.extensions.uiTest
+import software.aws.toolkits.jetbrains.uitests.fixtures.IdeaFrame
 import software.aws.toolkits.jetbrains.uitests.fixtures.JTreeFixture
 import software.aws.toolkits.jetbrains.uitests.fixtures.actionButton
 import software.aws.toolkits.jetbrains.uitests.fixtures.awsExplorer
@@ -74,7 +74,6 @@ class S3BrowserTest {
         }
         idea {
             waitForBackgroundTasks()
-            showAwsExplorer()
 
             step("Create bucket named $bucket") {
                 awsExplorer {
@@ -185,7 +184,6 @@ class S3BrowserTest {
             }
 
             step("Delete bucket named $bucket") {
-                showAwsExplorer()
                 awsExplorer {
                     openExplorerActionMenu(S3, bucket)
                 }
@@ -224,7 +222,7 @@ class S3BrowserTest {
         s3Client.waiter().waitUntilBucketExists { it.bucket(bucket) }
     }
 
-    private fun RemoteRobot.s3Tree(func: (JTreeFixture.() -> Unit)) {
+    private fun IdeaFrame.s3Tree(func: (JTreeFixture.() -> Unit)) {
         find<JTreeFixture>(byXpath("//div[@class='S3TreeTable']"), Duration.ofSeconds(5)).apply(func)
     }
 }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -22,6 +22,7 @@ import software.aws.toolkits.jetbrains.uitests.extensions.uiTest
 import software.aws.toolkits.jetbrains.uitests.fixtures.IdeaFrame
 import software.aws.toolkits.jetbrains.uitests.fixtures.JTreeFixture
 import software.aws.toolkits.jetbrains.uitests.fixtures.actionButton
+import software.aws.toolkits.jetbrains.uitests.fixtures.actionMenuItem
 import software.aws.toolkits.jetbrains.uitests.fixtures.awsExplorer
 import software.aws.toolkits.jetbrains.uitests.fixtures.fileBrowser
 import software.aws.toolkits.jetbrains.uitests.fixtures.fillSingleTextField
@@ -79,7 +80,7 @@ class S3BrowserTest {
                 awsExplorer {
                     openExplorerActionMenu(S3)
                 }
-                find<ComponentFixture>(byXpath("//div[@text='$createBucketText']")).click()
+                actionMenuItem(createBucketText).click()
                 find<JTextFieldFixture>(byXpath("//div[@class='JTextField']"), Duration.ofSeconds(5)).text = bucket
                 find<ComponentFixture>(byXpath("//div[@text='Create']")).click()
             }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -30,6 +30,7 @@ import software.aws.toolkits.jetbrains.uitests.fixtures.findAndClick
 import software.aws.toolkits.jetbrains.uitests.fixtures.idea
 import software.aws.toolkits.jetbrains.uitests.fixtures.pressDelete
 import software.aws.toolkits.jetbrains.uitests.fixtures.pressOk
+import software.aws.toolkits.jetbrains.uitests.fixtures.waitUntilLoaded
 import software.aws.toolkits.jetbrains.uitests.fixtures.welcomeFrame
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -134,6 +135,7 @@ class S3BrowserTest {
                 Thread.sleep(1000)
                 s3Tree {
                     findText(folder).doubleClick()
+                    waitUntilLoaded()
                     findText(jsonFile2)
                 }
             }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -8,6 +8,7 @@ import com.intellij.remoterobot.fixtures.JTextFieldFixture
 import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.stepsProcessing.log
 import com.intellij.remoterobot.stepsProcessing.step
+import com.intellij.remoterobot.utils.waitFor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -176,10 +177,10 @@ class S3BrowserTest {
                 s3Tree {
                     findText(newJsonName).doubleClick()
                 }
-                // Wait for the item to download and open
-                Thread.sleep(1000)
-                // Find the title bar
-                assertThat(findAll<ComponentFixture>(byXpath("//div[@accessiblename='$newJsonName']"))).isNotEmpty
+
+                waitFor {
+                    findAll<ComponentFixture>(byXpath("//div[@accessiblename='$newJsonName']")).isNotEmpty()
+                }
             }
 
             step("Delete bucket named $bucket") {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -96,10 +96,6 @@ class S3BrowserTest {
             // Click on the tree to make sure it's there + we aren't selecting anything else
             s3Tree { click() }
 
-            // If the project starts fast enough we start the test before the tip is shown, but if the tip is showing when we go to start using the file browser
-            // it will fail to find them. So check for it one last time.
-            tryCloseTips()
-
             step("Upload object to top-level") {
                 actionButton(upload).click()
                 fileBrowser("Select") {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -145,6 +145,7 @@ class S3BrowserTest {
 
             step("Rename a file") {
                 s3Tree {
+                    waitUntilLoaded()
                     findText(jsonFile).click()
                 }
                 actionButton(rename).click()
@@ -153,6 +154,7 @@ class S3BrowserTest {
                 // Wait for the item to be renamed
                 Thread.sleep(1000)
                 s3Tree {
+                    waitUntilLoaded()
                     findText(newJsonName)
                 }
             }
@@ -161,6 +163,7 @@ class S3BrowserTest {
                 s3Tree {
                     // Reopen the folder
                     findText(folder).doubleClick()
+                    waitUntilLoaded()
                     findText(jsonFile2).click()
                 }
                 actionButton(delete).click()
@@ -171,12 +174,14 @@ class S3BrowserTest {
                 s3Tree {
                     // Attempt to reopen the folder
                     findText(folder).doubleClick()
+                    waitUntilLoaded()
                     assertThat(findAllText(jsonFile2)).isEmpty()
                 }
             }
 
             step("Open known file-types") {
                 s3Tree {
+                    waitUntilLoaded()
                     findText(newJsonName).doubleClick()
                 }
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -16,8 +16,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.io.TempDir
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException
+import software.aws.toolkits.core.s3.deleteBucketAndContents
 import software.aws.toolkits.jetbrains.uitests.CoreTest
 import software.aws.toolkits.jetbrains.uitests.extensions.uiTest
 import software.aws.toolkits.jetbrains.uitests.fixtures.IdeaFrame
@@ -66,7 +68,7 @@ class S3BrowserTest {
 
     @BeforeAll
     fun setUp() {
-        s3Client = S3Client.create()
+        s3Client = S3Client.builder().region(Region.US_WEST_2).build()
     }
 
     @Test
@@ -198,7 +200,7 @@ class S3BrowserTest {
     @AfterAll
     fun cleanup() {
         try {
-            s3Client.deleteBucket { it.bucket(bucket) }
+            s3Client.deleteBucketAndContents(bucket)
             waitForS3BucketDeletion()
         } catch (e: Exception) {
             if (e is NoSuchBucketException) {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/SQSTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/SQSTest.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.uitests.tests
 
-import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.fixtures.ComponentFixture
 import com.intellij.remoterobot.fixtures.JTextFieldFixture
 import com.intellij.remoterobot.search.locators.byXpath
@@ -23,6 +22,7 @@ import software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry
 import software.aws.toolkits.jetbrains.uitests.CoreTest
 import software.aws.toolkits.jetbrains.uitests.extensions.uiTest
+import software.aws.toolkits.jetbrains.uitests.fixtures.IdeaFrame
 import software.aws.toolkits.jetbrains.uitests.fixtures.JTreeFixture
 import software.aws.toolkits.jetbrains.uitests.fixtures.actionMenuItem
 import software.aws.toolkits.jetbrains.uitests.fixtures.awsExplorer
@@ -74,9 +74,7 @@ class SQSTest {
         }
         idea {
             waitForBackgroundTasks()
-            showAwsExplorer()
-        }
-        idea {
+
             step("Create queues") {
                 step("Create queue $queueName") {
                     awsExplorer {
@@ -260,7 +258,7 @@ class SQSTest {
         }
     }
 
-    private fun RemoteRobot.openSendMessagePane(queueName: String) = step("Open send message pane") {
+    private fun IdeaFrame.openSendMessagePane(queueName: String) = step("Open send message pane") {
         awsExplorer {
             openExplorerActionMenu(sqsNodeLabel, queueName)
             actionMenuItem("Send a Message").click()
@@ -268,13 +266,13 @@ class SQSTest {
     }
 
     // If we don't do this, it fails to find the entry in the explorer
-    private fun RemoteRobot.closeToolWindowTab() = step("Close tool window so the robot can see the queues in the explorer") {
+    private fun IdeaFrame.closeToolWindowTab() = step("Close tool window so the robot can see the queues in the explorer") {
         val firstTab = findAll(ComponentFixture::class.java, byXpath("//div[contains(@accessiblename, 'uitest') and @class='ContentTabLabel']")).first()
         firstTab.rightClick()
         actionMenuItem("Close Tab").click()
     }
 
-    private fun RemoteRobot.openPollMessagePane(queueName: String) = step("Open view message pane") {
+    private fun IdeaFrame.openPollMessagePane(queueName: String) = step("Open view message pane") {
         awsExplorer {
             openExplorerActionMenu(sqsNodeLabel, queueName)
         }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/SamTemplateProjectWizardTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/SamTemplateProjectWizardTest.kt
@@ -90,7 +90,6 @@ class SamTemplateProjectWizardTest {
                 }
 
                 step("Validate project structure") {
-                    openProjectStructure()
                     projectStructureDialog {
                         val fixture = comboBox(byXpath("//div[@class='JdkComboBox']"))
                         // TODO set based on Runtime

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/utils/retryableAssert.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/utils/retryableAssert.kt
@@ -29,17 +29,16 @@ fun recheckAssert(
 
 fun reattemptAssert(
     maxAttempts: Int = 5,
-    interval: Duration = Duration.ofMillis(100),
+    interval: Duration = Duration.ofSeconds(1),
     assertion: () -> Unit
 ) {
-    var attempts = 0
-    while (true) {
+    for (i in 0..maxAttempts) {
         try {
             assertion()
             return
         } catch (e: AssertionError) { // deliberately narrowed to an AssertionError - this is intended to be used in a test assertion
             when {
-                ++attempts >= maxAttempts -> throw e
+                i >= maxAttempts -> throw e
                 else -> Thread.sleep(interval.toMillis())
             }
         }


### PR DESCRIPTION
…r more

* If we load an error node in the explorer, wait a few seconds and hit retry
* Change how we enter text into the file browser due to focus kept getting stolen

File browser logs:
```
                                 Set file path to /var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/junit14382372376297587214
13:37:23.789 INFO  -                 Search 'JTextFieldFixture' by '//div[@class='BorderlessTextField']'
13:37:23.866 INFO  -                 Set text ''
13:37:23.919 INFO  -                 Type path '/var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/junit14382372376297587214'
13:37:23.919 INFO  -                     Set text '/'
13:37:24.063 INFO  -                     Set text '/var'
13:37:24.213 INFO  -                     Set text '/var/folders'
13:37:24.363 INFO  -                     Set text '/var/folders/q5'
13:37:24.513 INFO  -                     Set text '/var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck'
13:37:24.666 INFO  -                     Set text '/var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T'
13:37:24.817 INFO  -                     Set text '/var/folders/q5/cfv4k63519vcllnnpwz5zsj0wnjvck/T/junit14382372376297587214'
13:37:24.968 INFO  -             Search 'ComponentFixture' by '//div[@accessiblename='Refresh']'
13:37:25.109 INFO  -             ..click
13:37:25.814 INFO  -             requireSelection /|var|folders|q5|cfv4k63519vcllnnpwz5zsj0wnjvck|T|junit14382372376297587214
```

Explorer node logs:
```
    13:38:13.337 INFO  -     Open editor for bucket uitest-20201222-ebe16daf-17f2-47c4-afd9-067278437643
    13:38:13.337 INFO  -         Search 'JTreeFixture' by '//div[@class='Tree']'
    13:38:13.355 INFO  -         expandPath S3
    13:38:18.525 INFO  -         Error node was returned, will wait and try again in PT2S . Attempt 1 of 5
    13:38:20.531 INFO  -             Pressing Refresh...
    13:38:20.531 INFO  -                 Search 'ComponentFixture' by '//div[@accessiblename='Refresh AWS Connection']'
    13:38:20.550 INFO  -                 ..click
    13:38:21.265 INFO  -         expandPath S3
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
