### PR TITLE
Fixed RIDER-60532. Enforce to trust generated AWS project templates

### DIFF
--- a/buildSrc/src/software/aws/toolkits/gradle/IdeVersions.kt
+++ b/buildSrc/src/software/aws/toolkits/gradle/IdeVersions.kt
@@ -74,7 +74,7 @@ object IdeVersions {
             riderSdkOverride = "2021.1-SNAPSHOT",
             ijSdkOverride = "211.6305-EAP-CANDIDATE-SNAPSHOT",
             rdGenVersion = "0.211.234",
-            nugetVersion = "2021.1.0-eap06"
+            nugetVersion = "2021.1.0-eap09"
         )
     ).associateBy { it.name }
 

--- a/jetbrains-rider/src-211+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
+++ b/jetbrains-rider/src-211+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt
@@ -203,7 +203,8 @@ class DotNetSamProjectGenerator(
         val project = SolutionManager.openExistingSolution(
             projectToClose = null,
             forceOpenInNewFrame = false,
-            solutionFile = solutionFile
+            solutionFile = solutionFile,
+            forceConsiderTrusted = true
         ) ?: return@Runnable
 
         vcsPanel?.createInitializer()?.execute(project)


### PR DESCRIPTION
We consider all projects from Rider templates as trusted. Set force trust project option for AWS templates as well.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Currently, JetBrains IDEs shows a security notification on project open that notifies users about untrusted sources. You can find details [here](https://blog.jetbrains.com/dotnet/2021/03/17/rider-resharper-2020-3-4/). We consider templates from Rider project templates wizard as trusted and do not show this notification. Set the same option for AWS template.

## Motivation and Context
Please see description.

## Related Issue(s)
[RIDER-60532](https://youtrack.jetbrains.com/issue/RIDER-60532)

## Testing
Verified before the fix we that tΩhere is a modal window asking to trust a project generated from AWS project template. Checked the notification has gone with the provided fix.

## Screenshots (if appropriate)
There is the modal notification is shown when generating project from AWS template:

<img width="826" alt="Trusted_Sources" src="https://user-images.githubusercontent.com/6064345/112951639-39e45100-9144-11eb-91cd-5da03ba47724.png">

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
