### PR TITLE
Move telemetry into registry key

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -228,6 +228,9 @@ with what features/services are supported.
         <fileEditorProvider implementation="software.aws.toolkits.jetbrains.services.dynamodb.editor.DynamoDbTableEditorProvider"/>
         <fileIconProvider order="first" implementation="software.aws.toolkits.jetbrains.services.dynamodb.editor.DynamoDbFileIconProvider"/>
 
+        <registryKey key="aws.telemetry.endpoint" description="Endpoint to use for publishing AWS client-side telemetry" defaultValue="https://client-telemetry.us-east-1.amazonaws.com" restartRequired="true"/>
+        <registryKey key="aws.telemetry.identityPool" description="Cognito identity pool to use for publishing AWS client-side telemetry" defaultValue="us-east-1:820fd6d1-95c0-4ca4-bffb-3f01d32da842" restartRequired="true"/>
+        <registryKey key="aws.telemetry.region" description="Region to use for publishing AWS client-side telemetry" defaultValue="us-east-1" restartRequired="true"/>
         <registryKey key="aws.credentialProcess.timeout" description="AWS Credential Process timeout (ms)" restartRequired="false" defaultValue="30000"/>
         <registryKey key="aws.debuggerAttach.timeout" description="Time allowed for debuggers to attach before timing out (ms)" restartRequired="false" defaultValue="60000"/>
         <registryKey key="aws.feature.ecsCloudDebug" description="Enables the Cloud Debug for ECS set of features" restartRequired="false" defaultValue="true"/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/RefreshConnectionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/RefreshConnectionAction.kt
@@ -26,9 +26,9 @@ class RefreshConnectionAction(text: String = message("settings.refresh.descripti
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
+        AwsTelemetry.refreshExplorer(project)
         val scope = project.applicationThreadPoolScope("RefreshConnectionAction")
         scope.launch { AwsResourceCache.getInstance().clear() }
         AwsConnectionManager.getInstance(project).refreshConnectionState()
-        AwsTelemetry.refreshExplorer(project)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/DefaultTelemetryPublisher.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/DefaultTelemetryPublisher.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.telemetry
 
+import com.intellij.openapi.util.registry.Registry
 import kotlinx.coroutines.withContext
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
 import software.amazon.awssdk.regions.Region
@@ -88,20 +89,21 @@ class DefaultTelemetryPublisher(
         private const val METADATA_AWS_REGION = "awsRegion"
 
         private fun createDefaultTelemetryClient(): ToolkitTelemetryClient {
+            val region = Region.of(Registry.get("aws.telemetry.region").asString())
             val sdkClient = AwsSdkClient.getInstance()
             return ToolkitClientManager.createNewClient(
                 ToolkitTelemetryClient::class,
                 sdkClient.sharedSdkClient(),
-                Region.US_EAST_1,
+                region,
                 AWSCognitoCredentialsProvider(
-                    "us-east-1:820fd6d1-95c0-4ca4-bffb-3f01d32da842",
+                    Registry.get("aws.telemetry.identityPool").asString(),
                     CognitoIdentityClient.builder()
                         .credentialsProvider(AnonymousCredentialsProvider.create())
-                        .region(Region.US_EAST_1)
+                        .region(region)
                         .httpClient(sdkClient.sharedSdkClient())
                         .build()
                 ),
-                endpointOverride = "https://client-telemetry.us-east-1.amazonaws.com"
+                endpointOverride = Registry.get("aws.telemetry.endpoint").asString()
             )
         }
     }


### PR DESCRIPTION
Enable telemetry endpoint, identityPool and region to be modified via the registry (e.g. for testing the toolkit against different telemetry stacks).

Also fix bug in the refresh explorer telemetry where cache (incl. acct id) was cleared before telemetry was recorded.