### PR TITLE
Use the new SERVICE_METADATA_ID field in the SDK

### DIFF
--- a/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
+++ b/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
@@ -52,7 +52,7 @@ abstract class ToolkitClientManager {
             serviceClass = sdkClass
         )
 
-        val serviceId = key.serviceClass.java.getField("SERVICE_NAME").get(null) as String
+        val serviceId = key.serviceClass.java.getField("SERVICE_METADATA_ID").get(null) as String
         if (serviceId !in GLOBAL_SERVICE_DENY_LIST && getRegionProvider().isServiceGlobal(region, serviceId)) {
             val globalRegion = getRegionProvider().getGlobalRegionForService(region, serviceId)
             return cachedClients.computeIfAbsent(key.copy(region = globalRegion)) { createNewClient(sdkClass, globalRegion, credProvider) } as T

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ ideProfileName=2020.2
 
 # Common dependencies
 kotlinVersion=1.4.21
-awsSdkVersion=2.16.3
+awsSdkVersion=2.16.36
 coroutinesVersion=1.3.3
 ktlintVersion=0.39.0
 jacksonVersion=2.11.1

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -139,7 +139,7 @@ class AwsClientManagerTest {
 
         assertThatThrownBy { sut.getClient<NoServiceNameClient>(credentialManager.createCredentialProvider(), regionProvider.createAwsRegion()) }
             .isInstanceOf(NoSuchFieldException::class.java)
-            .hasMessageContaining("SERVICE_NAME")
+            .hasMessageContaining("SERVICE_METADATA_ID")
     }
 
     @Test
@@ -233,7 +233,7 @@ class AwsClientManagerTest {
         companion object {
             @Suppress("unused", "MayBeConstant")
             @JvmField
-            val SERVICE_NAME = "DummyService"
+            val SERVICE_METADATA_ID = "DummyService"
         }
     }
 


### PR DESCRIPTION
Use the new field that exposes the endpoints.json field name which can differ from serviceIdd

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
