### PR TITLE
Fixup integrationTest to also retry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -185,7 +185,6 @@ subprojects {
 
         retry {
             failOnPassedAfterRetry.set(false)
-            // If there are 5 failures, don't even attempt a retry
             maxFailures.set(5)
             maxRetries.set(2)
         }
@@ -227,6 +226,12 @@ subprojects {
         systemProperty("testDataPath", project.rootDir.toPath().resolve("testdata").toString())
 
         mustRunAfter(tasks.test)
+
+        retry {
+            failOnPassedAfterRetry.set(false)
+            maxFailures.set(5)
+            maxRetries.set(2)
+        }
     }
 
     project.plugins.withId("org.jetbrains.intellij") {

--- a/ui-tests/build.gradle.kts
+++ b/ui-tests/build.gradle.kts
@@ -60,7 +60,6 @@ tasks.register<Test>("uiTestCore") {
     // uiTestCore needs its own version of this since it's not part of normal test tasks
     retry {
         failOnPassedAfterRetry.set(false)
-        // If there are 5 failures, don't even attempt a retry
         maxFailures.set(5)
         maxRetries.set(2)
     }


### PR DESCRIPTION
- Since the test suites are disjoint, they all need their own `retry` block, I forgot the integrationTest one
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
