### PR TITLE
Bump JetBrains Gradle plugin to 1.1.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ jgitVersion=5.11.0.202103091610-r
 
 gradleRetryPluginVersion=1.2.1
 gradleTestLoggerPlugin=3.0.0
-ideaPluginVersion=1.1.3
+ideaPluginVersion=1.1.4
 # Note: Versions > 10 use process isolation which blows us out of memory in CI,
 # only upgrade if that is fixed or move to a different plugin
 ktintPluginVersion=9.4.1

--- a/jetbrains-rider/build.gradle.kts
+++ b/jetbrains-rider/build.gradle.kts
@@ -260,10 +260,6 @@ tasks.withType<PrepareSandboxTask>().all {
     }
 }
 
-tasks.withType<Test>().all {
-    dependsOn(tasks.prepareTestingSandbox)
-}
-
 tasks.compileKotlin {
     dependsOn(generateModels)
 }


### PR DESCRIPTION

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
