### PR TITLE
Add forgotten changelog for dotnet5

### DIFF
--- a/.changes/next-release/feature-3a9d62a8-7d6c-405f-aa8d-057d2cfd97dd.json
+++ b/.changes/next-release/feature-3a9d62a8-7d6c-405f-aa8d-057d2cfd97dd.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Add Dotnet5 Lambda support (Image only)"
+}


### PR DESCRIPTION


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
