### PR TITLE
More fixes for CW event sorting

### DIFF
--- a/.changes/next-release/bugfix-70e4298a-227c-425a-9dec-99dabb4aece1.json
+++ b/.changes/next-release/bugfix-70e4298a-227c-425a-9dec-99dabb4aece1.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix CloudWatch sorting (#2737)"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogGroupTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogGroupTable.kt
@@ -34,6 +34,7 @@ import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 import java.awt.event.MouseEvent
 import javax.swing.JComponent
+import javax.swing.SortOrder
 
 class LogGroupTable(
     private val project: Project,
@@ -53,9 +54,15 @@ class LogGroupTable(
     }
 
     init {
+        val (sortColumn, sortOrder) = when (type) {
+            TableType.LIST -> 1 to SortOrder.DESCENDING
+            TableType.FILTER -> 1 to SortOrder.ASCENDING
+        }
         val tableModel = ListTableModel(
-            arrayOf(LogStreamsStreamColumn(), LogStreamsDateColumn()),
-            mutableListOf<LogStream>()
+            arrayOf(LogStreamsStreamColumn(sortable = type == TableType.FILTER), LogStreamsDateColumn(sortable = type == TableType.LIST)),
+            mutableListOf<LogStream>(),
+            sortColumn,
+            sortOrder
         )
         groupTable = TableView(tableModel).apply {
             setPaintBusy(true)
@@ -64,10 +71,6 @@ class LogGroupTable(
             emptyText.text = message("loading_resource.loading")
             tableHeader.reorderingAllowed = false
             tableHeader.resizingAllowed = false
-        }
-        groupTable.rowSorter = when (type) {
-            TableType.LIST -> LogGroupTableSorter(tableModel)
-            TableType.FILTER -> LogGroupFilterTableSorter(tableModel)
         }
         TableSpeedSearch(groupTable)
         addTableMouseListener(groupTable)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogGroupTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogGroupTable.kt
@@ -55,8 +55,8 @@ class LogGroupTable(
 
     init {
         val (sortColumn, sortOrder) = when (type) {
-            TableType.LIST -> 1 to SortOrder.DESCENDING
-            TableType.FILTER -> 1 to SortOrder.ASCENDING
+            TableType.LIST -> 1 to SortOrder.DESCENDING // Sort by event time, most recent first
+            TableType.FILTER -> 0 to SortOrder.ASCENDING // Sort by name alphabetically
         }
         val tableModel = ListTableModel(
             arrayOf(LogStreamsStreamColumn(sortable = type == TableType.FILTER), LogStreamsDateColumn(sortable = type == TableType.LIST)),

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/OpenLogStreamInEditorActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/OpenLogStreamInEditorActionTest.kt
@@ -66,7 +66,7 @@ class OpenLogStreamInEditorActionTest {
                 }
             )
 
-        val tableModel = ListTableModel<LogStream>(LogStreamsStreamColumn())
+        val tableModel = ListTableModel<LogStream>(LogStreamsStreamColumn(sortable = false))
         val table = JBTable(tableModel)
         tableModel.addRow(LogStream.builder().logStreamName("54321").build())
         // select the first row

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/TableUtilsTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/TableUtilsTest.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.cloudwatch.logs
 
 import com.intellij.ui.table.JBTable
-import com.intellij.util.text.DateFormatUtil
 import com.intellij.util.text.SyncDateFormat
 import com.intellij.util.ui.ListTableModel
 import org.assertj.core.api.Assertions.assertThat
@@ -13,33 +12,28 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogStream
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.LogStreamsDateColumn
-import software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.TimeFormatConversion
+import software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.LogStreamsStreamColumn
 import java.text.SimpleDateFormat
-import java.time.LocalDate
-import java.time.LocalTime
-import java.time.ZoneOffset
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import javax.swing.RowSorter
 import javax.swing.SortOrder
 
 class TableUtilsTest {
     @Test
+    fun `sorting must be enabled to work`() {
+        assertThat(LogStreamsDateColumn(sortable = false).comparator).isNull()
+        assertThat(LogStreamsDateColumn(sortable = true).comparator).isNotNull
+
+        assertThat(LogStreamsStreamColumn(sortable = false).comparator).isNull()
+        assertThat(LogStreamsStreamColumn(sortable = true).comparator).isNotNull
+    }
+
+    @Test
     fun `test short MDY sorting`() {
         val dateFormat = SimpleDateFormat("M/d/yy", Locale.ENGLISH)
-
-        val model = ListTableModel(
-            arrayOf(LogStreamsDateColumn(SyncDateFormat(dateFormat))),
-            mutableListOf(
-                mockLogStream(stringToEpoch("6/11/21", dateFormat)),
-                mockLogStream(stringToEpoch("2/1/21", dateFormat)),
-                mockLogStream(stringToEpoch("7/11/21", dateFormat)),
-            )
-        )
-
-        val table = JBTable(model).also {
-            it.rowSorter.sortKeys = listOf(RowSorter.SortKey(0, SortOrder.DESCENDING))
-        }
+        val table = JBTable(createTestMode(dateFormat))
 
         assertThat(table).satisfies {
             assertThat(it.getValueAt(0, 0)).isEqualTo("7/11/21")
@@ -51,19 +45,7 @@ class TableUtilsTest {
     @Test
     fun `test medium MDY sorting`() {
         val dateFormat = SimpleDateFormat("MMM d, y", Locale.ENGLISH)
-
-        val model = ListTableModel(
-            arrayOf(LogStreamsDateColumn(SyncDateFormat(dateFormat))),
-            mutableListOf(
-                mockLogStream(stringToEpoch("Jun 11, 2021", dateFormat)),
-                mockLogStream(stringToEpoch("Feb 1, 2021", dateFormat)),
-                mockLogStream(stringToEpoch("Jul 11, 2021", dateFormat)),
-            )
-        )
-
-        val table = JBTable(model).also {
-            it.rowSorter.sortKeys = listOf(RowSorter.SortKey(0, SortOrder.DESCENDING))
-        }
+        val table = JBTable(createTestMode(dateFormat))
 
         assertThat(table).satisfies {
             assertThat(it.getValueAt(0, 0)).isEqualTo("Jul 11, 2021")
@@ -75,19 +57,7 @@ class TableUtilsTest {
     @Test
     fun `test medium DMY sorting`() {
         val dateFormat = SimpleDateFormat("d MMM y", Locale.ENGLISH)
-
-        val model = ListTableModel(
-            arrayOf(LogStreamsDateColumn(SyncDateFormat(dateFormat))),
-            mutableListOf(
-                mockLogStream(stringToEpoch("11 Jun 2021", dateFormat)),
-                mockLogStream(stringToEpoch("1 Feb 2021", dateFormat)),
-                mockLogStream(stringToEpoch("11 Jul 2021", dateFormat)),
-            )
-        )
-
-        val table = JBTable(model).also {
-            it.rowSorter.sortKeys = listOf(RowSorter.SortKey(0, SortOrder.DESCENDING))
-        }
+        val table = JBTable(createTestMode(dateFormat))
 
         assertThat(table).satisfies {
             assertThat(it.getValueAt(0, 0)).isEqualTo("11 Jul 2021")
@@ -96,29 +66,22 @@ class TableUtilsTest {
         }
     }
 
-    @Test
-    fun `convert epoch time to string date time with seconds included`() {
-        val epochTime = 1621173813000
-        val showSeconds = true
-        val correctTime = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(epochTime)
-        val time = TimeFormatConversion.convertEpochTimeToStringDateTime(epochTime, showSeconds)
-        assertThat(time).isEqualTo(correctTime)
-    }
+    private fun createTestMode(format: SimpleDateFormat) = ListTableModel(
+        arrayOf(LogStreamsDateColumn(sortable = true, SyncDateFormat(format))),
+        mutableListOf(
+            mockLogStream(stringToEpoch("2021-06-11T00:00:00-08:00")),
+            mockLogStream(stringToEpoch("2021-02-01T00:00:00-08:00")),
+            mockLogStream(stringToEpoch("2021-07-11T00:00:00-08:00")),
+        ),
+        0,
+        SortOrder.DESCENDING
+    )
 
-    @Test
-    fun `convert epoch time to string date time with seconds excluded`() {
-        val epochTime = 1621173813000
-        val showSeconds = false
-        val correctTime = DateFormatUtil.getDateTimeFormat().format(epochTime)
-        val time = TimeFormatConversion.convertEpochTimeToStringDateTime(epochTime, showSeconds)
-        assertThat(time).isEqualTo(correctTime)
-    }
-
-    private fun stringToEpoch(string: String, formatter: SimpleDateFormat) =
-        LocalDate.parse(string, DateTimeFormatter.ofPattern(formatter.toPattern(), Locale.ENGLISH))
-            .atTime(LocalTime.NOON.atOffset(ZoneOffset.UTC))
-            .toInstant()
-            .toEpochMilli()
+    private fun stringToEpoch(string: String) = ZonedDateTime.parse(string, DateTimeFormatter.ISO_ZONED_DATE_TIME)
+        .toLocalDateTime()
+        .atZone(ZoneId.systemDefault())
+        .toInstant()
+        .toEpochMilli()
 
     private fun mockLogStream(epoch: Long): LogStream {
         val stream: LogStream = mock()


### PR DESCRIPTION
We were overriding the rowSorter on the JBTable, but this causes it to ignore the ColumnInfo class. Remove our custom sorters and configure it through the ListTableModel instead so ColumnInfo is respected.

## Related Issue(s)
#2737

## Screenshots (if appropriate)
![Screen Shot 2021-08-06 at 8 57 56 AM](https://user-images.githubusercontent.com/8992246/128557377-a247146b-0144-4b70-8aca-ad7134188a7e.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
