### PR TITLE
Get the Go branch back into shape after major refactors

### DIFF
--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -11,6 +11,12 @@ enum class LambdaRuntime(
     val minSamDebugging: String? = null,
     private val runtimeOverride: String? = null
 ) {
+    GO1_X(
+        Runtime.GO1_X,
+        // Although go sam debugging was supported before 1.17.0, it does not work on 1.13.0-1.16.0
+        // and 1.17.0 changed the arguments
+        minSamDebugging = "1.17.0"
+    ),
     NODEJS10_X(Runtime.NODEJS10_X),
     NODEJS12_X(Runtime.NODEJS12_X),
     JAVA8(Runtime.JAVA8),

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/ImageDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/ImageDebugSupport.kt
@@ -18,7 +18,7 @@ interface ImageDebugSupport : SamDebugSupport {
     val languageId: String
 
     fun displayName(): String
-    fun supportsPathMappings(): Boolean
+    fun supportsPathMappings(): Boolean = false
 
     override fun samArguments(debugPorts: List<Int>): List<String> = buildList {
         val containerEnvVars = containerEnvVars(debugPorts)

--- a/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/lambda/go/GoLocalRunConfigurationIntegrationTest.kt
+++ b/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/lambda/go/GoLocalRunConfigurationIntegrationTest.kt
@@ -19,25 +19,25 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialManagerRule
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
 import software.aws.toolkits.jetbrains.core.region.getDefaultRegion
 import software.aws.toolkits.jetbrains.services.lambda.execution.local.createHandlerBasedRunConfiguration
 import software.aws.toolkits.jetbrains.utils.checkBreakPointHit
-import software.aws.toolkits.jetbrains.utils.executeRunConfiguration
+import software.aws.toolkits.jetbrains.utils.executeRunConfigurationAndWait
 import software.aws.toolkits.jetbrains.utils.rules.HeavyGoCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.addGoModFile
 import software.aws.toolkits.jetbrains.utils.setSamExecutableFromEnvironment
 
 @RunWith(Parameterized::class)
-class GoLocalRunConfigurationIntegrationTest(private val runtime: Runtime) {
+class GoLocalRunConfigurationIntegrationTest(private val runtime: LambdaRuntime) {
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
-        fun parameters(): Collection<Array<Runtime>> = listOf(
-            arrayOf(Runtime.GO1_X)
+        fun parameters(): Collection<Array<LambdaRuntime>> = listOf(
+            arrayOf(LambdaRuntime.GO1_X)
         )
     }
 
@@ -113,39 +113,19 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: Runtime) {
 
         val runConfiguration = createHandlerBasedRunConfiguration(
             project = projectRule.project,
-            runtime = runtime,
+            runtime = runtime.toSdkRuntime(),
             handler = "handler",
             credentialsProviderId = mockId,
             environmentVariables = envVars
         )
         assertThat(runConfiguration).isNotNull
 
-        val executeLambda = executeRunConfiguration(runConfiguration)
+        val executeLambda = executeRunConfigurationAndWait(runConfiguration)
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(jsonToMap(executeLambda.stdout))
             .containsEntry("Foo", "Bar")
             .containsEntry("Bat", "Baz")
-    }
-
-    @Test
-    fun regionIsPassed() {
-        projectRule.fixture.addLambdaFile(envVarsFileContents)
-        projectRule.fixture.addGoModFile("hello-world")
-
-        val runConfiguration = createHandlerBasedRunConfiguration(
-            project = projectRule.project,
-            runtime = runtime,
-            handler = "handler",
-            credentialsProviderId = mockId
-        )
-        assertThat(runConfiguration).isNotNull
-
-        val executeLambda = executeRunConfiguration(runConfiguration)
-
-        assertThat(executeLambda.exitCode).isEqualTo(0)
-        assertThat(jsonToMap(executeLambda.stdout))
-            .containsEntry("AWS_REGION", getDefaultRegion().id)
     }
 
     @Test
@@ -155,13 +135,13 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: Runtime) {
 
         val runConfiguration = createHandlerBasedRunConfiguration(
             project = projectRule.project,
-            runtime = runtime,
+            runtime = runtime.toSdkRuntime(),
             handler = "handler",
             credentialsProviderId = mockId
         )
         assertThat(runConfiguration).isNotNull
 
-        val executeLambda = executeRunConfiguration(runConfiguration)
+        val executeLambda = executeRunConfigurationAndWait(runConfiguration)
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(jsonToMap(executeLambda.stdout))
@@ -183,14 +163,14 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: Runtime) {
 
         val runConfiguration = createHandlerBasedRunConfiguration(
             project = projectRule.project,
-            runtime = runtime,
+            runtime = runtime.toSdkRuntime(),
             handler = "handler",
             credentialsProviderId = mockSessionId
         )
 
         assertThat(runConfiguration).isNotNull
 
-        val executeLambda = executeRunConfiguration(runConfiguration)
+        val executeLambda = executeRunConfigurationAndWait(runConfiguration)
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(jsonToMap(executeLambda.stdout))
@@ -206,7 +186,7 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: Runtime) {
 
         val runConfiguration = createHandlerBasedRunConfiguration(
             project = projectRule.project,
-            runtime = runtime,
+            runtime = runtime.toSdkRuntime(),
             handler = "handler",
             input = "\"${input}\"",
             credentialsProviderId = mockId
@@ -214,10 +194,13 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: Runtime) {
 
         assertThat(runConfiguration).isNotNull
 
-        val executeLambda = executeRunConfiguration(runConfiguration)
+        val executeLambda = executeRunConfigurationAndWait(runConfiguration)
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(executeLambda.stdout).contains(input.toUpperCase())
+        assertThat(jsonToMap(executeLambda.stdout))
+            .describedAs("Region is passed")
+            .containsEntry("AWS_REGION", getDefaultRegion().id)
     }
 
     @Test
@@ -230,7 +213,7 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: Runtime) {
 
         val runConfiguration = createHandlerBasedRunConfiguration(
             project = projectRule.project,
-            runtime = runtime,
+            runtime = runtime.toSdkRuntime(),
             handler = "handler",
             input = "\"${input}\"",
             credentialsProviderId = mockId
@@ -241,7 +224,7 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: Runtime) {
         projectRule.addBreakpoint()
         val debuggerIsHit = checkBreakPointHit(projectRule.project)
 
-        val executeLambda = executeRunConfiguration(runConfiguration, DefaultDebugExecutor.EXECUTOR_ID)
+        val executeLambda = executeRunConfigurationAndWait(runConfiguration, DefaultDebugExecutor.EXECUTOR_ID)
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
         assertThat(executeLambda.stdout).contains(input.toUpperCase())

--- a/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/lambda/go/GoLocalRunConfigurationIntegrationTest.kt
+++ b/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/lambda/go/GoLocalRunConfigurationIntegrationTest.kt
@@ -153,7 +153,6 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: LambdaRuntime)
         val executeLambda = executeRunConfigurationAndWait(runConfiguration)
 
         assertThat(executeLambda.exitCode).isEqualTo(0)
-        assertThat(executeLambda.stdout).contains(input.toUpperCase())
         assertThat(jsonToMap(executeLambda.stdout))
             .describedAs("Region is passed")
             .containsEntry("AWS_REGION", getDefaultRegion().id)

--- a/jetbrains-ultimate/resources/META-INF/ext-go.xml
+++ b/jetbrains-ultimate/resources/META-INF/ext-go.xml
@@ -11,7 +11,8 @@
         <runtimeGroup implementation="software.aws.toolkits.jetbrains.services.lambda.go.GoRuntimeGroup"/>
         <builder id="GO" implementationClass="software.aws.toolkits.jetbrains.services.lambda.go.GoLambdaBuilder"/>
         <handlerResolver id="GO" implementationClass="software.aws.toolkits.jetbrains.services.lambda.go.GoLambdaHandlerResolver"/>
-        <sam.debugSupport id="GO" implementationClass="software.aws.toolkits.jetbrains.services.lambda.go.GoSamDebugSupport"/>
+        <sam.runtimeDebugSupport id="GO" implementationClass="software.aws.toolkits.jetbrains.services.lambda.go.GoSamDebugSupport"/>
+        <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.go.GoImageDebugSupport"/>
         <sam.projectWizard id="GO" implementationClass="software.aws.toolkits.jetbrains.services.lambda.go.GoSamProjectWizard"/>
     </extensions>
 </idea-plugin>

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoHelper.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoHelper.kt
@@ -3,9 +3,22 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.go
 
+import com.intellij.execution.process.ProcessAdapter
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.xdebugger.XDebugProcess
+import com.intellij.xdebugger.XDebugProcessStarter
+import com.intellij.xdebugger.XDebugSession
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunningState
+import software.aws.toolkits.jetbrains.utils.ApplicationThreadPoolScope
+import java.net.InetSocketAddress
+import java.nio.file.Files
 
 /**
  * "Light" ides like Goland do not rely on marking folders as source root, so infer it based on
@@ -30,4 +43,54 @@ fun inferSourceRoot(project: Project, virtualFile: VirtualFile): VirtualFile? {
         }
         return null
     }
+}
+
+suspend fun createGoDebugProcess(
+    environment: ExecutionEnvironment,
+    state: SamRunningState,
+    debugHost: String,
+    debugPorts: List<Int>
+): XDebugProcessStarter {
+    val executionResult = state.execute(environment.executor, environment.runner)
+
+    return object : XDebugProcessStarter() {
+        override fun start(session: XDebugSession): XDebugProcess {
+            val process = createDelveDebugProcess(session, executionResult)
+
+            val processHandler = executionResult.processHandler
+            val socketAddress = InetSocketAddress(debugHost, debugPorts.first())
+
+            if (processHandler == null || processHandler.isStartNotified) {
+                // this branch should never actually be hit because it gets here too fast
+                process.connect(socketAddress)
+            } else {
+                processHandler.addProcessListener(
+                    object : ProcessAdapter() {
+                        override fun startNotified(event: ProcessEvent) {
+                            ApplicationThreadPoolScope("GoSamDebugAttacher").launch {
+                                // If we don't wait, then then debugger will try to attach to
+                                // the container before it starts Devle. So, we have to add a sleep.
+                                // Delve takes quite a while to start in the sam cli images hence long sleep
+                                // See https://youtrack.jetbrains.com/issue/GO-10279
+                                // TODO revisit this to see if higher IDE versions help FIX_WHEN_MIN_IS_211 (?)
+                                // 2000 is what JB uses in this scenario, so use it as our default
+                                delay(Registry.intValue("aws.sam.goDebuggerDelay", 2000).toLong())
+                                process.connect(socketAddress)
+                            }
+                        }
+                    }
+                )
+            }
+            return process
+        }
+    }
+}
+
+fun copyDlv(): String {
+    val dlvFolder = getDelve()
+    val directory = Files.createTempDirectory("goDebugger")
+    Files.copy(dlvFolder.resolve("dlv").toPath(), directory.resolve("dlv"))
+    // Delve that comes packaged with the IDE does not have the executable flag set
+    directory.resolve("dlv").toFile().setExecutable(true)
+    return directory.toAbsolutePath().toString()
 }

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoImageDebugSupport.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoImageDebugSupport.kt
@@ -1,0 +1,35 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.go
+
+import com.goide.GoLanguage
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.xdebugger.XDebugProcessStarter
+import software.aws.toolkits.core.lambda.LambdaRuntime
+import software.aws.toolkits.jetbrains.services.lambda.execution.sam.ImageDebugSupport
+import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunningState
+
+class GoImageDebugSupport : ImageDebugSupport {
+    override val id = LambdaRuntime.GO1_X.toString()
+    override fun displayName() = LambdaRuntime.GO1_X.toString().capitalize()
+
+    override val languageId = GoLanguage.INSTANCE.id
+
+    override fun containerEnvVars(debugPorts: List<Int>): Map<String, String> {
+        val debugger = copyDlv()
+        return mapOf(
+            "_AWS_LAMBDA_GO_DEBUGGING" to "1",
+            "_AWS_LAMBDA_GO_DELVE_PATH" to debugger,
+            "_AWS_LAMBDA_GO_DELVE_API_VERSION" to "2",
+            "_AWS_LAMBDA_GO_DELVE_LISTEN_PORT" to debugPorts.first().toString(),
+        )
+    }
+
+    override suspend fun createDebugProcess(
+        environment: ExecutionEnvironment,
+        state: SamRunningState,
+        debugHost: String,
+        debugPorts: List<Int>
+    ): XDebugProcessStarter = createGoDebugProcess(environment, state, debugHost, debugPorts)
+}

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoRuntimeGroup.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoRuntimeGroup.kt
@@ -6,21 +6,23 @@ package software.aws.toolkits.jetbrains.services.lambda.go
 import com.goide.GoLanguage
 import com.goide.sdk.GoSdkType
 import com.goide.sdk.GoSdkUtil
+import com.intellij.openapi.module.ModuleType
+import com.intellij.openapi.module.WebModuleTypeBase
 import com.intellij.openapi.projectRoots.Sdk
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.BuiltInRuntimeGroups
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeInfo
 import software.aws.toolkits.jetbrains.services.lambda.SdkBasedRuntimeGroup
 
 class GoRuntimeGroup : SdkBasedRuntimeGroup() {
     override val id: String = BuiltInRuntimeGroups.Go
     override val languageIds: Set<String> = setOf(GoLanguage.INSTANCE.id)
     override val supportsPathMappings: Boolean = false
+    override fun getModuleType(): ModuleType<*> = WebModuleTypeBase.getInstance()
     override val supportedRuntimes = listOf(
-        RuntimeInfo(Runtime.GO1_X)
+        LambdaRuntime.GO1_X
     )
 
-    override fun runtimeForSdk(sdk: Sdk): Runtime? {
+    override fun runtimeForSdk(sdk: Sdk): LambdaRuntime? {
         if (sdk.sdkType !is GoSdkType) {
             return null
         }
@@ -29,7 +31,7 @@ class GoRuntimeGroup : SdkBasedRuntimeGroup() {
                 return null
             }
             GoSdkUtil.compareVersions(sdk.versionString, "2.0.0") < 0 -> {
-                Runtime.GO1_X
+                LambdaRuntime.GO1_X
             }
             else -> {
                 null

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoSamDebugSupport.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoSamDebugSupport.kt
@@ -3,91 +3,25 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.go
 
-import com.intellij.execution.process.ProcessAdapter
-import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.openapi.util.registry.Registry
-import com.intellij.xdebugger.XDebugProcess
 import com.intellij.xdebugger.XDebugProcessStarter
-import com.intellij.xdebugger.XDebugSession
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import software.amazon.awssdk.services.lambda.model.PackageType
-import software.amazon.awssdk.services.lambda.model.Runtime
-import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.core.utils.buildList
-import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamDebugSupport
+import software.aws.toolkits.jetbrains.services.lambda.execution.sam.RuntimeDebugSupport
 import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunningState
-import software.aws.toolkits.jetbrains.utils.ApplicationThreadPoolScope
-import java.net.InetSocketAddress
-import java.nio.file.Files
 
-class GoSamDebugSupport : SamDebugSupport {
+class GoSamDebugSupport : RuntimeDebugSupport {
     override suspend fun createDebugProcess(
         environment: ExecutionEnvironment,
         state: SamRunningState,
         debugHost: String,
         debugPorts: List<Int>
-    ): XDebugProcessStarter {
-        val executionResult = state.execute(environment.executor, environment.runner)
+    ): XDebugProcessStarter = createGoDebugProcess(environment, state, debugHost, debugPorts)
 
-        return object : XDebugProcessStarter() {
-            override fun start(session: XDebugSession): XDebugProcess {
-                val process = createDelveDebugProcess(session, executionResult)
-
-                val processHandler = executionResult.processHandler
-                val socketAddress = InetSocketAddress(debugHost, debugPorts.first())
-
-                if (processHandler == null || processHandler.isStartNotified) {
-                    // this branch should never actually be hit because it gets here too fast
-                    process.connect(socketAddress)
-                } else {
-                    processHandler.addProcessListener(
-                        object : ProcessAdapter() {
-                            override fun startNotified(event: ProcessEvent) {
-                                ApplicationThreadPoolScope("GoSamDebugAttacher").launch {
-                                    // If we don't wait, then then debugger will try to attach to
-                                    // the container before it starts Devle. So, we have to add a sleep.
-                                    // Delve takes quite a while to start in the sam cli images hence long sleep
-                                    // See https://youtrack.jetbrains.com/issue/GO-10279
-                                    // TODO revisit this to see if higher IDE versions help FIX_WHEN_MIN_IS_211 (?)
-                                    // 2000 is what JB uses in this scenario, so use it as our default
-                                    delay(Registry.intValue("aws.sam.goDebuggerDelay", 2000).toLong())
-                                    process.connect(socketAddress)
-                                }
-                            }
-                        }
-                    )
-                }
-                return process
-            }
-        }
-    }
-
-    override fun samArguments(runtime: Runtime, packageType: PackageType, debugPorts: List<Int>): List<String> = buildList {
+    override fun samArguments(debugPorts: List<Int>): List<String> = buildList {
         val debugger = copyDlv()
         add("--debugger-path")
         add(debugger)
         add("--debug-args")
-        if (packageType == PackageType.IMAGE) {
-            add(
-                "/var/runtime/aws-lambda-go delveAPI -delveAPI=2 -delvePort=${debugPorts.first()} -delvePath=/tmp/lambci_debug_files/dlv"
-            )
-        } else {
-            add("-delveAPI=2")
-        }
-    }
-
-    private fun copyDlv(): String {
-        val dlvFolder = getDelve()
-        val directory = Files.createTempDirectory("goDebugger")
-        Files.copy(dlvFolder.resolve("dlv").toPath(), directory.resolve("dlv"))
-        // Delve that comes packaged with the IDE does not have the executable flag set
-        directory.resolve("dlv").toFile().setExecutable(true)
-        return directory.toAbsolutePath().toString()
-    }
-
-    private companion object {
-        val LOG = getLogger<GoSamDebugSupport>()
+        add("-delveApi=2")
     }
 }

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoSamProjectWizard.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoSamProjectWizard.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.go
 
+import com.goide.project.GoProjectLibrariesService
 import com.goide.sdk.GoSdkService
 import com.goide.sdk.combobox.GoSdkChooserCombo
 import com.goide.vgo.configuration.VgoProjectSettings
@@ -12,8 +13,7 @@ import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.vfs.VirtualFile
-import software.amazon.awssdk.services.lambda.model.PackageType
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamAppTemplateBased
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamNewProjectSettings
 import software.aws.toolkits.jetbrains.services.lambda.wizard.SamProjectTemplate
@@ -53,18 +53,18 @@ class GoSdkSelectionPanel : SdkSelector {
 
 class SamHelloWorldGo : SamAppTemplateBased() {
     override fun postCreationAction(settings: SamNewProjectSettings, contentRoot: VirtualFile, rootModel: ModifiableRootModel, indicator: ProgressIndicator) {
+        super.postCreationAction(settings, contentRoot, rootModel, indicator)
+        // Turn off indexing entire gopath for the project since we are using go modules
+        GoProjectLibrariesService.getInstance(rootModel.project).isIndexEntireGopath = false
         // Turn on vgo integration, required for it to resolve dependencies properly
         VgoProjectSettings.getInstance(rootModel.project).isIntegrationEnabled = true
-        super.postCreationAction(settings, contentRoot, rootModel, indicator)
     }
 
     override fun displayName() = message("sam.init.template.hello_world.name")
-
     override fun description() = message("sam.init.template.hello_world.description")
 
-    override fun supportedRuntimes(): Set<Runtime> = setOf(Runtime.GO1_X)
-
-    override fun supportedPackagingTypes(): Set<PackageType> = setOf(PackageType.IMAGE, PackageType.ZIP)
+    override fun supportedZipRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.GO1_X)
+    override fun supportedImageRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.GO1_X)
 
     override val appTemplateName: String = "hello-world"
 

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/go/GoRuntimeGroupTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/go/GoRuntimeGroupTest.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.roots.ModuleRootModificationUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
-import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.utils.rules.GoCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.createMockSdk
 
@@ -45,7 +45,7 @@ class GoRuntimeGroupTest {
         }
 
         val runtime = sut.determineRuntime(module)
-        assertThat(runtime).isEqualTo(Runtime.GO1_X)
+        assertThat(runtime).isEqualTo(LambdaRuntime.GO1_X)
     }
 
     @Test


### PR DESCRIPTION
- Fixup the branch to build again
- Fix bug where the module was being set as `EMPTY_MODULE`
- Changes to debugging based on https://github.com/aws/aws-sam-cli/pull/2555
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
