### PR TITLE
Disable buildSearchableOptions in sub-plugins

### DIFF
--- a/jetbrains-core/build.gradle.kts
+++ b/jetbrains-core/build.gradle.kts
@@ -57,6 +57,10 @@ tasks.test {
     systemProperty("log.dir", "${project.intellij.sandboxDirectory}-test/logs")
 }
 
+tasks.buildSearchableOptions {
+    enabled = false
+}
+
 val changelog = tasks.register<GeneratePluginChangeLog>("pluginChangeLog") {
     includeUnreleased.set(true)
     changeLogFile.set(project.file("$buildDir/changelog/change-notes.xml"))

--- a/jetbrains-rider/build.gradle.kts
+++ b/jetbrains-rider/build.gradle.kts
@@ -270,6 +270,10 @@ tasks.integrationTest {
     environment("LOCAL_ENV_RUN", true)
 }
 
+tasks.buildSearchableOptions {
+    enabled = false
+}
+
 tasks.jar {
     archiveBaseName.set("aws-intellij-toolkit-rider")
 }

--- a/jetbrains-ultimate/build.gradle.kts
+++ b/jetbrains-ultimate/build.gradle.kts
@@ -31,6 +31,10 @@ tasks.test {
     systemProperty("log.dir", "${(project.extensions["intellij"] as IntelliJPluginExtension).sandboxDirectory}-test/logs")
 }
 
+tasks.buildSearchableOptions {
+    enabled = false
+}
+
 tasks.jar {
     archiveBaseName.set("aws-intellij-toolkit-ultimate")
 }


### PR DESCRIPTION
Restore https://github.com/aws/aws-toolkit-jetbrains/commit/587013e8726fe234fa82023e3d57f77e226d3f9a#diff-c0dfa6bc7a8685217f70a860145fbdf416d449eaff052fa28352c5cec1a98c06L305

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
