### PR TITLE
Use invalid metric string when project is disposed already

### DIFF
--- a/core/src/software/aws/toolkits/core/telemetry/MetricEvent.kt
+++ b/core/src/software/aws/toolkits/core/telemetry/MetricEvent.kt
@@ -64,7 +64,7 @@ interface MetricEvent {
 
 fun String.replaceIllegal(replacement: String = "") = this.replace(illegalCharsRegex, replacement)
 
-class DefaultMetricEvent internal constructor(
+data class DefaultMetricEvent internal constructor(
     override val createTime: Instant,
     override val awsAccount: String,
     override val awsRegion: String,
@@ -110,7 +110,7 @@ class DefaultMetricEvent internal constructor(
         const val METADATA_INVALID = "invalid"
     }
 
-    class DefaultDatum(
+    data class DefaultDatum(
         override val name: String,
         override val value: Double,
         override val unit: MetricUnit,


### PR DESCRIPTION
Since we can't access the connection settings on a diposed project,  use 'invalid' if the project is disposed

#2531 

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
