### PR TITLE
Use xi:include to cut down on misleading exceptions in jb-core tests

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -72,10 +72,14 @@ with what features/services are supported.
     <depends optional="true">Docker</depends>
     <depends optional="true" config-file="ext-java.xml">com.intellij.modules.java</depends>
     <depends optional="true" config-file="ext-python.xml">com.intellij.modules.python</depends>
-    <depends optional="true" config-file="ext-nodejs.xml">JavaScriptDebugger</depends>
-    <depends optional="true" config-file="ext-rider.xml">com.intellij.modules.rider</depends>
-    <depends optional="true" config-file="ext-datagrip.xml">com.intellij.database</depends>
-    <depends optional="true" config-file="ext-go.xml">org.jetbrains.plugins.go</depends>
+
+    <xi:include href="/META-INF/IU.xml" xpointer="xpointer(/idea-plugin/*)">
+        <xi:fallback/>
+    </xi:include>
+
+    <xi:include href="/META-INF/RD.xml" xpointer="xpointer(/idea-plugin/*)">
+        <xi:fallback/>
+    </xi:include>
 
     <xi:include href="/META-INF/change-notes.xml" xpointer="xpointer(/idea-plugin/*)">
         <xi:fallback/>

--- a/jetbrains-rider/resources/META-INF/RD.xml
+++ b/jetbrains-rider/resources/META-INF/RD.xml
@@ -1,0 +1,6 @@
+<!-- Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<idea-plugin>
+    <depends optional="true" config-file="ext-rider.xml">com.intellij.modules.rider</depends>
+</idea-plugin>

--- a/jetbrains-ultimate/resources/META-INF/IU.xml
+++ b/jetbrains-ultimate/resources/META-INF/IU.xml
@@ -1,0 +1,8 @@
+<!-- Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<idea-plugin>
+    <depends optional="true" config-file="ext-nodejs.xml">JavaScriptDebugger</depends>
+    <depends optional="true" config-file="ext-datagrip.xml">com.intellij.database</depends>
+    <depends optional="true" config-file="ext-go.xml">org.jetbrains.plugins.go</depends>
+</idea-plugin>


### PR DESCRIPTION
```
2021-04-05 13:40:45 INFO  PluginManager:58 - Plugin PluginDescriptor(name=AWS Toolkit, id=aws.toolkit, path=aws-toolkit-jetbrains/jetbrains-core/build/idea-sandbox/plugins-test/aws-toolkit-jetbrains, version=1.26-SNAPSHOT-202) misses optional descriptor ext-datagrip.xml
java.nio.file.NoSuchFileException: /META-INF/ext-datagrip.xml
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.newInputStream(ZipFileSystem.java:591)
	at jdk.zipfs/jdk.nio.zipfs.ZipPath.newInputStream(ZipPath.java:721)
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.newInputStream(ZipFileSystemProvider.java:275)
	at java.base/java.nio.file.Files.newInputStream(Files.java:156)
```

is no longer spammed in the core test suite

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
