### PR TITLE
Fix resource selector flaky tests

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ResourceSelector.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/ResourceSelector.kt
@@ -63,10 +63,7 @@ class ResourceSelector<T> private constructor(
     @Synchronized
     fun reload(forceFetch: Boolean = false) {
         val previouslySelected = model.selectedItem
-        loadingStatus = Status.LOADING
-
-        // If this reload will supersede a previous once, cancel it
-        loadingFuture?.cancel(true)
+        val previousLoading = loadingFuture
 
         runInEdt(ModalityState.any()) {
             loadingStatus = Status.LOADING
@@ -85,6 +82,11 @@ class ResourceSelector<T> private constructor(
                     connectionSettings = connectionSettings,
                     forceFetch = forceFetch
                 ).toCompletableFuture()
+
+                // If this reload will supersede a previous once, cancel it
+                if (previousLoading != resultFuture) {
+                    previousLoading?.cancel(true)
+                }
 
                 loadingFuture = resultFuture
                 resultFuture.whenComplete { value, error ->


### PR DESCRIPTION
* Fix flaky tests caused by the future being cancelled due to a reload and getting the same future back

#2535 

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
