### PR TITLE
Specify the default of devmode in code as well

### DIFF
--- a/.changes/next-release/bugfix-418d2fd4-42be-41b8-b29f-9c08a53cbf96.json
+++ b/.changes/next-release/bugfix-418d2fd4-42be-41b8-b29f-9c08a53cbf96.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix error on plugin installation related to missing IDE registry key"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/AwsToolkit.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/AwsToolkit.kt
@@ -14,5 +14,5 @@ object AwsToolkit {
         PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "Unknown"
     }
 
-    fun isDeveloperMode() = Registry.`is`("aws.toolkit.developerMode")
+    fun isDeveloperMode() = Registry.`is`("aws.toolkit.developerMode", false)
 }


### PR DESCRIPTION
It seems that sometimes during dynamic loading, the registry value is read before it is added to the registry leading to an error. Specify the default value if we can't locate it

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
#2976
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
