### PR TITLE
Fix integ tests using wrong service type for the http client provider

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
@@ -12,6 +12,7 @@ import com.intellij.testFramework.replaceService
 import org.junit.rules.ExternalResource
 import software.amazon.awssdk.core.SdkClient
 import software.aws.toolkits.core.ToolkitClientManager
+import software.aws.toolkits.core.clients.SdkClientProvider
 import software.aws.toolkits.core.credentials.ToolkitCredentialsProvider
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.core.region.ToolkitRegionProvider
@@ -76,7 +77,7 @@ class MockClientManager : AwsClientManager() {
 
             val httpClient = AwsSdkClient()
             Disposer.register(disposable, httpClient)
-            ApplicationManager.getApplication().replaceService(AwsSdkClient::class.java, httpClient, disposable)
+            ApplicationManager.getApplication().replaceService(SdkClientProvider::class.java, httpClient, disposable)
         }
     }
 }


### PR DESCRIPTION
```
  kotlin.TypeCastException: null cannot be cast to non-null type com.intellij.serviceContainer.ServiceComponentAdapter
      at com.intellij.serviceContainer.ComponentManagerImpl.replaceServiceInstance(ComponentManagerImpl.kt:569)
      at com.intellij.testFramework.ServiceContainerUtil.replaceService(ServiceContainerUtil.kt:23)
      at software.aws.toolkits.jetbrains.core.MockClientManager$Companion.useRealImplementations(MockClientManager.kt:79)
      at software.aws.toolkits.jetbrains.services.lambda.upload.CreateFunctionIntegrationTest.setUp(CreateFunctionIntegrationTest.kt:84)
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
