### PR TITLE
Fix BundledResourcesTest not having a deterministic test name

### DIFF
--- a/resources/tst/software/aws/toolkits/resources/BundledResourcesTest.kt
+++ b/resources/tst/software/aws/toolkits/resources/BundledResourcesTest.kt
@@ -10,12 +10,12 @@ import org.junit.runners.Parameterized
 import java.io.InputStream
 
 @RunWith(Parameterized::class)
-class BundledResourcesTest(private val file: InputStream) {
+class BundledResourcesTest(@Suppress("UNUSED_PARAMETER") name: String, private val file: InputStream) {
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
         fun data() = listOf(
-            BundledResources.ENDPOINTS_FILE
+            arrayOf("ENDPOINTS_FILE", BundledResources.ENDPOINTS_FILE)
         )
     }
 


### PR DESCRIPTION
The name had a hashcode toString 

`fileExistsAndHasContent[java.io.BufferedInputStream@6e6bc716]`

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
