### PR TITLE
Make the dotnet lambda image tests assert something, fix test data

### DIFF
--- a/jetbrains-rider/testData/solutions/ImageLambda2X/src/HelloWorld/Dockerfile
+++ b/jetbrains-rider/testData/solutions/ImageLambda2X/src/HelloWorld/Dockerfile
@@ -15,4 +15,4 @@ FROM public.ecr.aws/lambda/dotnet:core2.1
 COPY --from=build-image /build/bin/Release/netcoreapp2.1/publish/ /var/task/
 
 # Command can be overwritten by providing a different command in the template directly.
-CMD ["HelloWorld::HelloWorld.Function::FunctionHandler"]
+CMD ["HelloWorld::EchoLambda.Function::FunctionHandler"]

--- a/jetbrains-rider/testData/solutions/ImageLambda3X/src/HelloWorld/Dockerfile
+++ b/jetbrains-rider/testData/solutions/ImageLambda3X/src/HelloWorld/Dockerfile
@@ -20,4 +20,4 @@ FROM public.ecr.aws/lambda/dotnet:core3.1
 
 COPY --from=build-image /build/build_artifacts/ /var/task/
 # Command can be overwritten by providing a different command in the template directly.
-CMD ["HelloWorld::HelloWorld.Function::FunctionHandler"]
+CMD ["HelloWorld::EchoLambda.Function::FunctionHandler"]

--- a/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/Dockerfile
+++ b/jetbrains-rider/testData/solutions/ImageLambda5X/src/HelloWorld/Dockerfile
@@ -19,4 +19,4 @@ RUN if [ "$SAM_BUILD_MODE" = "debug" ]; then cp -r /build/bin/Debug/net5.0/publi
 FROM public.ecr.aws/lambda/dotnet:5.0
 
 COPY --from=build-image /build/build_artifacts/ /var/task/
-CMD ["HelloWorld::HelloWorld.Function::FunctionHandler"]
+CMD ["HelloWorld::EchoLambda.Function::FunctionHandler"]


### PR DESCRIPTION
The dockerfiles referenced Lambda handlers that did not eixst. This caused the tests to not actually run the Lambda handler but SAM would still be exit code 0 so tests would pass. Add an assert on the cred env vars to make sure handler is ran. Also make the handler correct in the dockerfiles

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
