### PR TITLE
Bump gradle-intellij-plugin and add 212 run configs

### DIFF
--- a/.run/Run IDE - Core [2021.2].run.xml
+++ b/.run/Run IDE - Core [2021.2].run.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run IDE - Core [2021.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2021.2">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/jetbrains-core/build/idea-sandbox/system/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="ALTERNATIVE_IDE_PROFILE_NAME" value="2021.2" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/jetbrains-core" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>false</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run IDE - Rider [2021.2].run.xml
+++ b/.run/Run IDE - Rider [2021.2].run.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run IDE - Rider [2021.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2021.2">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/jetbrains-rider/build/idea-sandbox/system/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="ALTERNATIVE_IDE_PROFILE_NAME" value="2021.2" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/jetbrains-rider" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>false</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run IDE - Ultimate [2021.2].run.xml
+++ b/.run/Run IDE - Ultimate [2021.2].run.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run IDE - Ultimate [2021.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2021.2">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/jetbrains-ultimate/build/idea-sandbox/system/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="ALTERNATIVE_IDE_PROFILE_NAME" value="2021.2" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/jetbrains-ultimate" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>false</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -18,5 +18,15 @@ dependencyResolutionManagement {
         }
         mavenCentral()
         gradlePluginPortal()
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            content {
+                // only allowed to pull snapshots of gradle-intellij-plugin from here
+                includeModule("org.jetbrains.intellij.plugins", "gradle-intellij-plugin")
+            }
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -135,7 +135,7 @@ object IdeVersions {
                 sdkFlavor = IdeFlavor.IU,
                 sdkVersion = "212.4638.7-EAP-SNAPSHOT",
                 plugins = commonPlugins + listOf(
-//                    "JavaScript",
+                    "JavaScript",
                     // Transitive dependency needed for javascript
                     // Can remove when https://github.com/JetBrains/gradle-intellij-plugin/issues/608 is fixed
                     "com.intellij.css",

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ jgitVersion=5.11.0.202103091610-r
 
 gradleRetryPluginVersion=1.2.1
 gradleTestLoggerPlugin=3.0.0
-ideaPluginVersion=1.1
+ideaPluginVersion=1.2-SNAPSHOT
 
 # Note: Versions > 10 use process isolation which blows us out of memory in CI,
 # only upgrade if that is fixed or move to a different plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,7 @@ jgitVersion=5.11.0.202103091610-r
 
 gradleRetryPluginVersion=1.2.1
 gradleTestLoggerPlugin=3.0.0
-ideaPluginVersion=1.2-SNAPSHOT
-
+ideaPluginVersion=1.1.3
 # Note: Versions > 10 use process isolation which blows us out of memory in CI,
 # only upgrade if that is fixed or move to a different plugin
 ktintPluginVersion=9.4.1

--- a/jetbrains-rider/build.gradle.kts
+++ b/jetbrains-rider/build.gradle.kts
@@ -258,6 +258,10 @@ tasks.withType<PrepareSandboxTask>().all {
     }
 }
 
+tasks.withType<Test>().all {
+    dependsOn(tasks.prepareTestingSandbox)
+}
+
 tasks.compileKotlin {
     dependsOn(generateModels)
 }


### PR DESCRIPTION
Latest 1.2-SNAPSHOT has fixes to allow us to build against JS plugin


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
