### PR TITLE
Change vendor URL to point to GitHub

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -52,7 +52,7 @@ with what features/services are supported.
 </ul>
     ]]></description>
 
-    <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://aws.amazon.com/">AWS</vendor>
+    <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://github.com/aws/aws-toolkit-jetbrains">AWS</vendor>
     <!-- 201.6668.113 is 2020.1 EAP 1 -->
     <idea-version since-build="201.6668.113" until-build="202.*"/>
 


### PR DESCRIPTION
Requested in #2313

Should be safe as marketplace URLs are independent and appears to be only used for the error report dialog in the IDE.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
