### PR TITLE
Hide ViewSettings parameter from AwsExplorerTreeStructureProvider

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerTreeStructure.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerTreeStructure.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.project.Project
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerRootNode
 
 class AwsExplorerTreeStructure(project: Project) : AbstractTreeStructureBase(project) {
-    override fun getProviders(): List<TreeStructureProvider>? = defaultTreeStructureProvider + AwsExplorerTreeStructureProvider.EP_NAME.extensionList
+    override fun getProviders(): List<TreeStructureProvider> = defaultTreeStructureProvider + AwsExplorerTreeStructureProvider.EP_NAME.extensionList
 
     override fun getRootElement() = AwsExplorerRootNode(myProject)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerTreeStructureProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AwsExplorerTreeStructureProvider.kt
@@ -9,17 +9,22 @@ import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.extensions.ExtensionPointName
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 
-interface AwsExplorerTreeStructureProvider : TreeStructureProvider {
+abstract class AwsExplorerTreeStructureProvider : TreeStructureProvider {
     companion object {
         val EP_NAME = ExtensionPointName<AwsExplorerTreeStructureProvider>("aws.toolkit.explorer.treeStructure")
     }
 
     /**
-     * Runs after the [AwsExplorerNode.update] allowing for changes to the tree, like collapsing nodes
+     * Hides the ViewSettings since it is tied to the project view tree
      */
-    override fun modify(
+    final override fun modify(
         parent: AbstractTreeNode<*>,
         children: MutableCollection<AbstractTreeNode<*>>,
         settings: ViewSettings?
-    ): MutableCollection<AbstractTreeNode<*>>
+    ): MutableCollection<AbstractTreeNode<*>> = modify(parent, children)
+
+    /**
+     * Runs after the [AwsExplorerNode.update] allowing for changes to the tree, like collapsing nodes
+     */
+    abstract fun modify(parent: AbstractTreeNode<*>, children: MutableCollection<AbstractTreeNode<*>>): MutableCollection<AbstractTreeNode<*>>
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/DefaultAwsExplorerTreeStructureProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/DefaultAwsExplorerTreeStructureProvider.kt
@@ -3,15 +3,10 @@
 
 package software.aws.toolkits.jetbrains.core.explorer
 
-import com.intellij.ide.projectView.ViewSettings
 import com.intellij.ide.util.treeView.AbstractTreeNode
 
-class DefaultAwsExplorerTreeStructureProvider : AwsExplorerTreeStructureProvider {
-    override fun modify(
-        parent: AbstractTreeNode<*>,
-        children: MutableCollection<AbstractTreeNode<*>>,
-        settings: ViewSettings?
-    ): MutableCollection<AbstractTreeNode<*>> =
+class DefaultAwsExplorerTreeStructureProvider : AwsExplorerTreeStructureProvider() {
+    override fun modify(parent: AbstractTreeNode<*>, children: MutableCollection<AbstractTreeNode<*>>): MutableCollection<AbstractTreeNode<*>> =
         // By default sort the children in alphabetical order
         children.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.toString() }).toMutableList()
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebuggingExplorerTreeStructureProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/clouddebug/CloudDebuggingExplorerTreeStructureProvider.kt
@@ -3,39 +3,32 @@
 
 package software.aws.toolkits.jetbrains.services.clouddebug
 
-import com.intellij.ide.projectView.ViewSettings
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import software.aws.toolkits.jetbrains.core.explorer.AwsExplorerTreeStructureProvider
 import software.aws.toolkits.jetbrains.services.ecs.EcsClusterNode
 import software.aws.toolkits.jetbrains.services.ecs.EcsServiceNode
 import software.aws.toolkits.jetbrains.services.ecs.EcsUtils
 
-class CloudDebuggingExplorerTreeStructureProvider : AwsExplorerTreeStructureProvider {
-    override fun modify(
-        parent: AbstractTreeNode<*>,
-        children: MutableCollection<AbstractTreeNode<*>>,
-        settings: ViewSettings?
-    ): MutableCollection<AbstractTreeNode<*>> =
+class CloudDebuggingExplorerTreeStructureProvider : AwsExplorerTreeStructureProvider() {
+    override fun modify(parent: AbstractTreeNode<*>, children: MutableCollection<AbstractTreeNode<*>>): MutableCollection<AbstractTreeNode<*>> =
         when (parent) {
             is EcsClusterNode ->
                 children
-                    .sortedWith(
-                        Comparator { x, y ->
-                            val service1 = (x as? EcsServiceNode)?.resourceArn()?.toLowerCase() ?: ""
-                            val service2 = (y as? EcsServiceNode)?.resourceArn()?.toLowerCase() ?: ""
-                            val value = EcsUtils.originalServiceName(service1).compareTo(EcsUtils.originalServiceName(service2))
-                            if (value != 0) {
-                                value
+                    .sortedWith { x, y ->
+                        val service1 = (x as? EcsServiceNode)?.resourceArn()?.toLowerCase() ?: ""
+                        val service2 = (y as? EcsServiceNode)?.resourceArn()?.toLowerCase() ?: ""
+                        val value = EcsUtils.originalServiceName(service1).compareTo(EcsUtils.originalServiceName(service2))
+                        if (value != 0) {
+                            value
+                        } else {
+                            // Always put the instrumented service first
+                            if (EcsUtils.isInstrumented(service1)) {
+                                -1
                             } else {
-                                // Always put the instrumented service first
-                                if (EcsUtils.isInstrumented(service1)) {
-                                    -1
-                                } else {
-                                    1
-                                }
+                                1
                             }
                         }
-                    )
+                    }
                     .toMutableList()
             else -> children
         }


### PR DESCRIPTION
* The parameter leaks into the TreeView from the ProjectView usage. Hide it from our method and use a concrete impl to delegate it to a new method ot hide it

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
