### PR TITLE
Dotnet5 wizard

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     api("software.amazon.awssdk:cognitoidentity:$awsSdkVersion")
     api("software.amazon.awssdk:ecr:$awsSdkVersion")
     api("software.amazon.awssdk:ecs:$awsSdkVersion")
+    api("software.amazon.awssdk:lambda:$awsSdkVersion")
     api("software.amazon.awssdk:s3:$awsSdkVersion")
     api("software.amazon.awssdk:sso:$awsSdkVersion")
     api("software.amazon.awssdk:ssooidc:$awsSdkVersion")

--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.core.lambda
 
 import software.amazon.awssdk.services.lambda.model.Runtime
 
-enum class LambdaRuntime(val runtime: Runtime?, val runtimeOverride: String? = null) {
+enum class LambdaRuntime(val runtime: Runtime?, private val runtimeOverride: String? = null) {
     NODEJS10_X(Runtime.NODEJS10_X),
     NODEJS12_X(Runtime.NODEJS12_X),
     JAVA8(Runtime.JAVA8),

--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -29,5 +29,7 @@ enum class LambdaRuntime(private val runtime: Runtime?, private val runtimeOverr
         } else {
             values().find { it.toString() == value }
         }
+
+        fun fromValue(value: Runtime): LambdaRuntime? = values().find { it.runtime == value }
     }
 }

--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -1,0 +1,29 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.core.lambda
+
+enum class LambdaRuntime(val value: String) {
+    NODEJS10_X("nodejs10.x"),
+    NODEJS12_X("nodejs12.x"),
+    JAVA8("java8"),
+    JAVA8_AL2("java8.al2"),
+    JAVA11("java11"),
+    PYTHON2_7("python2.7"),
+    PYTHON3_6("python3.6"),
+    PYTHON3_7("python3.7"),
+    PYTHON3_8("python3.8"),
+    DOTNETCORE2_1("dotnetcore2.1"),
+    DOTNETCORE3_1("dotnetcore3.1"),
+    DOTNET5_0("dotnet5.0");
+
+    override fun toString() = value
+
+    companion object {
+        fun fromValue(value: String?): LambdaRuntime? = if (value == null) {
+            null
+        } else {
+            values().find { it.toString() == value }
+        }
+    }
+}

--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.core.lambda
 
 import software.amazon.awssdk.services.lambda.model.Runtime
 
-enum class LambdaRuntime(val runtime: Runtime?, private val runtimeOverride: String? = null) {
+enum class LambdaRuntime(private val runtime: Runtime?, private val runtimeOverride: String? = null) {
     NODEJS10_X(Runtime.NODEJS10_X),
     NODEJS12_X(Runtime.NODEJS12_X),
     JAVA8(Runtime.JAVA8),

--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -3,6 +3,8 @@
 
 package software.aws.toolkits.core.lambda
 
+import software.amazon.awssdk.services.lambda.model.Runtime
+
 enum class LambdaRuntime(val value: String) {
     NODEJS10_X("nodejs10.x"),
     NODEJS12_X("nodejs12.x"),
@@ -18,6 +20,8 @@ enum class LambdaRuntime(val value: String) {
     DOTNET5_0("dotnet5.0");
 
     override fun toString() = value
+
+    fun toSdkRuntime() = Runtime.fromValue(value).validOrNull
 
     companion object {
         fun fromValue(value: String?): LambdaRuntime? = if (value == null) {

--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -5,23 +5,23 @@ package software.aws.toolkits.core.lambda
 
 import software.amazon.awssdk.services.lambda.model.Runtime
 
-enum class LambdaRuntime(val value: String) {
-    NODEJS10_X("nodejs10.x"),
-    NODEJS12_X("nodejs12.x"),
-    JAVA8("java8"),
-    JAVA8_AL2("java8.al2"),
-    JAVA11("java11"),
-    PYTHON2_7("python2.7"),
-    PYTHON3_6("python3.6"),
-    PYTHON3_7("python3.7"),
-    PYTHON3_8("python3.8"),
-    DOTNETCORE2_1("dotnetcore2.1"),
-    DOTNETCORE3_1("dotnetcore3.1"),
-    DOTNET5_0("dotnet5.0");
+enum class LambdaRuntime(val runtime: Runtime?, val runtimeOverride: String? = null) {
+    NODEJS10_X(Runtime.NODEJS10_X),
+    NODEJS12_X(Runtime.NODEJS12_X),
+    JAVA8(Runtime.JAVA8),
+    JAVA8_AL2(Runtime.JAVA8_AL2),
+    JAVA11(Runtime.JAVA11),
+    PYTHON2_7(Runtime.PYTHON2_7),
+    PYTHON3_6(Runtime.PYTHON3_6),
+    PYTHON3_7(Runtime.PYTHON3_7),
+    PYTHON3_8(Runtime.PYTHON3_8),
+    DOTNETCORE2_1(Runtime.DOTNETCORE2_1),
+    DOTNETCORE3_1(Runtime.DOTNETCORE3_1),
+    DOTNET5_0(null, "dotnet5.0");
 
-    override fun toString() = value
+    override fun toString() = runtime?.toString() ?: runtimeOverride ?: throw IllegalStateException("LambdaRuntime has no runtime or override string")
 
-    fun toSdkRuntime() = Runtime.fromValue(value).validOrNull
+    fun toSdkRuntime() = runtime.validOrNull
 
     companion object {
         fun fromValue(value: String?): LambdaRuntime? = if (value == null) {

--- a/core/src/software/aws/toolkits/core/lambda/LambdaUtils.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaUtils.kt
@@ -1,0 +1,8 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.core.lambda
+
+import software.amazon.awssdk.services.lambda.model.Runtime
+
+val Runtime?.validOrNull: Runtime? get() = this?.takeUnless { it == Runtime.UNKNOWN_TO_SDK_VERSION }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
@@ -96,8 +96,6 @@ abstract class SdkBasedRuntimeGroup : RuntimeGroup() {
     override fun determineRuntime(module: Module): Runtime? = ModuleRootManager.getInstance(module).sdk?.let { runtimeForSdk(it) }
 }
 
-val Runtime?.validOrNull: Runtime? get() = this?.takeUnless { it == Runtime.UNKNOWN_TO_SDK_VERSION }
-
 val Runtime.runtimeGroup: RuntimeGroup? get() = RuntimeGroup.find { this in it.runtimes }
 
 /**

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
@@ -23,6 +23,7 @@ import com.intellij.util.PathMappingSettings.PathMapping
 import com.intellij.util.text.SemVer
 import org.jetbrains.concurrency.isPending
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
@@ -24,6 +24,7 @@ import com.intellij.util.text.SemVer
 import org.jetbrains.concurrency.isPending
 import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.lambda.LambdaRuntime
+import software.aws.toolkits.core.lambda.validOrNull
 import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
@@ -48,7 +49,6 @@ import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils
-import software.aws.toolkits.jetbrains.services.lambda.validOrNull
 import software.aws.toolkits.jetbrains.services.lambda.validation.LambdaHandlerEvaluationListener
 import software.aws.toolkits.jetbrains.services.lambda.validation.LambdaHandlerValidator
 import software.aws.toolkits.jetbrains.ui.connection.AwsConnectionSettingsEditor
@@ -256,7 +256,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
         functionOptions.runtime = runtime
     }
 
-    fun useHandler(runtime: Runtime?, handler: String?) {
+    fun useHandler(runtime: LambdaRuntime?, handler: String?) {
         val functionOptions = serializableOptions.functionOptions
         functionOptions.useTemplate = false
 
@@ -275,7 +275,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
 
     fun handler() = serializableOptions.functionOptions.handler
 
-    fun runtime(): Runtime? = Runtime.fromValue(serializableOptions.functionOptions.runtime)?.validOrNull
+    fun runtime(): LambdaRuntime? = LambdaRuntime.fromValue(serializableOptions.functionOptions.runtime)
 
     /*
      * This is only to be called for Image functions, otherwise we do not store the runtime for ZIP based template functions
@@ -373,10 +373,10 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
 
     private fun handlerDisplayName(): String? {
         val handler = serializableOptions.functionOptions.handler ?: return null
-        return runtime()
-            ?.runtimeGroup
-            ?.let { LambdaHandlerResolver.getInstanceOrNull(it) }
-            ?.handlerDisplayName(handler) ?: handler
+        return Runtime.fromValue(runtime()?.value).validOrNull
+                ?.runtimeGroup
+                ?.let { LambdaHandlerResolver.getInstanceOrNull(it) }
+                ?.handlerDisplayName(handler) ?: handler
     }
 
     private fun resolveLambdaFromHandler(handler: String?, runtime: String?): Pair<String, Runtime> {
@@ -399,7 +399,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
             )
         }
 
-    private fun handlerPsiElement(handler: String? = handler(), runtime: Runtime? = runtime()) = try {
+    private fun handlerPsiElement(handler: String? = handler(), runtime: Runtime? = runtime()?.toSdkRuntime().validOrNull) = try {
         runtime?.let {
             handler?.let {
                 findPsiElementsForHandler(project, runtime, handler).firstOrNull()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
@@ -256,7 +256,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
         functionOptions.runtime = runtime
     }
 
-    fun useHandler(runtime: LambdaRuntime?, handler: String?) {
+    fun useHandler(runtime: Runtime?, handler: String?) {
         val functionOptions = serializableOptions.functionOptions
         functionOptions.useTemplate = false
 
@@ -373,10 +373,12 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
 
     private fun handlerDisplayName(): String? {
         val handler = serializableOptions.functionOptions.handler ?: return null
-        return runtime()?.toSdkRuntime().validOrNull
-                ?.runtimeGroup
-                ?.let { LambdaHandlerResolver.getInstanceOrNull(it) }
-                ?.handlerDisplayName(handler) ?: handler
+        return runtime()
+            ?.toSdkRuntime()
+            .validOrNull
+            ?.runtimeGroup
+            ?.let { LambdaHandlerResolver.getInstanceOrNull(it) }
+            ?.handlerDisplayName(handler) ?: handler
     }
 
     private fun resolveLambdaFromHandler(handler: String?, runtime: String?): Pair<String, Runtime> {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
@@ -373,7 +373,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
 
     private fun handlerDisplayName(): String? {
         val handler = serializableOptions.functionOptions.handler ?: return null
-        return Runtime.fromValue(runtime()?.value).validOrNull
+        return runtime()?.toSdkRuntime().validOrNull
                 ?.runtimeGroup
                 ?.let { LambdaHandlerResolver.getInstanceOrNull(it) }
                 ?.handlerDisplayName(handler) ?: handler

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import org.jetbrains.yaml.psi.YAMLKeyValue
 import org.jetbrains.yaml.psi.YAMLPsiElement
-import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
@@ -61,7 +60,7 @@ class LocalLambdaRunConfigurationProducer : LazyRunConfigurationProducer<LocalLa
         val runtime = RuntimeGroup.determineRuntime(context.module) ?: RuntimeGroup.determineRuntime(context.project)
 
         setAccountOptions(configuration)
-        configuration.useHandler(Runtime.fromValue(runtime.toString()), handler)
+        configuration.useHandler(runtime, handler)
 
         return true
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import org.jetbrains.yaml.psi.YAMLKeyValue
 import org.jetbrains.yaml.psi.YAMLPsiElement
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
@@ -60,7 +61,8 @@ class LocalLambdaRunConfigurationProducer : LazyRunConfigurationProducer<LocalLa
         val runtime = RuntimeGroup.determineRuntime(context.module) ?: RuntimeGroup.determineRuntime(context.project)
 
         setAccountOptions(configuration)
-        configuration.useHandler(runtime, handler)
+        // TODO
+        configuration.useHandler(LambdaRuntime.fromValue(runtime.toString()), handler)
 
         return true
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
@@ -61,7 +61,6 @@ class LocalLambdaRunConfigurationProducer : LazyRunConfigurationProducer<LocalLa
         val runtime = RuntimeGroup.determineRuntime(context.module) ?: RuntimeGroup.determineRuntime(context.project)
 
         setAccountOptions(configuration)
-        // TODO
         configuration.useHandler(LambdaRuntime.fromValue(runtime.toString()), handler)
 
         return true

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
@@ -13,7 +13,7 @@ import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import org.jetbrains.yaml.psi.YAMLKeyValue
 import org.jetbrains.yaml.psi.YAMLPsiElement
-import software.aws.toolkits.core.lambda.LambdaRuntime
+import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
@@ -61,7 +61,7 @@ class LocalLambdaRunConfigurationProducer : LazyRunConfigurationProducer<LocalLa
         val runtime = RuntimeGroup.determineRuntime(context.module) ?: RuntimeGroup.determineRuntime(context.project)
 
         setAccountOptions(configuration)
-        configuration.useHandler(LambdaRuntime.fromValue(runtime.toString()), handler)
+        configuration.useHandler(Runtime.fromValue(runtime.toString()), handler)
 
         return true
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditor.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.util.PathMappingSettings
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.execution.registerConfigValidationListeners
 import software.aws.toolkits.jetbrains.services.lambda.validation.LambdaHandlerValidator
 import software.aws.toolkits.jetbrains.utils.ui.selected
@@ -62,7 +63,7 @@ class LocalLambdaRunSettingsEditor(project: Project) : SettingsEditor<LocalLambd
                 configuration.pathMappings = view.templateSettings.pathMappingsTable.mappingSettings.pathMappings
             }
         } else {
-            configuration.useHandler(view.rawSettings.runtime.selected(), view.rawSettings.handlerPanel.handler.text)
+            configuration.useHandler(LambdaRuntime.fromValue(view.rawSettings.runtime.selected().toString()), view.rawSettings.handlerPanel.handler.text)
             configuration.timeout(view.rawSettings.timeoutSlider.value)
             configuration.memorySize(view.rawSettings.memorySlider.value)
             configuration.environmentVariables(view.rawSettings.environmentVariables.envVars)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditor.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.util.PathMappingSettings
-import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.execution.registerConfigValidationListeners
 import software.aws.toolkits.jetbrains.services.lambda.validation.LambdaHandlerValidator
 import software.aws.toolkits.jetbrains.utils.ui.selected
@@ -63,7 +62,7 @@ class LocalLambdaRunSettingsEditor(project: Project) : SettingsEditor<LocalLambd
                 configuration.pathMappings = view.templateSettings.pathMappingsTable.mappingSettings.pathMappings
             }
         } else {
-            configuration.useHandler(LambdaRuntime.fromValue(view.rawSettings.runtime.selected().toString()), view.rawSettings.handlerPanel.handler.text)
+            configuration.useHandler(view.rawSettings.runtime.selected(), view.rawSettings.handlerPanel.handler.text)
             configuration.timeout(view.rawSettings.timeoutSlider.value)
             configuration.memorySize(view.rawSettings.memorySlider.value)
             configuration.environmentVariables(view.rawSettings.environmentVariables.envVars)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamInvokeRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamInvokeRunner.kt
@@ -22,6 +22,7 @@ import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import org.slf4j.event.Level
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.validOrNull
 import software.aws.toolkits.core.telemetry.DefaultMetricEvent.Companion.METADATA_INVALID
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.tryOrNull
@@ -35,7 +36,6 @@ import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils
 import software.aws.toolkits.jetbrains.services.lambda.upload.steps.BuildLambda
-import software.aws.toolkits.jetbrains.services.lambda.validOrNull
 import software.aws.toolkits.jetbrains.services.sts.StsResources
 import software.aws.toolkits.jetbrains.services.telemetry.MetricEventMetadata
 import software.aws.toolkits.jetbrains.utils.execution.steps.StepExecutor
@@ -77,7 +77,7 @@ class SamInvokeRunner : AsyncProgramRunner<RunnerSettings>() {
                     }
             }
         } else if (!profile.isImage) {
-            profile.runtime()
+            profile.runtime()?.toSdkRuntime()
         } else {
             null
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaSamProjectWizard.kt
@@ -15,8 +15,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.jetbrains.idea.maven.project.MavenProjectsManager
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
 import org.jetbrains.plugins.gradle.util.GradleConstants
-import software.amazon.awssdk.services.lambda.model.PackageType
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.logWhenNull
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
@@ -42,7 +41,8 @@ class JavaSamProjectWizard : SamProjectWizard {
 }
 
 abstract class JavaSamProjectTemplate : SamAppTemplateBased() {
-    override fun supportedRuntimes() = setOf(Runtime.JAVA8, Runtime.JAVA8_AL2, Runtime.JAVA11)
+    override fun supportedZipRuntimes() = setOf(LambdaRuntime.JAVA8, LambdaRuntime.JAVA8_AL2, LambdaRuntime.JAVA11)
+    override fun supportedImageRuntimes() = setOf(LambdaRuntime.JAVA8, LambdaRuntime.JAVA8_AL2, LambdaRuntime.JAVA11)
 
     // Helper method to locate the build file, such as pom.xml in the project content root.
     protected fun locateBuildFile(contentRoot: VirtualFile, buildFileName: String): VirtualFile? {
@@ -111,8 +111,6 @@ class SamHelloWorldMaven : JavaMavenSamProjectTemplate() {
 
     override fun description() = message("sam.init.template.hello_world.description")
 
-    override fun supportedPackagingTypes(): Set<PackageType> = setOf(PackageType.IMAGE, PackageType.ZIP)
-
     override val appTemplateName: String = "hello-world"
 }
 
@@ -120,8 +118,6 @@ class SamHelloWorldGradle : JavaGradleSamProjectTemplate() {
     override fun displayName() = message("sam.init.template.hello_world_gradle.name")
 
     override fun description() = message("sam.init.template.hello_world.description")
-
-    override fun supportedPackagingTypes(): Set<PackageType> = setOf(PackageType.IMAGE, PackageType.ZIP)
 
     override val appTemplateName: String = "hello-world"
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PlatformUtils
 import software.amazon.awssdk.services.lambda.model.PackageType
-import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.wizard.IntelliJSdkSelectionPanel

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PlatformUtils
 import software.amazon.awssdk.services.lambda.model.PackageType
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.wizard.IntelliJSdkSelectionPanel
 import software.aws.toolkits.jetbrains.services.lambda.wizard.LocationBasedTemplate
@@ -21,7 +22,8 @@ import software.aws.toolkits.jetbrains.services.lambda.wizard.SdkSelector
 import software.aws.toolkits.jetbrains.services.lambda.wizard.TemplateParameters
 import software.aws.toolkits.resources.message
 
-private val pythonTemplateRuntimes = setOf(Runtime.PYTHON2_7, Runtime.PYTHON3_6, Runtime.PYTHON3_7, Runtime.PYTHON3_8)
+private val pythonTemplateRuntimes = setOf(LambdaRuntime.PYTHON2_7, LambdaRuntime.PYTHON3_6, LambdaRuntime.PYTHON3_7, LambdaRuntime.PYTHON3_8)
+private val eventBridgeTemplateRuntimes = setOf(LambdaRuntime.PYTHON3_6, LambdaRuntime.PYTHON3_7, LambdaRuntime.PYTHON3_8)
 
 class PythonSamProjectWizard : SamProjectWizard {
     override fun createSdkSelectionPanel(projectLocation: TextFieldWithBrowseButton?): SdkSelector? = when {
@@ -38,7 +40,8 @@ class PythonSamProjectWizard : SamProjectWizard {
 }
 
 abstract class PythonSamProjectTemplate : SamAppTemplateBased() {
-    override fun supportedRuntimes() = pythonTemplateRuntimes
+    override fun supportedZipRuntimes() = pythonTemplateRuntimes
+    override fun supportedImageRuntimes() = pythonTemplateRuntimes
 
     override val dependencyManager: String = "pip"
 
@@ -58,8 +61,6 @@ class SamHelloWorldPython : PythonSamProjectTemplate() {
 
     override fun description() = message("sam.init.template.hello_world.description")
 
-    override fun supportedPackagingTypes(): Set<PackageType> = setOf(PackageType.IMAGE, PackageType.ZIP)
-
     override val appTemplateName: String = "hello-world"
 }
 
@@ -68,7 +69,8 @@ class SamDynamoDBCookieCutter : SamProjectTemplate() {
 
     override fun description() = message("sam.init.template.dynamodb_cookiecutter.description")
 
-    override fun supportedRuntimes() = pythonTemplateRuntimes
+    override fun supportedZipRuntimes() = pythonTemplateRuntimes
+    override fun supportedImageRuntimes() = pythonTemplateRuntimes
 
     override fun postCreationAction(
         settings: SamNewProjectSettings,
@@ -86,7 +88,8 @@ class SamDynamoDBCookieCutter : SamProjectTemplate() {
 }
 
 class SamEventBridgeHelloWorld : PythonSamProjectTemplate() {
-    override fun supportedRuntimes() = setOf(Runtime.PYTHON3_6, Runtime.PYTHON3_7, Runtime.PYTHON3_8)
+    override fun supportedZipRuntimes() = eventBridgeTemplateRuntimes
+    override fun supportedImageRuntimes() = eventBridgeTemplateRuntimes
 
     override fun displayName() = message("sam.init.template.event_bridge_hello_world.name")
 
@@ -96,7 +99,8 @@ class SamEventBridgeHelloWorld : PythonSamProjectTemplate() {
 }
 
 class SamEventBridgeStarterApp : PythonSamProjectTemplate() {
-    override fun supportedRuntimes() = setOf(Runtime.PYTHON3_6, Runtime.PYTHON3_7, Runtime.PYTHON3_8)
+    override fun supportedZipRuntimes() = eventBridgeTemplateRuntimes
+    override fun supportedImageRuntimes() = eventBridgeTemplateRuntimes
 
     override fun displayName() = message("sam.init.template.event_bridge_starter_app.name")
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
@@ -82,7 +82,7 @@ class SamDynamoDBCookieCutter : SamProjectTemplate() {
         addSourceRoots(rootModel.project, rootModel, contentRoot)
     }
 
-    override fun templateParameters(projectName: String, runtime: Runtime, packagingType: PackageType): TemplateParameters = LocationBasedTemplate(
+    override fun templateParameters(projectName: String, runtime: LambdaRuntime, packagingType: PackageType): TemplateParameters = LocationBasedTemplate(
         "gh:aws-samples/cookiecutter-aws-sam-dynamodb-python"
     )
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionDialog.kt
@@ -12,6 +12,7 @@ import com.intellij.util.text.nullize
 import org.jetbrains.annotations.TestOnly
 import software.amazon.awssdk.services.lambda.model.PackageType
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.validOrNull
 import software.aws.toolkits.jetbrains.core.credentials.activeRegion
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.core.help.HelpIds
@@ -25,7 +26,6 @@ import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
 import software.aws.toolkits.jetbrains.services.lambda.upload.steps.CreateLambda.Companion.FUNCTION_ARN
 import software.aws.toolkits.jetbrains.services.lambda.upload.steps.createLambdaWorkflowForImage
 import software.aws.toolkits.jetbrains.services.lambda.upload.steps.createLambdaWorkflowForZip
-import software.aws.toolkits.jetbrains.services.lambda.validOrNull
 import software.aws.toolkits.jetbrains.settings.UpdateLambdaSettings
 import software.aws.toolkits.jetbrains.utils.execution.steps.StepExecutor
 import software.aws.toolkits.jetbrains.utils.notifyError

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
@@ -18,9 +18,7 @@ import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance.BadExecutable
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.ExecutableType.Companion.getExecutable
-import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup.Companion.find
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
@@ -105,8 +105,6 @@ class SamInitSelectionPanel(
                 }
             }
             .filter(runtimeFilter)
-            .filter { supportedRuntimeGroups.contains(find { runtimeGroup -> runtimeGroup.runtimes.contains(it.toSdkRuntime()) }) ||
-                (it.value == "dotnet5.0" && find { group -> group.id == BuiltInRuntimeGroups.Dotnet } != null)}
             .distinct()
             .sorted()
             .toMutableList()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamProjectWizard.kt
@@ -37,7 +37,7 @@ interface SamProjectWizard {
 
 data class SamNewProjectSettings(
     val template: SamProjectTemplate,
-    val runtime: Runtime,
+    val runtime: LambdaRuntime,
     val packagingType: PackageType
 )
 
@@ -56,7 +56,7 @@ abstract class SamProjectTemplate {
     // All SAM templates should support schema selection, but for launch include only EventBridge for most optimal customer experience
     open fun supportsDynamicSchemas(): Boolean = false
 
-    abstract fun templateParameters(projectName: String, runtime: Runtime, packagingType: PackageType): TemplateParameters
+    abstract fun templateParameters(projectName: String, runtime: LambdaRuntime, packagingType: PackageType): TemplateParameters
 
     open fun postCreationAction(
         settings: SamNewProjectSettings,
@@ -110,7 +110,7 @@ abstract class SamAppTemplateBased : SamProjectTemplate() {
     abstract val dependencyManager: String
     abstract val appTemplateName: String
 
-    override fun templateParameters(projectName: String, runtime: Runtime, packagingType: PackageType): TemplateParameters = when (packagingType) {
+    override fun templateParameters(projectName: String, runtime: LambdaRuntime, packagingType: PackageType): TemplateParameters = when (packagingType) {
         PackageType.IMAGE -> AppBasedImageTemplate(
             name = projectName,
             baseImage = "amazon/$runtime-base",

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamProjectWizard.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import software.amazon.awssdk.services.lambda.model.PackageType
-import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPointObject

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamProjectWizard.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import software.amazon.awssdk.services.lambda.model.PackageType
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroupExtensionPointObject
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
@@ -47,9 +48,9 @@ abstract class SamProjectTemplate {
 
     override fun toString() = displayName()
 
-    abstract fun supportedRuntimes(): Set<Runtime>
+    abstract fun supportedZipRuntimes(): Set<LambdaRuntime>
 
-    open fun supportedPackagingTypes(): Set<PackageType> = setOf(PackageType.ZIP)
+    abstract fun supportedImageRuntimes(): Set<LambdaRuntime>
 
     // Gradual opt-in for Schema support on a template by-template basis.
     // All SAM templates should support schema selection, but for launch include only EventBridge for most optimal customer experience

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SchemaSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SchemaSelectionPanel.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.ui.layout.panel
-import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SchemaSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SchemaSelectionPanel.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.ui.layout.panel
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
@@ -56,7 +57,7 @@ class SchemaSelectionPanel : WizardFragment {
 
     override fun isApplicable(template: SamProjectTemplate?): Boolean = template?.supportsDynamicSchemas() == true
 
-    override fun postProjectGeneration(model: ModifiableRootModel, template: SamProjectTemplate, runtime: Runtime, progressIndicator: ProgressIndicator) {
+    override fun postProjectGeneration(model: ModifiableRootModel, template: SamProjectTemplate, runtime: LambdaRuntime, progressIndicator: ProgressIndicator) {
         if (!template.supportsDynamicSchemas()) {
             return
         }
@@ -70,7 +71,7 @@ class SchemaSelectionPanel : WizardFragment {
             // We take the first since we don't have any way to say generate this schema for this function
             val codeUris = SamCommon.getCodeUrisFromTemplate(model.project, templateFile).firstOrNull() ?: return
             val connectionSettings = awsConnectionSelector.connectionSettings() ?: return
-            val runtimeGroup = runtime.runtimeGroup ?: return
+            val runtimeGroup = runtime.toSdkRuntime()?.runtimeGroup ?: return
 
             SamSchemaDownloadPostCreationAction().downloadCodeIntoWorkspace(
                 it,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SdkSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SdkSelectionPanel.kt
@@ -16,6 +16,7 @@ import com.intellij.ui.components.panels.Wrapper
 import com.intellij.ui.layout.panel
 import com.intellij.util.ThrowableRunnable
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import javax.swing.JComponent
 import javax.swing.JLabel
@@ -84,7 +85,7 @@ class SdkSelectionPanel : WizardFragment {
         }
     }
 
-    override fun postProjectGeneration(model: ModifiableRootModel, template: SamProjectTemplate, runtime: Runtime, progressIndicator: ProgressIndicator) {
+    override fun postProjectGeneration(model: ModifiableRootModel, template: SamProjectTemplate, runtime: LambdaRuntime, progressIndicator: ProgressIndicator) {
         sdkSelector?.let {
             progressIndicator.text = "Setting up SDK"
             ApplicationManager.getApplication().invokeAndWait {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SdkSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SdkSelectionPanel.kt
@@ -15,7 +15,6 @@ import com.intellij.ui.ErrorLabel
 import com.intellij.ui.components.panels.Wrapper
 import com.intellij.ui.layout.panel
 import com.intellij.util.ThrowableRunnable
-import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import javax.swing.JComponent

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/TemplateParameters.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/TemplateParameters.kt
@@ -3,10 +3,10 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.wizard
 
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 
 sealed class TemplateParameters
 
-data class AppBasedZipTemplate(val name: String, val runtime: Runtime, val appTemplate: String, val dependencyManager: String) : TemplateParameters()
+data class AppBasedZipTemplate(val name: String, val runtime: LambdaRuntime, val appTemplate: String, val dependencyManager: String) : TemplateParameters()
 data class AppBasedImageTemplate(val name: String, val baseImage: String, val dependencyManager: String) : TemplateParameters()
 data class LocationBasedTemplate(val location: String) : TemplateParameters()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/WizardFragment.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/WizardFragment.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
-import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import javax.swing.JComponent

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/WizardFragment.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/WizardFragment.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import javax.swing.JComponent
 
@@ -43,5 +44,5 @@ interface WizardFragment {
     /**
      * Runs after the initial template is executed to allow for post-generate activities such as code generation
      */
-    fun postProjectGeneration(model: ModifiableRootModel, template: SamProjectTemplate, runtime: Runtime, progressIndicator: ProgressIndicator) {}
+    fun postProjectGeneration(model: ModifiableRootModel, template: SamProjectTemplate, runtime: LambdaRuntime, progressIndicator: ProgressIndicator) {}
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroupTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroupTest.kt
@@ -16,6 +16,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.validOrNull
 import software.aws.toolkits.jetbrains.utils.rules.PyTestSdk
 import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducerTest.kt
@@ -18,7 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.yaml.psi.YAMLFile
 import org.junit.Rule
 import org.junit.Test
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.sam.findByLocation
 import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.openClass
@@ -49,7 +49,7 @@ class LocalLambdaRunConfigurationProducerTest {
             assertThat(runConfiguration).isNotNull
             val configuration = runConfiguration?.configuration as LocalLambdaRunConfiguration
             assertThat(configuration.isUsingTemplate()).isFalse()
-            assertThat(configuration.runtime()).isEqualTo(Runtime.JAVA8_AL2)
+            assertThat(configuration.runtime()).isEqualTo(LambdaRuntime.JAVA8_AL2)
             assertThat(configuration.handler()).isEqualTo("com.example.LambdaHandler::handleRequest")
             assertThat(configuration.name).isEqualTo("[Local] LambdaHandler.handleRequest")
         }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.core.rules.EnvironmentVariableHelper
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
@@ -637,7 +638,7 @@ class LocalLambdaRunConfigurationTest {
             assertThat(runConfiguration.templateFile()).isNull()
             assertThat(runConfiguration.logicalId()).isNull()
             assertThat(runConfiguration.handler()).isEqualTo("helloworld.App::handleRequest")
-            assertThat(runConfiguration.runtime()).isEqualTo(Runtime.PYTHON3_6)
+            assertThat(runConfiguration.runtime()).isEqualTo(LambdaRuntime.PYTHON3_6)
             assertThat(runConfiguration.environmentVariables()).containsAllEntriesOf(mapOf("Foo" to "Bar"))
             assertThat(runConfiguration.regionId()).isEqualTo("us-west-2")
             assertThat(runConfiguration.credentialProviderId()).isEqualTo("profile:default")

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamExecutableTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamExecutableTest.kt
@@ -8,7 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.deploy.CreateCapabilities
 import software.aws.toolkits.jetbrains.services.lambda.wizard.AppBasedImageTemplate
 import software.aws.toolkits.jetbrains.services.lambda.wizard.AppBasedZipTemplate
@@ -355,7 +355,7 @@ class SamExecutableTest {
             outputDir = outputDir.toPath(),
             parameters = AppBasedZipTemplate(
                 name = "Hello",
-                runtime = Runtime.JAVA11,
+                runtime = LambdaRuntime.JAVA11,
                 appTemplate = "HelloWorldTemplate",
                 dependencyManager = "maven"
             ),
@@ -444,7 +444,7 @@ class SamExecutableTest {
             outputDir = outputDir.toPath(),
             parameters = AppBasedZipTemplate(
                 name = "Hello",
-                runtime = Runtime.JAVA11,
+                runtime = LambdaRuntime.JAVA11,
                 appTemplate = "HelloWorldTemplate",
                 dependencyManager = "maven"
             ),

--- a/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -58,6 +58,7 @@ class DotNetSamProjectGenerator(
     private val generator = SamProjectGenerator()
     private val samPanel = SamInitSelectionPanel(generator.wizardFragments) {
         // Only show templates for DotNet in Rider
+        // TODO fix this to work properly, the issue is that RuntimeGroup contains the sdk built in Runtime
         it.value.startsWith("dotnet")
     }
 

--- a/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -58,7 +58,7 @@ class DotNetSamProjectGenerator(
     private val generator = SamProjectGenerator()
     private val samPanel = SamInitSelectionPanel(generator.wizardFragments) {
         // Only show templates for DotNet in Rider
-        RuntimeGroup.getById(BuiltInRuntimeGroups.Dotnet).runtimes.contains(it)
+        it.value.startsWith("dotnet")
     }
 
     private val projectStructurePanel: JTabbedPane

--- a/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -246,7 +246,7 @@ class DotNetSamProjectGenerator(
     private fun initSamPanel() {
         val availableRuntime = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime()
         val runtime = LambdaRuntime.fromValue(availableRuntime)
-            ?: throw IllegalStateException("DotNetRuntimeUtils.getCurrentDotNetCoreRuntime() returned invalid runtime ${availableRuntime}")
+            ?: throw IllegalStateException("DotNetRuntimeUtils.getCurrentDotNetCoreRuntime() returned invalid runtime $availableRuntime")
         samPanel.setRuntime(runtime)
     }
 

--- a/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -56,8 +56,11 @@ class DotNetSamProjectGenerator(
     private val generator = SamProjectGenerator()
     private val samPanel = SamInitSelectionPanel(generator.wizardFragments) {
         // Only show templates for DotNet in Rider
-        // TODO fix this to work properly, the issue is that RuntimeGroup contains the sdk built in Runtime
-        it.value.startsWith("dotnet")
+        // Restore this -> RuntimeGroup.getById(BuiltInRuntimeGroups.Dotnet).runtimes.contains(it)
+        // TODO fix this to work properly (and the 203 version), the issue is that RuntimeGroup contains the sdk
+        // built in Runtime so, dotnet5 will not show up if we do not do some additional check. Inverting the
+        // runtime group so it pulls from LambdaRuntime will fix this but needs additional testing/changes
+        it.toString().startsWith("dotnet")
     }
 
     private val projectStructurePanel: JTabbedPane

--- a/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -26,8 +26,6 @@ import com.jetbrains.rider.ui.themes.RiderTheme
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutableIfPresent
-import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamInitSelectionPanel
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamProjectGenerator

--- a/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -23,6 +23,7 @@ import com.jetbrains.rider.projectView.actions.projectTemplating.backend.ReSharp
 import com.jetbrains.rider.projectView.actions.projectTemplating.impl.ProjectTemplateDialogContext
 import com.jetbrains.rider.projectView.actions.projectTemplating.impl.ProjectTemplateTransferableModel
 import com.jetbrains.rider.ui.themes.RiderTheme
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutableIfPresent
@@ -244,7 +245,9 @@ class DotNetSamProjectGenerator(
 
     private fun initSamPanel() {
         val availableRuntime = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime()
-        samPanel.setRuntime(availableRuntime)
+        val runtime = LambdaRuntime.fromValue(availableRuntime)
+            ?: throw IllegalStateException("DotNetRuntimeUtils.getCurrentDotNetCoreRuntime() returned invalid runtime ${availableRuntime}")
+        samPanel.setRuntime(runtime)
     }
 
     private fun htmlText(baseDir: String, relativePath: String) =

--- a/jetbrains-rider/src-203+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-203+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -245,7 +245,7 @@ class DotNetSamProjectGenerator(
     private fun initSamPanel() {
         val availableRuntime = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime()
         val runtime = LambdaRuntime.fromValue(availableRuntime)
-            ?: throw IllegalStateException("DotNetRuntimeUtils.getCurrentDotNetCoreRuntime() returned invalid runtime ${availableRuntime}")
+            ?: throw IllegalStateException("DotNetRuntimeUtils.getCurrentDotNetCoreRuntime() returned invalid runtime $availableRuntime")
         samPanel.setRuntime(runtime)
     }
 

--- a/jetbrains-rider/src-203+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-203+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -244,7 +244,9 @@ class DotNetSamProjectGenerator(
 
     private fun initSamPanel() {
         val availableRuntime = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime()
-        samPanel.setRuntime(availableRuntime)
+        val runtime = LambdaRuntime.fromValue(availableRuntime)
+            ?: throw IllegalStateException("DotNetRuntimeUtils.getCurrentDotNetCoreRuntime() returned invalid runtime ${availableRuntime}")
+        samPanel.setRuntime(runtime)
     }
 
     private fun htmlText(baseDir: String, relativePath: String) =

--- a/jetbrains-rider/src-203+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-203+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -26,8 +26,6 @@ import com.jetbrains.rider.ui.themes.RiderTheme
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutableIfPresent
-import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamInitSelectionPanel
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamProjectGenerator
@@ -58,7 +56,11 @@ class DotNetSamProjectGenerator(
     private val generator = SamProjectGenerator()
     private val samPanel = SamInitSelectionPanel(generator.wizardFragments) {
         // Only show templates for DotNet in Rider
-        RuntimeGroup.getById(BuiltInRuntimeGroups.Dotnet).runtimes.contains(it)
+        // Restore this -> RuntimeGroup.getById(BuiltInRuntimeGroups.Dotnet).runtimes.contains(it)
+        // TODO fix this to work properly, the issue is that RuntimeGroup contains the sdk built in Runtime
+        // so, dotnet5 will not show up if we do not do some additional check. Inverting the runtime group so
+        // it pulls from LambdaRuntime will fix this but needs additional testing
+        it.toString().startsWith("dotnet")
     }
 
     private val projectStructurePanel: JTabbedPane

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
@@ -28,5 +28,6 @@ class DotNetRuntimeGroup : SdkBasedRuntimeGroup() {
 
     override fun runtimeForSdk(sdk: Sdk): Runtime? = null
 
-    override fun determineRuntime(project: Project): Runtime? = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime()
+    // TODO fix this
+    override fun determineRuntime(project: Project): Runtime? = Runtime.fromValue(DotNetRuntimeUtils.getCurrentDotNetCoreRuntime())
 }

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
@@ -29,6 +29,5 @@ class DotNetRuntimeGroup : SdkBasedRuntimeGroup() {
 
     override fun runtimeForSdk(sdk: Sdk): Runtime? = null
 
-    // TODO fix this to work for dotnet5
     override fun determineRuntime(project: Project): Runtime? = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime().toSdkRuntime().validOrNull
 }

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
@@ -29,5 +29,5 @@ class DotNetRuntimeGroup : SdkBasedRuntimeGroup() {
 
     override fun runtimeForSdk(sdk: Sdk): Runtime? = null
 
-    override fun determineRuntime(project: Project): Runtime? = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime().toSdkRuntime().validOrNull
+    override fun determineRuntime(project: Project): Runtime? = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime().validOrNull
 }

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.jetbrains.rider.ideaInterop.fileTypes.csharp.CSharpLanguage
 import com.jetbrains.rider.ideaInterop.fileTypes.vb.VbLanguage
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.validOrNull
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeInfo
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
@@ -28,6 +29,6 @@ class DotNetRuntimeGroup : SdkBasedRuntimeGroup() {
 
     override fun runtimeForSdk(sdk: Sdk): Runtime? = null
 
-    // TODO fix this
-    override fun determineRuntime(project: Project): Runtime? = Runtime.fromValue(DotNetRuntimeUtils.getCurrentDotNetCoreRuntime())
+    // TODO fix this to work for dotnet5
+    override fun determineRuntime(project: Project): Runtime? = DotNetRuntimeUtils.getCurrentDotNetCoreRuntime().toSdkRuntime().validOrNull
 }

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectTemplate.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectTemplate.kt
@@ -3,8 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.dotnet
 
-import software.amazon.awssdk.services.lambda.model.PackageType
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamAppTemplateBased
 import software.aws.toolkits.resources.message
 
@@ -17,7 +16,6 @@ class DotNetSamProjectTemplate : SamAppTemplateBased() {
 
     override fun description(): String = message("sam.init.template.hello_world.description")
 
-    override fun supportedRuntimes(): Set<Runtime> = setOf(Runtime.DOTNETCORE2_1, Runtime.DOTNETCORE3_1)
-
-    override fun supportedPackagingTypes(): Set<PackageType> = setOf(PackageType.IMAGE, PackageType.ZIP)
+    override fun supportedZipRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.DOTNETCORE2_1, LambdaRuntime.DOTNETCORE3_1)
+    override fun supportedImageRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.DOTNETCORE2_1, LambdaRuntime.DOTNETCORE3_1, LambdaRuntime.DOTNET5_0)
 }

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
@@ -4,9 +4,9 @@
 package software.aws.toolkits.jetbrains.utils
 
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.validOrNull
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
-import software.aws.toolkits.jetbrains.services.lambda.validOrNull
 import java.io.IOException
 
 object DotNetRuntimeUtils {

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
@@ -3,24 +3,25 @@
 
 package software.aws.toolkits.jetbrains.utils
 
-import software.aws.toolkits.core.lambda.LambdaRuntime
+import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
+import software.aws.toolkits.jetbrains.services.lambda.validOrNull
 import java.io.IOException
 
 object DotNetRuntimeUtils {
 
     private val logger = getLogger<DotNetRuntimeUtils>()
 
-    val defaultDotNetCoreRuntime = LambdaRuntime.DOTNETCORE2_1
+    val defaultDotNetCoreRuntime: Runtime = Runtime.DOTNETCORE2_1
 
     /**
      * Get information about current .NET runtime
      *
-     * @return the [software.aws.toolkits.core.lambda.LambdaRuntime] instance of current available runtime or
+     * @return the [software.amazon.awssdk.services.lambda.model.Runtime] instance of current available runtime or
      *         defaultDotnetCoreRuntime value if not defined.
      */
-    fun getCurrentDotNetCoreRuntime(): LambdaRuntime {
+    fun getCurrentDotNetCoreRuntime(): Runtime {
         val runtimeList = try {
             java.lang.Runtime.getRuntime().exec("dotnet --list-runtimes").inputStream.bufferedReader().readLines()
         } catch (e: IOException) {
@@ -39,7 +40,8 @@ object DotNetRuntimeUtils {
 
         val version = versions.maxBy { it } ?: return defaultDotNetCoreRuntime
 
-        return LambdaRuntime.fromValue("dotnetcore${version.split('.').take(2).joinToString(".")}") ?: defaultDotNetCoreRuntime
+        return Runtime.fromValue("dotnetcore${version.split('.').take(2).joinToString(".")}").validOrNull
+            ?: defaultDotNetCoreRuntime
     }
 
     const val RUNTIME_CONFIG_JSON_21 =

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetRuntimeUtils.kt
@@ -3,25 +3,24 @@
 
 package software.aws.toolkits.jetbrains.utils
 
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
-import software.aws.toolkits.jetbrains.services.lambda.validOrNull
 import java.io.IOException
 
 object DotNetRuntimeUtils {
 
     private val logger = getLogger<DotNetRuntimeUtils>()
 
-    val defaultDotNetCoreRuntime: Runtime = Runtime.DOTNETCORE2_1
+    val defaultDotNetCoreRuntime = LambdaRuntime.DOTNETCORE2_1
 
     /**
      * Get information about current .NET runtime
      *
-     * @return the [software.amazon.awssdk.services.lambda.model.Runtime] instance of current available runtime or
+     * @return the [software.aws.toolkits.core.lambda.LambdaRuntime] instance of current available runtime or
      *         defaultDotnetCoreRuntime value if not defined.
      */
-    fun getCurrentDotNetCoreRuntime(): Runtime {
+    fun getCurrentDotNetCoreRuntime(): LambdaRuntime {
         val runtimeList = try {
             java.lang.Runtime.getRuntime().exec("dotnet --list-runtimes").inputStream.bufferedReader().readLines()
         } catch (e: IOException) {
@@ -40,8 +39,7 @@ object DotNetRuntimeUtils {
 
         val version = versions.maxBy { it } ?: return defaultDotNetCoreRuntime
 
-        return Runtime.fromValue("dotnetcore${version.split('.').take(2).joinToString(".")}").validOrNull
-            ?: defaultDotNetCoreRuntime
+        return LambdaRuntime.fromValue("dotnetcore${version.split('.').take(2).joinToString(".")}") ?: defaultDotNetCoreRuntime
     }
 
     const val RUNTIME_CONFIG_JSON_21 =

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamProjectWizard.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamProjectWizard.kt
@@ -12,8 +12,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
-import software.amazon.awssdk.services.lambda.model.PackageType
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamAppTemplateBased
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamProjectTemplate
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamProjectWizard
@@ -60,9 +59,9 @@ class SamHelloWorldNodeJs : SamAppTemplateBased() {
 
     override fun description() = message("sam.init.template.hello_world.description")
 
-    override fun supportedRuntimes(): Set<Runtime> = setOf(Runtime.NODEJS10_X, Runtime.NODEJS12_X)
+    override fun supportedZipRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.NODEJS10_X, LambdaRuntime.NODEJS12_X)
 
-    override fun supportedPackagingTypes(): Set<PackageType> = setOf(PackageType.IMAGE, PackageType.ZIP)
+    override fun supportedImageRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.NODEJS10_X, LambdaRuntime.NODEJS12_X)
 
     override val appTemplateName: String = "hello-world"
 


### PR DESCRIPTION
- Create our own LambdaRuntime. In the future this can be expanded as needed
- Plumb LambdaRuntime through the project wizard and as little of the rest of the code as possible
- Split supportedRuntimes/supportedPackagingTypes into supportedZipRuntimes and supportedImageRuntimes

Out of scope:
- On top of this PR we need a way to gate creation to different sam versions (leveraging LambdaRuntime)
- We should move all of our code to use our own LambdaRuntime instead of the sdk Runtime
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
