### PR TITLE
Fix setting debian_frontend for the 5.0 standard image

### DIFF
--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -16,6 +16,8 @@ env:
     SCREEN_HEIGHT: 1080
     SCREEN_DEPTH: 24
 
+    DEBIAN_FRONTEND: noninteractive
+
 phases:
   install:
     runtime-versions:


### PR DESCRIPTION
- This seems to not be set properly on the CodeBuild 5.0 standard image

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
