### PR TITLE
Mark the last of the non dynamic extension points as dynamic

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -83,7 +83,7 @@ with what features/services are supported.
                   topic="software.aws.toolkits.jetbrains.core.credentials.ConnectionSettingsStateChangeNotifier"/>
     </projectListeners>
     <extensionPoints>
-        <extensionPoint name="credentialProviderFactory" interface="software.aws.toolkits.core.credentials.CredentialProviderFactory"/>
+        <extensionPoint name="credentialProviderFactory" interface="software.aws.toolkits.core.credentials.CredentialProviderFactory" dynamic="true"/>
 
         <extensionPoint name="lambda.runtimeGroup" interface="software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup" dynamic="true"/>
 
@@ -109,7 +109,7 @@ with what features/services are supported.
 
         <extensionPoint name="executable" interface="software.aws.toolkits.jetbrains.core.executables.ExecutableType" dynamic="true"/>
 
-        <extensionPoint name="clouddebug.debuggerSupport" interface="software.aws.toolkits.jetbrains.services.clouddebug.DebuggerSupport"/>
+        <extensionPoint name="clouddebug.debuggerSupport" interface="software.aws.toolkits.jetbrains.services.clouddebug.DebuggerSupport" dynamic="true"/>
         <extensionPoint name="notice" interface="software.aws.toolkits.jetbrains.core.notification.NoticeType" dynamic="true"/>
 
         <extensionPoint name="explorer.serviceNode" interface="software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode" dynamic="true"/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
@@ -108,11 +108,10 @@ abstract class CredentialManager : SimpleModificationTracker() {
 }
 
 class DefaultCredentialManager : CredentialManager() {
-    private val extensionMap: Map<String, CredentialProviderFactory> by lazy {
-        EP_NAME.extensionList.associateBy {
+    private val extensionMap: Map<String, CredentialProviderFactory>
+        get() = EP_NAME.extensionList.associateBy {
             it.id
         }
-    }
 
     init {
         extensionMap.values.forEach { providerFactory ->

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/DebuggerSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/DebuggerSupport.kt
@@ -122,7 +122,7 @@ abstract class DebuggerSupport {
 
         @JvmStatic
         fun debuggers(): EnumMap<CloudDebuggingPlatform, DebuggerSupport> {
-            val items = EP_NAME.extensions.map {
+            val items = EP_NAME.extensionList.map {
                 it.platform to it
             }
             return if (items.isEmpty()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- `clouddebug.debuggerSupport` was already not saved anywhere so it could be marked dynamic without any changes
- `credentialProviderFactory` just needed the `lazy` block removed so it is pulled every time
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
