### PR TITLE
Fix CFN throttling issues/speed up CFN nodes

### DIFF
--- a/.changes/next-release/bugfix-9b117ab4-a161-4b12-b5e3-cca10cc16416.json
+++ b/.changes/next-release/bugfix-9b117ab4-a161-4b12-b5e3-cca10cc16416.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Speed up loading CloudFormation resources"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/actions/DeleteStackAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/actions/DeleteStackAction.kt
@@ -26,6 +26,6 @@ class DeleteStackAction : DeleteResourceAction<CloudFormationStackNode>(
             StackWindowManager.getInstance(selected.nodeProject).openStack(selected.stackName, selected.stackId)
         }
         client.waitForStackDeletionComplete(selected.stackName)
-        selected.nodeProject.refreshAwsTree(CloudFormationResources.LIST_STACKS)
+        selected.nodeProject.refreshAwsTree(CloudFormationResources.ACTIVE_STACKS)
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationServiceNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationServiceNodeTest.kt
@@ -55,7 +55,7 @@ class CloudFormationServiceNodeTest {
     private fun stacksWithNames(names: List<Pair<String, StackStatus>>) {
         resourceCache.addEntry(
             projectRule.project,
-            CloudFormationResources.LIST_STACKS,
+            CloudFormationResources.ACTIVE_STACKS,
             CompletableFuture.completedFuture(
                 names.map {
                     StackSummary.builder()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationServiceNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationServiceNodeTest.kt
@@ -35,15 +35,6 @@ class CloudFormationServiceNodeTest {
     }
 
     @Test
-    fun deletedStacksAreNotShown() {
-        stacksWithNames(listOf("Stack" to StackStatus.DELETE_COMPLETE))
-
-        val node = CloudFormationServiceNode(projectRule.project, CF_EXPLORER_NODE)
-
-        assertThat(node.children).hasOnlyElementsOfType(AwsExplorerEmptyNode::class.java)
-    }
-
-    @Test
     fun noStacksShowsEmptyNode() {
         stacksWithNames(emptyList())
 


### PR DESCRIPTION
- Our UI tests keep throttling, but only in account 1. Account 1 has the longest history therefore the most deleted CFN stacks. 
- We were listing all stacks then filtering. This lists deleted stacks. There were a lot of deleted stacks. So, use the API to return all stack types other than deleted. There is currently nowhere where we actually want deleted stacks to show up, so get rid of the "List all" type that could cause issues like this again in the future.
- This has the added benefit of speeding up the CFN node. A lot in some cases!

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
