### PR TITLE
Migrate off deprecated S3 CopyObject parameter

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3VirtualBucket.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/editor/S3VirtualBucket.kt
@@ -84,7 +84,7 @@ class S3VirtualBucket(val s3Bucket: String, prefix: String, val client: S3Client
 
     suspend fun renameObject(fromKey: String, toKey: String) {
         withContext(getCoroutineBgContext()) {
-            client.copyObject { it.copySource("$s3Bucket/$fromKey").destinationBucket(s3Bucket).destinationKey(toKey) }
+            client.copyObject { it.sourceBucket(s3Bucket).sourceKey(fromKey).destinationBucket(s3Bucket).destinationKey(toKey) }
             client.deleteObject { it.bucket(s3Bucket).key(fromKey) }
         }
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3VirtualBucketTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/S3VirtualBucketTest.kt
@@ -119,7 +119,8 @@ class S3VirtualBucketTest {
 
         val copyRequestCapture = copyCaptor.firstValue
         assertThat(copyRequestCapture.destinationBucket()).isEqualTo("TestBucket")
-        assertThat(copyRequestCapture.copySource()).isEqualTo("TestBucket/key")
+        assertThat(copyRequestCapture.sourceBucket()).isEqualTo("TestBucket")
+        assertThat(copyRequestCapture.sourceKey()).isEqualTo("key")
 
         val deleteRequestCapture = deleteCaptor.firstValue
         assertThat(deleteRequestCapture.bucket()).isEqualTo("TestBucket")


### PR DESCRIPTION
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
