### PR TITLE
Allow the StepExecutor's lifecycle to be controlled by a different system (eg. RunConfig)

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunningState.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/sam/SamRunningState.kt
@@ -168,7 +168,9 @@ class SamRunningState(
         executor.onError = {
             reportMetric(settings, Result.Failed, environment.isDebug())
         }
-        return executor.startExecution()
+
+        // Let run config system start the execution through the process handler
+        return executor.getProcessHandler()
     }
 
     private fun runConfigId() = environment.executionId.toString()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/execution/steps/StepExecutorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/execution/steps/StepExecutorTest.kt
@@ -49,7 +49,7 @@ class StepExecutorTest {
         val step1 = mock<Step>()
         val step2 = mock<Step>()
 
-        createExecutor(step1, step2).startAndWait()
+        createExecutor(step1, step2).startExecution().waitFor(2_000)
 
         verify(step1).run(any(), any(), any())
         verify(step2).run(any(), any(), any())
@@ -73,7 +73,7 @@ class StepExecutorTest {
         }
         val step2 = mock<Step>()
 
-        createExecutor(step1, step2).startAndWait()
+        createExecutor(step1, step2).startExecution().waitFor(2_000)
 
         verify(step1).run(any(), any(), any())
         verifyZeroInteractions(step2)
@@ -98,7 +98,7 @@ class StepExecutorTest {
             on { invoke(any()) }.thenThrow(IllegalStateException("Simulated"))
         }
 
-        createExecutor().startAndWait()
+        createExecutor().startExecution().waitFor(2_000)
 
         verify(successCallback).invoke(any())
         verify(errorCallback).invoke(any())
@@ -126,15 +126,13 @@ class StepExecutorTest {
         }
         val step2 = mock<Step>()
 
-        val stepExecutor = createExecutor(step1, step2)
-        stepExecutor.startExecution()
-        val processHandler = stepExecutor.getProcessHandler()
+        val execution = createExecutor(step1, step2).startExecution()
 
         assertThat(stepStarted.await(3, TimeUnit.SECONDS)).isTrue
 
-        processHandler.destroyProcess()
+        execution.destroyProcess()
         stepPaused.countDown()
-        processHandler.waitFor(2_000)
+        execution.waitFor(2_000)
 
         verifyZeroInteractions(successCallback)
         verify(errorCallback).invoke(any())
@@ -160,7 +158,7 @@ class StepExecutorTest {
             on { invoke(any()) }.thenThrow(IllegalStateException("Simulated 2"))
         }
 
-        createExecutor().startAndWait()
+        createExecutor().startExecution().waitFor(2_000)
 
         verify(successCallback).invoke(any())
         verify(errorCallback).invoke(any())
@@ -180,10 +178,5 @@ class StepExecutorTest {
         executor.onSuccess = successCallback
         executor.onError = errorCallback
         return executor
-    }
-
-    private fun StepExecutor.startAndWait() {
-        this.startExecution()
-        this.getProcessHandler().waitFor(2_000)
     }
 }


### PR DESCRIPTION
## Motivation and Context
In order to make #2857 work with the StepExecutor based run configs, the run config needs to own starting the process handler's startNotify

See: https://github.com/JetBrains/intellij-community/blob/master/platform/execution-impl/src/com/intellij/execution/impl/ExecutionManagerImpl.kt#L251-L255

This change exposes the process handler in the workflow without starting it. We can either:
1. Start it explicitly
2. Delay execution until some other system calls startNotify() on the process handler

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
