### PR TITLE
Fix message bus usage after dispose

### DIFF
--- a/.changes/next-release/bugfix-aa7fdea0-8806-41d3-91f5-633c94850371.json
+++ b/.changes/next-release/bugfix-aa7fdea0-8806-41d3-91f5-633c94850371.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix using message bus after project has been closed (Fixes #2615)"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
@@ -6,7 +6,9 @@ package software.aws.toolkits.jetbrains.core.credentials
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.application.AppUIExecutor
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SimpleModificationTracker
@@ -41,7 +43,7 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
             field = value
             incModificationCount()
 
-            if (!project.isDisposed) {
+            AppUIExecutor.onWriteThread(ModalityState.any()).expireWith(this).execute {
                 project.messageBus.syncPublisher(CONNECTION_SETTINGS_STATE_CHANGED).settingsStateChanged(value)
             }
         }


### PR DESCRIPTION
* Use a write action so that project can't disappear under it
* Use the service as the Diposable key so coroutines and publishing are both cancelled if the projectService goes away

## Related Issue(s)
#2615 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
