### PR TITLE
Move toolkit bundling to a sub project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,9 +36,6 @@ val remoteRobotPort: String by project
 val ktlintVersion: String by project
 val remoteRobotVersion: String by project
 val ideaPluginVersion: String by project
-// publishing
-val publishToken: String by project
-val publishChannel: String by project
 
 plugins {
     java

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ val junitVersion: String by project
 val remoteRobotPort: String by project
 val ktlintVersion: String by project
 val remoteRobotVersion: String by project
-val ideaPluginVersion: String by project
 
 plugins {
     java

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ val publishChannel: String by project
 
 plugins {
     java
+    jacoco
     id("de.undercouch.download") apply false
     id("org.gradle.test-retry") version "1.2.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,11 +50,7 @@ group = "software.aws.toolkits"
 // please check changelog generation logic if this format is changed
 version = "$toolkitVersion-${ideProfile.shortName}"
 
-repositories {
-    maven("https://www.jetbrains.com/intellij-repository/snapshots/")
-}
-
-subprojects {
+allprojects {
     repositories {
         mavenLocal()
         System.getenv("CODEARTIFACT_URL")?.let {
@@ -70,7 +66,9 @@ subprojects {
         gradlePluginPortal()
         mavenCentral()
     }
+}
 
+subprojects {
     apply(plugin = "com.adarshr.test-logger")
     apply(plugin = "java")
     apply(plugin = "jacoco")

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -42,7 +42,7 @@ phases:
       - rsync -rmq --include='*/' --include '**/build/idea-sandbox/system*/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
-      - cp -r ./build/distributions/*.zip $BUILD_ARTIFACTS/ || true
+      - cp -r ./intellij/build/distributions/*.zip $BUILD_ARTIFACTS/ || true
 
 reports:
   unit-test:

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -31,6 +31,10 @@ tasks.getByName<PublishTask>("publishPlugin") {
     channels(publishChannel.split(",").map { it.trim() })
 }
 
+tasks.named("check") {
+    dependsOn(tasks.named("verifyPlugin"))
+}
+
 dependencies {
     implementation(project(":jetbrains-ultimate"))
     project.findProject(":jetbrains-rider")?.let {

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -1,0 +1,39 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.intellij.tasks.PrepareSandboxTask
+import org.jetbrains.intellij.tasks.PublishTask
+import software.aws.toolkits.gradle.IdeVersions
+import software.aws.toolkits.gradle.intellij
+
+plugins {
+    id("org.jetbrains.intellij")
+}
+
+val ideProfile = IdeVersions.ideProfile(project)
+
+val publishToken: String by project
+val publishChannel: String by project
+
+intellij {
+    version = ideProfile.community.sdkVersion
+    pluginName = "aws-toolkit-jetbrains"
+    updateSinceUntilBuild = false
+}
+
+tasks.getByName<PrepareSandboxTask>("prepareSandbox") {
+    project.findProject(":jetbrains-rider")?.let {
+        from(tasks.getByPath(":jetbrains-rider:prepareSandbox"))
+    }
+}
+
+tasks.getByName<PublishTask>("publishPlugin") {
+    token(publishToken)
+    channels(publishChannel.split(",").map { it.trim() })
+}
+
+dependencies {
+    implementation(project(":jetbrains-ultimate"))
+    project.findProject(":jetbrains-rider")?.let {
+        implementation(it)
+    }
+}

--- a/jetbrains-core/build.gradle.kts
+++ b/jetbrains-core/build.gradle.kts
@@ -26,12 +26,10 @@ val jacksonVersion: String by project
 val compileKotlin: KotlinCompile by tasks
 
 intellij {
-    val rootIntelliJTask = rootProject.intellij
+    pluginName = "aws-toolkit-jetbrains"
+
     version = ideProfile.community.sdkVersion
     setPlugins(*ideProfile.community.plugins)
-    pluginName = rootIntelliJTask.pluginName
-    updateSinceUntilBuild = rootIntelliJTask.updateSinceUntilBuild
-    downloadSources = rootIntelliJTask.downloadSources
 }
 
 tasks.patchPluginXml {
@@ -67,7 +65,7 @@ val changelog = tasks.register<GeneratePluginChangeLog>("pluginChangeLog") {
 tasks.jar {
     dependsOn(changelog)
     archiveBaseName.set("aws-intellij-toolkit-core")
-    from(changelog.get().changeLogFile) {
+    from(changelog) {
         into("META-INF")
     }
 }

--- a/jetbrains-rider/build.gradle.kts
+++ b/jetbrains-rider/build.gradle.kts
@@ -51,11 +51,9 @@ val rdgenDir = File("${project.buildDir}/rdgen/")
 rdgenDir.mkdirs()
 
 intellij {
-    val parentIntellijTask = rootProject.intellij
-    version = ideProfile.rider.sdkVersion
-    pluginName = parentIntellijTask.pluginName
-    updateSinceUntilBuild = parentIntellijTask.updateSinceUntilBuild
+    pluginName = "aws-toolkit-jetbrains"
 
+    version = ideProfile.rider.sdkVersion
     // Workaround for https://youtrack.jetbrains.com/issue/IDEA-179607
     val extraPlugins = arrayOf("rider-plugins-appender")
     setPlugins(*(ideProfile.rider.plugins + extraPlugins))

--- a/jetbrains-rider/build.gradle.kts
+++ b/jetbrains-rider/build.gradle.kts
@@ -58,8 +58,7 @@ intellij {
     val extraPlugins = arrayOf("rider-plugins-appender")
     setPlugins(*(ideProfile.rider.plugins + extraPlugins))
 
-    // Disable downloading source to avoid issues related to Rider SDK naming that is missed in Idea
-    // snapshots repository. The task is failed because if is unable to find related IC sources.
+    // RD is closed source, so nothing to download.
     downloadSources = false
     instrumentCode = false
 }

--- a/jetbrains-ultimate/build.gradle.kts
+++ b/jetbrains-ultimate/build.gradle.kts
@@ -23,6 +23,7 @@ intellij {
     version = ideProfile.ultimate.sdkVersion
     setPlugins(*ideProfile.ultimate.plugins)
 
+    // IU is closed source, so nothing to download.
     downloadSources = false
 }
 

--- a/jetbrains-ultimate/build.gradle.kts
+++ b/jetbrains-ultimate/build.gradle.kts
@@ -18,12 +18,12 @@ dependencies {
 val ideProfile = IdeVersions.ideProfile(project)
 
 intellij {
-    val parentIntellijTask = rootProject.intellij
+    pluginName = "aws-toolkit-jetbrains"
+
     version = ideProfile.ultimate.sdkVersion
     setPlugins(*ideProfile.ultimate.plugins)
-    pluginName = parentIntellijTask.pluginName
-    updateSinceUntilBuild = parentIntellijTask.updateSinceUntilBuild
-    downloadSources = parentIntellijTask.downloadSources
+
+    downloadSources = false
 }
 
 tasks.test {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-rootProject.name = "aws-jetbrains-toolkit"
+rootProject.name = "aws-toolkit-jetbrains"
 
 include("ktlint-rules")
 include("resources")
@@ -9,6 +9,7 @@ include("core")
 include("jetbrains-core")
 include("jetbrains-ultimate")
 include("jetbrains-rider")
+include("intellij")
 include("ui-tests")
 
 plugins {


### PR DESCRIPTION
Do not bundle the 3 "sub-plugins" into one in the root project, use a dedicated sub project for that

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
