### PR TITLE
Fix NPE from context.module being null

### DIFF
--- a/.changes/next-release/bugfix-f5af5b28-b2de-4eb6-8a23-7a725b8afe8b.json
+++ b/.changes/next-release/bugfix-f5af5b28-b2de-4eb6-8a23-7a725b8afe8b.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix IDE error about context.module being null (#2776)"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
It looks to either be a bug in CWM, or their new SharedDataContext stuff. Though nothing in the API says that the module (nor project) should be NotNull so defend against those scenarios in our code.

## Related Issue(s)
#2776

## Testing
The only way I found to reproduce this was using CodeWithMe as a guest (host does not trigger it).

## Screenshots (if appropriate)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
