### PR TITLE
Add Save action to cred file editing, remove the ability to hide the notifications

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ awsSdkVersion=2.17.76
 coroutinesVersion=1.3.9
 detektVersion=1.18.1
 jacksonVersion=2.11.1
-telemetryVersion=1.0.24
+telemetryVersion=1.0.25
 commonsMarkVersion=0.17.1
 jgitVersion=5.11.0.202103091610-r
 

--- a/jetbrains-core/resources/telemetryOverride.json
+++ b/jetbrains-core/resources/telemetryOverride.json
@@ -9,6 +9,14 @@
                     "type": "result"
                 }
             ]
+        },
+        {
+            "name": "aws_helpCredentials",
+            "description": "Open the help page of the profile credentials"
+        },
+        {
+            "name": "aws_saveCredentials",
+            "description": "Save action triggered by user in the credential editor"
         }
     ]
 }

--- a/jetbrains-core/resources/telemetryOverride.json
+++ b/jetbrains-core/resources/telemetryOverride.json
@@ -9,14 +9,6 @@
                     "type": "result"
                 }
             ]
-        },
-        {
-            "name": "aws_helpCredentials",
-            "description": "Open the help page of the profile credentials"
-        },
-        {
-            "name": "aws_saveCredentials",
-            "description": "Save action triggered by user in the credential editor"
         }
     ]
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialsFileHelpNotificationProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialsFileHelpNotificationProvider.kt
@@ -44,7 +44,7 @@ class CredentialsFileHelpNotificationProvider : EditorNotifications.Provider<Cre
 
             createActionLabel(message("general.help")) {
                 HelpManager.getInstance().invokeHelp(HelpIds.SETUP_CREDENTIALS.id)
-                AwsTelemetry.helpCredentials(project = project)
+                AwsTelemetry.help(project = project, name = HelpIds.SETUP_CREDENTIALS.id)
             }
 
             text(message("credentials.file.notification"))

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialsFileHelpNotificationProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialsFileHelpNotificationProvider.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.credentials
 
-import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.help.HelpManager
 import com.intellij.openapi.project.DumbAware
@@ -16,19 +16,16 @@ import software.amazon.awssdk.profiles.ProfileFileLocation
 import software.aws.toolkits.jetbrains.core.credentials.CredentialsFileHelpNotificationProvider.CredentialFileNotificationPanel
 import software.aws.toolkits.jetbrains.core.help.HelpIds
 import software.aws.toolkits.resources.message
+import software.aws.toolkits.telemetry.AwsTelemetry
 
 class CredentialsFileHelpNotificationProvider : EditorNotifications.Provider<CredentialFileNotificationPanel>(), DumbAware {
     override fun getKey(): Key<CredentialFileNotificationPanel> = KEY
 
     override fun createNotificationPanel(file: VirtualFile, fileEditor: FileEditor, project: Project): CredentialFileNotificationPanel? {
-        // Check if user dismissed permanently
-        if (PropertiesComponent.getInstance().isTrueValue(DISABLE_KEY)) return null
-        // Check if user hid per editor tab
-        if (fileEditor.getUserData(HIDE_KEY) != null) return null
         // Check if editor is for the config/credential file
         if (!isCredentialsFile(file)) return null
 
-        return CredentialFileNotificationPanel(file, project, fileEditor)
+        return CredentialFileNotificationPanel(project)
     }
 
     private fun isCredentialsFile(file: VirtualFile): Boolean = try {
@@ -38,34 +35,20 @@ class CredentialsFileHelpNotificationProvider : EditorNotifications.Provider<Cre
         false
     }
 
-    class CredentialFileNotificationPanel(file: VirtualFile, project: Project, fileEditor: FileEditor) : EditorNotificationPanel() {
+    class CredentialFileNotificationPanel(project: Project) : EditorNotificationPanel() {
         init {
+            createActionLabel(message("general.save")) {
+                FileDocumentManager.getInstance().saveAllDocuments()
+                AwsTelemetry.saveCredentials(project = project)
+            }
+
             createActionLabel(message("general.help")) {
                 HelpManager.getInstance().invokeHelp(HelpIds.SETUP_CREDENTIALS.id)
-            }
-
-            createActionLabel(message("general.notification.action.hide_once")) {
-                dismiss(file, project, fileEditor)
-            }
-
-            createActionLabel(message("general.notification.action.hide_forever")) {
-                hideForever(file, project)
+                AwsTelemetry.helpCredentials(project = project)
             }
 
             text(message("credentials.file.notification"))
         }
-
-        fun dismiss(file: VirtualFile, project: Project, fileEditor: FileEditor) {
-            fileEditor.putUserData(HIDE_KEY, true)
-            update(file, project)
-        }
-
-        fun hideForever(file: VirtualFile, project: Project) {
-            PropertiesComponent.getInstance().setValue(DISABLE_KEY, true)
-            update(file, project)
-        }
-
-        private fun update(file: VirtualFile, project: Project) = EditorNotifications.getInstance(project).updateNotifications(file)
     }
 
     companion object {
@@ -73,15 +56,5 @@ class CredentialsFileHelpNotificationProvider : EditorNotifications.Provider<Cre
          * Key used to store the notification panel in an editor
          */
         val KEY = Key.create<CredentialFileNotificationPanel>("software.aws.toolkits.jetbrains.core.credentials.editor.notification.provider")
-
-        /**
-         * Key to indicate we should hide the panel (per editor)
-         */
-        private val HIDE_KEY = Key.create<Boolean>("software.aws.toolkits.jetbrains.core.credentials.editor.notification.hidden")
-
-        /**
-         * Name of the IDE wide setting to never show again
-         */
-        const val DISABLE_KEY = "software.aws.toolkits.jetbrains.core.credentials.editor.notification.disabled"
     }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialsFileHelpNotificationProviderTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/CredentialsFileHelpNotificationProviderTest.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.core.credentials
 
-import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.application.impl.NonBlockingReadActionImpl
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
@@ -66,48 +65,12 @@ class CredentialsFileHelpNotificationProviderTest {
     }
 
     @Test
-    fun `notification not shown on credentials file when hidden forever`() {
-        val propertiesComponent = PropertiesComponent.getInstance()
-        val originalValue = propertiesComponent.getValue(CredentialsFileHelpNotificationProvider.DISABLE_KEY)
-        try {
-            val editor = openEditor(credentialsFile)
-            getEditorNotifications(editor)!!.hideForever(credentialsFile, projectRule.project)
-
-            assertThat(getEditorNotifications(editor)).isNull()
-
-            closeEditor(credentialsFile)
-
-            val newEditor = openEditor(credentialsFile)
-            assertThat(getEditorNotifications(newEditor)).isNull()
-        } finally {
-            propertiesComponent.setValue(CredentialsFileHelpNotificationProvider.DISABLE_KEY, originalValue)
-        }
-    }
-
-    @Test
-    fun `notification gets hidden on dismiss`() {
-        val editor = openEditor(credentialsFile)
-        getEditorNotifications(editor)!!.dismiss(credentialsFile, projectRule.project, editor)
-
-        assertThat(getEditorNotifications(editor)).isNull()
-
-        closeEditor(credentialsFile)
-
-        val newEditor = openEditor(credentialsFile)
-        assertThat(getEditorNotifications(newEditor)).isNotNull
-    }
-
-    @Test
     fun `notification not shown on non credentials files`() {
         val editor = openEditor(projectRule.fixture.tempDirFixture.createFile("foo.txt"))
         assertThat(getEditorNotifications(editor)).isNull()
     }
 
     private fun openEditor(file: VirtualFile): FileEditor = FileEditorManagerEx.getInstanceEx(projectRule.project).openFile(file, true).single()
-
-    private fun closeEditor(file: VirtualFile) {
-        FileEditorManagerEx.getInstanceEx(projectRule.project).closeFile(file)
-    }
 
     private fun getEditorNotifications(editor: FileEditor): CredentialFileNotificationPanel? {
         PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()

--- a/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -641,6 +641,7 @@ general.notification.action.hide_forever=Don't show again
 general.notification.action.hide_once=Dismiss
 general.policy=Policy
 general.refresh=Refresh
+general.save=Save
 general.select_button=Select
 general.step.canceled={0} has been canceled
 general.step.failed={0} has failed: {1}


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Save action added to credential file notification bar
Removed the ability to hide the bar due to adding Save action

## Motivation and Context
We get a lot of complaints around refreshing credentials. Issue is that if you edit the file and don't trigger an explicit save, the file contents won't be save to disk until later. Add a Save action to trigger the save to hopefully cut down on people being surprised by it

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
![Screen Shot 2021-11-03 at 3 06 58 PM](https://user-images.githubusercontent.com/8992246/140199920-419255c0-d350-40e6-a95c-c36a4226131d.png)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
