### PR TITLE
Fix test failures exposed by new Docker image

### DIFF
--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -8,7 +8,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.any
 import com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
-import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.verify
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.matching.ContainsPattern
@@ -189,7 +188,7 @@ class AwsClientManagerTest {
         try {
             wireMockServer.start()
 
-            stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)))
+            wireMockServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)))
 
             val sut = getClientManager().createNewClient(
                 LambdaClient::class,

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/toolwindow/ToolkitToolWindowManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/toolwindow/ToolkitToolWindowManagerTest.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.core.toolwindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.util.UUID
@@ -17,7 +18,12 @@ class ToolkitToolWindowManagerTest {
     @JvmField
     val projectRule = ProjectRule()
 
-    private val jbToolWindowManager = ToolWindowManager.getInstance(projectRule.project)
+    private lateinit var jbToolWindowManager: ToolWindowManager
+
+    @Before
+    fun setUp() {
+        jbToolWindowManager = ToolWindowManager.getInstance(projectRule.project)
+    }
 
     @Test
     fun canAddAToolWindow() {


### PR DESCRIPTION
* ToolkitToolWindowManagerTest can't run in isolation
* userAgentIsPassed test used wrong wiremock admin port if ran in wrong order

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
