### PR TITLE
Improve UX for uncaught UnsupportedAction exception

### DIFF
--- a/.changes/next-release/bugfix-08864682-ab15-45b0-8de8-d78ecfa8b85b.json
+++ b/.changes/next-release/bugfix-08864682-ab15-45b0-8de8-d78ecfa8b85b.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix uncaught exception when a resource does not support LIST in a certain region."
+}

--- a/core/tst/software/aws/toolkits/core/utils/test/AssertJAsserts.kt
+++ b/core/tst/software/aws/toolkits/core/utils/test/AssertJAsserts.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.core.utils.test
 
 import org.assertj.core.api.IterableAssert
+import org.assertj.core.api.ListAssert
 import org.assertj.core.api.ObjectAssert
 
 @Suppress("UNCHECKED_CAST")
@@ -13,3 +14,7 @@ val <T : Any> ObjectAssert<T?>.notNull: ObjectAssert<T>
 @Suppress("UNCHECKED_CAST")
 inline fun <reified SubType : Any> IterableAssert<*>.hasOnlyElementsOfType(): IterableAssert<SubType> =
     hasOnlyElementsOfType(SubType::class.java) as IterableAssert<SubType>
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified SubType : Any> ListAssert<*>.hasOnlyOneElementOfType(): ObjectAssert<SubType> =
+    (hasOnlyElementsOfType(SubType::class.java) as ListAssert<SubType>).singleElement()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceResourceTypeNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceResourceTypeNodeTest.kt
@@ -1,0 +1,71 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.dynamic.explorer
+
+import com.intellij.testFramework.ProjectRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.awssdk.services.cloudcontrol.model.UnsupportedActionException
+import software.aws.toolkits.core.utils.test.aString
+import software.aws.toolkits.core.utils.test.hasOnlyOneElementOfType
+import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
+import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
+import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerErrorNode
+import software.aws.toolkits.jetbrains.services.dynamic.CloudControlApiResources
+import software.aws.toolkits.jetbrains.services.dynamic.DynamicResource
+import software.aws.toolkits.jetbrains.services.dynamic.ResourceType
+import software.aws.toolkits.resources.message
+import java.util.concurrent.CompletableFuture
+
+class DynamicResourceResourceTypeNodeTest {
+
+    @Rule
+    @JvmField
+    val projectRule = ProjectRule()
+
+    @Rule
+    @JvmField
+    val resourceCache = MockResourceCacheRule()
+
+    @Test
+    fun returnsListFromProvider() {
+        val type = aString()
+        val identifier = aString()
+        val resources = listOf(DynamicResource(ResourceType(type, "foo", "bah"), identifier))
+        resourceCache.addEntry(projectRule.project, CloudControlApiResources.listResources(type), resources)
+
+        val sut = DynamicResourceResourceTypeNode(projectRule.project, type)
+
+        assertThat(sut.children).hasOnlyOneElementOfType<DynamicResourceNode>().satisfies {
+            assertThat(it.displayName()).isEqualTo(identifier)
+        }
+    }
+
+    @Test
+    fun unsupportedExceptionResultsInEmptyNode() {
+        val type = aString()
+        resourceCache.addEntry(
+            projectRule.project,
+            CloudControlApiResources.listResources(type),
+            CompletableFuture.failedFuture(UnsupportedActionException.builder().build())
+        )
+
+        val sut = DynamicResourceResourceTypeNode(projectRule.project, type)
+
+        assertThat(sut.children).hasOnlyOneElementOfType<AwsExplorerEmptyNode>().satisfies {
+            assertThat(it.displayName()).startsWith(message("dynamic_resources.unavailable_in_region", ""))
+        }
+    }
+
+    @Test
+    fun otherExceptionsBubble() {
+        val type = aString()
+        resourceCache.addEntry(projectRule.project, CloudControlApiResources.listResources(type), CompletableFuture.failedFuture(RuntimeException()))
+
+        val sut = DynamicResourceResourceTypeNode(projectRule.project, type)
+
+        assertThat(sut.children).hasOnlyOneElementOfType<AwsExplorerErrorNode>()
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Sometimes the Cloud Control API doesn't universally support "LIST" in a some regions - this results in an exception surfacing when that node is expanded. This change catches that exception and changes the node to be a "Unsupported in region" empty node.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Uncaught exception is a poor UX, much better to surface why there are no results

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit tests added.

## Screenshots (if appropriate)
![Screen Shot 2021-10-18 at 4 15 02 PM](https://user-images.githubusercontent.com/4661536/137818907-4e576c3e-edce-43dc-a14c-75318391f1b2.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
