### PR TITLE
Fix 2020.1 UI tests broken by the deprecation prompt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -256,6 +256,7 @@ subprojects {
             systemProperty("ide.show.tips.on.startup.default.value", false)
 
             systemProperty("aws.telemetry.skip_prompt", "true")
+            systemProperty("aws.suppress_deprecation_prompt", "true")
             ciOnly {
                 systemProperty("aws.sharedCredentialsFile", "/tmp/.aws/credentials")
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -256,7 +256,7 @@ subprojects {
             systemProperty("ide.show.tips.on.startup.default.value", false)
 
             systemProperty("aws.telemetry.skip_prompt", "true")
-            systemProperty("aws.suppress_deprecation_prompt", "true")
+            systemProperty("aws.suppress_deprecation_prompt", true)
             ciOnly {
                 systemProperty("aws.sharedCredentialsFile", "/tmp/.aws/credentials")
             }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/JetBrainsMinimumVersionChange.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/JetBrainsMinimumVersionChange.kt
@@ -23,6 +23,9 @@ class JetBrainsMinimumVersionChange : NoticeType {
     override fun getSuppressNotificationValue(): String = ApplicationInfo.getInstance().fullVersion
 
     override fun isNotificationSuppressed(previousSuppressNotificationValue: String?): Boolean {
+        if (System.getProperty(SKIP_PROMPT, null)?.toBoolean() == true) {
+            return true
+        }
         previousSuppressNotificationValue?.let {
             return previousSuppressNotificationValue == getSuppressNotificationValue()
         }
@@ -33,4 +36,9 @@ class JetBrainsMinimumVersionChange : NoticeType {
 
     override fun getNoticeContents(): NoticeContents = noticeContents
     override fun getNoticeType(): NotificationType = NotificationType.WARNING
+
+    private companion object {
+        // Used by tests to make sure the prompt never shows up
+        const val SKIP_PROMPT = "aws.suppress_deprecation_prompt"
+    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/NoticeManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/NoticeManager.kt
@@ -48,16 +48,9 @@ class DefaultNoticeManager :
     /**
      * Returns the notices that require notification
      */
-    override fun getRequiredNotices(notices: List<NoticeType>, project: Project): List<NoticeType> = notices.filter { it.isNotificationRequired() }
-        .filter {
-            internalState[it.id]?.let { state ->
-                state.noticeSuppressedValue?.let { previouslySuppressedValue ->
-                    return@filter !it.isNotificationSuppressed(previouslySuppressedValue)
-                }
-            }
-
-            true
-        }
+    override fun getRequiredNotices(notices: List<NoticeType>, project: Project): List<NoticeType> = notices
+        .filter { it.isNotificationRequired() }
+        .filter { !it.isNotificationSuppressed(internalState[it.id]?.noticeSuppressedValue) }
 
     override fun notify(notices: List<NoticeType>, project: Project) {
         notices.forEach { notify(it, project) }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/notification/NoticeManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/notification/NoticeManagerTest.kt
@@ -6,10 +6,10 @@ package software.aws.toolkits.jetbrains.core.notification
 import com.intellij.testFramework.ProjectRule
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import com.nhaarman.mockitokotlin2.spy
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/notification/NoticeManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/notification/NoticeManagerTest.kt
@@ -9,6 +9,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.spy
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -47,13 +48,15 @@ class NoticeManagerTest {
     }
 
     @Test
-    fun nonSerializedNoticeDoesRequiresNotification() {
-        val notice = createSampleNotice(true, true)
+    fun nonSerializedNoticeCallsIsNotificationSuppressed() {
+        val notice = spy(createSampleNotice(requiresNotification = true, isNotificationSuppressed = false))
 
         val notices = sut.getRequiredNotices(listOf(notice), projectRule.project)
 
         assertThat(notices).hasSize(1)
         assertThat(notices).contains(notice)
+
+        verify(notice).isNotificationSuppressed(null)
     }
 
     @Test


### PR DESCRIPTION
- The deprecation prompt was breaking 2020.1 SQS tests since it was over the send button
- Add a system property and check for it so we never show the prompt in UI tests
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
