### PR TITLE
Update .editorconfig to not use star imports in Kotlin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -41,6 +41,7 @@ ij_java_while_brace_force = always
 ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
 ij_kotlin_name_count_to_use_star_import = 2147483647
 ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
+ij_kotlin_packages_to_use_import_on_demand = unset
 
 [{*.markdown,*.md}]
 ij_markdown_force_one_space_after_blockquote_symbol = true


### PR DESCRIPTION

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
