### PR TITLE
Remove support for Python 2.7 Lambda runtime

### DIFF
--- a/.changes/next-release/removal-a4140ce1-4902-4925-9153-17c8e6f90d83.json
+++ b/.changes/next-release/removal-a4140ce1-4902-4925-9153-17c8e6f90d83.json
@@ -1,0 +1,4 @@
+{
+  "type" : "removal",
+  "description" : "Dropped support for the no longer supported Lambda runtime Python 2.7"
+}

--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -23,7 +23,6 @@ enum class LambdaRuntime(
     JAVA8(Runtime.JAVA8),
     JAVA8_AL2(Runtime.JAVA8_AL2, minSamDebugging = "1.2.0"),
     JAVA11(Runtime.JAVA11),
-    PYTHON2_7(Runtime.PYTHON2_7),
     PYTHON3_6(Runtime.PYTHON3_6),
     PYTHON3_7(Runtime.PYTHON3_7),
     PYTHON3_8(Runtime.PYTHON3_8),

--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
@@ -39,7 +39,6 @@ class PythonLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runt
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
         fun data(): Collection<Array<Runtime>> = listOf(
-            arrayOf(Runtime.PYTHON2_7),
             arrayOf(Runtime.PYTHON3_6),
             arrayOf(Runtime.PYTHON3_7),
             arrayOf(Runtime.PYTHON3_8),

--- a/jetbrains-core/resources/META-INF/ext-python.xml
+++ b/jetbrains-core/resources/META-INF/ext-python.xml
@@ -17,7 +17,6 @@
         <builder id="PYTHON" implementationClass="software.aws.toolkits.jetbrains.services.lambda.python.PythonLambdaBuilder"/>
         <handlerResolver id="PYTHON" implementationClass="software.aws.toolkits.jetbrains.services.lambda.python.PythonLambdaHandlerResolver"/>
         <sam.runtimeDebugSupport id="PYTHON" implementationClass="software.aws.toolkits.jetbrains.services.lambda.python.PythonRuntimeDebugSupport"/>
-        <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.python.Python27ImageDebugSupport"/>
         <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.python.Python36ImageDebugSupport"/>
         <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.python.Python37ImageDebugSupport"/>
         <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.python.Python38ImageDebugSupport"/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonDebugSupport.kt
@@ -72,13 +72,6 @@ abstract class PythonImageDebugSupport : ImageDebugSupport {
     }
 }
 
-class Python27ImageDebugSupport : PythonImageDebugSupport() {
-    override val id: String = LambdaRuntime.PYTHON2_7.toString()
-    override fun displayName() = LambdaRuntime.PYTHON2_7.toString().capitalize()
-    override val pythonPath: String = "/usr/bin/python2.7"
-    override val bootstrapPath: String = "/var/runtime/awslambda/bootstrap.py"
-}
-
 class Python36ImageDebugSupport : PythonImageDebugSupport() {
     override val id: String = LambdaRuntime.PYTHON3_6.toString()
     override fun displayName() = LambdaRuntime.PYTHON3_6.toString().capitalize()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
@@ -20,7 +20,6 @@ class PythonRuntimeGroup : SdkBasedRuntimeGroup() {
     override val supportsPathMappings: Boolean = true
 
     override val supportedRuntimes = listOf(
-        LambdaRuntime.PYTHON2_7,
         LambdaRuntime.PYTHON3_6,
         LambdaRuntime.PYTHON3_7,
         LambdaRuntime.PYTHON3_8,
@@ -32,7 +31,6 @@ class PythonRuntimeGroup : SdkBasedRuntimeGroup() {
         sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON38) -> LambdaRuntime.PYTHON3_8
         sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON37) -> LambdaRuntime.PYTHON3_7
         sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isPy3K -> LambdaRuntime.PYTHON3_6
-        sdk.sdkType is PythonSdkType && PythonSdkType.getLanguageLevelForSdk(sdk).isPython2 -> LambdaRuntime.PYTHON2_7
         else -> null
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroupTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/RuntimeGroupTest.kt
@@ -29,13 +29,13 @@ class RuntimeGroupTest {
 
     @Test
     fun canDetermineRuntimeFromAnActionEventUsingModule() {
-        ModuleRootModificationUtil.setModuleSdk(projectRule.module, PyTestSdk("2.7.0"))
+        ModuleRootModificationUtil.setModuleSdk(projectRule.module, PyTestSdk("3.9.0"))
         val event: AnActionEvent = mock {
             on { getData(LangDataKeys.LANGUAGE) }.thenReturn(PythonLanguage.INSTANCE)
             on { getData(LangDataKeys.MODULE) }.thenReturn(projectRule.module)
         }
 
-        assertThat(event.runtime()).isEqualTo(LambdaRuntime.PYTHON2_7)
+        assertThat(event.runtime()).isEqualTo(LambdaRuntime.PYTHON3_9)
     }
 
     @Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonHandlerCompletionProviderTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonHandlerCompletionProviderTest.kt
@@ -17,12 +17,6 @@ class PythonHandlerCompletionProviderTest {
     val projectRule = PythonCodeInsightTestFixtureRule()
 
     @Test
-    fun completionIsNotSupportedPython27() {
-        val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.PYTHON2_7)
-        assertFalse(provider.isCompletionSupported)
-    }
-
-    @Test
     fun completionIsNotSupportedPython36() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.PYTHON3_6)
         assertFalse(provider.isCompletionSupported)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroupTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroupTest.kt
@@ -19,14 +19,6 @@ class PythonRuntimeGroupTest {
     private val sut = PythonRuntimeGroup()
 
     @Test
-    fun testRuntimeDetection2x() {
-        val module = projectRule.module
-        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk("2.7.0"))
-
-        assertThat(sut.determineRuntime(module)).isEqualTo(LambdaRuntime.PYTHON2_7)
-    }
-
-    @Test
     fun testRuntimeDetection36() {
         val module = projectRule.module
         ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk("3.6.0"))
@@ -40,5 +32,21 @@ class PythonRuntimeGroupTest {
         ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk("3.7.0"))
 
         assertThat(sut.determineRuntime(module)).isEqualTo(LambdaRuntime.PYTHON3_7)
+    }
+
+    @Test
+    fun testRuntimeDetection38() {
+        val module = projectRule.module
+        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk("3.8.0"))
+
+        assertThat(sut.determineRuntime(module)).isEqualTo(LambdaRuntime.PYTHON3_8)
+    }
+
+    @Test
+    fun testRuntimeDetection39() {
+        val module = projectRule.module
+        ModuleRootModificationUtil.setModuleSdk(module, PyTestSdk("3.9.0"))
+
+        assertThat(sut.determineRuntime(module)).isEqualTo(LambdaRuntime.PYTHON3_9)
     }
 }


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
