### PR TITLE
Increase the test timeout for cacheExposesBlockingApiWhereExecutionExceptionIsUnwrapped

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -412,7 +412,7 @@ class AwsResourceCacheTest {
     @Test
     fun cacheExposesBlockingApiWhereExecutionExceptionIsUnwrapped() {
         whenever(mockResource.fetch(any(), any())).thenThrow(RuntimeException("boom"))
-        assertThatThrownBy { sut.getResourceNow(mockResource, connectionSettings, timeout = Duration.ofMillis(5)) }
+        assertThatThrownBy { sut.getResourceNow(mockResource, connectionSettings, timeout = Duration.ofSeconds(1)) }
             .isInstanceOf(RuntimeException::class.java)
             .withFailMessage("boom")
     }


### PR DESCRIPTION
Hopefully this will stabilize the test under higher CPU load

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
