### PR TITLE
Remove Python 2.7 from project wizard

### DIFF
--- a/.changes/next-release/breaking-5f9208ca-e491-42cb-92c8-613eb716b71d.json
+++ b/.changes/next-release/breaking-5f9208ca-e491-42cb-92c8-613eb716b71d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "breaking",
+  "description" : "Python 2.7 Lambda template removed from New Project Wizard"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
@@ -21,11 +21,11 @@ import software.aws.toolkits.jetbrains.services.lambda.wizard.SdkSelector
 import software.aws.toolkits.jetbrains.services.lambda.wizard.TemplateParameters
 import software.aws.toolkits.resources.message
 
-private val pythonTemplateRuntimes = setOf(LambdaRuntime.PYTHON2_7, LambdaRuntime.PYTHON3_6, LambdaRuntime.PYTHON3_7, LambdaRuntime.PYTHON3_8)
+private val pythonTemplateRuntimes = setOf(LambdaRuntime.PYTHON3_6, LambdaRuntime.PYTHON3_7, LambdaRuntime.PYTHON3_8)
 private val eventBridgeTemplateRuntimes = setOf(LambdaRuntime.PYTHON3_6, LambdaRuntime.PYTHON3_7, LambdaRuntime.PYTHON3_8)
 
 class PythonSamProjectWizard : SamProjectWizard {
-    override fun createSdkSelectionPanel(projectLocation: TextFieldWithBrowseButton?): SdkSelector? = when {
+    override fun createSdkSelectionPanel(projectLocation: TextFieldWithBrowseButton?): SdkSelector = when {
         PlatformUtils.isIntelliJ() -> IntelliJSdkSelectionPanel(BuiltInRuntimeGroups.Python)
         else -> PyCharmSdkSelectionPanel(projectLocation)
     }


### PR DESCRIPTION
* Start of Phase 1 of end of support is in July so go ahead and remove it from project wizard

https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
