### PR TITLE
Add test to verify user agent is passed

### DIFF
--- a/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
+++ b/core/src/software/aws/toolkits/core/ToolkitClientManager.kt
@@ -84,11 +84,19 @@ abstract class ToolkitClientManager {
      * Creates a new client for the requested [AwsClientKey]
      */
     @Suppress("UNCHECKED_CAST")
-    protected open fun <T : SdkClient> createNewClient(
+    open fun <T : SdkClient> createNewClient(
         sdkClass: KClass<T>,
         region: AwsRegion,
-        credProvider: ToolkitCredentialsProvider
-    ): T = createNewClient(sdkClass, sdkHttpClient(), Region.of(region.id), credProvider, userAgent)
+        credProvider: ToolkitCredentialsProvider,
+        endpointOverride: String? = null
+    ): T = createNewClient(
+        sdkClass = sdkClass,
+        httpClient = sdkHttpClient(),
+        region = Region.of(region.id),
+        credProvider = credProvider,
+        userAgent = userAgent,
+        endpointOverride = endpointOverride
+    )
 
     companion object {
         private val GLOBAL_SERVICE_DENY_LIST = setOf(

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/MockClientManager.kt
@@ -30,10 +30,14 @@ class MockClientManager : AwsClientManager() {
     private val mockClients = mutableMapOf<Key, SdkClient>()
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T : SdkClient> createNewClient(sdkClass: KClass<T>, region: AwsRegion, credProvider: ToolkitCredentialsProvider): T =
-        mockClients[Key(sdkClass, region, credProvider.id)] as? T
-            ?: mockClients[Key(sdkClass)] as? T
-            ?: throw IllegalStateException("No mock registered for $sdkClass")
+    override fun <T : SdkClient> createNewClient(
+        sdkClass: KClass<T>,
+        region: AwsRegion,
+        credProvider: ToolkitCredentialsProvider,
+        endpointOverride: String?
+    ): T = mockClients[Key(sdkClass, region, credProvider.id)] as? T
+        ?: mockClients[Key(sdkClass)] as? T
+        ?: throw IllegalStateException("No mock registered for $sdkClass")
 
     override fun dispose() {
         super.dispose()


### PR DESCRIPTION
## Testing
Forced breakage:

```
User-Agent [contains] : AWS-Toolkit-For-afaf/
> but was:<
GET
/2015-03-31/functions/

User-Agent: AWS-Toolkit-For-JetBrains/1.29-SNAPSHOT-202 IntelliJ-IDEA-Community-Edition/2020.2, aws-sdk-java/2.16.65 Mac_OS_X/10.15.7 OpenJDK_64-Bit_Server_VM/11.0.11+9-LTS Java/11.0.11 kotlin/1.4.21-release-351 (1.4.21) vendor/Amazon.com_Inc. io/sync http/UNKNOWN cfg/retry-mode/standard
>
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
