### PR TITLE
Add dotnet5 debugging

### DIFF
--- a/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetLocalLambdaRunConfigurationIntegrationTest.kt
@@ -23,6 +23,8 @@ class Dotnet21LocalLambdaImageRunConfigurationIntegrationTest :
     DotnetLocalLambdaImageRunConfigurationIntegrationTestBase("ImageLambda2X", Runtime.DOTNETCORE2_1)
 // TODO: Fix test not running on CodeBuild
 // class Dotnet31LocalLambdaRunConfigurationIntegrationTest : DotnetLocalLambdaRunConfigurationIntegrationTestBase("EchoLambda3X", Runtime.DOTNETCORE3_1)
+// class Dotnet31LocalLambdaImageRunConfigurationIntegrationTest : DotnetLocalLambdaRunConfigurationIntegrationTestBase("ImageLambda3X", Runtime.DOTNETCORE3_1)
+// class Dotnet50LocalLambdaImageRunConfigurationIntegrationTest : DotnetLocalLambdaRunConfigurationIntegrationTestBase("ImageLambda3X", Runtime.DOTNETCORE5_0)
 
 abstract class DotnetLocalLambdaRunConfigurationIntegrationTestBase(private val solutionName: String, private val runtime: Runtime) :
     AwsReuseSolutionTestBase() {

--- a/jetbrains-rider/resources/META-INF/ext-rider.xml
+++ b/jetbrains-rider/resources/META-INF/ext-rider.xml
@@ -31,6 +31,7 @@
         <sam.runtimeDebugSupport id="DOTNET" implementationClass="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetRuntimeDebugSupport"/>
         <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.Dotnet21ImageDebug"/>
         <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.Dotnet31ImageDebug"/>
+        <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.dotnet.Dotnet50ImageDebug"/>
         <sam.projectWizard id="DOTNET" implementationClass="software.aws.toolkits.jetbrains.services.lambda.dotnet.DotNetSamProjectWizard"/>
     </extensions>
 

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetImageDebugSupport.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetImageDebugSupport.kt
@@ -54,3 +54,9 @@ class Dotnet31ImageDebug : DotnetImageDebugSupport() {
     override val id: String = Runtime.DOTNETCORE3_1.toString()
     override fun displayName() = Runtime.DOTNETCORE3_1.toString().capitalize()
 }
+
+class Dotnet50ImageDebug : DotnetImageDebugSupport() {
+    // TODO pull the const from LambdaRuntime when the wizard PR merges
+    override val id: String = "dotnet5.0"
+    override fun displayName() = "dotnet5.0".capitalize()
+}

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetImageDebugSupport.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetImageDebugSupport.kt
@@ -7,7 +7,7 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.xdebugger.XDebugProcessStarter
 import com.jetbrains.rider.ideaInterop.fileTypes.csharp.CSharpLanguage
 import org.jetbrains.concurrency.Promise
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.core.utils.buildList
 import software.aws.toolkits.jetbrains.services.lambda.execution.sam.ImageDebugSupport
 import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunningState
@@ -46,17 +46,16 @@ abstract class DotnetImageDebugSupport : ImageDebugSupport {
 }
 
 class Dotnet21ImageDebug : DotnetImageDebugSupport() {
-    override val id: String = Runtime.DOTNETCORE2_1.toString()
-    override fun displayName() = Runtime.DOTNETCORE2_1.toString().capitalize()
+    override val id: String = LambdaRuntime.DOTNETCORE2_1.toString()
+    override fun displayName() = LambdaRuntime.DOTNETCORE2_1.toString().capitalize()
 }
 
 class Dotnet31ImageDebug : DotnetImageDebugSupport() {
-    override val id: String = Runtime.DOTNETCORE3_1.toString()
-    override fun displayName() = Runtime.DOTNETCORE3_1.toString().capitalize()
+    override val id: String = LambdaRuntime.DOTNETCORE3_1.toString()
+    override fun displayName() = LambdaRuntime.DOTNETCORE3_1.toString().capitalize()
 }
 
 class Dotnet50ImageDebug : DotnetImageDebugSupport() {
-    // TODO pull the const from LambdaRuntime when the wizard PR merges
-    override val id: String = "dotnet5.0"
-    override fun displayName() = "dotnet5.0".capitalize()
+    override val id: String = LambdaRuntime.DOTNET5_0.toString()
+    override fun displayName() = LambdaRuntime.DOTNET5_0.toString().capitalize()
 }

--- a/jetbrains-rider/testData/solutions/ImageLambda5X/ImageLambda.sln
+++ b/jetbrains-rider/testData/solutions/ImageLambda5X/ImageLambda.sln
@@ -1,0 +1,11 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageLambda", "src\HelloWorld\HelloWorld.csproj", "{CE37B7BD-6345-439A-9D36-C85C9697CCA7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{26111B38-0CBD-4F3C-9598-275DE0F6E99C}"
+ProjectSection(SolutionItems) = preProject
+	template.yaml = template.yaml
+EndProjectSection
+EndProject
+EndProjectSection
+Global
+EndGlobal

--- a/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/Dockerfile
+++ b/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build-image
+
+ARG FUNCTION_DIR="/build"
+ARG SAM_BUILD_MODE="run"
+ENV PATH="/root/.dotnet/tools:${PATH}"
+
+RUN apt-get update && apt-get -y install zip
+
+RUN mkdir $FUNCTION_DIR
+WORKDIR $FUNCTION_DIR
+COPY Function.cs HelloWorld.csproj aws-lambda-tools-defaults.json $FUNCTION_DIR/
+RUN dotnet tool install -g Amazon.Lambda.Tools
+
+# Build and Copy artifacts depending on build mode.
+RUN mkdir -p build_artifacts
+RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then dotnet lambda package --configuration Debug; else dotnet lambda package --configuration Release; fi
+RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net5.0/publish/* /build/build_artifacts; else cp -r /build/bin/Release/net5.0/publish/* /build/build_artifacts; fi
+
+FROM public.ecr.aws/lambda/dotnet:5.0
+
+COPY --from=build-image /build/build_artifacts/ /var/task/
+CMD ["HelloWorld::HelloWorld.Function::FunctionHandler"]

--- a/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/Function.cs
+++ b/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/Function.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using Newtonsoft.Json;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace HelloWorld
+{
+
+    public class Function
+    {
+
+        private static readonly HttpClient client = new HttpClient();
+
+        private static async Task<string> GetCallingIP()
+        {
+            client.DefaultRequestHeaders.Accept.Clear();
+            client.DefaultRequestHeaders.Add("User-Agent", "AWS Lambda .Net Client");
+
+            var msg = await client.GetStringAsync("http://checkip.amazonaws.com/").ConfigureAwait(continueOnCapturedContext:false);
+
+            return msg.Replace("\n","");
+        }
+
+        public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+
+            var location = await GetCallingIP();
+            var body = new Dictionary<string, string>
+            {
+                { "message", "hello world" },
+                { "location", location }
+            };
+
+            return new APIGatewayProxyResponse
+            {
+                Body = JsonConvert.SerializeObject(body),
+                StatusCode = 200,
+                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
+            };
+        }
+    }
+}

--- a/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/HelloWorld.csproj
+++ b/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/HelloWorld.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+  </ItemGroup>
+  
+</Project>
+

--- a/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -1,0 +1,14 @@
+{
+    "Information": [
+        "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+        "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+        "dotnet lambda help",
+        "All the command line options for the Lambda command can be specified in this file."
+    ],
+    "profile": "",
+    "region": "",
+    "configuration": "Release",
+    "function-memory-size": 256,
+    "function-timeout": 30,
+    "function-handler": "HelloWorld::HelloWorld.Function::FunctionHandler"
+}

--- a/jetbrains-rider/testData/solutions/ImageLambda5X/template.yaml
+++ b/jetbrains-rider/testData/solutions/ImageLambda5X/template.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      Timeout: 900
+    Metadata:
+      DockerTag: dotnet5.0-v1
+      DockerContext: ./src/HelloWorld
+      Dockerfile: Dockerfile


### PR DESCRIPTION
- Add dotnet5 debugging, tested and worked fine in 2020.1
- Add test data for integration tests, but we will need to fix them on codebuild per the existing comment, so that should be a different PR

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
