### PR TITLE
Fix runIde error causing Gradle import failing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -349,5 +349,7 @@ dependencies {
 }
 
 tasks.register("runIde") {
-    throw GradleException("Use project specific runIde command, i.e. :jetbrains-core:runIde, :intellij:runIde")
+    doFirst {
+        throw GradleException("Use project specific runIde command, i.e. :jetbrains-core:runIde, :intellij:runIde")
+    }
 }


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
