### PR TITLE
Disable keyboard repeat to fix flaky Sam UI test

### DIFF
--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -55,6 +55,8 @@ phases:
       - chmod +x gradlew
       - ./gradlew buildPlugin --console plain --info
 
+      # disable keyboard repeat
+      - xfconf-query -c keyboard -p /Default/KeyRepeat -t bool -s false
       - Xvfb ${DISPLAY} -screen 0 ${SCREEN_WIDTH}x${SCREEN_HEIGHT}x${SCREEN_DEPTH} &
       - while [ ! -e /tmp/.X11-unix/X99 ]; do sleep 0.1; done
       - XFCE_PANEL_MIGRATE_DEFAULT=1 xfce4-session --display=${DISPLAY} &

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -60,7 +60,7 @@ phases:
       - xinput list
       - xterm -e "xinput list | grep -Po 'id=\K\d+(?=.*slave)' | xargs -P0 -n1 xinput test" &
       # Disable keyboard repeat. Keyboard repeat can mess up hotkeys.
-      - xfconf-query -c keyboard -p /Default/KeyRepeat -t bool -s false
+      - xfconf-query -c keyboards --property /Default/KeyRepeat --create --type bool --set false
       - ffmpeg -loglevel quiet -f x11grab -video_size ${SCREEN_WIDTH}x${SCREEN_HEIGHT} -i ${DISPLAY} -codec:v libx264 -pix_fmt yuv420p -vf drawtext="fontsize=48:box=1:boxcolor=black@0.75:boxborderw=5:fontcolor=white:x=0:y=h-text_h:text='%{gmtime\:%H\\\\\:%M\\\\\:%S}'" -framerate 12 -g 12 /tmp/screen_recording.mp4 &
 
       - env AWS_ACCESS_KEY_ID=$KEY_ID AWS_SECRET_ACCESS_KEY=$SECRET AWS_SESSION_TOKEN=$TOKEN ./gradlew uiTestCore coverageReport --console plain --info

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -54,14 +54,13 @@ phases:
 
       - chmod +x gradlew
       - ./gradlew buildPlugin --console plain --info
-
-      # disable keyboard repeat
-      - xfconf-query -c keyboard -p /Default/KeyRepeat -t bool -s false
       - Xvfb ${DISPLAY} -screen 0 ${SCREEN_WIDTH}x${SCREEN_HEIGHT}x${SCREEN_DEPTH} &
       - while [ ! -e /tmp/.X11-unix/X99 ]; do sleep 0.1; done
       - XFCE_PANEL_MIGRATE_DEFAULT=1 xfce4-session --display=${DISPLAY} &
       - xinput list
       - xterm -e "xinput list | grep -Po 'id=\K\d+(?=.*slave)' | xargs -P0 -n1 xinput test" &
+      # Disable keyboard repeat. Keyboard repeat can mess up hotkeys.
+      - xfconf-query -c keyboard -p /Default/KeyRepeat -t bool -s false
       - ffmpeg -loglevel quiet -f x11grab -video_size ${SCREEN_WIDTH}x${SCREEN_HEIGHT} -i ${DISPLAY} -codec:v libx264 -pix_fmt yuv420p -vf drawtext="fontsize=48:box=1:boxcolor=black@0.75:boxborderw=5:fontcolor=white:x=0:y=h-text_h:text='%{gmtime\:%H\\\\\:%M\\\\\:%S}'" -framerate 12 -g 12 /tmp/screen_recording.mp4 &
 
       - env AWS_ACCESS_KEY_ID=$KEY_ID AWS_SECRET_ACCESS_KEY=$SECRET AWS_SESSION_TOKEN=$TOKEN ./gradlew uiTestCore coverageReport --console plain --info


### PR DESCRIPTION
Keyboard repeat seems to be leading to the project structure window being opened > 1 time. Disable it completely to not have this class of issues.
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
