### PR TITLE
Fix S3 UI tests

### DIFF
--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/tests/S3BrowserTest.kt
@@ -161,9 +161,6 @@ class S3BrowserTest {
 
             step("Delete a file") {
                 s3Tree {
-                    // Reopen the folder
-                    findText(folder).doubleClick()
-                    waitUntilLoaded()
                     findText(jsonFile2).click()
                 }
                 actionButton(delete).click()


### PR DESCRIPTION
- The recent S3 work inadvertently broke these. We now do not collapse folders on changes to parent folders (which is better behavior)
- On delete it assumed the folder was closed and tried to open it, but now that closes it, so it would fail every time. Sadly we don't have a great way to tell if folders are open or not (maybe we need to investigate this more), so we will probably encounter a scenario like this again.
- Tested on my mac, passed.
- As a side note, the S3 waiter still does not work
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
