### PR TITLE
Hopefully stabalize UI tests failing on tips

### DIFF
--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -16,12 +16,12 @@ import java.time.Duration
 
 fun RemoteRobot.idea(function: IdeaFrame.() -> Unit) {
     val frame = find<IdeaFrame>(timeout = Duration.ofSeconds(10))
-    // FIX_WHEN_MIN_IS_203 remove the next two lines
+    // FIX_WHEN_MIN_IS_203 remove closing tips
     // Wait for tips to appear. Otherwise, they might show up after the test starts, especially in
     // S3 tests
     frame.apply {
         dumbAware {
-            Thread.sleep(2000)
+            Thread.sleep(3000)
             tryCloseTips()
         }
     }

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -16,8 +16,15 @@ import java.time.Duration
 
 fun RemoteRobot.idea(function: IdeaFrame.() -> Unit) {
     val frame = find<IdeaFrame>(timeout = Duration.ofSeconds(10))
-    // FIX_WHEN_MIN_IS_203 remove this and set the system property "ide.show.tips.on.startup.default.value"
-    frame.apply { dumbAware { tryCloseTips() } }
+    // FIX_WHEN_MIN_IS_203 remove the next two lines
+    // Wait for tips to appear. Otherwise, they might show up after the test starts, especially in
+    // S3 tests
+    frame.apply {
+        dumbAware {
+            Thread.sleep(2000)
+            tryCloseTips()
+        }
+    }
     frame.apply(function)
 }
 
@@ -74,6 +81,7 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : Co
     )
 
     // Tips sometimes open when running, close it if it opens
+    // FIX_WHEN_MIN_IS_203 remove this
     fun tryCloseTips() {
         step("Close Tip of the Day if it appears") {
             try {

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/IdeaFrame.kt
@@ -18,10 +18,11 @@ fun RemoteRobot.idea(function: IdeaFrame.() -> Unit) {
     val frame = find<IdeaFrame>(timeout = Duration.ofSeconds(10))
     // FIX_WHEN_MIN_IS_203 remove closing tips
     // Wait for tips to appear. Otherwise, they might show up after the test starts, especially in
-    // S3 tests
+    // S3 tests. This does not actually slow down all tests as we wait for smart mode which takes longer
+    // in most other tests
     frame.apply {
         dumbAware {
-            Thread.sleep(3000)
+            Thread.sleep(5000)
             tryCloseTips()
         }
     }


### PR DESCRIPTION
- UI tests are still failing because the tips window opens after `tryCloseTips`. Add a wait to try to fix it

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
