### PR TITLE
Fix flaky ProfileWatcherTest.kt

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/BuildScriptUtils.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/BuildScriptUtils.kt
@@ -41,7 +41,7 @@ fun SourceSetContainer.getOrCreate(sourceSet: String, block: SourceSet.() -> Uni
 /**
  * Only run the given block if this build is running within a CI system (e.g. GitHub actions, CodeBuild etc)
  */
-fun Project.ciOnly(block: () -> Unit) {
+fun ciOnly(block: () -> Unit) {
     if (System.getenv("CI") != null) {
         block()
     }

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -131,7 +131,7 @@ afterEvaluate {
 
         systemProperty("aws.telemetry.skip_prompt", "true")
         systemProperty("aws.suppress_deprecation_prompt", true)
-        ciOnly {
+        ciOnly() {
             systemProperty("aws.sharedCredentialsFile", "/tmp/.aws/credentials")
         }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileWatcherTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/ProfileWatcherTest.kt
@@ -139,14 +139,20 @@ class ProfileWatcherTest {
         block()
 
         // Wait for fsnotify to see the change
-        assertThat(watcherTriggered.await(5, TimeUnit.SECONDS)).describedAs("FileWatcher is triggered").isTrue()
+        assertThat(watcherTriggered.await(5, TimeUnit.SECONDS)).describedAs("FileWatcher is triggered").isTrue
 
         val refreshComplete = CountDownLatch(1)
-        RefreshQueue.getInstance().refresh(true, true, Runnable { refreshComplete.countDown() }, *ManagingFS.getInstance().localRoots)
+        RefreshQueue.getInstance().refresh(true, true, { refreshComplete.countDown() }, *ManagingFS.getInstance().localRoots)
 
         // Wait for refresh to complete
         refreshComplete.await()
 
-        assertThat(updateCalled.get()).describedAs("ProfileWatcher is triggered").isTrue()
+        // The update is triggered asynchronously, so this does not mean it's done, especially when the system is under high load
+        // Since we are compiling ultimate/rider while running this test it can fail easily. 2000 is since we are dealing with the filesystem
+        // so, pick a high arbitrary value
+        if (updateCalled.get() == false) {
+            Thread.sleep(2000)
+        }
+        assertThat(updateCalled.get()).describedAs("ProfileWatcher is triggered").isTrue
     }
 }


### PR DESCRIPTION
- On my machine this test would fail about 1/100 runs, but it has been failing a lot more often on CI recently.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
