### PR TITLE
Fixing App Runner Copy/Open URL Messages

### DIFF
--- a/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -1,7 +1,7 @@
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-action.apprunner.service.copyServiceUri=Open Service URL
-action.apprunner.service.openServiceUri.text=Copy Service URL
+action.apprunner.service.copyServiceUri.text=Copy Service URL
+action.apprunner.service.openServiceUri.text=Open Service URL
 action.aws.toolkit.dynamoViewer.changeMaxResults.text=Max Results
 action.aws.toolkit.ecr.repository.push.text=Push to Repository...
 action.aws.toolkit.open.telemetry.viewer.text=View Telemetry


### PR DESCRIPTION
Oops #2626 introduced a bug in the action messages - this is the fix. Thanks @rli 

<img width="303" alt="Screen Shot 2021-06-09 at 7 50 25 PM" src="https://user-images.githubusercontent.com/4661536/121457090-f5eba480-c95b-11eb-9d47-42da4b75c1b5.png">
