### PR TITLE
Attempt to stabilize clouddebug tests by using public ECR

### DIFF
--- a/testdata/testFiles/cloudDebugTestCluster.yaml
+++ b/testdata/testFiles/cloudDebugTestCluster.yaml
@@ -21,7 +21,7 @@ Resources:
       TaskRoleArn: !Ref TaskRole
       ContainerDefinitions:
         - Name: 'ContainerName'
-          Image: "amazoncorretto"
+          Image: "public.ecr.aws/amazoncorretto/amazoncorretto:latest"
           Command:
             - 'tail -f /dev/null'
           EntryPoint:
@@ -50,7 +50,7 @@ Resources:
       TaskRoleArn: !Ref TaskRole
       ContainerDefinitions:
         - Name: 'ContainerName'
-          Image: "node"
+          Image: "public.ecr.aws/lambda/nodejs:latest"
           Command:
             - 'tail -f /dev/null'
           EntryPoint:


### PR DESCRIPTION

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
