### PR TITLE
Remove `docker` from integration tests so that we can update to Codebuild standard 5.0 images

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -15,7 +15,6 @@ phases:
   install:
     runtime-versions:
       java: corretto11
-      docker: 19
       dotnet: 3.1
 
     commands:


### PR DESCRIPTION
- The Codebuild standard Linux image removed the `docker` runtime version, so remove it so we can deploy the infrastructure.
- 5.0 is needed for dotnet5

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
