### PR TITLE
Fix Go tests for 211

### DIFF
--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/GoCodeInsightTestFixtureRule.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/GoCodeInsightTestFixtureRule.kt
@@ -101,8 +101,9 @@ fun runGoModTidy(goModFile: VirtualFile) {
 }
 
 fun compatibleGoForIde() = when (ApplicationInfo.getInstance().build.baselineVersion) {
-    202 -> "1.14.15" // TODO: FIX_WHEN_MIN_IS_202
-    203 -> "1.15.14" // TODO: FIX_WHEN_MIN_IS_203
+    202 -> "1.14.15" // TODO: FIX_WHEN_MIN_IS_203
+    203 -> "1.15.14" // TODO: FIX_WHEN_MIN_IS_211
+    211 -> "1.16.6" // TODO: FIX_WHEN_MIN_IS_212
     else -> null
 }
 


### PR DESCRIPTION
Go 1.17 came out and broke the 211 tests by using golang:1. Set max go version for 211

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
