### PR TITLE
Revert "Remove Dotnet5 from the wizard for now"

### DIFF
--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectTemplate.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectTemplate.kt
@@ -17,5 +17,5 @@ class DotNetSamProjectTemplate : SamAppTemplateBased() {
     override fun description(): String = message("sam.init.template.hello_world.description")
 
     override fun supportedZipRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.DOTNETCORE2_1, LambdaRuntime.DOTNETCORE3_1)
-    override fun supportedImageRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.DOTNETCORE2_1, LambdaRuntime.DOTNETCORE3_1)
+    override fun supportedImageRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.DOTNETCORE2_1, LambdaRuntime.DOTNETCORE3_1, LambdaRuntime.DOTNET5_0)
 }


### PR DESCRIPTION
It's now in SAM cli 1.16.0 that came out Friday. No further adjustments are needed because that is the version we expected

## License

I confirm that my contribution is made under the terms of the Apache 2.0 license.