### PR TITLE
Fix regression in 2020.3.2 with SecretsManager Auth

### DIFF
--- a/.changes/next-release/bugfix-4758f339-3b53-474a-b0ca-31e128f6945b.json
+++ b/.changes/next-release/bugfix-4758f339-3b53-474a-b0ca-31e128f6945b.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix Secrets Manager-based databse auth throwing NullPointer when editing settings in 2020.3.2 (Fixes #2403)"
+}

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnection.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/datagrip/actions/AddSecretsManagerConnection.kt
@@ -87,7 +87,6 @@ fun DataSourceRegistry.createDatasource(project: Project, secret: SecretsManager
         .withJdbcAdditionalProperty(CREDENTIAL_ID_PROPERTY, connectionSettings?.credentials?.id)
         .withJdbcAdditionalProperty(REGION_ID_PROPERTY, connectionSettings?.region?.id)
         .withJdbcAdditionalProperty(SECRET_ID_PROPERTY, secretArn)
-        .withUrl(secret.host)
         .withUser(secret.username)
         .withUrl("jdbc:$jdbcAdapter://${secret.host}:${secret.port}")
         .commit()

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthWidget.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/datagrip/auth/SecretsManagerAuthWidget.kt
@@ -20,7 +20,7 @@ import javax.swing.JPanel
 const val SECRET_ID_PROPERTY = "AWS.SecretId"
 const val GET_URL_FROM_SECRET = "AWS.getUrlFromSecret"
 
-class SecretsManagerAuthWidget : AwsAuthWidget(userField = false) {
+class SecretsManagerAuthWidget : AwsAuthWidget(userFieldEnabled = false) {
     private val secretIdSelector = JBTextField()
     private val urlFromSecret = JBCheckBox(message("datagrip.secret_host"))
 

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/auth/IamAuthWidget.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/auth/IamAuthWidget.kt
@@ -21,7 +21,7 @@ class IamAuthWidget : AwsAuthWidget() {
     private val rdsSigningHostField = JBTextField()
     private val rdsSigningPortField = JBTextField()
 
-    override val rowCount = 4
+    override val rowCount = 5
     override fun getRegionFromUrl(url: String?): String? = RdsResources.extractRegionFromUrl(url)
 
     override fun createPanel(): JPanel {

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/auth/IamAuthWidget.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/auth/IamAuthWidget.kt
@@ -21,7 +21,7 @@ class IamAuthWidget : AwsAuthWidget() {
     private val rdsSigningHostField = JBTextField()
     private val rdsSigningPortField = JBTextField()
 
-    override val rowCount = 5
+    override val rowCount = 4
     override fun getRegionFromUrl(url: String?): String? = RdsResources.extractRegionFromUrl(url)
 
     override fun createPanel(): JPanel {

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/ui/AwsAuthWidget.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/ui/AwsAuthWidget.kt
@@ -22,7 +22,7 @@ import software.aws.toolkits.resources.message
 import javax.swing.JPanel
 import javax.swing.event.DocumentListener
 
-abstract class AwsAuthWidget(private val userField: Boolean = true) : DatabaseCredentialsAuthProvider.UserWidget() {
+abstract class AwsAuthWidget(private val userFieldEnabled: Boolean = true) : DatabaseCredentialsAuthProvider.UserWidget() {
     private val credentialSelector = CredentialProviderSelector()
     private val regionSelector = RegionSelector()
 
@@ -37,9 +37,11 @@ abstract class AwsAuthWidget(private val userField: Boolean = true) : DatabaseCr
 
     override fun createPanel(): JPanel {
         val panel = JPanel(GridLayoutManager(rowCount, columnCount))
-        if (userField) {
-            addUserField(panel, 0)
-        }
+        addUserField(panel, 0)
+
+        // Disable the user field if we treat it as immutable
+        myUserField.isEnabled = userFieldEnabled
+
         val credsLabel = JBLabel(message("aws_connection.credentials.label"))
         val regionLabel = JBLabel(message("aws_connection.region.label"))
         panel.add(credsLabel, UrlPropertiesPanel.createLabelConstraints(1, 0, credsLabel.preferredSize.getWidth()))
@@ -51,10 +53,7 @@ abstract class AwsAuthWidget(private val userField: Boolean = true) : DatabaseCr
     }
 
     override fun save(dataSource: LocalDataSource, copyCredentials: Boolean) {
-        // Tries to set username so if we don't have one, don't set
-        if (userField) {
-            super.save(dataSource, copyCredentials)
-        }
+        super.save(dataSource, copyCredentials)
 
         DataSourceUiUtil.putOrRemove(
             dataSource.additionalJdbcProperties,
@@ -69,10 +68,7 @@ abstract class AwsAuthWidget(private val userField: Boolean = true) : DatabaseCr
     }
 
     override fun reset(dataSource: LocalDataSource, resetCredentials: Boolean) {
-        // Tries to set username so if we don't have one, don't set
-        if (userField) {
-            super.reset(dataSource, resetCredentials)
-        }
+        super.reset(dataSource, resetCredentials)
 
         val regionProvider = AwsRegionProvider.getInstance()
         val allRegions = regionProvider.allRegions()
@@ -102,7 +98,7 @@ abstract class AwsAuthWidget(private val userField: Boolean = true) : DatabaseCr
     override fun isPasswordChanged(): Boolean = false
     override fun onChanged(r: DocumentListener) {
         // Tries to set username so if we don't have one, don't set
-        if (userField) {
+        if (userFieldEnabled) {
             super.onChanged(r)
         }
     }


### PR DESCRIPTION
2020.3.2 expects there it always be a username field in the auth widget. Since we always take the username from the secret, we did not create it. Instead, we will now create it but mark the field as immutable so it can't be altered.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#2403

## Testing

## Screenshots (if appropriate)
<img width="510" alt="Screen Shot 2021-02-04 at 12 21 45 PM" src="https://user-images.githubusercontent.com/8992246/106957417-d2ce9100-66ec-11eb-96ea-c3840b472565.png">


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
