### PR TITLE
Fix and Improve the SAM init wizard

### DIFF
--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -5,11 +5,16 @@ package software.aws.toolkits.core.lambda
 
 import software.amazon.awssdk.services.lambda.model.Runtime
 
-enum class LambdaRuntime(private val runtime: Runtime?, private val runtimeOverride: String? = null) {
+enum class LambdaRuntime(
+    private val runtime: Runtime?,
+    val minSamInit: String? = null,
+    val minSamDebugging: String? = null,
+    private val runtimeOverride: String? = null
+) {
     NODEJS10_X(Runtime.NODEJS10_X),
     NODEJS12_X(Runtime.NODEJS12_X),
     JAVA8(Runtime.JAVA8),
-    JAVA8_AL2(Runtime.JAVA8_AL2),
+    JAVA8_AL2(Runtime.JAVA8_AL2, minSamDebugging = "1.2.0"),
     JAVA11(Runtime.JAVA11),
     PYTHON2_7(Runtime.PYTHON2_7),
     PYTHON3_6(Runtime.PYTHON3_6),
@@ -17,7 +22,7 @@ enum class LambdaRuntime(private val runtime: Runtime?, private val runtimeOverr
     PYTHON3_8(Runtime.PYTHON3_8),
     DOTNETCORE2_1(Runtime.DOTNETCORE2_1),
     DOTNETCORE3_1(Runtime.DOTNETCORE3_1),
-    DOTNET5_0(null, "dotnet5.0");
+    DOTNET5_0(null, minSamInit = "1.16.0", minSamDebugging = "1.13.0", runtimeOverride = "dotnet5.0");
 
     override fun toString() = runtime?.toString() ?: runtimeOverride ?: throw IllegalStateException("LambdaRuntime has no runtime or override string")
 

--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -22,7 +22,7 @@ enum class LambdaRuntime(
     PYTHON3_8(Runtime.PYTHON3_8),
     DOTNETCORE2_1(Runtime.DOTNETCORE2_1),
     DOTNETCORE3_1(Runtime.DOTNETCORE3_1),
-    DOTNET5_0(null, minSamInit = "1.16.0", minSamDebugging = "1.13.0", runtimeOverride = "dotnet5.0");
+    DOTNET5_0(null, minSamInit = "1.16.0", runtimeOverride = "dotnet5.0");
 
     override fun toString() = runtime?.toString() ?: runtimeOverride ?: throw IllegalStateException("LambdaRuntime has no runtime or override string")
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaUtils.kt
@@ -1,0 +1,14 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda
+
+import com.intellij.util.text.SemVer
+import software.aws.toolkits.core.lambda.LambdaRuntime
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
+
+fun LambdaRuntime.minSamDebuggingVersion(): SemVer =
+    minSamDebugging?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("TODO enter message about why this is bad") } ?: SamExecutable.minVersion
+
+fun LambdaRuntime.minSamInitVersion(): SemVer =
+    minSamInit?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("TODO enter message about why this is bad") } ?: SamExecutable.minVersion

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaUtils.kt
@@ -8,7 +8,7 @@ import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 
 fun LambdaRuntime.minSamDebuggingVersion(): SemVer =
-    minSamDebugging?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("TODO enter message about why this is bad") } ?: SamExecutable.minVersion
+    minSamDebugging?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("$this has bad minSamDebuggingVersion! It should be a semver string!") } ?: SamExecutable.minVersion
 
 fun LambdaRuntime.minSamInitVersion(): SemVer =
-    minSamInit?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("TODO enter message about why this is bad") } ?: SamExecutable.minVersion
+    minSamInit?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("$this has bad minSamInitVersion! It should be a semver string!") } ?: SamExecutable.minVersion

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaUtils.kt
@@ -8,7 +8,9 @@ import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 
 fun LambdaRuntime.minSamDebuggingVersion(): SemVer =
-    minSamDebugging?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("$this has bad minSamDebuggingVersion! It should be a semver string!") } ?: SamExecutable.minVersion
+    minSamDebugging?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("$this has bad minSamDebuggingVersion! It should be a semver string!") }
+        ?: SamExecutable.minVersion
 
 fun LambdaRuntime.minSamInitVersion(): SemVer =
-    minSamInit?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("$this has bad minSamInitVersion! It should be a semver string!") } ?: SamExecutable.minVersion
+    minSamInit?.let { SemVer.parseFromText(it) ?: throw IllegalStateException("$this has bad minSamInitVersion! It should be a semver string!") }
+        ?: SamExecutable.minVersion

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
@@ -55,7 +55,7 @@ abstract class RuntimeGroup {
 
     open fun supportsSamBuild(): Boolean = true
 
-    // This only works with Zip and is only called on that path since image is based on what we support
+    // This only works with Zip and is only called on that path since image is based on what debugger EPs we have
     fun validateSamVersionForZipDebugging(runtime: Runtime, samVersion: SemVer) {
         val minVersion = supportedRuntimes.first { it.toSdkRuntime() == runtime }.minSamDebuggingVersion()
         if (samVersion < minVersion) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroup.kt
@@ -18,8 +18,8 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.KeyedExtensionCollector
 import com.intellij.util.text.SemVer
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.core.IdBasedExtensionPoint
-import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.resources.message
 
 /**
@@ -32,8 +32,6 @@ object BuiltInRuntimeGroups {
     const val NodeJs = "NODEJS"
 }
 
-data class RuntimeInfo(val runtime: Runtime, val minimumVersion: SemVer = SamExecutable.minVersion)
-
 /**
  * Grouping of Lambda [Runtime] by parent language.
  *
@@ -44,11 +42,11 @@ abstract class RuntimeGroup {
     abstract val languageIds: Set<String>
     abstract val supportsPathMappings: Boolean
 
-    val runtimes: List<Runtime> by lazy {
-        supportedRuntimes.map { it.runtime }
+    val supportedSdkRuntimes: List<Runtime> by lazy {
+        supportedRuntimes.mapNotNull { it.toSdkRuntime() }
     }
 
-    protected abstract val supportedRuntimes: List<RuntimeInfo>
+    abstract val supportedRuntimes: List<LambdaRuntime>
 
     open fun determineRuntime(project: Project): Runtime? = null
     open fun determineRuntime(module: Module): Runtime? = null
@@ -57,8 +55,9 @@ abstract class RuntimeGroup {
 
     open fun supportsSamBuild(): Boolean = true
 
-    fun validateSamVersion(runtime: Runtime, samVersion: SemVer) {
-        val minVersion = supportedRuntimes.first { it.runtime == runtime }.minimumVersion
+    // This only works with Zip and is only called on that path since image is based on what we support
+    fun validateSamVersionForZipDebugging(runtime: Runtime, samVersion: SemVer) {
+        val minVersion = supportedRuntimes.first { it.toSdkRuntime() == runtime }.minSamDebuggingVersion()
         if (samVersion < minVersion) {
             throw RuntimeException(message("sam.executable.minimum_too_low_runtime", runtime, minVersion))
         }
@@ -96,7 +95,8 @@ abstract class SdkBasedRuntimeGroup : RuntimeGroup() {
     override fun determineRuntime(module: Module): Runtime? = ModuleRootManager.getInstance(module).sdk?.let { runtimeForSdk(it) }
 }
 
-val Runtime.runtimeGroup: RuntimeGroup? get() = RuntimeGroup.find { this in it.runtimes }
+val Runtime.runtimeGroup: RuntimeGroup? get() = RuntimeGroup.find { this in it.supportedSdkRuntimes }
+val LambdaRuntime.runtimeGroup: RuntimeGroup? get() = RuntimeGroup.find { this in it.supportedRuntimes }
 
 /**
  * For a given [com.intellij.lang.Language] determine the corresponding Lambda [RuntimeGroup]

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
@@ -119,7 +119,7 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
             SemVer.parseFromText(executable.version)?.let { semVer ->
                 // TODO: Executable manager should better expose the VersionScheme of the Executable...
                 try {
-                    runtimeGroup.validateSamVersion(runtime, semVer)
+                    runtimeGroup.validateSamVersionForZipDebugging(runtime, semVer)
                 } catch (e: Exception) {
                     throw RuntimeConfigurationError(e.message)
                 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/RawSettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/RawSettings.kt
@@ -56,7 +56,7 @@ class RawSettings(private val project: Project) {
             lastSelectedRuntime = selectedRuntime
             handlerPanel.setRuntime(selectedRuntime)
         }
-        val supportedRuntimes = LambdaBuilder.supportedRuntimeGroups().flatMap { it.runtimes }.sorted()
+        val supportedRuntimes = LambdaBuilder.supportedRuntimeGroups().flatMap { it.supportedSdkRuntimes }.sorted()
         runtimeModel.setAll(supportedRuntimes)
         runtime.selectedItem = RuntimeGroup.determineRuntime(project)?.let { if (it in supportedRuntimes) it else null }
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaRuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/java/JavaRuntimeGroup.kt
@@ -11,10 +11,9 @@ import com.intellij.openapi.projectRoots.JavaSdkType
 import com.intellij.openapi.projectRoots.JavaSdkVersion
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkType
-import com.intellij.util.text.SemVer
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeInfo
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
 class JavaRuntimeGroup : SdkBasedRuntimeGroup() {
@@ -22,10 +21,10 @@ class JavaRuntimeGroup : SdkBasedRuntimeGroup() {
     override val languageIds = setOf(JavaLanguage.INSTANCE.id)
     override val supportsPathMappings: Boolean = false
 
-    override val supportedRuntimes: List<RuntimeInfo> = listOf(
-        RuntimeInfo(Runtime.JAVA8),
-        RuntimeInfo(Runtime.JAVA8_AL2, SemVer("1.2.0", 1, 2, 0)),
-        RuntimeInfo(Runtime.JAVA11)
+    override val supportedRuntimes: List<LambdaRuntime> = listOf(
+        LambdaRuntime.JAVA8,
+        LambdaRuntime.JAVA8_AL2,
+        LambdaRuntime.JAVA11
     )
 
     override fun runtimeForSdk(sdk: Sdk): Runtime? {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
@@ -11,8 +11,8 @@ import com.jetbrains.python.PythonModuleTypeBase
 import com.jetbrains.python.psi.LanguageLevel
 import com.jetbrains.python.sdk.PythonSdkType
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeInfo
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
 class PythonRuntimeGroup : SdkBasedRuntimeGroup() {
@@ -21,10 +21,10 @@ class PythonRuntimeGroup : SdkBasedRuntimeGroup() {
     override val supportsPathMappings: Boolean = true
 
     override val supportedRuntimes = listOf(
-        RuntimeInfo(Runtime.PYTHON2_7),
-        RuntimeInfo(Runtime.PYTHON3_6),
-        RuntimeInfo(Runtime.PYTHON3_7),
-        RuntimeInfo(Runtime.PYTHON3_8)
+        LambdaRuntime.PYTHON2_7,
+        LambdaRuntime.PYTHON3_6,
+        LambdaRuntime.PYTHON3_7,
+        LambdaRuntime.PYTHON3_8
     )
 
     override fun runtimeForSdk(sdk: Sdk): Runtime? = when {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionDialog.kt
@@ -51,7 +51,7 @@ class CreateFunctionDialog(private val project: Project, private val initialRunt
             memorySlider.value = DEFAULT_MEMORY_SIZE
 
             // show a filtered list of runtimes to only ones we can build (since we have to build)
-            runtimeModel.setAll(LambdaBuilder.supportedRuntimeGroups().flatMap { it.runtimes })
+            runtimeModel.setAll(LambdaBuilder.supportedRuntimeGroups().flatMap { it.supportedSdkRuntimes })
 
             handlerName?.let { handler ->
                 handlerPanel.handler.text = handler

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
@@ -124,7 +124,7 @@ class SamInitSelectionPanel(
 
         val selectedTemplate = templateComboBox.selectedItem as? SamProjectTemplate
         templateComboBox.removeAllItems()
-        val selectedRuntime = runtimeComboBox.selectedItem as? LambdaRuntime ?: return
+        val selectedRuntime = runtimes.selected ?: return
 
         val packagingType = packageType()
         SamProjectTemplate.supportedTemplates().asSequence()
@@ -147,7 +147,7 @@ class SamInitSelectionPanel(
      * Updates UI fragments in the wizard after a combobox update
      */
     private fun wizardUpdate() {
-        val selectedRuntime = runtimeComboBox.selectedItem as? LambdaRuntime
+        val selectedRuntime = runtimes.selected
         val selectedTemplate = templateComboBox.selectedItem as? SamProjectTemplate
         wizardFragments.forEach { (wizardFragment, jComponent) ->
             wizardFragment.updateUi(projectLocation, selectedRuntime?.runtimeGroup, selectedTemplate)
@@ -168,8 +168,7 @@ class SamInitSelectionPanel(
             return ValidationInfo(message("lambda.image.sam_version_too_low", samVersion, SamCommon.minImageVersion))
         }
 
-        val selectedRuntime = runtimeComboBox.selectedItem as? LambdaRuntime
-            ?: return templateComboBox.validationInfo(message("sam.init.error.no.runtime.selected"))
+        val selectedRuntime = runtimes.selected ?: return templateComboBox.validationInfo(message("sam.init.error.no.runtime.selected"))
 
         val minSamVersion = selectedRuntime.minSamInitVersion()
         if (samVersion < minSamVersion) {
@@ -186,7 +185,7 @@ class SamInitSelectionPanel(
     }
 
     fun getNewProjectSettings(): SamNewProjectSettings {
-        val lambdaRuntime = runtimeComboBox.selectedItem as? LambdaRuntime
+        val lambdaRuntime = runtimes.selected
             ?: throw RuntimeException("No Runtime is supported in this Platform.")
         val samProjectTemplate = templateComboBox.selectedItem as? SamProjectTemplate
             ?: throw RuntimeException("No SAM template is supported for this runtime: $lambdaRuntime")

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamProjectGenerator.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamProjectGenerator.kt
@@ -79,7 +79,7 @@ class SamProjectGenerator :
     // these overrides will give us a section for non-IntelliJ IDEs
     override fun getName() = message("sam.init.name")
 
-    override fun getDescription(): String? = message("sam.init.description")
+    override fun getDescription(): String = message("sam.init.description")
 
     override fun getLogo(): Icon = AwsIcons.Resources.SERVERLESS_APP
 
@@ -90,7 +90,7 @@ class SamProjectGenerator :
     // validation is done in the peer
     override fun validateSettings(): ValidationInfo? = null
 
-    override fun getHelpId(): String? = HelpIds.NEW_SERVERLESS_PROJECT_DIALOG.id
+    override fun getHelpId(): String = HelpIds.NEW_SERVERLESS_PROJECT_DIALOG.id
 }
 
 /**

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionDialogTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/upload/CreateFunctionDialogTest.kt
@@ -21,6 +21,6 @@ class CreateFunctionDialogTest {
             CreateFunctionDialog(project = projectRule.project, initialRuntime = null, handlerName = null)
         }
         assertThat(dialog.getViewForTestAssertions().configSettings.runtimeModel.items)
-            .containsExactlyInAnyOrderElementsOf(LambdaBuilder.supportedRuntimeGroups().flatMap { it.runtimes })
+            .containsExactlyInAnyOrderElementsOf(LambdaBuilder.supportedRuntimeGroups().flatMap { it.supportedSdkRuntimes })
     }
 }

--- a/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-201-202/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -27,6 +27,8 @@ import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutableIfPresent
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
+import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamInitSelectionPanel
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamProjectGenerator
@@ -57,11 +59,7 @@ class DotNetSamProjectGenerator(
     private val generator = SamProjectGenerator()
     private val samPanel = SamInitSelectionPanel(generator.wizardFragments) {
         // Only show templates for DotNet in Rider
-        // Restore this -> RuntimeGroup.getById(BuiltInRuntimeGroups.Dotnet).runtimes.contains(it)
-        // TODO fix this to work properly (and the 203 version), the issue is that RuntimeGroup contains the sdk
-        // built in Runtime so, dotnet5 will not show up if we do not do some additional check. Inverting the
-        // runtime group so it pulls from LambdaRuntime will fix this but needs additional testing/changes
-        it.toString().startsWith("dotnet")
+        RuntimeGroup.getById(BuiltInRuntimeGroups.Dotnet).supportedRuntimes.contains(it)
     }
 
     private val projectStructurePanel: JTabbedPane

--- a/jetbrains-rider/src-203+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-203+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -26,6 +26,8 @@ import com.jetbrains.rider.ui.themes.RiderTheme
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.getExecutableIfPresent
+import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
+import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamInitSelectionPanel
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamProjectGenerator
@@ -55,12 +57,7 @@ class DotNetSamProjectGenerator(
     // TODO: Decouple SamProjectGenerator from the framework wizards so we can re-use its panels
     private val generator = SamProjectGenerator()
     private val samPanel = SamInitSelectionPanel(generator.wizardFragments) {
-        // Only show templates for DotNet in Rider
-        // Restore this -> RuntimeGroup.getById(BuiltInRuntimeGroups.Dotnet).runtimes.contains(it)
-        // TODO fix this to work properly, the issue is that RuntimeGroup contains the sdk built in Runtime
-        // so, dotnet5 will not show up if we do not do some additional check. Inverting the runtime group so
-        // it pulls from LambdaRuntime will fix this but needs additional testing
-        it.toString().startsWith("dotnet")
+        RuntimeGroup.getById(BuiltInRuntimeGroups.Dotnet).supportedRuntimes.contains(it)
     }
 
     private val projectStructurePanel: JTabbedPane

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt
@@ -8,9 +8,9 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.jetbrains.rider.ideaInterop.fileTypes.csharp.CSharpLanguage
 import com.jetbrains.rider.ideaInterop.fileTypes.vb.VbLanguage
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.core.lambda.validOrNull
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeInfo
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 import software.aws.toolkits.jetbrains.utils.DotNetRuntimeUtils
 
@@ -22,9 +22,10 @@ class DotNetRuntimeGroup : SdkBasedRuntimeGroup() {
         CSharpLanguage.id,
         VbLanguage.id
     )
-    override val supportedRuntimes: List<RuntimeInfo> = listOf(
-        RuntimeInfo(Runtime.DOTNETCORE2_1),
-        RuntimeInfo(Runtime.DOTNETCORE3_1)
+    override val supportedRuntimes = listOf(
+        LambdaRuntime.DOTNETCORE2_1,
+        LambdaRuntime.DOTNETCORE3_1,
+        LambdaRuntime.DOTNET5_0
     )
 
     override fun runtimeForSdk(sdk: Sdk): Runtime? = null

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
@@ -12,8 +12,8 @@ import com.intellij.openapi.module.WebModuleTypeBase
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeInfo
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
 class NodeJsRuntimeGroup : SdkBasedRuntimeGroup() {
@@ -25,8 +25,8 @@ class NodeJsRuntimeGroup : SdkBasedRuntimeGroup() {
     override val supportsPathMappings: Boolean = true
 
     override val supportedRuntimes = listOf(
-        RuntimeInfo(Runtime.NODEJS10_X),
-        RuntimeInfo(Runtime.NODEJS12_X)
+        LambdaRuntime.NODEJS10_X,
+        LambdaRuntime.NODEJS12_X
     )
 
     override fun determineRuntime(module: Module): Runtime? = determineRuntime(module.project)


### PR DESCRIPTION
- The last PR broke the wizard because validation will always fail since `as? Runtime` no longer works (I missed this because Rider does no validation :( )
- add `minSamInit` and `minSamDebugging` to LambdaRuntime. They can't be `SemVer` since that comes from the intellij sdk and they are in core, so there are extension functions for that
  - With this, make `RuntimeGroup` based off of `LambdaRuntime` which allows us to remove hacks in the wizard for dotnet

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
