### PR TITLE
Also add the yarn workaround to UI tests

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -20,7 +20,7 @@ phases:
     commands:
       # Added for Python2 for Ubuntu 20.4
       - add-apt-repository universe
-      # WORKAROUND for yarn key being out of date, update keys so we can run builds TODO remove dirmngr and apt-key
+      # WORKAROUND for yarn key being out of date, update keys so we can run builds TODO remove dirmngr and apt-key commands
       - apt-get install dirmngr
       - apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
       - apt-get update

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -25,6 +25,9 @@ phases:
       dotnet: 3.1
 
     commands:
+      # WORKAROUND for yarn key being out of date, update keys so we can run builds TODO remove dirmngr and apt-key commands
+      - apt-get install dirmngr
+      - apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
       - apt-get update
       - apt-get install -y xvfb xfce4 procps ffmpeg xterm xinput
 


### PR DESCRIPTION
- UI tests are failing for the same reason integration tests were: the yarn key is out of date.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
