### PR TITLE
Upgrade from rider 2020.3 EAP to 2020.3 stable

### DIFF
--- a/buildSrc/src/software/aws/toolkits/gradle/IdeVersions.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/IdeVersions.kt
@@ -64,9 +64,8 @@ object IdeVersions {
                 "Pythonid:203.5981.165"
             ),
             ijSdkOverride = "2020.3",
-            riderSdkOverride = "2020.3-SNAPSHOT",
             rdGenVersion = "0.203.161",
-            nugetVersion = "2020.3.0-eap04"
+            nugetVersion = "2020.3.0"
         )
     ).associateBy { it.name }
 

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -20,6 +20,8 @@ phases:
     commands:
       # Added for Python2 for Ubuntu 20.4
       - add-apt-repository universe
+      # WORKAROUND for yarn key being out of date, update keys so we can run builds
+      - apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
       - apt-get update
       - apt-get install -y jq python2.7 python3.6 python3.7 python3.8 python3-pip python3-distutils
       # As of Ubuntu 20.4, there is no longer pip for Python 2, so we need to install it manually

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -21,7 +21,7 @@ phases:
       # Added for Python2 for Ubuntu 20.4
       - add-apt-repository universe
       # WORKAROUND for yarn key being out of date, update keys so we can run builds TODO remove dirmngr and apt-key
-      - sudo apt-get install dirmngr
+      - apt-get install dirmngr
       - apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
       - apt-get update
       - apt-get install -y jq python2.7 python3.6 python3.7 python3.8 python3-pip python3-distutils

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -20,7 +20,8 @@ phases:
     commands:
       # Added for Python2 for Ubuntu 20.4
       - add-apt-repository universe
-      # WORKAROUND for yarn key being out of date, update keys so we can run builds
+      # WORKAROUND for yarn key being out of date, update keys so we can run builds TODO remove dirmngr and apt-key
+      - sudo apt-get install dirmngr
       - apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
       - apt-get update
       - apt-get install -y jq python2.7 python3.6 python3.7 python3.8 python3-pip python3-distutils

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Daemon/RunMarkers/LambdaRunMarkerGutterMark.cs
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Daemon/RunMarkers/LambdaRunMarkerGutterMark.cs
@@ -27,7 +27,11 @@ namespace AWS.Daemon.RunMarkers
     {
         private static readonly ILogger ourLogger = Logger.GetLogger<LambdaRunMarkerGutterMark>();
 
+#if !PROFILE_2020_3 // TODO: Remove preprocessor conditions FIX_WHEN_MIN_IS_203
         public override IAnchor Anchor => BulbMenuAnchors.PermanentBackgroundItems;
+#else
+        public override IAnchor Priority => BulbMenuAnchors.PermanentBackgroundItems;
+#endif
 
         protected LambdaRunMarkerGutterMark([NotNull] IconId iconId) : base(iconId)
         {


### PR DESCRIPTION


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
