### PR TITLE
Fix Detekt Gradle plugin deprecation warning

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
 detekt {
     val rulesProject = project(":detekt-rules").projectDir
-    input.setFrom("$projectDir")
+    source.setFrom("$projectDir")
     buildUponDefaultConfig = false
     parallel = true
     allRules = false


### PR DESCRIPTION
```
aws-toolkit-jetbrains/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts: (21, 5): 'input: ConfigurableFileCollection' is deprecated. Please use the source property instead.
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
