### PR TITLE
Save UI hierarchy on test failure

### DIFF
--- a/ui-tests/build.gradle.kts
+++ b/ui-tests/build.gradle.kts
@@ -46,7 +46,9 @@ tasks.register<Test>("uiTestCore") {
 
     systemProperty("robot-server.port", remoteRobotPort)
     systemProperty("junit.jupiter.extensions.autodetection.enabled", true)
+
     systemProperty("testDataPath", project.rootDir.toPath().resolve("testdata").toString())
+    systemProperty("testReportPath", project.buildDir.toPath().resolve("reports").resolve("tests").resolve("testRecordings").toString())
 
     systemProperty("GRADLE_PROJECT", "jetbrains-core")
     useJUnitPlatform {

--- a/ui-tests/tst-resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/ui-tests/tst-resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,2 @@
 software.aws.toolkits.jetbrains.uitests.extensions.Ide
+software.aws.toolkits.jetbrains.uitests.extensions.TestRecorder

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/extensions/IdeExtension.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/extensions/IdeExtension.kt
@@ -26,7 +26,7 @@ import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
 
 private val initialSetup = AtomicBoolean(false)
-private val robotPort = System.getProperty("robot-server.port")?.toInt() ?: throw IllegalStateException("System Property 'robot-server.port' is not set")
+val robotPort = System.getProperty("robot-server.port")?.toInt() ?: throw IllegalStateException("System Property 'robot-server.port' is not set")
 
 fun uiTest(test: RemoteRobot.() -> Unit) {
     if (!initialSetup.getAndSet(true)) {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/extensions/TestRecorder.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/extensions/TestRecorder.kt
@@ -1,0 +1,36 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.extensions
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.TestWatcher
+import software.aws.toolkits.core.utils.outputStream
+import java.net.URL
+import java.nio.file.Paths
+
+class TestRecorder : TestWatcher {
+    private companion object {
+        val TEST_REPORTS_LOCATION by lazy {
+            System.getProperty("testReportPath")?.let {
+                Paths.get(it)
+            }
+        }
+    }
+
+    override fun testFailed(context: ExtensionContext, cause: Throwable) {
+        val testReport = TEST_REPORTS_LOCATION?.resolve(context.displayName) ?: return
+
+        uiTest {
+            testReport.resolve("uiHierarchy.html").outputStream().use {
+                URL("http://127.0.0.1:$robotPort/").openStream().copyTo(it)
+            }
+
+            listOf("scripts.js", "xpathEditor.js", "updateButton.js", "styles.css", "img/locator.png").forEach { file ->
+                testReport.resolve(Paths.get(file)).outputStream().use {
+                    URL("http://127.0.0.1:$robotPort/$file").openStream().copyTo(it)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Saves the browser XPath view on failure

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
