### PR TITLE
Clean up S3 bucket browser nodes, fix several bugs

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeCellRenderer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeCellRenderer.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.aws.toolkits.jetbrains.services.s3.editor
 
-import com.intellij.icons.AllIcons
 import com.intellij.ui.ColoredTreeCellRenderer
 import com.intellij.ui.LoadingNode
 import com.intellij.ui.SimpleTextAttributes
@@ -25,18 +24,13 @@ class S3TreeCellRenderer(private val speedSearchTarget: JComponent) : ColoredTre
         val selectedNode = value as? DefaultMutableTreeNode
         val node = selectedNode?.userObject as? S3TreeNode ?: return
 
-        when {
-            node.isDirectory -> {
-                icon = AllIcons.Nodes.Folder
-                append(node.name.trimEnd('/'))
-            }
-            node is S3TreeContinuationNode -> {
-                icon = AllIcons.Nodes.EmptyNode
-                append(node.name, SimpleTextAttributes.LINK_ATTRIBUTES)
+        icon = node.icon
+        when (node) {
+            is S3TreeContinuationNode<*> -> {
+                append(node.displayName(), SimpleTextAttributes.LINK_ATTRIBUTES)
             }
             else -> {
-                icon = node.icon ?: AllIcons.FileTypes.Unknown
-                append(node.name)
+                append(node.displayName())
             }
         }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeNode.kt
@@ -3,31 +3,39 @@
 
 package software.aws.toolkits.jetbrains.services.s3.editor
 
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.fileTypes.FileTypeRegistry
-import com.intellij.openapi.fileTypes.UnknownFileType
 import com.intellij.openapi.util.io.FileUtilRt
 import com.intellij.ui.treeStructure.SimpleNode
 import kotlinx.coroutines.runBlocking
-import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse
 import software.aws.toolkits.jetbrains.services.s3.NOT_VERSIONED_VERSION_ID
 import software.aws.toolkits.resources.message
 import java.time.Instant
 
-sealed class S3TreeNode(val bucketName: String, val parent: S3LazyLoadParentNode?, val key: String) : SimpleNode() {
-    open val isDirectory = false
+sealed class S3TreeNode(val bucket: S3VirtualBucket, val parent: S3LazyLoadParentNode<*>?, val key: String) : SimpleNode() {
     override fun getChildren(): Array<S3TreeNode> = arrayOf()
-    override fun getName(): String = key.substringAfterLast('/')
+
+    @Deprecated("Do not use, exists due to SimpleNode. Use more use case specific methods", ReplaceWith("displayName()"))
+    final override fun getName(): String = displayName()
+
+    /**
+     * String representation of this node in UIs
+     */
+    open fun displayName(): String = key.trimEnd('/').substringAfterLast('/')
+
+    /**
+     * Directory path to this node
+     */
+    open fun directoryPath() = parent?.key ?: throw IllegalStateException("$key has no parent!")
+
+    override fun toString(): String = "${this::class.simpleName}(key='$key')"
+
+    override fun getEqualityObjects(): Array<Any?> = arrayOf(bucket, key)
 }
 
-fun S3TreeNode.getDirectoryKey() = if (isDirectory) {
-    key
-} else {
-    parent?.key ?: throw IllegalStateException("$key claimed it was not a directory but has no parent!")
-}
-
-abstract class S3LazyLoadParentNode(bucketName: String, parent: S3LazyLoadParentNode?, key: String) : S3TreeNode(bucketName, parent, key) {
+abstract class S3LazyLoadParentNode<T>(bucket: S3VirtualBucket, parent: S3LazyLoadParentNode<*>?, key: String) : S3TreeNode(bucket, parent, key) {
     private val childrenLock = Object()
-    private val loadedPages = mutableSetOf<String>()
+    private val loadedPages = mutableSetOf<T>()
     private var cachedList: List<S3TreeNode> = listOf()
 
     override fun getChildren(): Array<S3TreeNode> {
@@ -35,30 +43,38 @@ abstract class S3LazyLoadParentNode(bucketName: String, parent: S3LazyLoadParent
             if (cachedList.isEmpty()) {
                 cachedList = loadObjects()
             }
+            return cachedList.toTypedArray()
         }
-        return cachedList.toTypedArray()
     }
 
     fun removeAllChildren() {
-        cachedList = listOf()
-    }
-
-    @Synchronized
-    fun loadMore(continuationMarker: String) {
-        // dedupe calls
-        if (loadedPages.contains(continuationMarker)) {
-            return
+        synchronized(childrenLock) {
+            cachedList = listOf()
+            loadedPages.clear()
         }
-        cachedList = children.dropLastWhile { it is S3TreeContinuationNode } + loadObjects(continuationMarker)
-        loadedPages.add(continuationMarker)
     }
 
-    protected abstract fun loadObjects(continuationMarker: String? = null): List<S3TreeNode>
+    fun loadMore(continuationMarker: T) {
+        synchronized(childrenLock) {
+            // dedupe calls
+            if (loadedPages.contains(continuationMarker)) {
+                return
+            }
+
+            loadedPages.add(continuationMarker)
+            cachedList = children.dropLastWhile { it is S3TreeContinuationNode<*> } + loadObjects(continuationMarker)
+        }
+    }
+
+    protected abstract fun loadObjects(continuationMarker: T? = null): List<S3TreeNode>
 }
 
-class S3TreeDirectoryNode(private val bucket: S3VirtualBucket, parent: S3LazyLoadParentNode?, key: String) : S3LazyLoadParentNode(bucket.name, parent, key) {
-    override val isDirectory = true
-    override fun getName(): String = key.dropLast(1).substringAfterLast('/') + '/'
+class S3TreeDirectoryNode(bucket: S3VirtualBucket, parent: S3TreeDirectoryNode?, key: String) : S3LazyLoadParentNode<String>(bucket, parent, key) {
+    init {
+        icon = AllIcons.Nodes.Folder
+    }
+
+    override fun directoryPath(): String = key
 
     override fun loadObjects(continuationMarker: String?): List<S3TreeNode> {
         val response = runBlocking {
@@ -67,7 +83,7 @@ class S3TreeDirectoryNode(private val bucket: S3VirtualBucket, parent: S3LazyLoa
 
         val continuation = listOfNotNull(
             response.nextContinuationToken()?.let {
-                S3TreeContinuationNode(bucketName, this, "${this.key}/${message("s3.load_more")}", it)
+                S3TreeContinuationNode(bucket, this, this.key, it)
             }
         )
 
@@ -77,68 +93,118 @@ class S3TreeDirectoryNode(private val bucket: S3VirtualBucket, parent: S3LazyLoa
             .contents()
             ?.filterNotNull()
             ?.filterNot { it.key() == key }
-            ?.map { S3TreeObjectNode(bucket, this, it.key(), it.size(), it.lastModified()) as S3TreeNode }
+            ?.map { S3TreeObjectNode(this, it.key(), it.size(), it.lastModified()) as S3TreeNode }
             ?: emptyList()
 
         return (folders + s3Objects).sortedBy { it.key } + continuation
     }
 }
 
-private val fileTypeRegistry = FileTypeRegistry.getInstance()
+interface S3Object {
+    val bucket: S3VirtualBucket
+    val key: String
+    val versionId: String?
 
-open class S3TreeObjectNode(val bucket: S3VirtualBucket, parent: S3LazyLoadParentNode?, key: String, val size: Long, val lastModified: Instant) :
-    S3LazyLoadParentNode(bucket.name, parent, key) {
+    val size: Long
+    val lastModified: Instant
 
+    fun fileName(): String
+}
+
+data class VersionContinuationToken(val keyMarker: String, val versionId: String)
+
+class S3TreeObjectNode(parent: S3TreeDirectoryNode, key: String, override val size: Long, override val lastModified: Instant) :
+    S3LazyLoadParentNode<VersionContinuationToken>(parent.bucket, parent, key), S3Object {
     var showHistory: Boolean = false
-    var responseIterator: Iterator<ListObjectVersionsResponse>? = null
-    private val fileType = fileTypeRegistry.getFileTypeByFileName(name)
 
     init {
-        fileType.takeIf { it !is UnknownFileType }?.icon.let { icon = it }
+        icon = FileTypeRegistry.getInstance().getFileTypeByFileName(key.substringAfterLast("/")).icon
     }
 
-    override fun loadObjects(continuationMarker: String?): List<S3TreeNode> {
+    override val versionId: String? = null
+
+    /**
+     * The name of this object if saved to a file
+     */
+    override fun fileName() = key.substringAfterLast("/")
+
+    override fun loadObjects(continuationMarker: VersionContinuationToken?): List<S3TreeNode> {
         if (showHistory) {
-            responseIterator = responseIterator ?: runBlocking {
-                bucket.listObjectVersionsPaginated(key)
-            }.iterator()
-
-            val nextPage = responseIterator
-                ?.takeIf { it.hasNext() }
-                ?.next()
-                ?.versions()
-                ?.filter { it.versionId() != NOT_VERSIONED_VERSION_ID }
-                ?.map { S3TreeObjectVersionNode(bucket, this, key, it.size(), it.lastModified(), it.versionId()) as S3TreeNode }
-                ?: emptyList()
-
-            if (responseIterator?.hasNext() == true) {
-                return nextPage + S3TreeContinuationNode(
-                    bucketName,
-                    this,
-                    "${this.key}/${message("s3.load_more")}",
-                    (nextPage.last() as S3TreeObjectVersionNode).versionId
-                )
+            val response = runBlocking {
+                bucket.listObjectVersions(key, continuationMarker?.keyMarker, continuationMarker?.versionId)
             }
-            return nextPage
+
+            return mutableListOf<S3TreeNode>().apply {
+                response?.versions()
+                    ?.filter { it.key() == key && it.versionId() != NOT_VERSIONED_VERSION_ID }
+                    ?.map { S3TreeObjectVersionNode(this@S3TreeObjectNode, it.versionId(), it.size(), it.lastModified()) }
+                    ?.onEach { add(it) }
+
+                if (response?.isTruncated == true) {
+                    val nextKey = response.nextKeyMarker()
+                    val nextVersion = response.nextVersionIdMarker()
+
+                    add(
+                        S3TreeContinuationNode(
+                            bucket,
+                            this@S3TreeObjectNode,
+                            this@S3TreeObjectNode.key,
+                            VersionContinuationToken(nextKey, nextVersion)
+                        )
+                    )
+                }
+            }
         }
+
         return emptyList()
     }
 }
 
-class S3TreeObjectVersionNode(bucket: S3VirtualBucket, parent: S3TreeObjectNode, key: String, size: Long, lastModified: Instant, val versionId: String) :
-    S3TreeObjectNode(bucket, parent, key, size, lastModified) {
+class S3TreeObjectVersionNode(parent: S3TreeObjectNode, override val versionId: String, override val size: Long, override val lastModified: Instant) :
+    S3TreeNode(parent.bucket, parent, parent.key), S3Object {
 
-    override fun getName(): String {
-        // For not versioned buckets api can return versionId as literal 'null' so we avoid propagating null string to UI.
-        val versionId = if (versionId != NOT_VERSIONED_VERSION_ID) versionId else (parent as S3TreeObjectNode).name
-        val originalExtension = FileUtilRt.getExtension((parent as S3TreeObjectNode).name)
-        val extension = if (originalExtension.isNotBlank()) ".$originalExtension" else ""
-
-        return "$versionId$extension"
+    init {
+        icon = parent.icon
     }
 
+    override fun directoryPath(): String = (parent as S3TreeObjectNode).directoryPath()
+
+    override fun fileName(): String {
+        val parentObjectName = (parent as S3TreeObjectNode).fileName()
+
+        val filenamePrefix = FileUtilRt.getNameWithoutExtension(parentObjectName) + "@" + versionId
+        val extension = FileUtilRt.getExtension(parentObjectName)
+        return if (extension.isNotEmpty()) {
+            "$filenamePrefix.$extension"
+        } else {
+            filenamePrefix
+        }
+    }
+
+    override fun displayName(): String = versionId
+
     override fun getChildren(): Array<S3TreeNode> = emptyArray()
+
+    override fun getEqualityObjects(): Array<Any?> = arrayOf(bucket, key, versionId)
+
+    override fun toString(): String = "S3TreeObjectVersionNode(key='$key', versionId='$versionId')"
 }
 
-class S3TreeContinuationNode(bucketName: String, parent: S3LazyLoadParentNode, key: String, val continuationMarker: String) :
-    S3TreeNode(bucketName, parent, key)
+class S3TreeContinuationNode<T>(
+    bucket: S3VirtualBucket,
+    private val parentNode: S3LazyLoadParentNode<T>,
+    key: String,
+    private val continuationMarker: T
+) : S3TreeNode(bucket, parentNode, key) {
+    init {
+        icon = AllIcons.Nodes.EmptyNode
+    }
+
+    override fun displayName(): String = message("s3.load_more")
+
+    fun loadMore() {
+        parentNode.loadMore(continuationMarker)
+    }
+
+    override fun getEqualityObjects(): Array<Any?> = arrayOf(bucket, key, continuationMarker)
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3VirtualBucket.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3VirtualBucket.kt
@@ -12,9 +12,9 @@ import kotlinx.coroutines.withContext
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.Bucket
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier
-import software.amazon.awssdk.services.s3.paginators.ListObjectVersionsIterable
 import software.aws.toolkits.jetbrains.services.s3.download
 import software.aws.toolkits.jetbrains.services.s3.upload
 import java.io.InputStream
@@ -50,9 +50,9 @@ class S3VirtualBucket(val s3Bucket: Bucket, val client: S3Client) : LightVirtual
         }
     }
 
-    suspend fun listObjectVersionsPaginated(key: String): ListObjectVersionsIterable = withContext(Dispatchers.IO) {
-        client.listObjectVersionsPaginator {
-            it.bucket(s3Bucket.name()).prefix(key).maxKeys(MAX_ITEMS_TO_LOAD)
+    suspend fun listObjectVersions(key: String, keyMarker: String?, versionIdMarker: String?): ListObjectVersionsResponse? = withContext(Dispatchers.IO) {
+        client.listObjectVersions {
+            it.bucket(s3Bucket.name()).prefix(key).delimiter("/").maxKeys(MAX_ITEMS_TO_LOAD).keyMarker(keyMarker).versionIdMarker(versionIdMarker)
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/NewFolderAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/NewFolderAction.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeNode
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeTable
-import software.aws.toolkits.jetbrains.services.s3.editor.getDirectoryKey
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
 
@@ -22,7 +21,7 @@ class NewFolderAction(
         Messages.showInputDialog(project, message("s3.new.folder.name"), message("s3.new.folder"), null)?.let { key ->
             GlobalScope.launch {
                 try {
-                    treeTable.bucket.newFolder(node.getDirectoryKey() + key)
+                    treeTable.bucket.newFolder(node.directoryPath() + key)
                     treeTable.invalidateLevel(node)
                     treeTable.refresh()
                 } catch (e: Exception) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/RenameObjectAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/RenameObjectAction.kt
@@ -24,13 +24,12 @@ class RenameObjectAction(
     override fun enabled(node: S3TreeNode): Boolean = node::class == S3TreeObjectNode::class
 
     override fun performAction(node: S3TreeNode) {
-
         val newName = Messages.showInputDialog(
             project,
-            message("s3.rename.object.title", node.name),
+            message("s3.rename.object.title", node.displayName()),
             message("s3.rename.object.action"),
             null,
-            node.name,
+            node.displayName(),
             object : InputValidator {
                 override fun checkInput(inputString: String?): Boolean = true
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/S3ObjectAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/S3ObjectAction.kt
@@ -18,10 +18,10 @@ abstract class S3ObjectAction(protected val treeTable: S3TreeTable, title: Strin
 
     override fun update(e: AnActionEvent) {
         val selected = selected()
-        e.presentation.isEnabled = selected.none { it is S3TreeContinuationNode } && enabled(selected)
+        e.presentation.isEnabled = selected.none { it is S3TreeContinuationNode<*> } && enabled(selected)
     }
 
-    override fun actionPerformed(e: AnActionEvent) = performAction(selected().filter { it !is S3TreeContinuationNode })
+    override fun actionPerformed(e: AnActionEvent) = performAction(selected().filter { it !is S3TreeContinuationNode<*> })
 
     private fun selected(): List<S3TreeNode> = treeTable.getSelectedNodes().takeIf { it.isNotEmpty() } ?: listOf(treeTable.rootNode)
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeDirectoryNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeDirectoryNodeTest.kt
@@ -1,0 +1,184 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.s3.editor
+
+import com.intellij.icons.AllIcons
+import com.intellij.testFramework.ProjectRule
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.Bucket
+import software.amazon.awssdk.services.s3.model.CommonPrefix
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
+import software.amazon.awssdk.services.s3.model.S3Object
+import software.aws.toolkits.core.utils.delegateMock
+import java.time.Instant
+
+class S3TreeDirectoryNodeTest {
+    @Rule
+    @JvmField
+    val projectRule = ProjectRule()
+
+    private val lastModifiedTime = Instant.now()
+    private val objectSize = 1L
+    private val s3Bucket = Bucket.builder().name("foo").build()
+
+    @Test
+    fun `directory path`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val sut = S3TreeDirectoryNode(bucket, null, "my/folder/")
+
+        assertThat(sut.directoryPath()).isEqualTo("my/folder/")
+    }
+
+    @Test
+    fun `display name`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val sut = S3TreeDirectoryNode(bucket, null, "my/folder/")
+
+        assertThat(sut.displayName()).isEqualTo("folder")
+    }
+
+    @Test
+    fun `get icon`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val sut = S3TreeDirectoryNode(bucket, null, "my/folder/")
+
+        assertThat(sut.icon).isEqualTo(AllIcons.Nodes.Folder)
+    }
+
+    @Test
+    fun `get children with no pagination`() {
+        val requestCaptor = argumentCaptor<ListObjectsV2Request>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectsV2(requestCaptor.capture()) } doReturn ListObjectsV2Response.builder()
+                .commonPrefixes(CommonPrefix.builder().prefix("my/folder/aFolder/").build(), CommonPrefix.builder().prefix("my/folder/zFolder/").build())
+                .contents(createS3Object("my/folder/picture.png"), createS3Object("my/folder/file.txt"))
+                .build()
+        }
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val sut = S3TreeDirectoryNode(bucket, null, "my/folder/")
+
+        assertThat(sut.children).containsExactly(
+            S3TreeDirectoryNode(bucket, sut, "my/folder/aFolder/"),
+            S3TreeObjectNode(sut, "my/folder/file.txt", objectSize, lastModifiedTime),
+            S3TreeObjectNode(sut, "my/folder/picture.png", objectSize, lastModifiedTime),
+            S3TreeDirectoryNode(bucket, sut, "my/folder/zFolder/")
+        )
+
+        val request = requestCaptor.firstValue
+        assertThat(request.bucket()).isEqualTo("foo")
+        assertThat(request.prefix()).isEqualTo("my/folder/")
+        assertThat(request.delimiter()).isEqualTo("/")
+    }
+
+    @Test
+    fun `get children with pagination`() {
+        val requestCaptor = argumentCaptor<ListObjectsV2Request>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectsV2(requestCaptor.capture()) } doReturn ListObjectsV2Response.builder()
+                .contents(createS3Object("my/folder/picture.png"))
+                .nextContinuationToken("Token")
+                .build()
+        }
+
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val sut = S3TreeDirectoryNode(bucket, null, "my/folder")
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectNode(sut, "my/folder/picture.png", objectSize, lastModifiedTime),
+            S3TreeContinuationNode(bucket, sut, sut.key, "Token")
+        )
+    }
+
+    @Test
+    fun `get children with more loaded`() {
+        val requestCaptor = argumentCaptor<ListObjectsV2Request>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectsV2(requestCaptor.capture()) }.thenReturn(
+                ListObjectsV2Response.builder()
+                    .contents(createS3Object("my/folder/file.txt"))
+                    .nextContinuationToken("Token")
+                    .build(),
+                ListObjectsV2Response.builder()
+                    .contents(createS3Object("my/folder/picture.png"))
+                    .build()
+            )
+        }
+
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val sut = S3TreeDirectoryNode(bucket, null, "my/folder/")
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectNode(sut, "my/folder/file.txt", objectSize, lastModifiedTime),
+            S3TreeContinuationNode(bucket, sut, sut.key, "Token")
+        )
+
+        (sut.children.last() as S3TreeContinuationNode<*>).loadMore()
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectNode(sut, "my/folder/file.txt", objectSize, lastModifiedTime),
+            S3TreeObjectNode(sut, "my/folder/picture.png", objectSize, lastModifiedTime)
+        )
+
+        assertThat(requestCaptor.allValues).hasSize(2)
+        val firstRequest = requestCaptor.firstValue
+        assertThat(firstRequest.bucket()).isEqualTo("foo")
+        assertThat(firstRequest.prefix()).isEqualTo("my/folder/")
+        assertThat(firstRequest.delimiter()).isEqualTo("/")
+        assertThat(firstRequest.continuationToken()).isNull()
+
+        val secondRequest = requestCaptor.secondValue
+        assertThat(secondRequest.bucket()).isEqualTo("foo")
+        assertThat(secondRequest.prefix()).isEqualTo("my/folder/")
+        assertThat(secondRequest.delimiter()).isEqualTo("/")
+        assertThat(secondRequest.continuationToken()).isEqualTo("Token")
+    }
+
+    @Test
+    fun `load more is idempotent`() {
+        val requestCaptor = argumentCaptor<ListObjectsV2Request>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectsV2(requestCaptor.capture()) }.thenReturn(
+                ListObjectsV2Response.builder()
+                    .contents(createS3Object("my/folder/file.txt"))
+                    .nextContinuationToken("Token")
+                    .build(),
+                ListObjectsV2Response.builder()
+                    .contents(createS3Object("my/folder/picture.png"))
+                    .build()
+            )
+        }
+
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val sut = S3TreeDirectoryNode(bucket, null, "my/folder/")
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectNode(sut, "my/folder/file.txt", objectSize, lastModifiedTime),
+            S3TreeContinuationNode(bucket, sut, sut.key, "Token")
+        )
+
+        val continuationNode = sut.children.last() as S3TreeContinuationNode<*>
+        continuationNode.loadMore()
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectNode(sut, "my/folder/file.txt", objectSize, lastModifiedTime),
+            S3TreeObjectNode(sut, "my/folder/picture.png", objectSize, lastModifiedTime)
+        )
+
+        continuationNode.loadMore()
+
+        assertThat(sut.children).hasSize(2)
+        assertThat(requestCaptor.allValues).hasSize(2)
+    }
+
+    private fun createS3Object(name: String) = S3Object.builder().key(name).size(objectSize).lastModified(lastModifiedTime).build()
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeObjectNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeObjectNodeTest.kt
@@ -1,0 +1,284 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.s3.editor
+
+import com.intellij.icons.AllIcons
+import com.intellij.testFramework.ProjectRule
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.Bucket
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse
+import software.amazon.awssdk.services.s3.model.ObjectVersion
+import software.aws.toolkits.core.utils.delegateMock
+import java.time.Instant
+
+class S3TreeObjectNodeTest {
+    @Rule
+    @JvmField
+    val projectRule = ProjectRule()
+
+    private val lastModifiedTime = Instant.now()
+    private val objectSize = 1L
+    private val s3Bucket = Bucket.builder().name("foo").build()
+
+    @Test
+    fun `directory path`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/file.txt", objectSize, lastModifiedTime)
+
+        assertThat(sut.directoryPath()).isEqualTo("my/folder/")
+    }
+
+    @Test
+    fun `display name`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/file.txt", objectSize, lastModifiedTime)
+
+        assertThat(sut.displayName()).isEqualTo("file.txt")
+    }
+
+    @Test
+    fun `file name with extension`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/file.txt", objectSize, lastModifiedTime)
+
+        assertThat(sut.fileName()).isEqualTo("file.txt")
+    }
+
+    @Test
+    fun `file name without extension`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/file", objectSize, lastModifiedTime)
+
+        assertThat(sut.displayName()).isEqualTo("file")
+    }
+
+    @Test
+    fun `known file type icon`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/file.txt", objectSize, lastModifiedTime)
+
+        assertThat(sut.icon).isEqualTo(AllIcons.FileTypes.Text)
+    }
+
+    @Test
+    fun `unknown file type icon`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/file.unknownFile", objectSize, lastModifiedTime)
+
+        assertThat(sut.icon).isEqualTo(AllIcons.FileTypes.Unknown)
+    }
+
+    @Test
+    fun `showHistory false has no children`() {
+        val s3Client = delegateMock<S3Client>()
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/picture.png", objectSize, lastModifiedTime)
+        sut.showHistory = false
+
+        assertThat(sut.children).isEmpty()
+    }
+
+    @Test
+    fun `get children with no pagination`() {
+        val requestCaptor = argumentCaptor<ListObjectVersionsRequest>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectVersions(requestCaptor.capture()) } doReturn
+                ListObjectVersionsResponse.builder()
+                    .versions(createS3ObjectVersion("my/folder/picture.png", "1"), createS3ObjectVersion("my/folder/picture.png", "2"))
+                    .build()
+        }
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/picture.png", objectSize, lastModifiedTime)
+        sut.showHistory = true
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectVersionNode(sut, "1", objectSize, lastModifiedTime),
+            S3TreeObjectVersionNode(sut, "2", objectSize, lastModifiedTime)
+        )
+
+        val request = requestCaptor.firstValue
+        assertThat(request.bucket()).isEqualTo("foo")
+        assertThat(request.prefix()).isEqualTo("my/folder/picture.png")
+    }
+
+    @Test
+    fun `get children with pagination`() {
+        val requestCaptor = argumentCaptor<ListObjectVersionsRequest>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectVersions(requestCaptor.capture()) } doReturn ListObjectVersionsResponse.builder()
+                .versions(createS3ObjectVersion("my/folder/picture.png", "1"), createS3ObjectVersion("my/folder/picture.png", "2"))
+                .nextKeyMarker("KeyToken")
+                .nextVersionIdMarker("VersionToken")
+                .isTruncated(true)
+                .build()
+        }
+
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/picture.png", objectSize, lastModifiedTime)
+        sut.showHistory = true
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectVersionNode(sut, "1", objectSize, lastModifiedTime),
+            S3TreeObjectVersionNode(sut, "2", objectSize, lastModifiedTime),
+            S3TreeContinuationNode(bucket, sut, sut.key, VersionContinuationToken("KeyToken", "VersionToken"))
+        )
+    }
+
+    @Test
+    fun `get children must match key`() {
+        val requestCaptor = argumentCaptor<ListObjectVersionsRequest>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectVersions(requestCaptor.capture()) } doReturn ListObjectVersionsResponse.builder()
+                .versions(createS3ObjectVersion("my/folder/picture.png", "1"), createS3ObjectVersion("my/folder/file.txt", "1"))
+                .nextKeyMarker("KeyToken")
+                .nextVersionIdMarker("VersionToken")
+                .isTruncated(true)
+                .build()
+        }
+
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/picture.png", objectSize, lastModifiedTime)
+        sut.showHistory = true
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectVersionNode(sut, "1", objectSize, lastModifiedTime),
+            S3TreeContinuationNode(bucket, sut, sut.key, VersionContinuationToken("KeyToken", "VersionToken"))
+        )
+    }
+
+    @Test
+    fun `get children ignores versionId 'null'`() {
+        val requestCaptor = argumentCaptor<ListObjectVersionsRequest>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectVersions(requestCaptor.capture()) } doReturn
+                ListObjectVersionsResponse.builder()
+                    .versions(createS3ObjectVersion("my/folder/picture.png", "null"))
+                    .build()
+        }
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/picture.png", objectSize, lastModifiedTime)
+        sut.showHistory = true
+
+        assertThat(sut.children).isEmpty()
+    }
+
+    @Test
+    fun `get children with more loaded`() {
+        val requestCaptor = argumentCaptor<ListObjectVersionsRequest>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectVersions(requestCaptor.capture()) }.thenReturn(
+                ListObjectVersionsResponse.builder()
+                    .versions(createS3ObjectVersion("my/folder/picture.png", "1"), createS3ObjectVersion("my/folder/picture.png", "2"))
+                    .nextKeyMarker("KeyToken")
+                    .nextVersionIdMarker("VersionToken")
+                    .isTruncated(true)
+                    .build(),
+                ListObjectVersionsResponse.builder()
+                    .versions(createS3ObjectVersion("my/folder/picture.png", "3"))
+                    .build()
+            )
+        }
+
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/picture.png", objectSize, lastModifiedTime)
+        sut.showHistory = true
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectVersionNode(sut, "1", objectSize, lastModifiedTime),
+            S3TreeObjectVersionNode(sut, "2", objectSize, lastModifiedTime),
+            S3TreeContinuationNode(bucket, sut, sut.key, VersionContinuationToken("KeyToken", "VersionToken"))
+        )
+
+        (sut.children.last() as S3TreeContinuationNode<*>).loadMore()
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectVersionNode(sut, "1", objectSize, lastModifiedTime),
+            S3TreeObjectVersionNode(sut, "2", objectSize, lastModifiedTime),
+            S3TreeObjectVersionNode(sut, "3", objectSize, lastModifiedTime)
+        )
+
+        assertThat(requestCaptor.allValues).hasSize(2)
+        val firstRequest = requestCaptor.firstValue
+        assertThat(firstRequest.bucket()).isEqualTo("foo")
+        assertThat(firstRequest.prefix()).isEqualTo("my/folder/picture.png")
+        assertThat(firstRequest.keyMarker()).isNull()
+        assertThat(firstRequest.versionIdMarker()).isNull()
+
+        val secondRequest = requestCaptor.secondValue
+        assertThat(secondRequest.bucket()).isEqualTo("foo")
+        assertThat(secondRequest.prefix()).isEqualTo("my/folder/picture.png")
+        assertThat(secondRequest.keyMarker()).isEqualTo("KeyToken")
+        assertThat(secondRequest.versionIdMarker()).isEqualTo("VersionToken")
+    }
+
+    @Test
+    fun `load more is idempotent`() {
+        val requestCaptor = argumentCaptor<ListObjectVersionsRequest>()
+        val s3Client = delegateMock<S3Client> {
+            on { listObjectVersions(requestCaptor.capture()) }.thenReturn(
+                ListObjectVersionsResponse.builder()
+                    .versions(createS3ObjectVersion("my/folder/picture.png", "1"), createS3ObjectVersion("my/folder/picture.png", "2"))
+                    .nextKeyMarker("KeyToken")
+                    .nextVersionIdMarker("VersionToken")
+                    .isTruncated(true)
+                    .build(),
+                ListObjectVersionsResponse.builder()
+                    .versions(createS3ObjectVersion("my/folder/picture.png", "3"))
+                    .build()
+            )
+        }
+
+        val bucket = S3VirtualBucket(s3Bucket, s3Client)
+        val parent = S3TreeDirectoryNode(bucket, null, "my/folder/")
+        val sut = S3TreeObjectNode(parent, "my/folder/picture.png", objectSize, lastModifiedTime)
+        sut.showHistory = true
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectVersionNode(sut, "1", objectSize, lastModifiedTime),
+            S3TreeObjectVersionNode(sut, "2", objectSize, lastModifiedTime),
+            S3TreeContinuationNode(bucket, sut, sut.key, VersionContinuationToken("KeyToken", "VersionToken"))
+        )
+
+        val continuationNode = sut.children.last() as S3TreeContinuationNode<*>
+        continuationNode.loadMore()
+
+        assertThat(sut.children).containsExactly(
+            S3TreeObjectVersionNode(sut, "1", objectSize, lastModifiedTime),
+            S3TreeObjectVersionNode(sut, "2", objectSize, lastModifiedTime),
+            S3TreeObjectVersionNode(sut, "3", objectSize, lastModifiedTime)
+        )
+
+        continuationNode.loadMore()
+
+        assertThat(sut.children).hasSize(3)
+        assertThat(requestCaptor.allValues).hasSize(2)
+    }
+
+    private fun createS3ObjectVersion(name: String, versionId: String) =
+        ObjectVersion.builder().key(name).versionId(versionId).size(objectSize).lastModified(lastModifiedTime).build()
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeObjectVersionNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3TreeObjectVersionNodeTest.kt
@@ -1,0 +1,83 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.s3.editor
+
+import com.intellij.icons.AllIcons
+import com.intellij.testFramework.ProjectRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.Bucket
+import software.aws.toolkits.core.utils.delegateMock
+import java.time.Instant
+
+class S3TreeObjectVersionNodeTest {
+    @Rule
+    @JvmField
+    val projectRule = ProjectRule()
+
+    private val s3Client = delegateMock<S3Client>()
+    private val lastModifiedTime = Instant.now()
+    private val objectSize = 1L
+    private val s3Bucket = Bucket.builder().name("foo").build()
+
+    private lateinit var bucket: S3VirtualBucket
+    private lateinit var dirNode: S3TreeDirectoryNode
+
+    @Before
+    fun setUp() {
+        bucket = S3VirtualBucket(s3Bucket, s3Client)
+        dirNode = S3TreeDirectoryNode(bucket, null, "my/folder/")
+    }
+
+    @Test
+    fun `directory path`() {
+        val parent = S3TreeObjectNode(dirNode, "my/folder/file.txt", objectSize, lastModifiedTime)
+        val sut = S3TreeObjectVersionNode(parent, "version1", objectSize, lastModifiedTime)
+
+        assertThat(sut.directoryPath()).isEqualTo("my/folder/")
+    }
+
+    @Test
+    fun `display name`() {
+        val parent = S3TreeObjectNode(dirNode, "my/folder/file.txt", objectSize, lastModifiedTime)
+        val sut = S3TreeObjectVersionNode(parent, "version1", objectSize, lastModifiedTime)
+
+        assertThat(sut.displayName()).isEqualTo("version1")
+    }
+
+    @Test
+    fun `file name with extension`() {
+        val parent = S3TreeObjectNode(dirNode, "my/folder/file.txt", objectSize, lastModifiedTime)
+        val sut = S3TreeObjectVersionNode(parent, "version1", objectSize, lastModifiedTime)
+
+        assertThat(sut.fileName()).isEqualTo("file@version1.txt")
+    }
+
+    @Test
+    fun `file name without extension`() {
+        val parent = S3TreeObjectNode(dirNode, "my/folder/file", objectSize, lastModifiedTime)
+        val sut = S3TreeObjectVersionNode(parent, "version1", objectSize, lastModifiedTime)
+
+        assertThat(sut.fileName()).isEqualTo("file@version1")
+    }
+
+    @Test
+    fun `known file type icon`() {
+        val parent = S3TreeObjectNode(dirNode, "my/folder/file.txt", objectSize, lastModifiedTime)
+        val sut = S3TreeObjectVersionNode(parent, "version1", objectSize, lastModifiedTime)
+
+        assertThat(sut.icon).isEqualTo(AllIcons.FileTypes.Text)
+    }
+
+    @Test
+    fun `unknown file type icon`() {
+        val parent = S3TreeObjectNode(dirNode, "my/folder/file.unknownFile", objectSize, lastModifiedTime)
+        val sut = S3TreeObjectVersionNode(parent, "version1", objectSize, lastModifiedTime)
+
+        assertThat(sut.icon).isEqualTo(AllIcons.FileTypes.Unknown)
+    }
+}


### PR DESCRIPTION
* Introduce more specific and clearer APIs into the nodes to prevent bugs
* Version nodes now show only the version ID as the display value
* Version files are downloaded as `<parentName>@<versionId>[.<parentExtension>]`

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
