### PR TITLE
Fix CW and CFN tool windows showing in status bar before needed

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/toolwindow/CloudFormationToolWindowFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/toolwindow/CloudFormationToolWindowFactory.kt
@@ -17,4 +17,6 @@ class CloudFormationToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun init(toolWindow: ToolWindow) {
         toolWindow.stripeTitle = message("cloudformation.toolwindow.label")
     }
+
+    override fun shouldBeAvailable(project: Project): Boolean = false
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/toolwindow/CloudWatchLogsToolWindowFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/toolwindow/CloudWatchLogsToolWindowFactory.kt
@@ -18,6 +18,8 @@ class CloudWatchLogsToolWindowFactory : ToolWindowFactory, DumbAware {
         toolWindow.stripeTitle = message("cloudwatch.logs.toolwindow")
     }
 
+    override fun shouldBeAvailable(project: Project): Boolean = false
+
     companion object {
         const val TOOLWINDOW_ID = "aws.cloudwatchlogs"
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
The CFN and CW tool windows showed in the bottom status bar upon opening a project. If you clicked them they would instantly disappear. This keeps them from showing until they have content

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
