### PR TITLE
Fix NPE calling isInTestSourceContent

### DIFF
--- a/.changes/next-release/bugfix-0d3ce222-365f-4cbb-8d1e-b7189e71816d.json
+++ b/.changes/next-release/bugfix-0d3ce222-365f-4cbb-8d1e-b7189e71816d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix NullPointerException calling isInTestSourceContent (#2752)"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/PsiUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/PsiUtils.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiElement
 
 fun PsiElement.isTestOrInjectedText(): Boolean {
     val project = this.project
-    val virtualFile = this.containingFile.virtualFile
+    val virtualFile = this.containingFile.virtualFile ?: return false
     if (virtualFile is VirtualFileWindow) {
         return true
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Motivation and Context
When you use IntelliJ's de-compiler to turn a PsiClass into a PsiJava file, the PSI element lacks a virtual file.

## Related Issue(s)
#2752

## Testing
Manually, I could not find a way to reproduce it using the test harnesses

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
