### PR TITLE
S3 viewer test needs to be on UI thread

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3ViewerPanelTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3ViewerPanelTest.kt
@@ -7,6 +7,7 @@ import com.intellij.ide.DataManager
 import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.ProjectRule
 import com.intellij.testFramework.TestApplicationManager
+import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -49,12 +50,14 @@ class S3ViewerPanelTest {
 
     @Test
     fun `data provider selected nodes key returns table selected values`() {
-        val dataProvider = DataManager.getInstance().getDataContext(sut.component)
-        sut.treeTable.clearSelection()
-        assertThat(dataProvider.getData(S3EditorDataKeys.SELECTED_NODES)).isEmpty()
+        runInEdtAndWait {
+            val dataProvider = DataManager.getInstance().getDataContext(sut.component)
+            sut.treeTable.clearSelection()
+            assertThat(dataProvider.getData(S3EditorDataKeys.SELECTED_NODES)).isEmpty()
 
-        sut.treeTable.addRowSelectionInterval(0, 0)
-        assertThat(dataProvider.getData(S3EditorDataKeys.SELECTED_NODES)).containsExactly(S3TreeDirectoryNode(s3Bucket, null, "folder/"))
+            sut.treeTable.addRowSelectionInterval(0, 0)
+            assertThat(dataProvider.getData(S3EditorDataKeys.SELECTED_NODES)).containsExactly(S3TreeDirectoryNode(s3Bucket, null, "folder/"))
+        }
     }
 
     @Test


### PR DESCRIPTION
We are messing with a Swing components state so we should make sure we execute it on EDT

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
