### PR TITLE
Remove support for NodeJS 10.x Lambda runtime

### DIFF
--- a/.changes/next-release/removal-cee4f334-2a0a-4bdc-a6b0-8089aa2e508a.json
+++ b/.changes/next-release/removal-cee4f334-2a0a-4bdc-a6b0-8089aa2e508a.json
@@ -1,0 +1,4 @@
+{
+  "type" : "removal",
+  "description" : "Dropped support for the no longer supported Lambda runtime Node.js 10.x"
+}

--- a/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -17,7 +17,6 @@ enum class LambdaRuntime(
         // and 1.17.0 broke the arguments
         minSamDebugging = "1.18.1"
     ),
-    NODEJS10_X(Runtime.NODEJS10_X),
     NODEJS12_X(Runtime.NODEJS12_X),
     NODEJS14_X(Runtime.NODEJS14_X, minSamDebugging = "1.17.0", minSamInit = "1.17.0"),
     JAVA8(Runtime.JAVA8),

--- a/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/lambda/nodejs/SupportedNodeJsRuntimes.kt
+++ b/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/lambda/nodejs/SupportedNodeJsRuntimes.kt
@@ -6,7 +6,6 @@ package software.aws.toolkits.jetbrains.services.lambda.nodejs
 import software.amazon.awssdk.services.lambda.model.Runtime
 
 val SUPPORTED_NODE_RUNTIMES = listOf(
-    arrayOf(Runtime.NODEJS10_X),
     arrayOf(Runtime.NODEJS12_X),
     arrayOf(Runtime.NODEJS14_X)
 )

--- a/jetbrains-ultimate/resources/META-INF/ext-nodejs.xml
+++ b/jetbrains-ultimate/resources/META-INF/ext-nodejs.xml
@@ -11,7 +11,6 @@
         <builder id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsLambdaBuilder"/>
         <handlerResolver id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsLambdaHandlerResolver"/>
         <sam.runtimeDebugSupport id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsRuntimeDebugSupport"/>
-        <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJs10ImageDebug"/>
         <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJs12ImageDebug"/>
         <sam.imageDebuggerSupport implementation="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJs14ImageDebug"/>
         <sam.projectWizard id="NODEJS" implementationClass="software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsSamProjectWizard"/>

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsDebugSupport.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsDebugSupport.kt
@@ -53,11 +53,6 @@ abstract class NodeJsImageDebugSupport : ImageDebugSupport {
     )
 }
 
-class NodeJs10ImageDebug : NodeJsImageDebugSupport() {
-    override val id: String = LambdaRuntime.NODEJS10_X.toString()
-    override fun displayName() = LambdaRuntime.NODEJS10_X.toString().capitalize()
-}
-
 class NodeJs12ImageDebug : NodeJsImageDebugSupport() {
     override val id: String = LambdaRuntime.NODEJS12_X.toString()
     override fun displayName() = LambdaRuntime.NODEJS12_X.toString().capitalize()

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroup.kt
@@ -24,7 +24,6 @@ class NodeJsRuntimeGroup : SdkBasedRuntimeGroup() {
     override val supportsPathMappings: Boolean = true
 
     override val supportedRuntimes = listOf(
-        LambdaRuntime.NODEJS10_X,
         LambdaRuntime.NODEJS12_X,
         LambdaRuntime.NODEJS14_X
     )
@@ -34,7 +33,6 @@ class NodeJsRuntimeGroup : SdkBasedRuntimeGroup() {
     override fun determineRuntime(project: Project): LambdaRuntime? =
         NodeJsInterpreterManager.getInstance(project).interpreter?.cachedVersion?.get()?.let {
             when {
-                it.major <= 10 -> LambdaRuntime.NODEJS10_X
                 it.major <= 12 -> LambdaRuntime.NODEJS12_X
                 it.major <= 14 -> LambdaRuntime.NODEJS14_X
                 else -> null

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamProjectWizard.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsSamProjectWizard.kt
@@ -60,9 +60,9 @@ class SamHelloWorldNodeJs : SamAppTemplateBased() {
 
     override fun description() = message("sam.init.template.hello_world.description")
 
-    override fun supportedZipRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.NODEJS10_X, LambdaRuntime.NODEJS12_X, LambdaRuntime.NODEJS14_X)
+    override fun supportedZipRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.NODEJS12_X, LambdaRuntime.NODEJS14_X)
 
-    override fun supportedImageRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.NODEJS10_X, LambdaRuntime.NODEJS12_X, LambdaRuntime.NODEJS14_X)
+    override fun supportedImageRuntimes(): Set<LambdaRuntime> = setOf(LambdaRuntime.NODEJS12_X, LambdaRuntime.NODEJS14_X)
 
     override val appTemplateName: String = "hello-world"
 

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsHandlerCompletionProviderTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsHandlerCompletionProviderTest.kt
@@ -16,12 +16,6 @@ class NodeJsHandlerCompletionProviderTest {
     val projectRule = NodeJsCodeInsightTestFixtureRule()
 
     @Test
-    fun completionIsNotSupportedNodeJs10X() {
-        val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.NODEJS10_X)
-        assertFalse(provider.isCompletionSupported)
-    }
-
-    @Test
     fun completionIsNotSupportedNodeJs12X() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.NODEJS12_X)
         assertFalse(provider.isCompletionSupported)

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroupTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsRuntimeGroupTest.kt
@@ -20,31 +20,10 @@ class NodeJsRuntimeGroupTest {
     private val sut = NodeJsRuntimeGroup()
 
     @Test
-    fun testRuntime43() {
-        projectRule.project.setNodeJsInterpreterVersion(SemVer("v4.3.0", 4, 3, 0))
-        val runtime = sut.determineRuntime(projectRule.project)
-        assertThat(runtime).isEqualTo(LambdaRuntime.NODEJS10_X)
-    }
-
-    @Test
-    fun testRuntime610() {
-        projectRule.project.setNodeJsInterpreterVersion(SemVer("v6.10.3", 6, 10, 3))
-        val runtime = sut.determineRuntime(projectRule.project)
-        assertThat(runtime).isEqualTo(LambdaRuntime.NODEJS10_X)
-    }
-
-    @Test
-    fun testRuntime810() {
-        projectRule.project.setNodeJsInterpreterVersion(SemVer("v8.10.0", 8, 10, 0))
-        val runtime = sut.determineRuntime(projectRule.project)
-        assertThat(runtime).isEqualTo(LambdaRuntime.NODEJS10_X)
-    }
-
-    @Test
     fun testRuntime1010() {
         projectRule.project.setNodeJsInterpreterVersion(SemVer("v10.10.0", 10, 10, 0))
         val runtime = sut.determineRuntime(projectRule.project)
-        assertThat(runtime).isEqualTo(LambdaRuntime.NODEJS10_X)
+        assertThat(runtime).isEqualTo(LambdaRuntime.NODEJS12_X)
     }
 
     @Test


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
