### PR TITLE
Revert changes to CloudFormationLazyInitRule waiter usage

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CloudFormationLazyInitRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CloudFormationLazyInitRule.kt
@@ -9,8 +9,8 @@ import software.amazon.awssdk.services.cloudformation.model.Capability
 import software.amazon.awssdk.services.cloudformation.model.ChangeSetType
 import software.amazon.awssdk.services.cloudformation.model.CloudFormationException
 import software.amazon.awssdk.services.cloudformation.model.Parameter
-import software.aws.toolkits.core.utils.unwrapResponse
 import software.aws.toolkits.jetbrains.services.cloudformation.executeChangeSetAndWait
+import software.aws.toolkits.jetbrains.services.cloudformation.waitForChangeSetCreateComplete
 import java.util.UUID
 
 class CloudFormationLazyInitRule(
@@ -53,10 +53,7 @@ class CloudFormationLazyInitRule(
 
         // wait for changeset creation to complete
         try {
-            cloudformationClient.waiter().waitUntilChangeSetCreateComplete {
-                it.stackName(stackName)
-                it.changeSetName(changeSetArn)
-            }.unwrapResponse()
+            cloudformationClient.waitForChangeSetCreateComplete(stackName, changeSetArn)
         } catch (e: Exception) {
             if (e.message?.contains("The submitted information didn't contain changes") == true) {
                 cloudformationClient.deleteChangeSet {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CloudFormationLazyInitRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/CloudFormationLazyInitRule.kt
@@ -53,6 +53,7 @@ class CloudFormationLazyInitRule(
 
         // wait for changeset creation to complete
         try {
+            // Use custom waiter due to https://github.com/aws/aws-sdk-java-v2/issues/2262
             cloudformationClient.waitForChangeSetCreateComplete(stackName, changeSetArn)
         } catch (e: Exception) {
             if (e.message?.contains("The submitted information didn't contain changes") == true) {


### PR DESCRIPTION
* The SDK waiter transitions the waiter to be failed in the case of no changes in the change set. It then proceeds to not give s enough info to recover in that case. Switch back to our manual waiter since we will get the info we need to recover from that expected failure state

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
