### PR TITLE
Cleanup telemetry overrides

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ awsSdkVersion=2.16.65
 coroutinesVersion=1.3.3
 detektVersion=1.16.0
 jacksonVersion=2.11.1
-telemetryVersion=1.0.5
+telemetryVersion=1.0.6
 commonsMarkVersion=0.17.1
 jgitVersion=5.11.0.202103091610-r
 

--- a/jetbrains-core/resources/telemetryOverride.json
+++ b/jetbrains-core/resources/telemetryOverride.json
@@ -1,9 +1,5 @@
 {
     "types": [],
     "metrics": [
-        {
-            "name": "apprunner_openServiceUrl",
-            "description": "Open the service URL in a browser"
-        }
     ]
 }


### PR DESCRIPTION


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
