### PR TITLE
Migrate off ServiceManager for App services

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/RemoteResourceResolverProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/RemoteResourceResolverProvider.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.jetbrains.core
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.util.io.createDirectories
 import software.aws.toolkits.core.utils.DefaultRemoteResourceResolver
 import software.aws.toolkits.core.utils.RemoteResourceResolver
@@ -18,7 +18,7 @@ interface RemoteResourceResolverProvider {
     fun get(): RemoteResourceResolver
 
     companion object {
-        fun getInstance(): RemoteResourceResolverProvider = ServiceManager.getService(RemoteResourceResolverProvider::class.java)
+        fun getInstance(): RemoteResourceResolverProvider = service()
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/CredentialManager.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkits.jetbrains.core.credentials
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.util.messages.MessageBus
@@ -93,7 +93,7 @@ abstract class CredentialManager : SimpleModificationTracker() {
 
     companion object {
         @JvmStatic
-        fun getInstance(): CredentialManager = ServiceManager.getService(CredentialManager::class.java)
+        fun getInstance(): CredentialManager = service()
 
         /***
          * [MessageBus] topic for when credential providers get added/changed/deleted

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
@@ -6,9 +6,9 @@ package software.aws.toolkits.jetbrains.core.executables
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
@@ -45,7 +45,7 @@ interface ExecutableManager {
 
     companion object {
         @JvmStatic
-        fun getInstance(): ExecutableManager = ServiceManager.getService(ExecutableManager::class.java)
+        fun getInstance(): ExecutableManager = service()
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/region/AwsRegionProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/region/AwsRegionProvider.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.region
 
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import org.slf4j.event.Level
 import software.amazon.awssdk.regions.providers.AwsProfileRegionProvider
 import software.amazon.awssdk.regions.providers.AwsRegionProviderChain
@@ -63,6 +63,6 @@ class AwsRegionProvider : ToolkitRegionProvider() {
         private val LOG = getLogger<AwsRegionProvider>()
 
         @JvmStatic
-        fun getInstance(): ToolkitRegionProvider = ServiceManager.getService(ToolkitRegionProvider::class.java)
+        fun getInstance(): ToolkitRegionProvider = service()
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkits.jetbrains.services.telemetry
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import software.amazon.awssdk.services.toolkittelemetry.model.Sentiment
 import software.aws.toolkits.core.ConnectionSettings
@@ -121,7 +121,7 @@ abstract class TelemetryService(private val publisher: TelemetryPublisher, priva
         private const val TELEMETRY_KEY = "aws.toolkits.enableTelemetry"
         private val TELEMETRY_ENABLED = System.getProperty(TELEMETRY_KEY)?.toBoolean() ?: true
 
-        fun getInstance(): TelemetryService = ServiceManager.getService(TelemetryService::class.java)
+        fun getInstance(): TelemetryService = service()
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/AwsSettings.kt
@@ -7,9 +7,9 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.DumbAware
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
@@ -26,7 +26,7 @@ interface AwsSettings {
 
     companion object {
         @JvmStatic
-        fun getInstance(): AwsSettings = ServiceManager.getService(AwsSettings::class.java)
+        fun getInstance(): AwsSettings = service()
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/CloudDebugSettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/CloudDebugSettings.kt
@@ -4,9 +4,9 @@
 package software.aws.toolkits.jetbrains.settings
 
 import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 
 @State(name = "cloud_debug", storages = [Storage("aws.xml")])
 class CloudDebugSettings : PersistentStateComponent<AwsCloudDebugConfiguration> {
@@ -26,7 +26,7 @@ class CloudDebugSettings : PersistentStateComponent<AwsCloudDebugConfiguration> 
 
     companion object {
         @JvmStatic
-        fun getInstance(): CloudDebugSettings = ServiceManager.getService(CloudDebugSettings::class.java)
+        fun getInstance(): CloudDebugSettings = service()
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/SamSettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/SamSettings.kt
@@ -4,9 +4,9 @@
 package software.aws.toolkits.jetbrains.settings
 
 import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import org.jetbrains.annotations.TestOnly
 
 @State(name = "sam", storages = [Storage("aws.xml")])
@@ -22,7 +22,7 @@ class SamSettings : PersistentStateComponent<SamConfiguration> {
     companion object {
         @JvmStatic
         @TestOnly
-        fun getInstance(): SamSettings = ServiceManager.getService(SamSettings::class.java)
+        fun getInstance(): SamSettings = service()
     }
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/UpdateLambdaSettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/UpdateLambdaSettings.kt
@@ -4,9 +4,9 @@
 package software.aws.toolkits.jetbrains.settings
 
 import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 
 @State(name = "updateLambdaState", storages = [Storage("aws.xml")])
 private class UpdateLambdaState : PersistentStateComponent<UpdateLambda> {
@@ -19,7 +19,7 @@ private class UpdateLambdaState : PersistentStateComponent<UpdateLambda> {
 
     companion object {
         @JvmStatic
-        internal fun getInstance(): UpdateLambdaState = ServiceManager.getService(UpdateLambdaState::class.java)
+        internal fun getInstance(): UpdateLambdaState = service()
     }
 }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/MockCredentialsManager.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.credentials
 
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.testFramework.ApplicationRule
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.AwsCredentials
@@ -66,7 +66,8 @@ class MockCredentialsManager : CredentialManager() {
         mapOf<String, CredentialProviderFactory>(MockCredentialProviderFactory.id to MockCredentialProviderFactory)
 
     companion object {
-        fun getInstance(): MockCredentialsManager = ServiceManager.getService(CredentialManager::class.java) as MockCredentialsManager
+        @Suppress("DEPRECATION")
+        fun getInstance(): MockCredentialsManager = service<CredentialManager>() as MockCredentialsManager
     }
 
     class MockCredentialIdentifier(override val displayName: String, val credentials: AwsCredentialsProvider, override val defaultRegionId: String?) :

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/region/MockRegionProvider.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.core.region
 
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.service
 import com.intellij.testFramework.ApplicationRule
 import software.amazon.awssdk.regions.Region
@@ -59,7 +58,7 @@ private class MockRegionProvider : ToolkitRegionProvider() {
     companion object {
         private val AWS_CLASSIC = AwsPartition("aws", "AWS Classic", listOf(US_EAST_1))
         private val regions = mapOf(US_EAST_1.id to US_EAST_1)
-        fun getInstance(): MockRegionProvider = ServiceManager.getService(ToolkitRegionProvider::class.java) as MockRegionProvider
+        fun getInstance(): MockRegionProvider = service<ToolkitRegionProvider>() as MockRegionProvider
     }
 }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
@@ -5,7 +5,6 @@ package software.aws.toolkits.jetbrains.utils
 
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.application.runWriteActionAndWait
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder
 import com.intellij.openapi.externalSystem.model.DataNode
 import com.intellij.openapi.externalSystem.model.project.ProjectData
@@ -127,7 +126,7 @@ fun HeavyJavaCodeInsightTestFixtureRule.setUpGradleProject(compatibility: String
                 System.err.println("Got null External project after import")
                 return
             }
-            ServiceManager.getService(ProjectDataManager::class.java).importData(externalProject, project, true)
+            ProjectDataManager.getInstance().importData(externalProject, project, true)
             println("External project was successfully imported")
         }
 


### PR DESCRIPTION
ServiceManager is now deprecated, so migrate our ApplicationServices off of it
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
