### PR TITLE
Add compatability typealias hacks for dockerfile parser

### DIFF
--- a/jetbrains-core/src-202-211/software/aws/toolkits/jetbrains/core/docker/compatability/DockerfileParser.kt
+++ b/jetbrains-core/src-202-211/software/aws/toolkits/jetbrains/core/docker/compatability/DockerfileParser.kt
@@ -1,0 +1,10 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.docker.compatability
+
+typealias DockerFileAddOrCopyCommand = com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileAddOrCopyCommand
+typealias DockerFileCmdCommand = com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileCmdCommand
+typealias DockerFileExposeCommand = com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileExposeCommand
+typealias DockerFileFromCommand = com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileFromCommand
+typealias DockerFileWorkdirCommand = com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileWorkdirCommand

--- a/jetbrains-core/src-212+/software/aws/toolkits/jetbrains/core/docker/compatability/DockerfileParser.kt
+++ b/jetbrains-core/src-212+/software/aws/toolkits/jetbrains/core/docker/compatability/DockerfileParser.kt
@@ -1,0 +1,10 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.docker.compatability
+
+typealias DockerFileAddOrCopyCommand = com.intellij.docker.dockerFile.parser.psi.DockerFileAddOrCopyCommand
+typealias DockerFileCmdCommand = com.intellij.docker.dockerFile.parser.psi.DockerFileCmdCommand
+typealias DockerFileExposeCommand = com.intellij.docker.dockerFile.parser.psi.DockerFileExposeCommand
+typealias DockerFileFromCommand = com.intellij.docker.dockerFile.parser.psi.DockerFileFromCommand
+typealias DockerFileWorkdirCommand = com.intellij.docker.dockerFile.parser.psi.DockerFileWorkdirCommand

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/docker/DockerfileParser.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/docker/DockerfileParser.kt
@@ -1,19 +1,19 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.ecs.execution.docker
+package software.aws.toolkits.jetbrains.core.docker
 
 import com.intellij.docker.dockerFile.parser.psi.DockerPsiCommand
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileAddOrCopyCommand
-import com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileCmdCommand
-import com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileExposeCommand
-import com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileFromCommand
-import com.intellij.plugins.docker.dockerFile.parser.psi.DockerFileWorkdirCommand
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.psi.impl.source.tree.LeafPsiElement
+import software.aws.toolkits.jetbrains.core.docker.compatability.DockerFileAddOrCopyCommand
+import software.aws.toolkits.jetbrains.core.docker.compatability.DockerFileCmdCommand
+import software.aws.toolkits.jetbrains.core.docker.compatability.DockerFileExposeCommand
+import software.aws.toolkits.jetbrains.core.docker.compatability.DockerFileFromCommand
+import software.aws.toolkits.jetbrains.core.docker.compatability.DockerFileWorkdirCommand
 import java.io.File
 
 class DockerfileParser(private val project: Project) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/execution/ImportFromDockerfile.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/execution/ImportFromDockerfile.kt
@@ -10,8 +10,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.ui.Messages
 import software.aws.toolkits.core.utils.tryOrNull
+import software.aws.toolkits.jetbrains.core.docker.DockerfileParser
 import software.aws.toolkits.jetbrains.core.plugins.pluginIsInstalledAndEnabled
-import software.aws.toolkits.jetbrains.services.ecs.execution.docker.DockerfileParser
 import software.aws.toolkits.resources.message
 import java.awt.event.ActionEvent
 import java.awt.event.ActionListener

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/docker/DockerfileParserTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/docker/DockerfileParserTest.kt
@@ -1,7 +1,7 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.services.ecs.execution.docker
+package software.aws.toolkits.jetbrains.core.docker
 
 import com.intellij.docker.dockerFile.DockerFileType
 import com.intellij.docker.dockerFile.DockerLanguage


### PR DESCRIPTION

- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
