### PR TITLE
Emit a credential change event when a profile's source has been modified

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
@@ -881,18 +881,80 @@ class ProfileCredentialProviderFactoryTest {
     }
 
     @Test
+    fun testModifyingSourceProfileOrder() {
+        profileFile.writeToFile(
+            """
+            [profile role]
+            role_arn=arn1
+            source_profile=source_profile
+
+            [profile source_profile]
+            aws_access_key_id=BarAccessKey
+            aws_secret_access_key=BarSecretKey
+            """.trimIndent()
+        )
+
+        mockSdkHttpClient.stub {
+            on { prepareRequest(any()) }
+                .thenReturn(
+                    createAssumeRoleResponse(
+                        "AccessKey",
+                        "SecretKey",
+                        "SessionToken",
+                        ZonedDateTime.now().plus(1, ChronoUnit.HOURS)
+                    )
+                )
+        }
+
+        val providerFactory = createProviderFactory()
+        val roleProfile = findCredentialIdentifier("role")
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        profileFile.writeToFile(
+            """
+            [profile source_profile]
+            aws_access_key_id=BarAccessKey2
+            aws_secret_access_key=BarSecretKey2
+
+            [profile role]
+            role_arn=arn1
+            source_profile=source_profile
+            """.trimIndent()
+        )
+
+        mockProfileWatcher.triggerListeners()
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        argumentCaptor<CredentialsChangeEvent>().apply {
+            verify(profileLoadCallback, times(2)).invoke(capture())
+
+            assertThat(firstValue.added).hasSize(2).has(profileName("role")).has(profileName("source_profile"))
+            assertThat(firstValue.modified).isEmpty()
+            assertThat(firstValue.removed).isEmpty()
+
+            assertThat(secondValue.added).isEmpty()
+            assertThat(secondValue.modified).hasSize(2).has(profileName("role")).has(profileName("source_profile"))
+            assertThat(secondValue.removed).isEmpty()
+        }
+
+        verify(mockSdkHttpClient, times(2)).prepareRequest(any())
+    }
+
+    @Test
     fun testModifyingAnIntermediateSourceProfile() {
         profileFile.writeToFile(
             """
             [profile leaf_role]
             role_arn=arn2
-            source_profile=middle_role
+            source_profile=intermediate_role
 
-            [profile middle_role]
+            [profile intermediate_role]
             role_arn=arn1
-            source_profile=source_profile
+            source_profile=root_role
 
-            [profile source_profile]
+            [profile root_role]
             aws_access_key_id=BarAccessKey
             aws_secret_access_key=BarSecretKey
             """.trimIndent()
@@ -919,13 +981,13 @@ class ProfileCredentialProviderFactoryTest {
             """
             [profile leaf_role]
             role_arn=arn2
-            source_profile=middle_role
+            source_profile=intermediate_role
 
-            [profile middle_role]
+            [profile intermediate_role]
             role_arn=a_different_arn
-            source_profile=source_profile
+            source_profile=root_role
 
-            [profile source_profile]
+            [profile root_role]
             aws_access_key_id=BarAccessKey
             aws_secret_access_key=BarSecretKey
             """.trimIndent()
@@ -938,12 +1000,87 @@ class ProfileCredentialProviderFactoryTest {
         argumentCaptor<CredentialsChangeEvent>().apply {
             verify(profileLoadCallback, times(2)).invoke(capture())
 
-            assertThat(firstValue.added).hasSize(3).has(profileName("leaf_role")).has(profileName("middle_role")).has(profileName("source_profile"))
+            assertThat(firstValue.added).hasSize(3).has(profileName("leaf_role")).has(profileName("intermediate_role")).has(profileName("root_role"))
             assertThat(firstValue.modified).isEmpty()
             assertThat(firstValue.removed).isEmpty()
 
             assertThat(secondValue.added).isEmpty()
-            assertThat(secondValue.modified).hasSize(2).has(profileName("middle_role")).has(profileName("leaf_role"))
+            assertThat(secondValue.modified).hasSize(2).has(profileName("leaf_role")).has(profileName("intermediate_role"))
+            assertThat(secondValue.removed).isEmpty()
+        }
+
+        // 1: assume middle_role using source_profile
+        // 2: assume leaf_role using middle_role
+        // trigger revalidation
+        // 3: assume middle_role using source_profile
+        // 4: assume leaf_role using middle_role
+        verify(mockSdkHttpClient, times(4)).prepareRequest(any())
+    }
+
+    @Test
+    fun testModifyingRootSourceProfile() {
+        profileFile.writeToFile(
+            """
+            [profile leaf_role]
+            role_arn=arn2
+            source_profile=intermediate_role
+
+            [profile intermediate_role]
+            role_arn=arn1
+            source_profile=root_role
+
+            [profile root_role]
+            aws_access_key_id=BarAccessKey
+            aws_secret_access_key=BarSecretKey
+            """.trimIndent()
+        )
+
+        mockSdkHttpClient.stub {
+            on { prepareRequest(any()) }
+                .thenReturn(
+                    createAssumeRoleResponse(
+                        "AccessKey",
+                        "SecretKey",
+                        "SessionToken",
+                        ZonedDateTime.now().plus(1, ChronoUnit.HOURS)
+                    )
+                )
+        }
+
+        val providerFactory = createProviderFactory()
+        val roleProfile = findCredentialIdentifier("leaf_role")
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        profileFile.writeToFile(
+            """
+            [profile leaf_role]
+            role_arn=arn2
+            source_profile=intermediate_role
+
+            [profile intermediate_role]
+            role_arn=arn1
+            source_profile=root_role
+
+            [profile root_role]
+            aws_access_key_id=BarAccessKey2
+            aws_secret_access_key=BarSecretKey2
+            """.trimIndent()
+        )
+
+        mockProfileWatcher.triggerListeners()
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        argumentCaptor<CredentialsChangeEvent>().apply {
+            verify(profileLoadCallback, times(2)).invoke(capture())
+
+            assertThat(firstValue.added).hasSize(3).has(profileName("leaf_role")).has(profileName("intermediate_role")).has(profileName("root_role"))
+            assertThat(firstValue.modified).isEmpty()
+            assertThat(firstValue.removed).isEmpty()
+
+            assertThat(secondValue.added).isEmpty()
+            assertThat(secondValue.modified).hasSize(3).has(profileName("leaf_role")).has(profileName("intermediate_role")).has(profileName("root_role"))
             assertThat(secondValue.removed).isEmpty()
         }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileCredentialProviderFactoryTest.kt
@@ -818,6 +818,217 @@ class ProfileCredentialProviderFactoryTest {
         assertThat(runBlocking { (findCredentialIdentifier("chain") as InteractiveCredential).userActionRequired() }).isFalse()
     }
 
+    @Test
+    fun testModifyingASourceProfile() {
+        profileFile.writeToFile(
+            """
+            [profile role]
+            role_arn=arn1
+            source_profile=source_profile
+
+            [profile source_profile]
+            aws_access_key_id=BarAccessKey
+            aws_secret_access_key=BarSecretKey
+            """.trimIndent()
+        )
+
+        mockSdkHttpClient.stub {
+            on { prepareRequest(any()) }
+                .thenReturn(
+                    createAssumeRoleResponse(
+                        "AccessKey",
+                        "SecretKey",
+                        "SessionToken",
+                        ZonedDateTime.now().plus(1, ChronoUnit.HOURS)
+                    )
+                )
+        }
+
+        val providerFactory = createProviderFactory()
+        val roleProfile = findCredentialIdentifier("role")
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        profileFile.writeToFile(
+            """
+            [profile role]
+            role_arn=arn1
+            source_profile=source_profile
+
+            [profile source_profile]
+            aws_access_key_id=BarAccessKey2
+            aws_secret_access_key=BarSecretKey2
+            """.trimIndent()
+        )
+
+        mockProfileWatcher.triggerListeners()
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        argumentCaptor<CredentialsChangeEvent>().apply {
+            verify(profileLoadCallback, times(2)).invoke(capture())
+
+            assertThat(firstValue.added).hasSize(2).has(profileName("role")).has(profileName("source_profile"))
+            assertThat(firstValue.modified).isEmpty()
+            assertThat(firstValue.removed).isEmpty()
+
+            assertThat(secondValue.added).isEmpty()
+            assertThat(secondValue.modified).hasSize(2).has(profileName("role")).has(profileName("source_profile"))
+            assertThat(secondValue.removed).isEmpty()
+        }
+
+        verify(mockSdkHttpClient, times(2)).prepareRequest(any())
+    }
+
+    @Test
+    fun testModifyingAnIntermediateSourceProfile() {
+        profileFile.writeToFile(
+            """
+            [profile leaf_role]
+            role_arn=arn2
+            source_profile=middle_role
+
+            [profile middle_role]
+            role_arn=arn1
+            source_profile=source_profile
+
+            [profile source_profile]
+            aws_access_key_id=BarAccessKey
+            aws_secret_access_key=BarSecretKey
+            """.trimIndent()
+        )
+
+        mockSdkHttpClient.stub {
+            on { prepareRequest(any()) }
+                .thenReturn(
+                    createAssumeRoleResponse(
+                        "AccessKey",
+                        "SecretKey",
+                        "SessionToken",
+                        ZonedDateTime.now().plus(1, ChronoUnit.HOURS)
+                    )
+                )
+        }
+
+        val providerFactory = createProviderFactory()
+        val roleProfile = findCredentialIdentifier("leaf_role")
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        profileFile.writeToFile(
+            """
+            [profile leaf_role]
+            role_arn=arn2
+            source_profile=middle_role
+
+            [profile middle_role]
+            role_arn=a_different_arn
+            source_profile=source_profile
+
+            [profile source_profile]
+            aws_access_key_id=BarAccessKey
+            aws_secret_access_key=BarSecretKey
+            """.trimIndent()
+        )
+
+        mockProfileWatcher.triggerListeners()
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        argumentCaptor<CredentialsChangeEvent>().apply {
+            verify(profileLoadCallback, times(2)).invoke(capture())
+
+            assertThat(firstValue.added).hasSize(3).has(profileName("leaf_role")).has(profileName("middle_role")).has(profileName("source_profile"))
+            assertThat(firstValue.modified).isEmpty()
+            assertThat(firstValue.removed).isEmpty()
+
+            assertThat(secondValue.added).isEmpty()
+            assertThat(secondValue.modified).hasSize(2).has(profileName("middle_role")).has(profileName("leaf_role"))
+            assertThat(secondValue.removed).isEmpty()
+        }
+
+        // 1: assume middle_role using source_profile
+        // 2: assume leaf_role using middle_role
+        // trigger revalidation
+        // 3: assume middle_role using source_profile
+        // 4: assume leaf_role using middle_role
+        verify(mockSdkHttpClient, times(4)).prepareRequest(any())
+    }
+
+    @Test
+    fun testModifyingMultipleRolesWithSourceProfile() {
+        profileFile.writeToFile(
+            """
+            [profile role1]
+            role_arn=arn2
+            source_profile=source_profile
+
+            [profile role2]
+            role_arn=arn1
+            source_profile=source_profile
+
+            [profile source_profile]
+            aws_access_key_id=BarAccessKey
+            aws_secret_access_key=BarSecretKey
+            """.trimIndent()
+        )
+
+        mockSdkHttpClient.stub {
+            on { prepareRequest(any()) }
+                .thenReturn(
+                    createAssumeRoleResponse(
+                        "AccessKey",
+                        "SecretKey",
+                        "SessionToken",
+                        ZonedDateTime.now().plus(1, ChronoUnit.HOURS)
+                    )
+                )
+        }
+
+        val providerFactory = createProviderFactory()
+        val roleProfile = findCredentialIdentifier("role1")
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        profileFile.writeToFile(
+            """
+            [profile role1]
+            role_arn=arn2
+            source_profile=role2
+
+            [profile role2]
+            role_arn=a_different_arn
+            source_profile=source_profile
+
+            [profile source_profile]
+            aws_access_key_id=BarAccessKey
+            aws_secret_access_key=BarSecretKey
+            """.trimIndent()
+        )
+
+        mockProfileWatcher.triggerListeners()
+
+        providerFactory.createProvider(roleProfile).resolveCredentials()
+
+        argumentCaptor<CredentialsChangeEvent>().apply {
+            verify(profileLoadCallback, times(2)).invoke(capture())
+
+            assertThat(firstValue.added).hasSize(3).has(profileName("role1")).has(profileName("role2")).has(profileName("source_profile"))
+            assertThat(firstValue.modified).isEmpty()
+            assertThat(firstValue.removed).isEmpty()
+
+            assertThat(secondValue.added).isEmpty()
+            assertThat(secondValue.modified).hasSize(2).has(profileName("role1")).has(profileName("role2"))
+            assertThat(secondValue.removed).isEmpty()
+        }
+
+        // 1: assume role1 using source_profile
+        // trigger revalidation
+        // 2: assume role2 using source_profile
+        // 3: assume role1 using role2
+        verify(mockSdkHttpClient, times(3)).prepareRequest(any())
+    }
+
     private fun File.writeToFile(content: String) {
         WriteCommandAction.runWriteCommandAction(projectRule.project) {
             FileUtil.createIfDoesntExist(this)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Should probably move the diff logic out of `loadProfiles` and be a bit smarter with keeping track of dependencies between profiles, but the naive for-loop only adds on the order of couple ms for a large profile file and SDK calls to STS dominate the clock time for profiles with deep nested chains.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
