### PR TITLE
Fix bug with determineRuntime and go

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/completion/HandlerCompletionProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/completion/HandlerCompletionProvider.kt
@@ -11,7 +11,6 @@ import com.intellij.util.textCompletion.TextCompletionProvider
 import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 
 class HandlerCompletionProvider(private val project: Project, runtime: LambdaRuntime?) : TextCompletionProvider {
@@ -19,7 +18,7 @@ class HandlerCompletionProvider(private val project: Project, runtime: LambdaRun
     private val logger = getLogger<HandlerCompletionProvider>()
 
     private val handlerCompletion: HandlerCompletion? by lazy {
-        val runtimeGroup = runtime?.runtimeGroup ?: RuntimeGroup.determineRuntime(project)?.runtimeGroup ?: return@lazy null
+        val runtimeGroup = runtime?.runtimeGroup ?: return@lazy null
 
         return@lazy HandlerCompletion.getInstanceOrNull(runtimeGroup) ?: let {
             logger.info { "Lambda handler completion provider is not registered for runtime: ${runtimeGroup.id}. Completion is not supported." }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationProducer.kt
@@ -16,7 +16,6 @@ import org.jetbrains.yaml.psi.YAMLPsiElement
 import software.aws.toolkits.core.region.AwsRegion
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
-import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfigurationType
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils.functionFromElement
@@ -57,7 +56,7 @@ class LocalLambdaRunConfigurationProducer : LazyRunConfigurationProducer<LocalLa
         }
         val resolver = LambdaHandlerResolver.getInstance(runtimeGroup)
         val handler = resolver.determineHandler(element) ?: return false
-        val runtime = RuntimeGroup.determineRuntime(context.module) ?: RuntimeGroup.determineRuntime(context.project)
+        val runtime = runtimeGroup.determineRuntime(context.module) ?: runtimeGroup.determineRuntime(context.project)
 
         setAccountOptions(configuration)
         configuration.useHandler(runtime?.toSdkRuntime(), handler)

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoRuntimeGroup.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/go/GoRuntimeGroup.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.lambda.go
 
 import com.goide.GoLanguage
+import com.goide.sdk.GoSdkService
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleType
 import com.intellij.openapi.module.WebModuleTypeBase
@@ -22,12 +23,14 @@ class GoRuntimeGroup : SdkBasedRuntimeGroup() {
         LambdaRuntime.GO1_X
     )
 
-    // Since we only have one option, we don't need to actually determine it. This is only called
-    // when we already suspect it's a go project, so we only have one real option. In the future
-    // we can look at using something like GoModuleSettings.
-    override fun determineRuntime(module: Module): LambdaRuntime = determineRuntime(module.project)
-    override fun determineRuntime(project: Project): LambdaRuntime = LambdaRuntime.GO1_X
-
-    // Go kind of has this but real projects don't always have an sdk, so ignore it in favor for determineRuntime
     override fun runtimeForSdk(sdk: Sdk): LambdaRuntime? = null
+    override fun determineRuntime(project: Project): LambdaRuntime? = null
+    override fun determineRuntime(module: Module): LambdaRuntime? {
+        val goSdkService = GoSdkService.getInstance(module.project)
+        return if (goSdkService.isGoModule(module)) {
+            LambdaRuntime.GO1_X
+        } else {
+            null
+        }
+    }
 }

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/go/GoRuntimeGroupTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/go/GoRuntimeGroupTest.kt
@@ -3,11 +3,14 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.go
 
+import com.goide.sdk.GoSdkService
+import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.lambda.LambdaRuntime
 import software.aws.toolkits.jetbrains.utils.rules.GoCodeInsightTestFixtureRule
+import software.aws.toolkits.jetbrains.utils.rules.createMockSdk
 
 class GoRuntimeGroupTest {
     @Rule
@@ -18,6 +21,10 @@ class GoRuntimeGroupTest {
 
     @Test
     fun runtimeForSdk() {
+        val sdk = createMockSdk(projectRule.module.moduleFilePath, "1.0.0")
+        runInEdtAndWait {
+            GoSdkService.getInstance(projectRule.project).setSdk(sdk)
+        }
         val module = projectRule.module
         val runtime = sut.determineRuntime(module)
         assertThat(runtime).isEqualTo(LambdaRuntime.GO1_X)

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/GoCodeInsightTestFixtureRule.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/GoCodeInsightTestFixtureRule.kt
@@ -4,10 +4,11 @@
 package software.aws.toolkits.jetbrains.utils.rules
 
 import com.goide.GoConstants
+import com.goide.project.GoModuleSettings
 import com.goide.psi.GoFile
-import com.goide.sdk.GoSdkType
+import com.goide.sdk.GoSdk
+import com.goide.sdk.GoSdkImpl
 import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.testFramework.LightProjectDescriptor
@@ -22,6 +23,7 @@ class GoCodeInsightTestFixtureRule : CodeInsightTestFixtureRule(GoLightProjectDe
     override fun createTestFixture(): CodeInsightTestFixture {
         val codeInsightFixture = super.createTestFixture()
         PsiTestUtil.addContentRoot(codeInsightFixture.module, codeInsightFixture.tempDirFixture.getFile(".")!!)
+        GoModuleSettings.getInstance(codeInsightFixture.module).isGoSupportEnabled = true
         return codeInsightFixture
     }
 }
@@ -87,9 +89,4 @@ fun CodeInsightTestFixture.addGoModFile(
         """.trimIndent()
 ): PsiFile = this.addFileToProject("$subPath/go.mod", content)
 
-fun createMockSdk(version: String): Sdk {
-    val sdk = ProjectJdkImpl("Go $version", GoSdkType())
-    sdk.versionString = version
-    GoSdkType().setupSdkPaths(sdk)
-    return sdk
-}
+fun createMockSdk(root: String, version: String): GoSdk = GoSdkImpl(root, version, null)


### PR DESCRIPTION
- Fix bug introduced by go fixes (https://github.com/aws/aws-toolkit-jetbrains/pull/2514). When adding a Lambda handler from source, it would always be Go based.
- Fixup the run configuration producer to use the runtimegroup we have already determined instead of looking through all of them
- Remove an unnecessary `RuntimeGroup.determineRuntime(project)?.runtimeGroup` from handler completion provider
## Additional Testing
Made sure Rider handler completion still worked:
<img width="705" alt="Screen Shot 2021-04-01 at 8 48 49 AM" src="https://user-images.githubusercontent.com/11964782/113320217-1b5a9300-92c7-11eb-9c0b-83170fb25f70.png">

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
