### PR TITLE
Send product build base version instead of marketing name as product version

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/ClientMetadata.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/ClientMetadata.kt
@@ -15,7 +15,7 @@ data class ClientMetadata(
     val productVersion: String = AwsToolkit.PLUGIN_VERSION,
     val clientId: String = AwsSettings.getInstance().clientId.toString(),
     val parentProduct: String = ApplicationNamesInfo.getInstance().fullProductNameWithEdition,
-    val parentProductVersion: String = ApplicationInfo.getInstance().fullVersion,
+    val parentProductVersion: String = ApplicationInfo.getInstance().build.baselineVersion.toString(),
     val os: String = SystemInfo.OS_NAME,
     val osVersion: String = SystemInfo.OS_VERSION
 ) {


### PR DESCRIPTION
```
    "parentProduct": "Android Studio",
    "parentProductVersion": "211",
    "timestamp": "1623268509942",
    "value": "1.0",
    "passive": "true",
    "metadata.metricName": "aws_validateCredentials",
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
