### PR TITLE
Fix python and nodejs breakpoints sometimes not working

### DIFF
--- a/.changes/next-release/bugfix-d667eec9-bbce-4522-9402-2dc3630e3c93.json
+++ b/.changes/next-release/bugfix-d667eec9-bbce-4522-9402-2dc3630e3c93.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix NodeJS and Python breakpoints failing to hit sometimes"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilder.kt
@@ -42,10 +42,10 @@ abstract class LambdaBuilder {
      * @param buildDir The root directory where SAM built the function into
      */
     open fun defaultPathMappings(sourceTemplate: Path, logicalId: String, buildDir: Path): List<PathMapping> = buildList {
-        add(PathMapping(buildDir.resolve(logicalId).normalize().toString(), TASK_PATH))
-
         val codeLocation = SamTemplateUtils.getCodeLocation(sourceTemplate, logicalId)
+        // First one wins, so code needs to go before build
         add(PathMapping(sourceTemplate.resolveSibling(codeLocation).normalize().toString(), TASK_PATH))
+        add(PathMapping(buildDir.resolve(logicalId).normalize().toString(), TASK_PATH))
     }
 
     /**

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilderTestUtils.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/LambdaBuilderTestUtils.kt
@@ -17,5 +17,6 @@ fun verifyPathMappings(module: Module, actualMappings: List<PathMapping>, expect
                 it.remoteRoot
             )
         }
-    assertThat(actualMappings).containsAll(updatedPaths)
+    // Path mapping order matters so we do not just check content, we also check order
+    assertThat(actualMappings).containsExactly(*updatedPaths.toTypedArray())
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilderTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonLambdaBuilderTest.kt
@@ -79,8 +79,8 @@ class PythonLambdaBuilderTest {
         verifyPathMappings(
             projectRule.module, actualMappings,
             listOf(
-                PathMapping(buildDir.resolve(logicalId).toString(), LambdaBuilder.TASK_PATH),
-                PathMapping(codeUri.toString(), LambdaBuilder.TASK_PATH)
+                PathMapping(codeUri.toString(), LambdaBuilder.TASK_PATH),
+                PathMapping(buildDir.resolve(logicalId).toString(), LambdaBuilder.TASK_PATH)
             )
         )
     }

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilderTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilderTest.kt
@@ -85,8 +85,8 @@ class NodeJsLambdaBuilderTest {
         verifyPathMappings(
             projectRule.module, actualMappings,
             listOf(
-                PathMapping(buildDir.resolve(logicalId).toString(), LambdaBuilder.TASK_PATH),
-                PathMapping(codeUri.toString(), LambdaBuilder.TASK_PATH)
+                PathMapping(codeUri.toString(), LambdaBuilder.TASK_PATH),
+                PathMapping(buildDir.resolve(logicalId).toString(), LambdaBuilder.TASK_PATH)
             )
         )
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Because path mappings are first one wins, the order matters. Build was moved before source which would break path mappings if the VFS for build updated by the time the debugger attached. In this scenario, it would map to the build folder and not break on breakpoints in the source folder which is undesired.

## Related Issue(s)
#2274

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
