### PR TITLE
Remove the convention from changelog version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,10 @@ tasks.register<GenerateGithubChangeLog>("generateChangeLog") {
     changeLogFile.set(project.file("CHANGELOG.md"))
 }
 
+tasks.createRelease.configure {
+    releaseVersion.set(providers.gradleProperty("toolkitVersion"))
+}
+
 dependencies {
     aggregateCoverage(project(":intellij"))
 }

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
@@ -23,11 +23,7 @@ open class CreateRelease @Inject constructor(projectLayout: ProjectLayout) : Cha
     val releaseDate: Property<String> = project.objects.property(String::class.java).convention(DateTimeFormatter.ISO_DATE.format(LocalDate.now()))
 
     @Input
-    val releaseVersion: Property<String> = project.objects.property(String::class.java).convention(
-        project.provider {
-            (project.version as String).substringBeforeLast('-')
-        }
-    )
+    val releaseVersion: Property<String> = project.objects.property(String::class.java)
 
     @Input
     @Optional


### PR DESCRIPTION
Remove the convention to force us to remember to set it, since `project.version` defaults to "unspecified" which is surprising and hard to find issues

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
