### PR TITLE
Fix Rider deadlocking due to using UI coroutines

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/steps/AttachDebugger.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/steps/AttachDebugger.kt
@@ -53,7 +53,10 @@ class AttachDebugger(val environment: ExecutionEnvironment, val state: SamRunnin
             // saveDocumentsAndProjectsAndApp has a runBlocking call that needs EDT and deadlocks coroutines
             invokeAndWaitIfNeeded {
                 val session = debugManager.startSessionAndShowTab(environment.runProfile.name, environment.contentToReuse, debugProcessStarter)
+                // Tie SAM output to the Debug tab's console so that it is viewable in both spots
                 samProcessHandler.addProcessListener(buildProcessAdapter { session.consoleView })
+
+                // Tie the debug session to the overall workflow, so if it gets cancelled (Stop button on SAM tab), we tell the debugger to stop too
                 context.addListener(object : Context.Listener {
                     override fun onCancel() {
                         session.stop()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/steps/AttachDebugger.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/steps/AttachDebugger.kt
@@ -6,22 +6,17 @@ package software.aws.toolkits.jetbrains.services.lambda.steps
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.ConsoleView
 import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.application.invokeAndWaitIfNeeded
 import com.intellij.openapi.util.Key
-import com.intellij.xdebugger.XDebugSessionListener
 import com.intellij.xdebugger.XDebuggerManager
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import software.aws.toolkits.core.utils.getLogger
-import software.aws.toolkits.core.utils.warn
-import software.aws.toolkits.jetbrains.core.coroutines.getCoroutineUiContext
-import software.aws.toolkits.jetbrains.core.coroutines.projectCoroutineScope
 import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamDebugSupport
 import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamRunningState
 import software.aws.toolkits.jetbrains.services.lambda.execution.sam.resolveDebuggerSupport
@@ -33,98 +28,85 @@ import software.aws.toolkits.jetbrains.utils.execution.steps.Step
 import software.aws.toolkits.resources.message
 import java.util.concurrent.atomic.AtomicBoolean
 
-class AttachDebugger(
-    val environment: ExecutionEnvironment,
-    val state: SamRunningState
-) : Step() {
+class AttachDebugger(val environment: ExecutionEnvironment, val state: SamRunningState) : Step() {
     override val stepName = message("sam.debug.attach")
     override val hidden = false
 
     override fun execute(context: Context, messageEmitter: MessageEmitter, ignoreCancellation: Boolean) {
-        val session = runBlocking {
-            try {
-                withTimeout(SamDebugSupport.debuggerConnectTimeoutMs()) {
-                    val debugPorts = context.getRequiredAttribute(DEBUG_PORTS)
-                    val debugProcessStarter = state
-                        .settings
-                        .resolveDebuggerSupport()
-                        .createDebugProcess(context, environment, state, state.settings.debugHost, debugPorts)
-                    val session = runBlocking(getCoroutineUiContext()) {
-                        val debugManager = XDebuggerManager.getInstance(environment.project)
-                        // Requires EDT on some paths, so always requires to be run on EDT
-                        debugManager.startSessionAndShowTab(environment.runProfile.name, environment.contentToReuse, debugProcessStarter)
+        try {
+            val samProcessHandler = getSamProcess(context)
+            val samCompleted = AtomicBoolean(false)
+
+            samProcessHandler.addProcessListener(object : ProcessAdapter() {
+                override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+                    if (event.text.contains(SamExecutable.endDebuggingText)) {
+                        samCompleted.set(true)
                     }
-                    val samProcessHandler = context.pollingGet(SamRunnerStep.SAM_PROCESS_HANDLER)
-                    val samCompleted = AtomicBoolean(false)
-                    samProcessHandler.addProcessListener(buildProcessAdapter { session.consoleView })
-                    samProcessHandler.addProcessListener(object : ProcessAdapter() {
-                        override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
-                            if (event.text.contains(SamExecutable.endDebuggingText)) {
-                                samCompleted.set(true)
-                            }
-                        }
-                    })
-                    // Since there are two process's running (The SAM cli + the remote debugger), stopping
-                    // the sam cli process ends the debugger, but not the other way around. To fix this, we
-                    // could just always context.cancel(), which makes the SAM CLI process end, which works
-                    // perfectly if the user presses stop. However, if the process ends normally, SAM cli will
-                    // output the dreaded "Aborted!" after it prints the output. So, we need to keep track of
-                    // if SAM cli is ending normally, and not exit when that happens. If the string ever changes,
-                    // or there is an issue, the run configuration will always still end, it will just cause the
-                    // "Aborted!" text to be printed
-                    session.addSessionListener(object : XDebugSessionListener {
-                        override fun sessionStopped() {
-                            launch {
-                                // So sadly this has a race condition, the debugger disconnects before
-                                // the process actually ends, so if that branch goes faster, then we still
-                                // call cancel. So, wait an arbitrary short amount of time (500ms) that should
-                                // strike a good balance between speed and a reasonable amount of time for it to
-                                // print and exit
-                                for (i in 1..5) {
-                                    if (samCompleted.get()) {
-                                        return@launch
-                                    } else {
-                                        delay(100)
-                                    }
-                                }
-                                context.cancel()
-                            }
-                        }
-                    })
-                    session
                 }
-            } catch (e: TimeoutCancellationException) {
-                throw ExecutionException(message("lambda.debug.process.start.timeout"))
-            } catch (e: Throwable) {
-                LOG.warn(e) { "Failed to start debugger" }
-                throw ExecutionException(e)
+            })
+
+            val debugPorts = context.getRequiredAttribute(DEBUG_PORTS)
+            val debugProcessStarter = prepAndCreateDebugProcessStart(context, debugPorts)
+            val debugManager = XDebuggerManager.getInstance(environment.project)
+
+            // Note: Do NOT use coroutines here due to it will deadlock Rider when starting the DotnetDebugProcess due to in storeUtil.kt
+            // saveDocumentsAndProjectsAndApp has a runBlocking call that needs EDT and deadlocks coroutines
+            invokeAndWaitIfNeeded {
+                val session = debugManager.startSessionAndShowTab(environment.runProfile.name, environment.contentToReuse, debugProcessStarter)
+                samProcessHandler.addProcessListener(buildProcessAdapter { session.consoleView })
+                context.addListener(object : Context.Listener {
+                    override fun onCancel() {
+                        session.stop()
+                    }
+
+                    override fun onComplete() {
+                        session.stop()
+                    }
+                })
+
+                session.debugProcess.processHandler.addProcessListener(object : ProcessAdapter() {
+                    override fun processWillTerminate(event: ProcessEvent, willBeDestroyed: Boolean) {
+                        // If the user pressed Stop on the debug tab, cancel the entire flow
+                        val requestedTermination = event.processHandler.getUserData(ProcessHandler.TERMINATION_REQUESTED) ?: false
+                        if (requestedTermination) {
+                            context.cancel()
+                        }
+                    }
+                })
             }
-        }
-        val scope = projectCoroutineScope(context.project)
-        // Make sure the session is always cleaned up
-        scope.launch {
-            while (!context.isCompleted()) {
-                delay(100)
-            }
-            session.stop()
+        } catch (e: TimeoutCancellationException) {
+            throw ExecutionException(message("lambda.debug.process.start.timeout"))
+        } catch (e: Throwable) {
+            throw ExecutionException(e)
         }
     }
 
-    private companion object {
-        val LOG = getLogger<AttachDebugger>()
-        fun buildProcessAdapter(console: (() -> ConsoleView?)) = object : ProcessAdapter() {
-            override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
-                // Skip system messages
-                if (outputType == ProcessOutputTypes.SYSTEM) {
-                    return
-                }
-                val viewType = if (outputType == ProcessOutputTypes.STDERR) {
-                    ConsoleViewContentType.ERROR_OUTPUT
-                } else {
-                    ConsoleViewContentType.NORMAL_OUTPUT
-                }
-                console()?.print(event.text, viewType)
+    private fun prepAndCreateDebugProcessStart(context: Context, debugPorts: List<Int>) = runBlocking {
+        withTimeout(SamDebugSupport.debuggerConnectTimeoutMs()) {
+            state.settings
+                .resolveDebuggerSupport()
+                .createDebugProcess(context, environment, state, state.settings.debugHost, debugPorts)
+        }
+    }
+
+    private fun getSamProcess(context: Context) = runBlocking {
+        withTimeout(SamDebugSupport.debuggerConnectTimeoutMs()) {
+            context.pollingGet(SamRunnerStep.SAM_PROCESS_HANDLER)
+        }
+    }
+
+    private fun buildProcessAdapter(console: (() -> ConsoleView?)) = object : ProcessAdapter() {
+        override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+            // Skip system messages
+            if (outputType == ProcessOutputTypes.SYSTEM) {
+                return
             }
+            val viewType = if (outputType == ProcessOutputTypes.STDERR) {
+                ConsoleViewContentType.ERROR_OUTPUT
+            } else {
+                ConsoleViewContentType.NORMAL_OUTPUT
+            }
+            console()?.print(event.text, viewType)
         }
     }
 }


### PR DESCRIPTION
IntelliJ save framework that Rider invokes when starting a DotnetDebugProcess has a runBlocking call on EDT. This causes a dead lock when we start the debuggr using coroutines. Remove using coroutines for that logic. Also simplify how we listen for context to be cancelled

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
