### PR TITLE
Fix SSO auth flow not throwing away the access token on error

### DIFF
--- a/.changes/next-release/bugfix-3f6e3ea2-c428-4495-b0a5-7f77a2d66c62.json
+++ b/.changes/next-release/bugfix-3f6e3ea2-c428-4495-b0a5-7f77a2d66c62.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix SSO login not being triggered when the auth code is invalid (#2796)"
+}

--- a/core/src/software/aws/toolkits/core/credentials/sso/SsoCredentialProvider.kt
+++ b/core/src/software/aws/toolkits/core/credentials/sso/SsoCredentialProvider.kt
@@ -11,7 +11,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import software.amazon.awssdk.services.sso.SsoClient
-import software.amazon.awssdk.services.ssooidc.model.AccessDeniedException
+import software.amazon.awssdk.services.sso.model.UnauthorizedException
 import software.amazon.awssdk.utils.cache.CachedSupplier
 import software.amazon.awssdk.utils.cache.RefreshResult
 import java.time.Duration
@@ -43,7 +43,7 @@ class SsoCredentialProvider(
                 it.accountId(ssoAccount)
                 it.roleName(ssoRole)
             }
-        } catch (e: AccessDeniedException) {
+        } catch (e: UnauthorizedException) {
             // OIDC access token was rejected, invalidate the cache and throw
             ssoAccessTokenProvider.invalidate()
             throw e

--- a/core/tst/software/aws/toolkits/core/credentials/sso/SsoCredentialProviderTest.kt
+++ b/core/tst/software/aws/toolkits/core/credentials/sso/SsoCredentialProviderTest.kt
@@ -17,7 +17,7 @@ import software.amazon.awssdk.services.sso.SsoClient
 import software.amazon.awssdk.services.sso.model.GetRoleCredentialsRequest
 import software.amazon.awssdk.services.sso.model.GetRoleCredentialsResponse
 import software.amazon.awssdk.services.sso.model.RoleCredentials
-import software.amazon.awssdk.services.ssooidc.model.AccessDeniedException
+import software.amazon.awssdk.services.sso.model.UnauthorizedException
 import software.aws.toolkits.core.utils.delegateMock
 import software.aws.toolkits.core.utils.test.aString
 import java.time.Instant
@@ -80,7 +80,7 @@ class SsoCredentialProviderTest {
             on(
                 ssoClient.getRoleCredentials(any<GetRoleCredentialsRequest>())
             ).thenThrow(
-                AccessDeniedException.builder().build()
+                UnauthorizedException.builder().build()
             )
         }
 


### PR DESCRIPTION
We caught the exception from SSO OIDC instead of SSO causing the access token to never be invalidated so every retry would fail

## Related Issue(s)
#2796

## Testing
Corrupted my SSO access token, and re-triggered login

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
