### PR TITLE
Attempt to fix Jacoco server running past test life cycle

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/jacoco/RemoteCoverage.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/jacoco/RemoteCoverage.kt
@@ -47,8 +47,10 @@ class RemoteCoverage private constructor(task: Test) {
                 jacocoServer.get().start()
                 task.project.gradle.addBuildListener(object : BuildAdapter() {
                     override fun buildFinished(result: BuildResult) {
-                        jacocoServer.get().close()
                         task.project.gradle.removeListener(this)
+                        runCatching {
+                            jacocoServer.get().close()
+                        }
                     }
                 })
             }

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/jacoco/RemoteCoverage.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/jacoco/RemoteCoverage.kt
@@ -65,7 +65,7 @@ class RemoteCoverage private constructor(task: Test) {
 
         private val serverRunnable = Runnable {
             parameters.execFile.asFile.get().outputStream().use {
-                while (!isRunning.get()) {
+                while (isRunning.get()) {
                     val clientSocket = serverSocket.accept()
                     JacocoHandler(clientSocket, it).run()
                 }


### PR DESCRIPTION
Attempt to make the jacoco remote server build service be re-entrant in case the daemon hasnt stopped it yet

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
