### PR TITLE
Mark the plugin as not dynamic

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <!-- Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+<idea-plugin require-restart="true" xmlns:xi="http://www.w3.org/2001/XInclude">
     <id>aws.toolkit</id>
     <name>AWS Toolkit</name>
     <version>1.0</version>


### PR DESCRIPTION
- On install, it tries to reload it dynamically. However, this fails which leads to the customer waiting for a while then they are told to restart. Mark it as not dynamic so they customer is told to restart immediately.
- Comes from: https://plugins.jetbrains.com/docs/intellij/dynamic-plugins.html
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
