### PR TITLE
Tweak the dotnet PID script to work with cross architecture images

### DIFF
--- a/.changes/next-release/bugfix-0a2ea1a8-3999-4605-8068-3264b144f9c7.json
+++ b/.changes/next-release/bugfix-0a2ea1a8-3999-4605-8068-3264b144f9c7.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix not being able to start Rider debugger against a Lambda running on a host ARM machine"
+}

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DebuggingSteps.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DebuggingSteps.kt
@@ -9,6 +9,7 @@ import com.intellij.execution.util.ExecUtil
 import com.intellij.util.text.nullize
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import org.intellij.lang.annotations.Language
 import software.aws.toolkits.core.utils.AttributeBagKey
 import software.aws.toolkits.jetbrains.services.lambda.execution.sam.SamDebugSupport
 import software.aws.toolkits.jetbrains.services.lambda.steps.GetPorts.Companion.DEBUG_PORTS
@@ -67,14 +68,17 @@ class FindPid : Step() {
 
     companion object {
         val DOTNET_PID = AttributeBagKey.create<Int>("DOTNET_PID")
+
+        @Language("sh")
         private const val FIND_PID_SCRIPT =
             """
-            for i in `ls /proc/*/cmdline` ; do
-                if cat "$i" 2>/dev/null | tr '\0' ' ' | grep -cq '/usr/bin/dotnet'; then
-                    echo  $i | sed -n 's/.*\/proc\/\(.*\)\/cmdline.*/\1/p'
+            for i in /proc/*/cmdline ; do
+                if tr '\0' ' ' < "${'$'}i" 2>/dev/null | grep -cq 'dotnet'; then
+                    echo  ${'$'}i | sed -n 's/.*\/proc\/\(.*\)\/cmdline.*/\1/p'
+                    break
                 fi;
             done;
-        """
+            """
     }
 }
 

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DebuggingSteps.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DebuggingSteps.kt
@@ -69,10 +69,9 @@ class FindPid : Step() {
         val DOTNET_PID = AttributeBagKey.create<Int>("DOTNET_PID")
         private const val FIND_PID_SCRIPT =
             """
-            for i in `ls /proc/*/exe` ; do
-                symlink=`readlink  ${'$'}i 2>/dev/null`;
-                if [[ "${'$'}symlink" == *"/dotnet" ]]; then
-                    echo  ${'$'}i | sed -n 's/.*\/proc\/\(.*\)\/exe.*/\1/p'
+            for i in `ls /proc/*/cmdline` ; do
+                if cat "$i" 2>/dev/null | tr '\0' ' ' | grep -cq '/usr/bin/dotnet'; then
+                    echo  $i | sed -n 's/.*\/proc\/\(.*\)\/cmdline.*/\1/p'
                 fi;
             done;
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
When running cross-architecture (X86 lambda on M1 mac), qemu is wrapping each docker process. Tweak the PID finding script to look at the command instead of the exe path so we can find the correct process.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#2207

## Testing
Tested as best as I can, but I do not have access to an M1 machine right now

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
