### PR TITLE
Docker login for public.ecr.aws in addition to Dockerhub

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -35,6 +35,8 @@ phases:
       - export DOCKER_USERNAME=`echo $DOCKER_HUB_TOKEN | jq -r '.username'`
       - export DOCKER_PASSWORD=`echo $DOCKER_HUB_TOKEN | jq -r '.password'`
       - docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD || true
+      # Login to AWS Public ECR so we don't get throttled
+      - env AWS_ACCESS_KEY_ID=$KEY_ID AWS_SECRET_ACCESS_KEY=$SECRET AWS_SESSION_TOKEN=$TOKEN aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
   build:
     commands:

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -36,7 +36,7 @@ phases:
       - export DOCKER_PASSWORD=`echo $DOCKER_HUB_TOKEN | jq -r '.password'`
       - docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD || true
       # Login to AWS Public ECR so we don't get throttled
-      - env AWS_ACCESS_KEY_ID=$KEY_ID AWS_SECRET_ACCESS_KEY=$SECRET AWS_SESSION_TOKEN=$TOKEN aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+      - env AWS_ACCESS_KEY_ID=$KEY_ID AWS_SECRET_ACCESS_KEY=$SECRET AWS_SESSION_TOKEN=$TOKEN aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
   build:
     commands:

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -36,7 +36,7 @@ phases:
       - export DOCKER_PASSWORD=`echo $DOCKER_HUB_TOKEN | jq -r '.password'`
       - docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD || true
       # Login to AWS Public ECR so we don't get throttled
-      - env AWS_ACCESS_KEY_ID=$KEY_ID AWS_SECRET_ACCESS_KEY=$SECRET AWS_SESSION_TOKEN=$TOKEN aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+      - env AWS_ACCESS_KEY_ID=$KEY_ID AWS_SECRET_ACCESS_KEY=$SECRET AWS_SESSION_TOKEN=$TOKEN aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
   build:
     commands:


### PR DESCRIPTION
We are getting throttled sometimes by public.ecr.aws:
```
2021-01-29 20:04:38 DEBUG CliBasedStep:73 - [STDERR] Step 7/10 : FROM public.ecr.aws/lambda/java:11
2021-01-29 20:04:39 DEBUG CliBasedStep:73 - [STDOUT] 
2021-01-29 20:04:39 DEBUG CliBasedStep:73 - [STDOUT] Build Failed
2021-01-29 20:04:39 DEBUG CliBasedStep:73 - [STDERR] Error: SomeFunction failed to build: toomanyrequests: Rate exceeded
```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
