### PR TITLE
Upgrade Rider 211 SDK

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -112,7 +112,7 @@ object IdeVersions {
                 )
             ),
             rider = RiderProfile(
-                sdkVersion = "2021.1.1",
+                sdkVersion = "2021.1.5",
                 plugins = commonPlugins + listOf(
                     "rider-plugins-appender" // Workaround for https://youtrack.jetbrains.com/issue/IDEA-179607
                 ),


### PR DESCRIPTION
The older SDK (2021.1.1) was pulled from the Maven repo. Upgrade to newest 211 version
https://www.jetbrains.com/intellij-repository/releases

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
