### PR TITLE
Add hidden action to view the recorded telemetry

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -259,6 +259,9 @@ with what features/services are supported.
     </extensions>
 
     <actions>
+        <action internal="true" id="aws.toolkit.open.telemetry.viewer"
+                class="software.aws.toolkits.jetbrains.services.telemetry.viewer.OpenTelemetryAction"/>
+
         <group id="aws.toolkit.explorer.ecr" popup="true" compact="false">
             <action id="ecr.repository.create" class="software.aws.toolkits.jetbrains.services.ecr.actions.CreateRepositoryAction"/>
         </group>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/viewer/OpenTelemetryAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/viewer/OpenTelemetryAction.kt
@@ -1,0 +1,31 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.telemetry.viewer
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.wm.RegisterToolWindowTask
+import com.intellij.openapi.wm.ToolWindowManager
+
+class OpenTelemetryAction : DumbAwareAction() {
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.getRequiredData(CommonDataKeys.PROJECT)
+        val id = "aws.telemetryViewer"
+        val toolWindowManager = ToolWindowManager.getInstance(project)
+        val toolWindow = toolWindowManager.getToolWindow(id) ?: run {
+            val newToolWindow = toolWindowManager.registerToolWindow(
+                RegisterToolWindowTask(
+                    id = id,
+                    component = TelemetryToolWindow(project),
+                    canCloseContent = false,
+                )
+            )
+
+            newToolWindow
+        }
+
+        toolWindow.show()
+    }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/viewer/TelemetryToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/viewer/TelemetryToolWindow.kt
@@ -1,0 +1,36 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.telemetry.viewer
+
+import com.intellij.execution.filters.TextConsoleBuilderFactory
+import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.openapi.util.Disposer
+import software.aws.toolkits.core.telemetry.MetricEvent
+import software.aws.toolkits.jetbrains.services.telemetry.TelemetryListener
+import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
+
+class TelemetryToolWindow(project: Project) : SimpleToolWindowPanel(false, true), Disposable, TelemetryListener {
+    private val consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).apply {
+        setViewer(true)
+    }.console
+
+    init {
+        Disposer.register(this, consoleView)
+
+        setContent(consoleView.component)
+
+        TelemetryService.getInstance().addListener(this)
+    }
+
+    override fun onTelemetryEvent(event: MetricEvent) {
+        consoleView.print(event.toString() + "\n", ConsoleViewContentType.NORMAL_OUTPUT)
+    }
+
+    override fun dispose() {
+        TelemetryService.getInstance().removeListener(this)
+    }
+}

--- a/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 action.aws.toolkit.dynamoViewer.changeMaxResults.text=Max Results
 action.aws.toolkit.ecr.repository.push.text=Push to Repository...
+action.aws.toolkit.open.telemetry.viewer.text=View Telemetry
 action.aws.toolkit.s3.open.bucket.viewer.prefixed.text=View Bucket with Prefix...
 action.aws.toolkit.s3.open.bucket.viewer.text=View Bucket
 apprunner.action.configure=Configure Service


### PR DESCRIPTION
Add a hidden action (IDE must be in internal mode (i.e. sandbox)) and searched for in the Action search.

Any recorded telemetry post opening will be printed to the tool window to help speed up development

<img width="1373" alt="Screen Shot 2021-06-07 at 5 22 57 PM" src="https://user-images.githubusercontent.com/8992246/121104694-6dcc9a00-c7b7-11eb-84f4-4ad943a3db14.png">


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
