### PR TITLE
Remove jcenter from Gradle build files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,6 @@ buildscript {
     repositories {
         maven("https://plugins.gradle.org/m2/")
         mavenCentral()
-        jcenter()
     }
     val kotlinVersion: String by project
     val ideaPluginVersion: String by project
@@ -67,7 +66,6 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
     }
 
     apply(plugin = "com.adarshr.test-logger")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,7 +22,6 @@ repositories {
     maven("https://plugins.gradle.org/m2/")
     mavenLocal()
     mavenCentral()
-    jcenter()
 }
 
 plugins {


### PR DESCRIPTION
- It's being deprecated and according to a build scan we actually don't use it
- See the build scan: https://scans.gradle.com/s/i5ghg36kyuhlg#dependencies
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
