### PR TITLE
Clean up DownloadCodeForSchemaDialogTest

### DIFF
--- a/detekt-rules/baseline.xml
+++ b/detekt-rules/baseline.xml
@@ -233,19 +233,7 @@
     <ID>FunctionNaming:SamVersionCacheTest.kt$SamVersionCacheTest$@Test fun successExecution_EmptyOutput()</ID>
     <ID>TopLevelPropertyNaming:EventsFetcherTest.kt$private const val nonEmptyMessage = "Second call on the same page must not return anything"</ID>
     <ID>TopLevelPropertyNaming:EventsFetcherTest.kt$private const val wrongPageMessage = "Wrong list of available pages"</ID>
-    <ID>TopLevelPropertyNaming:RdsResources.kt$// These are the member engine in DBInstance, but it is a string const val mysqlEngineType = "mysql"</ID>
-    <ID>TopLevelPropertyNaming:RdsResources.kt$const val jdbcMysql = "mysql"</ID>
-    <ID>TopLevelPropertyNaming:RdsResources.kt$const val jdbcMysqlAurora = "mysql:aurora"</ID>
-    <ID>TopLevelPropertyNaming:RdsResources.kt$const val jdbcPostgres = "postgresql"</ID>
-    <ID>TopLevelPropertyNaming:RdsResources.kt$const val postgresEngineType = "postgres"</ID>
     <ID>TopLevelPropertyNaming:SqsUtils.kt$const val sqsPolicyStatementArray = "Statement"</ID>
-    <ID>VariableNaming:DownloadCodeForSchemaDialogTest.kt$DownloadCodeForSchemaDialogTest$private val LANGUAGE = SchemaCodeLangs.JAVA8</ID>
-    <ID>VariableNaming:DownloadCodeForSchemaDialogTest.kt$DownloadCodeForSchemaDialogTest$private val LATEST = "5"</ID>
-    <ID>VariableNaming:DownloadCodeForSchemaDialogTest.kt$DownloadCodeForSchemaDialogTest$private val REGISTRY = "registry"</ID>
-    <ID>VariableNaming:DownloadCodeForSchemaDialogTest.kt$DownloadCodeForSchemaDialogTest$private val SCHEMA = Schema(SCHEMA_NAME, REGISTRY, null)</ID>
-    <ID>VariableNaming:DownloadCodeForSchemaDialogTest.kt$DownloadCodeForSchemaDialogTest$private val SCHEMA_NAME = "schema"</ID>
-    <ID>VariableNaming:DownloadCodeForSchemaDialogTest.kt$DownloadCodeForSchemaDialogTest$private val VERSION = "4"</ID>
-    <ID>VariableNaming:DownloadCodeForSchemaDialogTest.kt$DownloadCodeForSchemaDialogTest$private val VERSIONS = listOf("3", VERSION, LATEST)</ID>
     <ID>VariableNaming:InsightsQueryTest.kt$InsightsQueryTest$/** * We can't reach into jetbrains-core by design, so copy the default string out of * QueryEditorUtils.kt . If the string changes it needs to change in both places */ private val DEFAULT_INSIGHTS_QUERY_STRING = """fields @timestamp, @message | sort @timestamp desc | limit 20 """</ID>
     <ID>VariableNaming:NodeJsDebugEndToEndTest.kt$NodeJsDebugEndToEndTest$private val WEB_CONSOLE_JB_REGISTRY_KEY = "js.debugger.webconsole"</ID>
     <ID>VariableNaming:NodeJsDebuggerSupport.kt$NodeJsDebuggerSupport$private val NODE_DEBUG = "--inspect-brk"</ID>

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ ideaPluginVersion=0.7.3
 # only upgrade if that is fixed or move to a different plugin
 ktintPluginVersion=9.4.1
 
-assertjVersion=3.15.0
+assertjVersion=3.20.2
 junitVersion=4.13.1
 junit5Version=5.6.2
 apacheCommonsVersion=2.8.0

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialsRegionHandlerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialsRegionHandlerTest.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.core.credentials
 
 import com.intellij.notification.Notification
+import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.ProjectRule
 import com.intellij.testFramework.TestDataProvider
 import com.intellij.testFramework.runInEdtAndWait
@@ -32,7 +33,11 @@ class CredentialsRegionHandlerTest {
 
     @Rule
     @JvmField
-    val notificationListener = NotificationListenerRule(projectRule)
+    val disposableRule = DisposableRule()
+
+    @Rule
+    @JvmField
+    val notificationListener = NotificationListenerRule(projectRule, disposableRule.disposable)
 
     private lateinit var sut: DefaultCredentialsRegionHandler
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/NotificationUtilsTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/NotificationUtilsTest.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.utils
 
+import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -10,14 +11,17 @@ import org.junit.Test
 import software.aws.toolkits.jetbrains.utils.rules.NotificationListenerRule
 
 class NotificationUtilsTest {
-
     @Rule
     @JvmField
     val projectRule = ProjectRule()
 
     @Rule
     @JvmField
-    val notificationListener = NotificationListenerRule(projectRule)
+    val disposableRule = DisposableRule()
+
+    @Rule
+    @JvmField
+    val notificationListener = NotificationListenerRule(projectRule, disposableRule.disposable)
 
     @Test
     fun `Notifications show stack traces for exceptions`() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/NotificationListenerRule.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/rules/NotificationListenerRule.kt
@@ -5,20 +5,39 @@ package software.aws.toolkits.jetbrains.utils.rules
 
 import com.intellij.notification.Notification
 import com.intellij.notification.Notifications
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
 import com.intellij.testFramework.ProjectRule
 import org.junit.rules.ExternalResource
 import java.util.concurrent.CopyOnWriteArrayList
 
-class NotificationListenerRule(private val projectRule: ProjectRule) : ExternalResource() {
-    val notifications = CopyOnWriteArrayList<Notification>()
+class NotificationListenerRule : ExternalResource {
+    private val projectSupplier: () -> Project
+    private val disposable: Disposable
+
+    constructor(projectRule: ProjectRule, disposable: Disposable) : super() {
+        this.projectSupplier = { projectRule.project }
+        this.disposable = disposable
+        this.notifications = CopyOnWriteArrayList<Notification>()
+    }
+
+    constructor(projectRule: CodeInsightTestFixtureRule, disposable: Disposable) : super() {
+        this.projectSupplier = { projectRule.project }
+        this.disposable = disposable
+        this.notifications = CopyOnWriteArrayList<Notification>()
+    }
+
+    val notifications: CopyOnWriteArrayList<Notification>
 
     override fun before() {
-        with(projectRule.project.messageBus.connect()) {
-            setDefaultHandler { _, params ->
-                notifications.add(params[0] as Notification)
+        projectSupplier().messageBus.connect(disposable).subscribe(
+            Notifications.TOPIC,
+            object : Notifications {
+                override fun notify(notification: Notification) {
+                    notifications.add(notification)
+                }
             }
-            subscribe(Notifications.TOPIC)
-        }
+        )
         notifications.clear()
     }
 }


### PR DESCRIPTION
* Notification listener rule has a proper disposable requirement to prevent leaks
* Fix naming violations
* Use notification listener rule instead of one off method
* Update asserts to be clearer

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
