### PR TITLE
Fix DownloadRobotServerPluginTask

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -119,7 +119,7 @@ tasks.runIde {
 // TODO: https://github.com/gradle/gradle/issues/15383
 val versionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 tasks.withType<DownloadRobotServerPluginTask> {
-    version.set(versionCatalog.findVersion("intellijRemoteRobot").get().preferredVersion)
+    version.set(versionCatalog.findVersion("intellijRemoteRobot").get().requiredVersion)
 }
 
 // Enable coverage for the UI test target IDE


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Fixes regression from #2963 that broke the` DownloadRobotServerPluginTask` causing the UI tests to fail to initialize. There is no `preferredVersion` specified for this dependency.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
