### PR TITLE
Remove checking for the stack in the list call to reduce risk of throttle

### DIFF
--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/CloudFormationBrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/CloudFormationBrowserTest.kt
@@ -5,9 +5,6 @@ package software.aws.toolkits.jetbrains.uitests.tests
 
 import com.intellij.remoterobot.stepsProcessing.log
 import com.intellij.remoterobot.stepsProcessing.step
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -50,22 +47,6 @@ class CloudFormationBrowserTest {
         cloudFormationClient.createStack { it.templateBody(templateFile.toFile().readText()).stackName(stack) }
         cloudFormationClient.waiter().waitUntilStackCreateComplete { it.stackName(stack) }
         log.info("Successfully deployed $stack")
-        // Even when it's deployed, the stack can still take extra time to show up in the list operation
-        // so, we have to also confirm that it shows up in list
-        runBlocking {
-            withTimeoutOrNull(20000) {
-                while (true) {
-                    try {
-                        if (cloudFormationClient.listStacksPaginator().stackSummaries().any { it.stackName() == stack }) {
-                            log.info("Successfully listed $stack")
-                            break
-                        }
-                    } catch (e: Exception) {
-                    }
-                    delay(2000)
-                }
-            }
-        }
     }
 
     @Test


### PR DESCRIPTION
Logs show it being listed, but then getting throttled in the explorer, so lets try not doing that check and seeing how that goes.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
