### PR TITLE
Fix Rider SDK that got downgraded in #2704

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -74,7 +74,7 @@ object IdeVersions {
                 )
             ),
             rider = RiderProfile(
-                sdkVersion = "2020.3",
+                sdkVersion = "2020.3.2",
                 plugins = commonPlugins + listOf(
                     "rider-plugins-appender" // Workaround for https://youtrack.jetbrains.com/issue/IDEA-179607
                 ),


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
