### PR TITLE
Set target component on Explorer's ToolBar

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -86,6 +86,7 @@ class ExplorerToolWindow(project: Project) : SimpleToolWindowPanel(true, true), 
 
         toolbar = ActionManager.getInstance().createActionToolbar(ActionPlaces.TOOLBAR, group, true).apply {
             layoutPolicy = WRAP_LAYOUT_POLICY
+            setTargetComponent(this@ExplorerToolWindow)
         }.component
 
         background = UIUtil.getTreeBackground()


### PR DESCRIPTION
Fix warning about not setting the target component for the explorer's toolbar

```
2021-07-29 17:33:13,961 [  29558]   WARN - nSystem.impl.ActionToolbarImpl - 'toolbar' toolbar by default uses any focused component to update its actions. Toolbar actions that need local UI context would be incorrectly disabled. Please call toolbar.setTargetComponent() explicitly. 
java.lang.Throwable: toolbar creation trace
	at com.intellij.openapi.actionSystem.impl.ActionToolbarImpl.<init>(ActionToolbarImpl.java:111)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.createActionToolbar(ActionManagerImpl.java:424)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.createActionToolbar(ActionManagerImpl.java:418)
	at software.aws.toolkits.jetbrains.core.explorer.ExplorerToolWindow.<init>(ExplorerToolWindow.kt:87)
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
