### PR TITLE
Suppress docker stdout when validating it

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/ValidateDocker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/ValidateDocker.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.lambda.execution.sam
 
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ProcessListener
 import software.aws.toolkits.jetbrains.utils.execution.steps.CliBasedStep
 import software.aws.toolkits.jetbrains.utils.execution.steps.Context
 import software.aws.toolkits.jetbrains.utils.execution.steps.MessageEmitter
@@ -17,4 +18,7 @@ class ValidateDocker : CliBasedStep() {
     override fun handleErrorResult(exitCode: Int, output: String, messageEmitter: MessageEmitter): Nothing? {
         throw Exception(message("lambda.debug.docker.not_connected"))
     }
+
+    // Change logger to not log std out since we dont actually want the output of docker
+    override fun createProcessEmitter(messageEmitter: MessageEmitter): ProcessListener = CliOutputEmitter(messageEmitter, printStdOut = false)
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/CliBasedStep.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/CliBasedStep.kt
@@ -62,7 +62,7 @@ abstract class CliBasedStep : Step() {
 
     protected open fun createProcessEmitter(messageEmitter: MessageEmitter): ProcessListener = CliOutputEmitter(messageEmitter)
 
-    private class CliOutputEmitter(private val messageEmitter: MessageEmitter) : ProcessAdapter() {
+    protected class CliOutputEmitter(private val messageEmitter: MessageEmitter, private val printStdOut: Boolean = true) : ProcessAdapter() {
         override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
             LOG.debug {
                 val prefix = if (outputType == ProcessOutputTypes.STDERR) {
@@ -73,7 +73,14 @@ abstract class CliBasedStep : Step() {
 
                 "$prefix ${event.text.trim()}"
             }
-            messageEmitter.emitMessage(event.text, outputType == ProcessOutputTypes.STDERR)
+
+            if (outputType == ProcessOutputTypes.STDOUT) {
+                if (printStdOut) {
+                    messageEmitter.emitMessage(event.text, isError = false)
+                }
+            } else {
+                messageEmitter.emitMessage(event.text, outputType == ProcessOutputTypes.STDERR)
+            }
         }
     }
 


### PR DESCRIPTION
Suppress the `docker ps` stdout since it is not useful

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
