### PR TITLE
Add account settings to ResourceSelectorTest

### DIFF
--- a/forceRetry.txt
+++ b/forceRetry.txt
@@ -1,0 +1,1 @@
+attempt 3

--- a/forceRetry.txt
+++ b/forceRetry.txt
@@ -1,1 +1,1 @@
-attempt 3
+attempt 4

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
@@ -45,6 +45,11 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
     var connectionState: ConnectionState = ConnectionState.InitializingToolkit
         internal set(value) {
             field = value
+
+            if (project.isDisposed != project.messageBus.isDisposed) {
+                throw IllegalStateException("WTF ${project.isDisposed} ${project.messageBus.isDisposed}")
+            }
+
             if (!project.isDisposed) {
                 project.messageBus.syncPublisher(CONNECTION_SETTINGS_STATE_CHANGED).settingsStateChanged(value)
             }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
@@ -134,9 +134,11 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
         val isInitial = connectionState is ConnectionState.InitializingToolkit
         connectionState = ConnectionState.ValidatingConnection
 
+        // Grab the current state stamp
+        val modificationStamp = this.modificationCount
+
         fieldUpdateBlock()
 
-        val modificationStamp = this.modificationCount
         val validateCredentialsResult = validateCredentials(selectedCredentialIdentifier, selectedRegion, isInitial)
         validationJob.getAndSet(validateCredentialsResult)?.cancel()
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
@@ -168,8 +168,8 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
                 selectedCredentialsProvider = credentialsProvider
                 connectionState = ConnectionState.ValidConnection(credentialsProvider, region)
             } catch (e: Exception) {
-                connectionState = ConnectionState.InvalidConnection(e)
                 LOGGER.warn(e) { message("credentials.profile.validation_error", credentialsIdentifier.displayName) }
+                connectionState = ConnectionState.InvalidConnection(e)
             } finally {
                 incModificationCount()
                 AwsTelemetry.validateCredentials(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
@@ -12,13 +12,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.util.ExceptionUtil
 import com.intellij.util.messages.Topic
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.future.await
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import org.jetbrains.concurrency.AsyncPromise
 import software.aws.toolkits.core.credentials.CredentialIdentifier
 import software.aws.toolkits.core.credentials.CredentialProviderNotFoundException
 import software.aws.toolkits.core.credentials.ToolkitCredentialsChangeListener
@@ -32,23 +26,20 @@ import software.aws.toolkits.jetbrains.services.sts.StsResources
 import software.aws.toolkits.jetbrains.utils.MRUList
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
+import java.util.concurrent.atomic.AtomicReference
 
 abstract class AwsConnectionManager(private val project: Project) : SimpleModificationTracker(), Disposable {
     private val resourceCache = AwsResourceCache.getInstance()
     private val regionProvider = AwsRegionProvider.getInstance()
     private val credentialsRegionHandler = CredentialsRegionHandler.getInstance(project)
 
-    @Volatile
-    private var validationJob: Job? = null
+    private val validationJob = AtomicReference<AsyncPromise<ConnectionState>>()
 
     @Volatile
     var connectionState: ConnectionState = ConnectionState.InitializingToolkit
         internal set(value) {
             field = value
-
-            if (project.isDisposed != project.messageBus.isDisposed) {
-                throw IllegalStateException("WTF ${project.isDisposed} ${project.messageBus.isDisposed}")
-            }
+            incModificationCount()
 
             if (!project.isDisposed) {
                 project.messageBus.syncPublisher(CONNECTION_SETTINGS_STATE_CHANGED).settingsStateChanged(value)
@@ -61,8 +52,6 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
     // Internal state is visible for AwsSettingsPanel and ChangeAccountSettingsActionGroup
     internal var selectedCredentialIdentifier: CredentialIdentifier? = null
     internal var selectedRegion: AwsRegion? = null
-
-    private var selectedCredentialsProvider: ToolkitCredentialsProvider? = null
 
     init {
         @Suppress("LeakingThis")
@@ -142,49 +131,59 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
 
     @Synchronized
     private fun changeFieldsAndNotify(fieldUpdateBlock: () -> Unit) {
-        incModificationCount()
-
-        validationJob?.cancel(CancellationException("Newer connection settings chosen"))
         val isInitial = connectionState is ConnectionState.InitializingToolkit
         connectionState = ConnectionState.ValidatingConnection
 
         fieldUpdateBlock()
 
-        validationJob = GlobalScope.launch(Dispatchers.IO) {
-            val credentialsIdentifier = selectedCredentialIdentifier
-            val region = selectedRegion
+        val modificationStamp = this.modificationCount
+        val validateCredentialsResult = validateCredentials(selectedCredentialIdentifier, selectedRegion, isInitial)
+        validationJob.getAndSet(validateCredentialsResult)?.cancel()
+
+        validateCredentialsResult.onSuccess {
+            // Validate we are still operating in the latest view of the world
+            if (modificationStamp == this.modificationCount) {
+                connectionState = it
+            } else {
+                LOGGER.warn("validateCredentials returned but the account manager state has been manipulated before results were back, ignoring")
+            }
+        }
+    }
+
+    private fun validateCredentials(credentialsIdentifier: CredentialIdentifier?, region: AwsRegion?, isInitial: Boolean): AsyncPromise<ConnectionState> {
+        val promise = AsyncPromise<ConnectionState>()
+        ApplicationManager.getApplication().executeOnPooledThread {
             if (credentialsIdentifier == null || region == null) {
-                connectionState = ConnectionState.IncompleteConfiguration(credentialsIdentifier, region)
-                incModificationCount()
-                return@launch
+                promise.setResult(ConnectionState.IncompleteConfiguration(credentialsIdentifier, region))
+                return@executeOnPooledThread
             }
 
             if (isInitial && credentialsIdentifier is InteractiveCredential && credentialsIdentifier.userActionRequired()) {
-                connectionState = ConnectionState.RequiresUserAction(credentialsIdentifier)
-
-                incModificationCount()
-                return@launch
+                promise.setResult(ConnectionState.RequiresUserAction(credentialsIdentifier))
+                return@executeOnPooledThread
             }
 
+            var success = true
             try {
                 val credentialsProvider = CredentialManager.getInstance().getAwsCredentialProvider(credentialsIdentifier, region)
 
                 validate(credentialsProvider, region)
-                selectedCredentialsProvider = credentialsProvider
-                connectionState = ConnectionState.ValidConnection(credentialsProvider, region)
+
+                promise.setResult(ConnectionState.ValidConnection(credentialsProvider, region))
             } catch (e: Exception) {
                 LOGGER.warn(e) { message("credentials.profile.validation_error", credentialsIdentifier.displayName) }
-                connectionState = ConnectionState.InvalidConnection(e)
+                success = false
+                promise.setResult(ConnectionState.InvalidConnection(e))
             } finally {
-                incModificationCount()
                 AwsTelemetry.validateCredentials(
                     project,
-                    success = isValidConnectionSettings(),
+                    success = success,
                     credentialType = credentialsIdentifier.credentialType.toTelemetryType()
                 )
-                validationJob = null
             }
         }
+
+        return promise
     }
 
     /**
@@ -200,8 +199,17 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
      */
     val activeCredentialProvider: ToolkitCredentialsProvider
         @Throws(CredentialProviderNotFoundException::class)
-        get() = selectedCredentialsProvider ?: throw CredentialProviderNotFoundException(message("credentials.profile.not_configured")).also {
-            LOGGER.warn(IllegalStateException()) { "Using activeCredentialProvider when credentials is null, calling code needs to be migrated to handle null" }
+        get() {
+            val state = connectionState
+            return if (state is ConnectionState.ValidConnection) {
+                state.credentials
+            } else {
+                throw CredentialProviderNotFoundException(message("credentials.profile.not_configured")).also {
+                    LOGGER.warn(IllegalStateException()) {
+                        "Using activeCredentialProvider when credentials is null, calling code needs to be migrated to handle null"
+                    }
+                }
+            }
         }
 
     /**
@@ -220,17 +228,14 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
     /**
      * Internal method that executes the actual validation of credentials
      */
-    protected open suspend fun validate(credentialsProvider: ToolkitCredentialsProvider, region: AwsRegion) {
-        withContext(Dispatchers.IO) {
-            // TODO: Convert the cache over to suspend methods
-            resourceCache.getResource(
-                StsResources.ACCOUNT,
-                region = region,
-                credentialProvider = credentialsProvider,
-                useStale = false,
-                forceFetch = true
-            ).await()
-        }
+    protected open fun validate(credentialsProvider: ToolkitCredentialsProvider, region: AwsRegion) {
+        resourceCache.getResource(
+            StsResources.ACCOUNT,
+            region = region,
+            credentialProvider = credentialsProvider,
+            useStale = false,
+            forceFetch = true
+        ).toCompletableFuture().get()
     }
 
     override fun dispose() {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/InteractiveCredential.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/InteractiveCredential.kt
@@ -18,5 +18,5 @@ interface InteractiveCredential : CredentialIdentifier {
     /**
      * Determines if user action is required at this time (e.g. may check expiry of cookies, etc)
      */
-    suspend fun userActionRequired(): Boolean
+    fun userActionRequired(): Boolean
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/MfaSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/MfaSupport.kt
@@ -17,7 +17,7 @@ interface MfaRequiredInteractiveCredentials : InteractiveCredential {
 
     override val userAction: AnAction get() = RefreshConnectionAction(message("credentials.mfa.action"))
 
-    override suspend fun userActionRequired(): Boolean = true
+    override fun userActionRequired(): Boolean = true
 }
 
 fun promptForMfaToken(name: String, mfaSerial: String): String = runBlocking {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/SsoSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/SsoSupport.kt
@@ -56,5 +56,5 @@ interface SsoRequiredInteractiveCredentials : InteractiveCredential {
 
     override val userAction: AnAction get() = RefreshConnectionAction(message("credentials.sso.action"))
 
-    override suspend fun userActionRequired(): Boolean = ssoCache.loadAccessToken(ssoUrl) == null
+    override fun userActionRequired(): Boolean = ssoCache.loadAccessToken(ssoUrl) == null
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockResourceCache.kt
@@ -10,9 +10,8 @@ import com.intellij.testFramework.ApplicationRule
 import kotlinx.coroutines.runBlocking
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
-import software.aws.toolkits.jetbrains.core.credentials.activeCredentialProvider
-import software.aws.toolkits.jetbrains.core.credentials.activeRegion
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.ConcurrentHashMap
@@ -109,11 +108,15 @@ class MockResourceCacheRule : ApplicationRule() {
         runBlocking { cache.clear() }
     }
 
-    fun <T> addEntry(project: Project, resource: Resource.Cached<T>, value: T) =
-        cache.addEntry(resource, project.activeRegion().id, project.activeCredentialProvider().id, value)
+    fun <T> addEntry(project: Project, resource: Resource.Cached<T>, value: T) {
+        val connectionManager = AwsConnectionManager.getInstance(project)
+        cache.addEntry(resource, connectionManager.selectedRegion!!.id, connectionManager.selectedCredentialIdentifier!!.id, value)
+    }
 
-    fun <T> addEntry(project: Project, resource: Resource.Cached<T>, value: CompletableFuture<T>) =
-        cache.addEntry(resource, project.activeRegion().id, project.activeCredentialProvider().id, value)
+    fun <T> addEntry(project: Project, resource: Resource.Cached<T>, value: CompletableFuture<T>) {
+        val connectionManager = AwsConnectionManager.getInstance(project)
+        cache.addEntry(resource, connectionManager.selectedRegion!!.id, connectionManager.selectedCredentialIdentifier!!.id, value)
+    }
 
     fun <T> addEntry(resource: Resource.Cached<T>, regionId: String, credentialsId: String, value: T) {
         cache.addEntry(resource, regionId, credentialsId, value)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockAwsConnectionManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockAwsConnectionManager.kt
@@ -49,7 +49,7 @@ class MockAwsConnectionManager(project: Project) : AwsConnectionManager(project)
         connectionState = state
     }
 
-    override suspend fun validate(credentialsProvider: ToolkitCredentialsProvider, region: AwsRegion) {}
+    override fun validate(credentialsProvider: ToolkitCredentialsProvider, region: AwsRegion) {}
 
     companion object {
         fun getInstance(project: Project): MockAwsConnectionManager =

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/ResourceSelectorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/ui/ResourceSelectorTest.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.ui
 
 import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.RuleChain
 import com.intellij.testFramework.runInEdtAndWait
 import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
@@ -16,17 +17,18 @@ import software.aws.toolkits.core.utils.test.retryableAssert
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.Resource
 import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
+import software.aws.toolkits.jetbrains.core.credentials.MockAwsConnectionManager.ProjectAccountSettingsManagerRule
 import software.aws.toolkits.resources.message
 import java.util.concurrent.CompletableFuture
 
 class ResourceSelectorTest {
-    @Rule
-    @JvmField
-    val projectRule = ProjectRule()
+    private val projectRule = ProjectRule()
+    private val accountSettings = ProjectAccountSettingsManagerRule(projectRule)
+    private val resourceCache = MockResourceCacheRule()
 
     @JvmField
     @Rule
-    val resourceCache = MockResourceCacheRule()
+    val ruleChain = RuleChain(projectRule, accountSettings, resourceCache)
 
     private val mockResource = mock<Resource.Cached<List<String>>> {
         on { id }.thenReturn("mockResource")


### PR DESCRIPTION
* Add settings manager rule due to resource cache has an implicit requirement on account settings
* Use a rule chain to make sure they get created and deleted in correct order

Let's see if this helps our Windows tests

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
