### PR TITLE
add a version guide comment at CONTRIBUTING.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ guitest.log
 stale_outputs_checked
 # sam build directory
 .aws-sam/
+
+# dotnet version
+global.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ reported the issue. Please try to include as much information as you can. Detail
     ```
     brew install --cask dotnet-sdk
     ```
-
+  * It is recommended dotnet version `5.0.403` and `below`. If your dotnet versions were higher, you should refer to this [link](https://github.com/isen-ng/homebrew-dotnet-sdk-versions).
 ### Instructions
 
 1. Clone the github repository and run `./gradlew :intellij:buildPlugin` <br/> (This will produce a plugin zip under `intellij/build/distributions`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
documenation.

## Description

- Dotnet Framework (Windows)
   -  macOS steps:
        ``` bash 
        brew install --cask dotnet-sdk
        ```
This statements were deprecated. Basically, `brew install dotnet-sdk` command install 6.x.
This project cannot build using dotnet 6.x. So, I think this CONTRIBUTING.md add a version guide comment.

## Related Issue(s)

https://github.com/aws/aws-toolkit-jetbrains/issues/2960
 
## License

I confirm that my contribution is made under the terms of the Apache 2.0 license.
