### PR TITLE
Speed up integration tests by grouping tests together

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
@@ -133,12 +133,14 @@ class PythonLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runt
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(jsonToMap(executeLambda.stdout))
-            // env vars are passed
+            .describedAs("Environment variables are passed")
             .containsEntry("Foo", "Bar")
             .containsEntry("Bat", "Baz")
-            // region is set
+        assertThat(jsonToMap(executeLambda.stdout))
+            .describedAs("Region is set")
             .containsEntry("AWS_REGION", getDefaultRegion().id)
-            // credentials are passed
+        assertThat(jsonToMap(executeLambda.stdout))
+            .describedAs("Credentials are passed")
             .containsEntry("AWS_ACCESS_KEY_ID", mockCreds.accessKeyId())
             .containsEntry("AWS_SECRET_ACCESS_KEY", mockCreds.secretAccessKey())
             // An empty AWS_SESSION_TOKEN is inserted by Samcli/the Lambda runtime as of 1.13.1

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
@@ -90,24 +90,6 @@ class PythonLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runt
     }
 
     @Test
-    fun samIsExecuted() {
-        projectRule.fixture.addFileToProject("requirements.txt", "")
-
-        val runConfiguration = createHandlerBasedRunConfiguration(
-            project = projectRule.project,
-            runtime = runtime,
-            handler = "src/hello_world.app.lambda_handler",
-            input = "\"Hello World\"",
-            credentialsProviderId = mockId
-        )
-        assertThat(runConfiguration).isNotNull
-
-        val executeLambda = executeRunConfigurationAndWait(runConfiguration)
-        assertThat(executeLambda.exitCode).isEqualTo(0)
-        assertThat(executeLambda.stdout).contains("Hello world")
-    }
-
-    @Test
     fun samIsExecutedWithContainer() {
         projectRule.fixture.addFileToProject("requirements.txt", "")
 
@@ -132,7 +114,7 @@ class PythonLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runt
     }
 
     @Test
-    fun envVarsArePassed() {
+    fun samIsExecuted() {
         projectRule.fixture.addFileToProject("requirements.txt", "")
 
         val envVars = mutableMapOf("Foo" to "Bar", "Bat" to "Baz")
@@ -151,47 +133,12 @@ class PythonLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runt
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(jsonToMap(executeLambda.stdout))
+            // env vars are passed
             .containsEntry("Foo", "Bar")
             .containsEntry("Bat", "Baz")
-    }
-
-    @Test
-    fun regionIsPassed() {
-        projectRule.fixture.addFileToProject("requirements.txt", "")
-
-        val runConfiguration = createHandlerBasedRunConfiguration(
-            project = projectRule.project,
-            runtime = runtime,
-            handler = "src/hello_world.app.env_print",
-            input = "\"Hello World\"",
-            credentialsProviderId = mockId
-        )
-        assertThat(runConfiguration).isNotNull
-
-        val executeLambda = executeRunConfigurationAndWait(runConfiguration)
-
-        assertThat(executeLambda.exitCode).isEqualTo(0)
-        assertThat(jsonToMap(executeLambda.stdout))
+            // region is set
             .containsEntry("AWS_REGION", getDefaultRegion().id)
-    }
-
-    @Test
-    fun credentialsArePassed() {
-        projectRule.fixture.addFileToProject("requirements.txt", "")
-
-        val runConfiguration = createHandlerBasedRunConfiguration(
-            project = projectRule.project,
-            runtime = runtime,
-            handler = "src/hello_world.app.env_print",
-            input = "\"Hello World\"",
-            credentialsProviderId = mockId
-        )
-        assertThat(runConfiguration).isNotNull
-
-        val executeLambda = executeRunConfigurationAndWait(runConfiguration)
-
-        assertThat(executeLambda.exitCode).isEqualTo(0)
-        assertThat(jsonToMap(executeLambda.stdout))
+            // credentials are passed
             .containsEntry("AWS_ACCESS_KEY_ID", mockCreds.accessKeyId())
             .containsEntry("AWS_SECRET_ACCESS_KEY", mockCreds.secretAccessKey())
             // An empty AWS_SESSION_TOKEN is inserted by Samcli/the Lambda runtime as of 1.13.1

--- a/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetLocalLambdaRunConfigurationIntegrationTest.kt
@@ -84,14 +84,18 @@ abstract class DotnetLocalLambdaRunConfigurationIntegrationTestBase(private val 
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(jsonToMap(executeLambda.stdout))
-            // env vars passed
+            .describedAs("Environment variables are passed")
             .containsEntry("Foo", "Bar")
             .containsEntry("Bat", "Baz")
-            // region passed
+        assertThat(jsonToMap(executeLambda.stdout))
+            .describedAs("Region is set")
             .containsEntry("AWS_REGION", getDefaultRegion().id)
-            // credentials passed
+        assertThat(jsonToMap(executeLambda.stdout))
+            .describedAs("Credentials are passed")
             .containsEntry("AWS_ACCESS_KEY_ID", mockCreds.accessKeyId())
             .containsEntry("AWS_SECRET_ACCESS_KEY", mockCreds.secretAccessKey())
+            // An empty AWS_SESSION_TOKEN is inserted by Samcli/the Lambda runtime as of 1.13.1
+            .containsEntry("AWS_SESSION_TOKEN", "")
     }
 
     private fun jsonToMap(data: String) = jacksonObjectMapper().readValue<Map<String, Any>>(data)

--- a/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-rider/it/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetLocalLambdaRunConfigurationIntegrationTest.kt
@@ -51,19 +51,6 @@ abstract class DotnetLocalLambdaRunConfigurationIntegrationTestBase(private val 
     override fun getSolutionDirectoryName(): String = solutionName
 
     @Test
-    fun samIsExecuted() {
-        val runConfiguration = createHandlerBasedRunConfiguration(
-            project = project,
-            runtime = runtime.toSdkRuntime(),
-            credentialsProviderId = mockId,
-            handler = handler
-        )
-
-        val executeLambda = executeRunConfigurationAndWaitRider(runConfiguration)
-        assertThat(executeLambda.exitCode).isEqualTo(0)
-    }
-
-    @Test
     fun samIsExecutedDebugger() {
         setBreakpoint()
 
@@ -82,7 +69,7 @@ abstract class DotnetLocalLambdaRunConfigurationIntegrationTestBase(private val 
     }
 
     @Test
-    fun envVarsArePassed() {
+    fun samIsExecuted() {
         val envVars = mutableMapOf("Foo" to "Bar", "Bat" to "Baz")
 
         val runConfiguration = createHandlerBasedRunConfiguration(
@@ -97,39 +84,12 @@ abstract class DotnetLocalLambdaRunConfigurationIntegrationTestBase(private val 
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(jsonToMap(executeLambda.stdout))
+            // env vars passed
             .containsEntry("Foo", "Bar")
             .containsEntry("Bat", "Baz")
-    }
-
-    @Test
-    fun regionIsPassed() {
-        val runConfiguration = createHandlerBasedRunConfiguration(
-            project = project,
-            runtime = runtime.toSdkRuntime(),
-            credentialsProviderId = mockId,
-            handler = handler
-        )
-
-        val executeLambda = executeRunConfigurationAndWaitRider(runConfiguration)
-
-        assertThat(executeLambda.exitCode).isEqualTo(0)
-        assertThat(jsonToMap(executeLambda.stdout))
+            // region passed
             .containsEntry("AWS_REGION", getDefaultRegion().id)
-    }
-
-    @Test
-    fun credentialsArePassed() {
-        val runConfiguration = createHandlerBasedRunConfiguration(
-            project = project,
-            runtime = runtime.toSdkRuntime(),
-            credentialsProviderId = mockId,
-            handler = handler
-        )
-
-        val executeLambda = executeRunConfigurationAndWaitRider(runConfiguration)
-
-        assertThat(executeLambda.exitCode).isEqualTo(0)
-        assertThat(jsonToMap(executeLambda.stdout))
+            // credentials passed
             .containsEntry("AWS_ACCESS_KEY_ID", mockCreds.accessKeyId())
             .containsEntry("AWS_SECRET_ACCESS_KEY", mockCreds.secretAccessKey())
     }


### PR DESCRIPTION
- Each run of these integration tests duplicated work and took several seconds each * number of runtimes. This leads to minutes of unnecessary running SAM and more potential for stochastic failure.
- Speeds up integration tests by 2-3 minutes

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
