### PR TITLE
Defend against index out of bounds on CW tail

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchActor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchActor.kt
@@ -146,10 +146,12 @@ abstract class CloudWatchLogsActor<T>(
                             title = message("cloudwatch.logs.exception"),
                             content = message("cloudwatch.logs.failed_to_load_more")
                         )
-                        listOf<T>()
+                        listOf()
                     }
                     withContext(edtContext) {
-                        table.listTableModel.addRows(items)
+                        if (items.isNotEmpty()) {
+                            table.listTableModel.addRows(items)
+                        }
                         table.setPaintBusy(false)
                     }
                 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogStreamTable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/LogStreamTable.kt
@@ -28,7 +28,6 @@ import software.aws.toolkits.jetbrains.utils.ui.topReached
 import software.aws.toolkits.resources.message
 import javax.swing.JComponent
 import javax.swing.JTable
-import javax.swing.SortOrder
 
 class LogStreamTable(
     val project: Project,
@@ -53,9 +52,6 @@ class LogStreamTable(
         val model = ListTableModel(
             arrayOf(LogStreamDateColumn(), LogStreamMessageColumn()),
             mutableListOf<LogStreamEntry>(),
-            // Don't sort in the model because the requests come sorted
-            -1,
-            SortOrder.UNSORTED
         )
         logsTable = TableView(model).apply {
             autoscrolls = true

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/LogStreamListActorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudwatch/logs/LogStreamListActorTest.kt
@@ -19,6 +19,8 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.GetLogEventsRequest
 import software.amazon.awssdk.services.cloudwatchlogs.model.GetLogEventsResponse
 import software.amazon.awssdk.services.cloudwatchlogs.model.OutputLogEvent
 import software.amazon.awssdk.services.cloudwatchlogs.paginators.GetLogEventsIterable
+import software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.LogStreamDateColumn
+import software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.LogStreamMessageColumn
 import software.aws.toolkits.jetbrains.utils.BaseCoroutineTest
 import software.aws.toolkits.jetbrains.utils.waitForModelToBeAtLeast
 import software.aws.toolkits.jetbrains.utils.waitForTrue
@@ -35,7 +37,10 @@ class LogStreamListActorTest : BaseCoroutineTest() {
     @Before
     fun loadVariables() {
         client = mockClientManagerRule.create()
-        tableModel = ListTableModel<LogStreamEntry>()
+        tableModel = ListTableModel(
+            arrayOf(LogStreamDateColumn(), LogStreamMessageColumn()),
+            mutableListOf<LogStreamEntry>()
+        )
         table = TableView(tableModel)
         actor = LogStreamListActor(projectRule.project, client, table, "abc", "def")
     }


### PR DESCRIPTION
* This was actually fixed by accident in #2753 by removing the comparator, but we should make it explicit by:
1. Not passing -1 column number
2. If the results are empty, there is nothing to insert
3. Make the tests make the model the same way (this should be refactored to keep it from getting out of sync)

## Related Issue(s)
#2761 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
