### PR TITLE
Use the debug connect timeout for container id timeout

### DIFF
--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt
@@ -209,7 +209,7 @@ object DotnetDebugUtils {
     }
 
     private suspend fun findDockerContainer(frontendPort: Int): String = runProcessUntil(
-        duration = Duration.ofSeconds(30),
+        duration = Duration.ofMillis(debuggerConnectTimeoutMs()),
         cmd = GeneralCommandLine(
             "docker",
             "ps",
@@ -222,7 +222,7 @@ object DotnetDebugUtils {
     }
 
     private suspend fun findDotnetPid(dockerContainer: String): Int = runProcessUntil(
-        duration = Duration.ofSeconds(30),
+        duration = Duration.ofMillis(debuggerConnectTimeoutMs()),
         cmd = GeneralCommandLine(
             "docker",
             "exec",


### PR DESCRIPTION
* Share the debugger connect timeout setting for finding the container and PID for dotnet debugging

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
