### PR TITLE
Fix memory leak on plugin unloading caused by CW Logs breadcrumbs

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogGroup.kt
@@ -70,7 +70,6 @@ class CloudWatchLogGroup(
         val locationCrumbs = LocationCrumbs(project, logGroup)
         locationInformation.crumbs = locationCrumbs.crumbs
         breadcrumbHolder.border = locationCrumbs.border
-        locationInformation.installClickListener()
 
         Disposer.register(this, groupTable)
         tablePanel.setContent(groupTable.component)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogStream.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/CloudWatchLogStream.kt
@@ -71,7 +71,6 @@ class CloudWatchLogStream(
         val locationCrumbs = LocationCrumbs(project, logGroup, logStream)
         locationInformation.crumbs = locationCrumbs.crumbs
         breadcrumbHolder.border = locationCrumbs.border
-        locationInformation.installClickListener()
 
         addActionToolbar()
         addSearchListener()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/insights/DetailedLogRecord.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/insights/DetailedLogRecord.kt
@@ -20,7 +20,6 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.coroutines.disposableCoroutineScope
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.LocationCrumbs
-import software.aws.toolkits.jetbrains.services.cloudwatch.logs.editor.installClickListener
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CloudwatchinsightsTelemetry
@@ -71,7 +70,6 @@ class DetailedLogRecord(
                 val locationCrumbs = LocationCrumbs(project, extractLogGroup(logGroup), logStream)
                 locationInformation.crumbs = locationCrumbs.crumbs
                 breadcrumbHolder.border = locationCrumbs.border
-                locationInformation.installClickListener()
                 locationInformation.isVisible = true
             }
         }


### PR DESCRIPTION
The listener was leading to a memory leak, so switch to the onSelect method.

Also tweak the rendering to make the rendering colors make more sense (since we can't "switch" selection in a tab, don't highlight selection)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
