### PR TITLE
Fix Kotlin warning about not implementing getChildren

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/nodes/AwsExplorerServiceRootNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/nodes/AwsExplorerServiceRootNode.kt
@@ -18,6 +18,8 @@ abstract class AwsExplorerServiceRootNode(project: Project, service: AwsExplorer
     private val serviceId = service.serviceId
 
     abstract override fun displayName(): String
+
+    override fun getChildren(): List<AwsExplorerNode<*>> = super.getChildren()
     override fun isAlwaysShowPlus(): Boolean = true
     override fun actionGroupName() = "aws.toolkit.explorer.$serviceId"
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/apprunner/AppRunnerExplorerNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/apprunner/AppRunnerExplorerNode.kt
@@ -10,16 +10,15 @@ import software.amazon.awssdk.services.apprunner.model.ServiceSummary
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
-import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceRootNode
-import software.aws.toolkits.jetbrains.core.getResourceNow
+import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
 import software.aws.toolkits.jetbrains.services.apprunner.resources.AppRunnerResources
 import software.aws.toolkits.jetbrains.utils.toHumanReadable
 import software.aws.toolkits.resources.message
 
-class AppRunnerNode(project: Project, service: AwsExplorerServiceNode) : AwsExplorerServiceRootNode(project, service) {
+class AppRunnerNode(project: Project, service: AwsExplorerServiceNode) :
+    CacheBackedAwsExplorerServiceRootNode<ServiceSummary>(project, service, AppRunnerResources.LIST_SERVICES) {
     override fun displayName() = message("explorer.node.apprunner")
-    override fun getChildrenInternal(): List<AwsExplorerNode<*>> =
-        nodeProject.getResourceNow(AppRunnerResources.LIST_SERVICES).map { AppRunnerServiceNode(nodeProject, it) }
+    override fun toNode(child: ServiceSummary): AwsExplorerNode<*> = AppRunnerServiceNode(nodeProject, child)
 }
 
 class AppRunnerServiceNode(


### PR DESCRIPTION
## Description
Fixes the warnings that look like

```
Deprecated: Class 'SqsServiceNode' is not abstract and does not implement abstract base class member public abstract fun getChildren(): (MutableCollection<out AbstractTreeNode<*>!>..Collection<AbstractTreeNode<*>!>) defined in software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
