### PR TITLE
Fix sam init selection panel making 2 sdks

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
@@ -89,7 +89,7 @@ class SamInitSelectionPanel(
         )
 
         // this will also fire wizardUpdate since templateComboBox will change
-        // othwise we make 2 of them
+        // otherwise we make 2 of them
         runtimeUpdate()
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
@@ -17,7 +17,6 @@ import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance.BadExecutable
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.core.executables.ExecutableType.Companion.getExecutable
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.minSamInitVersion
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
@@ -89,13 +89,13 @@ class SamInitSelectionPanel(
             }
         )
 
+        // this will also fire wizardUpdate since templateComboBox will change
+        // othwise we make 2 of them
         runtimeUpdate()
-        wizardUpdate()
     }
 
     private fun supportedRuntimes(): MutableList<LambdaRuntime> {
         // Source all templates, find all the runtimes they support, then filter those by what the IDE supports
-        val supportedRuntimeGroups = RuntimeGroup.registeredRuntimeGroups()
         return SamProjectTemplate.supportedTemplates().asSequence()
             .flatMap {
                 when (packageType()) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/wizard/SamInitSelectionPanel.kt
@@ -93,20 +93,18 @@ class SamInitSelectionPanel(
         runtimeUpdate()
     }
 
-    private fun supportedRuntimes(): MutableList<LambdaRuntime> {
-        // Source all templates, find all the runtimes they support, then filter those by what the IDE supports
-        return SamProjectTemplate.supportedTemplates().asSequence()
-            .flatMap {
-                when (packageType()) {
-                    PackageType.ZIP -> it.supportedZipRuntimes().asSequence()
-                    else -> it.supportedImageRuntimes().asSequence()
-                }
+    // Source all templates, find all the runtimes they support, then filter those by what the IDE supports
+    private fun supportedRuntimes(): MutableList<LambdaRuntime> = SamProjectTemplate.supportedTemplates().asSequence()
+        .flatMap {
+            when (packageType()) {
+                PackageType.ZIP -> it.supportedZipRuntimes().asSequence()
+                else -> it.supportedImageRuntimes().asSequence()
             }
-            .filter(runtimeFilter)
-            .distinct()
-            .sorted()
-            .toMutableList()
-    }
+        }
+        .filter(runtimeFilter)
+        .distinct()
+        .sorted()
+        .toMutableList()
 
     private fun packageType() = when {
         packageZip.isSelected -> PackageType.ZIP


### PR DESCRIPTION
- wizardUpdate was called twice. Once by setting the runtime the first time, then again when we called the wizardUpdate manually.
- This caused an ide fatal error with the Go one
- In general we were making 2 of the panel though which makes 0 sense

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
