### PR TITLE
Upgrade SDK, fix edge cases with new S3 versioning support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ publishChannel=
 # Common dependencies
 ideProfileName=2020.1
 kotlinVersion=1.3.70
-awsSdkVersion=2.15.38
+awsSdkVersion=2.15.60
 coroutinesVersion=1.3.3
 ideaPluginVersion=0.6.3
 ktlintVersion=0.39.0

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/S3Utils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/S3Utils.kt
@@ -6,3 +6,5 @@ package software.aws.toolkits.jetbrains.services.s3
 import software.aws.toolkits.core.region.AwsRegion
 
 fun bucketArn(bucketName: String, region: AwsRegion) = "arn:${region.partitionId}:s3:::$bucketName"
+
+const val NOT_VERSIONED_VERSION_ID = "null"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeNode.kt
@@ -128,8 +128,6 @@ open class S3TreeObjectNode(val bucket: S3VirtualBucket, parent: S3LazyLoadParen
 class S3TreeObjectVersionNode(bucket: S3VirtualBucket, parent: S3TreeObjectNode, key: String, size: Long, lastModified: Instant, val versionId: String) :
     S3TreeObjectNode(bucket, parent, key, size, lastModified) {
 
-
-
     override fun getName(): String {
         // For not versioned buckets api can return versionId as literal 'null' so we avoid propagating null string to UI.
         val versionId = if (versionId != NOT_VERSIONED_VERSION_ID) versionId else (parent as S3TreeObjectNode).name

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeNode.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.util.io.FileUtilRt
 import com.intellij.ui.treeStructure.SimpleNode
 import kotlinx.coroutines.runBlocking
 import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse
+import software.aws.toolkits.jetbrains.services.s3.NOT_VERSIONED_VERSION_ID
 import software.aws.toolkits.resources.message
 import java.time.Instant
 
@@ -103,8 +104,10 @@ open class S3TreeObjectNode(val bucket: S3VirtualBucket, parent: S3LazyLoadParen
             }.iterator()
 
             val nextPage = responseIterator
+                ?.takeIf { it.hasNext() }
                 ?.next()
                 ?.versions()
+                ?.filter { it.versionId() != NOT_VERSIONED_VERSION_ID }
                 ?.map { S3TreeObjectVersionNode(bucket, this, key, it.size(), it.lastModified(), it.versionId()) as S3TreeNode }
                 ?: emptyList()
 
@@ -125,9 +128,11 @@ open class S3TreeObjectNode(val bucket: S3VirtualBucket, parent: S3LazyLoadParen
 class S3TreeObjectVersionNode(bucket: S3VirtualBucket, parent: S3TreeObjectNode, key: String, size: Long, lastModified: Instant, val versionId: String) :
     S3TreeObjectNode(bucket, parent, key, size, lastModified) {
 
+
+
     override fun getName(): String {
         // For not versioned buckets api can return versionId as literal 'null' so we avoid propagating null string to UI.
-        val versionId = if (versionId != "null") versionId else (parent as S3TreeObjectNode).name
+        val versionId = if (versionId != NOT_VERSIONED_VERSION_ID) versionId else (parent as S3TreeObjectNode).name
         val originalExtension = FileUtilRt.getExtension((parent as S3TreeObjectNode).name)
         val extension = if (originalExtension.isNotBlank()) ".$originalExtension" else ""
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3VirtualBucket.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3VirtualBucket.kt
@@ -82,9 +82,10 @@ class S3VirtualBucket(val s3Bucket: Bucket, val client: S3Client) : LightVirtual
         }
     }
 
-    fun generateUrl(key: String): URL = client.utilities().getUrl {
+    fun generateUrl(key: String, versionId: String?): URL = client.utilities().getUrl {
         it.bucket(s3Bucket.name())
         it.key(key)
+        it.versionId(versionId)
     }
 
     private companion object {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyPathAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyPathAction.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.services.s3.objectActions
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeNode
+import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeObjectVersionNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeTable
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.S3Telemetry
@@ -16,4 +17,6 @@ class CopyPathAction(private val project: Project, treeTable: S3TreeTable) : Sin
         CopyPasteManager.getInstance().setContents(StringSelection(node.key))
         S3Telemetry.copyPath(project)
     }
+
+    override fun enabled(node: S3TreeNode): Boolean = node !is S3TreeObjectVersionNode
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyUrlAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyUrlAction.kt
@@ -16,7 +16,7 @@ import java.awt.datatransfer.StringSelection
 
 class CopyUrlAction(private val project: Project, treeTable: S3TreeTable) : SingleS3ObjectAction(treeTable, message("s3.copy.url")) {
     override fun performAction(node: S3TreeNode) = try {
-        val versionId =  (node as? S3TreeObjectVersionNode)?.versionId?.takeIf { it != NOT_VERSIONED_VERSION_ID }
+        val versionId = (node as? S3TreeObjectVersionNode)?.versionId?.takeIf { it != NOT_VERSIONED_VERSION_ID }
         val url = treeTable.bucket.generateUrl(node.key, versionId).toString()
         CopyPasteManager.getInstance().setContents(StringSelection(url))
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyUrlAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyUrlAction.kt
@@ -5,6 +5,7 @@ package software.aws.toolkits.jetbrains.services.s3.objectActions
 
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
+import software.aws.toolkits.jetbrains.services.s3.NOT_VERSIONED_VERSION_ID
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeObjectVersionNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeTable
@@ -15,11 +16,8 @@ import java.awt.datatransfer.StringSelection
 
 class CopyUrlAction(private val project: Project, treeTable: S3TreeTable) : SingleS3ObjectAction(treeTable, message("s3.copy.url")) {
     override fun performAction(node: S3TreeNode) = try {
-        var url = treeTable.bucket.generateUrl(node.key).toString()
-        if (node is S3TreeObjectVersionNode) {
-            // TODO replace with api call one available https://github.com/aws/aws-sdk-java-v2/issues/2224
-            url += "?versionId=${node.versionId}"
-        }
+        val versionId =  (node as? S3TreeObjectVersionNode)?.versionId?.takeIf { it != NOT_VERSIONED_VERSION_ID }
+        val url = treeTable.bucket.generateUrl(node.key, versionId).toString()
         CopyPasteManager.getInstance().setContents(StringSelection(url))
 
         S3Telemetry.copyUrl(project, presigned = false, success = true)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3VirtualBucketTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3VirtualBucketTest.kt
@@ -216,7 +216,20 @@ class S3VirtualBucketTest {
         AwsClientManager().getClient<S3Client>(awsConnectionManager.activeCredentialProvider, awsConnectionManager.activeRegion).use {
             val sut = S3VirtualBucket(Bucket.builder().name("test-bucket").build(), it)
 
-            assertThat(sut.generateUrl("prefix/key")).isEqualTo(URL("https://test-bucket.s3.us-west-2.amazonaws.com/prefix/key"))
+            assertThat(sut.generateUrl("prefix/key", null)).isEqualTo(URL("https://test-bucket.s3.us-west-2.amazonaws.com/prefix/key"))
+        }
+    }
+
+    @Test
+    fun getUrlWithVersion() {
+        val awsConnectionManager = settingsManagerRule.settingsManager
+        awsConnectionManager.changeRegionAndWait(AwsRegion("us-west-2", "US West (Oregon)", "aws"))
+
+        // Use real manager for this since it can affect the S3Configuration that goes into S3Utilities
+        AwsClientManager().getClient<S3Client>(awsConnectionManager.activeCredentialProvider, awsConnectionManager.activeRegion).use {
+            val sut = S3VirtualBucket(Bucket.builder().name("test-bucket").build(), it)
+
+            assertThat(sut.generateUrl("prefix/key", "123")).isEqualTo(URL("https://test-bucket.s3.us-west-2.amazonaws.com/prefix/key?versionId=123"))
         }
     }
 
@@ -230,7 +243,7 @@ class S3VirtualBucketTest {
             val sut = S3VirtualBucket(Bucket.builder().name("test-bucket").build(), it)
 
             assertThatThrownBy {
-                sut.generateUrl("")
+                sut.generateUrl("", null)
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
* Only take the paginator next if it has one
* Use the SDK to generate the copy URL
* Do not append the version to url if its "null"
* Do not show versions under a node if its not really versioned ("null" ID)
* If expanded with versions, disable double click to open in IDE since it also expands the tree. Enter key still works
* Disable Copy Path action for versioned object entries

## Related Issue(s)
#2312 

## Testing
Manually

## Screenshots (if appropriate)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
