### PR TITLE
Re-enable Rider debug tests on 2020.3

### DIFF
--- a/buildSrc/src/software/aws/toolkits/gradle/IdeVersions.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/IdeVersions.kt
@@ -63,6 +63,7 @@ object IdeVersions {
                 "com.intellij.database",
                 "Pythonid:203.5981.165"
             ),
+            riderSdkOverride = "2020.3.2",
             ijSdkOverride = "2020.3",
             rdGenVersion = "0.203.161",
             nugetVersion = "2020.3.0"


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
