### PR TITLE
Use RemoteRobot instead of IdeaFrame to find project structure dialog

### DIFF
--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -57,7 +57,7 @@ phases:
       - while [ ! -e /tmp/.X11-unix/X99 ]; do sleep 0.1; done
       - XFCE_PANEL_MIGRATE_DEFAULT=1 xfce4-session --display=${DISPLAY} &
       - xinput list
-      - xterm -e "xinput list | grep -Po 'id=\K\d+(?=.*slave\s*pointer)' | xargs -P0 -n1 xinput test" &
+      - xterm -e "xinput list | grep -Po 'id=\K\d+(?=.*slave)' | xargs -P0 -n1 xinput test" &
       - ffmpeg -loglevel quiet -f x11grab -video_size ${SCREEN_WIDTH}x${SCREEN_HEIGHT} -i ${DISPLAY} -codec:v libx264 -pix_fmt yuv420p -framerate 12 -g 12 /tmp/screen_recording.mp4 &
 
       - env AWS_ACCESS_KEY_ID=$KEY_ID AWS_SECRET_ACCESS_KEY=$SECRET AWS_SESSION_TOKEN=$TOKEN ./gradlew uiTestCore coverageReport --console plain --info

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
@@ -23,7 +23,7 @@ fun IdeaFrame.projectStructureDialog(
             keyboard { hotKey(KeyEvent.VK_CONTROL, KeyEvent.VK_ALT, KeyEvent.VK_SHIFT, KeyEvent.VK_S) }
         }
 
-        val dialog = RemoteRobot.find<ProjectStructureDialog>(byXpath("//div[@accessiblename='Project Structure']"), timeout)
+        val dialog = remoteRobot.find<ProjectStructureDialog>(byXpath("//div[@accessiblename='Project Structure']"), timeout)
 
         dialog.apply(function)
 

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/ProjectStructure.kt
@@ -23,7 +23,7 @@ fun IdeaFrame.projectStructureDialog(
             keyboard { hotKey(KeyEvent.VK_CONTROL, KeyEvent.VK_ALT, KeyEvent.VK_SHIFT, KeyEvent.VK_S) }
         }
 
-        val dialog = find<ProjectStructureDialog>(byXpath("//div[@accessiblename='Project Structure']"), timeout)
+        val dialog = RemoteRobot.find<ProjectStructureDialog>(byXpath("//div[@accessiblename='Project Structure']"), timeout)
 
         dialog.apply(function)
 


### PR DESCRIPTION


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
