### PR TITLE
Fix S3 actions failing when short cuts are triggered outside of viewer

### DIFF
--- a/.changes/next-release/bugfix-967da0c8-b378-43be-8a38-d7728963e781.json
+++ b/.changes/next-release/bugfix-967da0c8-b378-43be-8a38-d7728963e781.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix S3 bucket viewer actions being triggered by short cuts even if it is not focused"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/S3ObjectAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/objectActions/S3ObjectAction.kt
@@ -18,6 +18,13 @@ abstract class S3ObjectAction(title: String, icon: Icon? = null) : DumbAwareActi
     protected abstract fun performAction(dataContext: DataContext, nodes: List<S3TreeNode>)
 
     final override fun update(e: AnActionEvent) {
+        val bucketViewer = e.dataContext.getData(S3EditorDataKeys.BUCKET_TABLE)
+        // Disable the action if the bucket viewer is not in our UI hierarchy
+        if (bucketViewer == null) {
+            e.presentation.isEnabledAndVisible = false
+            return
+        }
+
         val selected = selected(e.dataContext)
         e.presentation.isEnabled = selected.none { it is S3TreeContinuationNode<*> || it is S3TreeErrorNode } && enabled(selected)
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyPathActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyPathActionTest.kt
@@ -15,7 +15,7 @@ import java.awt.datatransfer.DataFlavor
 import java.time.Instant
 
 class CopyPathActionTest : ObjectActionTestBase() {
-    private val sut = CopyPathAction()
+    override val sut = CopyPathAction()
 
     @Test
     fun `copy path disabled with no nodes`() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyUriActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyUriActionTest.kt
@@ -15,7 +15,7 @@ import java.awt.datatransfer.DataFlavor
 import java.time.Instant
 
 class CopyUriActionTest : ObjectActionTestBase() {
-    private val sut = CopyUriAction()
+    override val sut = CopyUriAction()
 
     @Test
     fun `copy uri disabled with no nodes`() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyUrlActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/CopyUrlActionTest.kt
@@ -31,7 +31,7 @@ class CopyUrlActionTest : ObjectActionTestBase() {
     @JvmField
     val disposableRule = DisposableRule()
 
-    private val sut = CopyUrlAction()
+    override val sut = CopyUrlAction()
 
     @Before
     fun setUpMock() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/DeleteObjectActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/DeleteObjectActionTest.kt
@@ -23,7 +23,7 @@ import software.aws.toolkits.jetbrains.ui.TestDialogService
 import java.time.Instant
 
 class DeleteObjectActionTest : ObjectActionTestBase() {
-    private val sut = DeleteObjectAction()
+    override val sut = DeleteObjectAction()
 
     @After
     fun tearDown() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/DownloadObjectActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/DownloadObjectActionTest.kt
@@ -44,7 +44,7 @@ class DownloadObjectActionTest : ObjectActionTestBase() {
     @JvmField
     val testDisposable = DisposableRule()
 
-    private val sut = DownloadObjectAction()
+    override val sut = DownloadObjectAction()
 
     @After
     fun tearDown() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/NewFolderActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/NewFolderActionTest.kt
@@ -23,7 +23,7 @@ import software.aws.toolkits.jetbrains.ui.TestDialogService
 import java.time.Instant
 
 class NewFolderActionTest : ObjectActionTestBase() {
-    private val sut = NewFolderAction()
+    override val sut = NewFolderAction()
 
     @After
     fun tearDown() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/ObjectActionTestBase.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/ObjectActionTestBase.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.testFramework.ProjectRule
 import com.intellij.ui.treeStructure.treetable.TreeTableTree
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -62,9 +62,8 @@ abstract class ObjectActionTestBase {
 
         sut.update(actionEvent)
 
-        Assertions.assertThat(actionEvent.presentation.isEnabled).isFalse
+        assertThat(actionEvent.presentation.isEnabled).isFalse
     }
-
 
     protected fun AnAction.executeAction(nodes: List<S3TreeNode>) {
         val event = createEventFor(this, nodes)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/ObjectActionTestBase.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/ObjectActionTestBase.kt
@@ -10,8 +10,10 @@ import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.testFramework.ProjectRule
 import com.intellij.ui.treeStructure.treetable.TreeTableTree
+import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Rule
+import org.junit.Test
 import org.mockito.kotlin.mock
 import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.jetbrains.services.s3.editor.S3EditorDataKeys
@@ -21,10 +23,12 @@ import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeTable
 import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeTableModel
 import software.aws.toolkits.jetbrains.services.s3.editor.S3VirtualBucket
 
-open class ObjectActionTestBase {
+abstract class ObjectActionTestBase {
     @Rule
     @JvmField
     val projectRule = ProjectRule()
+
+    protected abstract val sut: S3ObjectAction
 
     protected val bucketName = aString()
     protected lateinit var treeTable: S3TreeTable
@@ -44,6 +48,23 @@ open class ObjectActionTestBase {
             on { tree }.thenReturn(mockModel)
         }
     }
+
+    @Test
+    fun `action is disabled when UI element is not present`() {
+        val projectContext = SimpleDataContext.getProjectContext(projectRule.project)
+        val dc = SimpleDataContext.getSimpleContext(
+            mapOf(
+                S3EditorDataKeys.BUCKET_TABLE.name to null
+            ),
+            projectContext
+        )
+        val actionEvent = AnActionEvent.createFromAnAction(sut, null, ActionPlaces.UNKNOWN, dc)
+
+        sut.update(actionEvent)
+
+        Assertions.assertThat(actionEvent.presentation.isEnabled).isFalse
+    }
+
 
     protected fun AnAction.executeAction(nodes: List<S3TreeNode>) {
         val event = createEventFor(this, nodes)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/RefreshTreeActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/RefreshTreeActionTest.kt
@@ -16,7 +16,7 @@ import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeObjectVersionNod
 import java.time.Instant
 
 class RefreshTreeActionTest : ObjectActionTestBase() {
-    private val sut = RefreshTreeAction()
+    override val sut = RefreshTreeAction()
 
     @Test
     fun `refresh tree action is enabled on empty selection`() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/RenameObjectActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/RenameObjectActionTest.kt
@@ -23,7 +23,7 @@ import software.aws.toolkits.jetbrains.ui.TestDialogService
 import java.time.Instant
 
 class RenameObjectActionTest : ObjectActionTestBase() {
-    private val sut = RenameObjectAction()
+    override val sut = RenameObjectAction()
 
     @After
     fun tearDown() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectActionTest.kt
@@ -43,7 +43,7 @@ class UploadObjectActionTest : ObjectActionTestBase() {
     @JvmField
     val disposableRule = DisposableRule()
 
-    private val sut = UploadObjectAction()
+    override val sut = UploadObjectAction()
 
     @Test
     fun `upload object action is enabled on empty selection`() {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/ViewObjectVersionActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/ViewObjectVersionActionTest.kt
@@ -13,7 +13,7 @@ import software.aws.toolkits.jetbrains.services.s3.editor.S3TreeObjectNode
 import java.time.Instant
 
 class ViewObjectVersionActionTest : ObjectActionTestBase() {
-    private val sut = ViewObjectVersionAction()
+    override val sut = ViewObjectVersionAction()
 
     @Test
     fun `show history is disabled on empty selection`() {


### PR DESCRIPTION
## Related Issue(s)
#2690

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
