### PR TITLE
Attach the debugger asyncronously

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
@@ -86,7 +86,7 @@ interface SamDebugSupport {
         return promise
     }
 
-    fun createDebugProcess(
+    suspend fun createDebugProcess(
         environment: ExecutionEnvironment,
         state: SamRunningState,
         debugHost: String,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
@@ -4,14 +4,25 @@
 package software.aws.toolkits.jetbrains.services.lambda.execution.sam
 
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.application.ExpirableExecutor
+import com.intellij.openapi.application.impl.coroutineDispatchingContext
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.net.NetUtils
 import com.intellij.xdebugger.XDebugProcessStarter
+import kotlinx.coroutines.launch
+import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
-import org.jetbrains.concurrency.resolvedPromise
 import software.amazon.awssdk.services.lambda.model.PackageType
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.utils.getLogger
+import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPointObject
+import software.aws.toolkits.jetbrains.utils.ApplicationThreadPoolScope
+import software.aws.toolkits.resources.message
+import java.util.Timer
+import kotlin.concurrent.schedule
 
 interface SamDebugSupport {
 
@@ -45,7 +56,35 @@ interface SamDebugSupport {
         state: SamRunningState,
         debugHost: String,
         debugPorts: List<Int>
-    ): Promise<XDebugProcessStarter?> = resolvedPromise(createDebugProcess(environment, state, debugHost, debugPorts))
+    ): Promise<XDebugProcessStarter?> {
+        val promise = AsyncPromise<XDebugProcessStarter?>()
+        val bgContext = ExpirableExecutor.on(AppExecutorUtil.getAppExecutorService()).expireWith(environment).coroutineDispatchingContext()
+
+        ApplicationThreadPoolScope(environment.runProfile.name).launch(bgContext) {
+            try {
+                val debug = createDebugProcess(environment, state, debugHost, debugPorts)
+
+                runInEdt {
+                    promise.setResult(debug)
+                }
+            } catch (t: Throwable) {
+                LOG.warn(t) { "Failed to start debugger" }
+                runInEdt {
+                    promise.setError(t)
+                }
+            }
+        }
+
+        Timer("Debugger Worker launch timer", true).schedule(debuggerAttachTimeoutMs) {
+            if (!promise.isDone) {
+                runInEdt {
+                    promise.setError(message("lambda.debug.process.start.timeout"))
+                }
+            }
+        }
+
+        return promise
+    }
 
     fun createDebugProcess(
         environment: ExecutionEnvironment,
@@ -58,5 +97,7 @@ interface SamDebugSupport {
 
     fun getDebugPorts(): List<Int> = listOf(NetUtils.tryToFindAvailableSocketPort())
 
-    companion object : RuntimeGroupExtensionPointObject<SamDebugSupport>(ExtensionPointName("aws.toolkit.lambda.sam.debugSupport"))
+    companion object : RuntimeGroupExtensionPointObject<SamDebugSupport>(ExtensionPointName("aws.toolkit.lambda.sam.debugSupport")) {
+        private val LOG = getLogger<SamDebugSupport>()
+    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
@@ -70,10 +70,10 @@ interface SamDebugSupport {
 
         ApplicationThreadPoolScope(environment.runProfile.name).launch(bgContext) {
             try {
-                val debug = createDebugProcess(environment, state, debugHost, debugPorts)
+                val debugProcess = createDebugProcess(environment, state, debugHost, debugPorts)
 
                 runInEdt {
-                    promise.setResult(debug)
+                    promise.setResult(debugProcess)
                 }
             } catch (t: Throwable) {
                 LOG.warn(t) { "Failed to start debugger" }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
@@ -4,10 +4,12 @@
 package software.aws.toolkits.jetbrains.services.lambda.execution.sam
 
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ExpirableExecutor
 import com.intellij.openapi.application.impl.coroutineDispatchingContext
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.testFramework.ThreadTracker
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.net.NetUtils
 import com.intellij.xdebugger.XDebugProcessStarter
@@ -67,6 +69,7 @@ interface SamDebugSupport {
                 }
             }
         }
+        ThreadTracker.longRunningThreadCreated(ApplicationManager.getApplication(), "Debugger Worker launch timer")
 
         ApplicationThreadPoolScope(environment.runProfile.name).launch(bgContext) {
             try {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamDebugSupport.kt
@@ -4,12 +4,10 @@
 package software.aws.toolkits.jetbrains.services.lambda.execution.sam
 
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ExpirableExecutor
 import com.intellij.openapi.application.impl.coroutineDispatchingContext
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.extensions.ExtensionPointName
-import com.intellij.testFramework.ThreadTracker
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.net.NetUtils
 import com.intellij.xdebugger.XDebugProcessStarter
@@ -69,7 +67,6 @@ interface SamDebugSupport {
                 }
             }
         }
-        ThreadTracker.longRunningThreadCreated(ApplicationManager.getApplication(), "Debugger Worker launch timer")
 
         ApplicationThreadPoolScope(environment.runProfile.name).launch(bgContext) {
             try {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamDebugSupport.kt
@@ -41,7 +41,7 @@ class PythonSamDebugSupport : SamDebugSupport {
         )
     }
 
-    override fun createDebugProcess(
+    override suspend fun createDebugProcess(
         environment: ExecutionEnvironment,
         state: SamRunningState,
         debugHost: String,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamDebugSupport.kt
@@ -46,7 +46,7 @@ class PythonSamDebugSupport : SamDebugSupport {
         state: SamRunningState,
         debugHost: String,
         debugPorts: List<Int>
-    ): XDebugProcessStarter? = object : XDebugProcessStarter() {
+    ): XDebugProcessStarter = object : XDebugProcessStarter() {
         override fun start(session: XDebugSession): XDebugProcess {
             val mappings = state.pathMappings.plus(
                 listOf(

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CodeInsightTestFixtureRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CodeInsightTestFixtureRule.kt
@@ -72,6 +72,8 @@ open class CodeInsightTestFixtureRule(protected val testDescription: LightProjec
         // https://github.com/JetBrains/intellij-community/commit/0a6c9e16e95983ae0786d7667290c07b420ce705
         // TODO: Remove this FIX_WHEN_MIN_IS_203
         ThreadTracker.longRunningThreadCreated(ApplicationManager.getApplication(), "ForkJoinPool.commonPool-worker-")
+        // This timer is cancelled but it still continues running when the test is over since it cancels lazily. This is fine, so suppress the leak
+        ThreadTracker.longRunningThreadCreated(ApplicationManager.getApplication(), "Debugger Worker launch timer")
     }
 
     override fun finished(description: Description?) {

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
@@ -106,7 +106,7 @@ class DotNetSamDebugSupport : SamDebugSupport {
         )
     }
 
-    override fun createDebugProcess(
+    override suspend fun createDebugProcess(
         environment: ExecutionEnvironment,
         state: SamRunningState,
         debugHost: String,

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamDebugSupport.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamDebugSupport.kt
@@ -35,7 +35,7 @@ class NodeJsSamDebugSupport : SamDebugSupport {
         )
     }
 
-    override fun createDebugProcess(
+    override suspend fun createDebugProcess(
         environment: ExecutionEnvironment,
         state: SamRunningState,
         debugHost: String,

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamDebugSupport.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamDebugSupport.kt
@@ -40,7 +40,7 @@ class NodeJsSamDebugSupport : SamDebugSupport {
         state: SamRunningState,
         debugHost: String,
         debugPorts: List<Int>
-    ): XDebugProcessStarter? = object : XDebugProcessStarter() {
+    ): XDebugProcessStarter = object : XDebugProcessStarter() {
         override fun start(session: XDebugSession): XDebugProcess {
             val mappings = createBiMapMappings(state.pathMappings)
             val fileFinder = RemoteDebuggingFileFinder(mappings, LocalFileSystemFileFinder())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Since we can resolve credentials before we attach, we can lock up edt/throw because we are making network calls on edt. Make the default implementation of attachasync run the syncronous part on its own thread with a timeout.

## Related Issue(s)
#2025

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
