### PR TITLE
Add extension point for contributing explorer node actions

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -166,6 +166,7 @@ with what features/services are supported.
         <extensionPoint name="executable" interface="software.aws.toolkits.jetbrains.core.executables.ExecutableType" dynamic="true"/>
 
         <extensionPoint name="explorer.serviceNode" interface="software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode" dynamic="true"/>
+        <extensionPoint name="explorer.actionContributor" interface="software.aws.toolkits.jetbrains.core.explorer.actions.AwsExplorerActionContributor" dynamic="true"/>
         <extensionPoint name="explorer.nodeProcessor" interface="software.aws.toolkits.jetbrains.core.explorer.AwsExplorerNodeProcessor" dynamic="true"/>
         <extensionPoint name="explorer.treeStructure" interface="software.aws.toolkits.jetbrains.core.explorer.AwsExplorerTreeStructureProvider" dynamic="true"/>
         <extensionPoint name="sdk.clientCustomizer" interface="software.aws.toolkits.core.ToolkitClientCustomizer" dynamic="true"/>
@@ -367,6 +368,11 @@ with what features/services are supported.
 
         <!-- Executables -->
         <executable implementation="software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable"/>
+
+        <!-- Explorer action contributors -->
+        <explorer.actionContributor implementation="software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceActionNodeContributor"/>
+        <explorer.actionContributor implementation="software.aws.toolkits.jetbrains.core.explorer.actions.CopyArnAction"/>
+        <explorer.actionContributor implementation="software.aws.toolkits.jetbrains.core.explorer.actions.ExplorerActionSorter" order="last"/>
 
         <!-- Explorer nodes -->
         <explorer.treeStructure implementation="software.aws.toolkits.jetbrains.services.dynamic.explorer.DynamicResourceTreeStructureProvider"/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -14,8 +14,6 @@ import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataKey
-import com.intellij.openapi.actionSystem.DefaultActionGroup
-import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.application.runReadAction
@@ -26,7 +24,6 @@ import com.intellij.ui.DoubleClickListener
 import com.intellij.ui.HyperlinkAdapter
 import com.intellij.ui.HyperlinkLabel
 import com.intellij.ui.JBColor
-import com.intellij.ui.PopupHandler
 import com.intellij.ui.ScrollPaneFactory
 import com.intellij.ui.TreeUIHelper
 import com.intellij.ui.components.panels.NonOpaquePanel
@@ -40,7 +37,6 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import com.intellij.util.ui.tree.TreeUtil
 import org.jetbrains.concurrency.CancellablePromise
-import software.aws.toolkits.jetbrains.ToolkitPlaces
 import software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManagerConnection
@@ -52,13 +48,12 @@ import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.explorer.ExplorerDataKeys.SELECTED_NODES
 import software.aws.toolkits.jetbrains.core.explorer.ExplorerDataKeys.SELECTED_RESOURCE_NODES
 import software.aws.toolkits.jetbrains.core.explorer.ExplorerDataKeys.SELECTED_SERVICE_NODE
-import software.aws.toolkits.jetbrains.core.explorer.actions.AwsExplorerActionContributor
+import software.aws.toolkits.jetbrains.core.explorer.actions.AwsExplorerActionPopupHandler
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceRootNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceLocationNode
 import software.aws.toolkits.jetbrains.services.dynamic.explorer.DynamicResourceResourceTypeNode
-import java.awt.Component
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.event.MouseEvent
@@ -77,7 +72,6 @@ class ExplorerToolWindow(project: Project) :
     ConnectionSettingsStateChangeNotifier,
     ToolkitConnectionManagerListener,
     Disposable {
-    private val actionManager = ActionManagerEx.getInstanceEx()
     private val treePanelWrapper = NonOpaquePanel()
     private val awsTreeModel = AwsExplorerTreeStructure(project)
 
@@ -170,11 +164,13 @@ class ExplorerToolWindow(project: Project) :
                                 invalidateTree()
                                 awsTreePanel
                             }
+
                             else -> createInfoPanel(credentialstate)
                         }
                     )
                 }
             }
+
             null, is AwsBearerTokenConnection -> {
                 runInEdt {
                     treePanelWrapper.setContent(
@@ -184,6 +180,7 @@ class ExplorerToolWindow(project: Project) :
                     )
                 }
             }
+
             else -> {
                 // TODO: tree doesn't support other connection types yet
             }
@@ -246,23 +243,7 @@ class ExplorerToolWindow(project: Project) :
             }
         }.installOn(awsTree)
 
-        awsTree.addMouseListener(
-            object : PopupHandler() {
-                override fun invokePopup(comp: Component?, x: Int, y: Int) {
-                    // Build a right click menu based on the selected first node
-                    // All nodes must be the same type (e.g. all S3 buckets, or a service node)
-                    val explorerNode = getSelectedNodesSameType<AwsExplorerNode<*>>()?.get(0) ?: return
-                    val actionGroup = DefaultActionGroup()
-                    AwsExplorerActionContributor.EP_NAME.forEachExtensionSafe {
-                        it.process(actionGroup, explorerNode)
-                    }
-                    if (actionGroup.childrenCount > 0) {
-                        val popupMenu = actionManager.createActionPopupMenu(ToolkitPlaces.EXPLORER_TOOL_WINDOW, actionGroup)
-                        popupMenu.component.show(comp, x, y)
-                    }
-                }
-            }
-        )
+        awsTree.addMouseListener(AwsExplorerActionPopupHandler { getSelectedNodesSameType<AwsExplorerNode<*>>()?.get(0) })
 
         return awsTree
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/AwsExplorerActionContributor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/AwsExplorerActionContributor.kt
@@ -1,0 +1,24 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.explorer.actions
+
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.extensions.ExtensionPointName
+import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
+
+/**
+ * Primarily used to add actions to explorer nodes.
+ *
+ * Can also be used to do other processing of the action group, e.g. ordering etc
+ */
+interface AwsExplorerActionContributor {
+    companion object {
+        val EP_NAME = ExtensionPointName<AwsExplorerActionContributor>("aws.toolkit.explorer.actionContributor")
+    }
+
+    /**
+     * Add (or mutate) the action [group] for the specified [node]
+     */
+    fun process(group: DefaultActionGroup, node: AwsExplorerNode<*>)
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/AwsExplorerActionPopupHandler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/AwsExplorerActionPopupHandler.kt
@@ -1,0 +1,34 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.explorer.actions
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPopupMenu
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.ui.PopupHandler
+import org.jetbrains.annotations.VisibleForTesting
+import software.aws.toolkits.jetbrains.ToolkitPlaces
+import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
+import java.awt.Component
+
+class AwsExplorerActionPopupHandler(private val explorerNodeResolver: () -> AwsExplorerNode<*>?) : PopupHandler() {
+    override fun invokePopup(comp: Component?, x: Int, y: Int) {
+        buildPopup()?.component?.show(comp, x, y)
+    }
+
+    @VisibleForTesting
+    internal fun buildPopup(): ActionPopupMenu? {
+        // Build a right click menu based on the selected first node
+        // All nodes must be the same type (e.g. all S3 buckets, or a service node)
+        val explorerNode = explorerNodeResolver() ?: return null
+        val actionGroup = DefaultActionGroup()
+        AwsExplorerActionContributor.EP_NAME.forEachExtensionSafe {
+            it.process(actionGroup, explorerNode)
+        }
+        return when {
+            actionGroup.childrenCount > 0 -> ActionManager.getInstance().createActionPopupMenu(ToolkitPlaces.EXPLORER_TOOL_WINDOW, actionGroup)
+            else -> null
+        }
+    }
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/CopyArnAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/CopyArnAction.kt
@@ -5,16 +5,27 @@ package software.aws.toolkits.jetbrains.core.explorer.actions
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.DumbAware
+import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
 import java.awt.datatransfer.StringSelection
 
-class CopyArnAction : SingleResourceNodeAction<AwsExplorerResourceNode<*>>(message("explorer.copy_arn"), icon = AllIcons.Actions.Copy), DumbAware {
+class CopyArnAction :
+    SingleResourceNodeAction<AwsExplorerResourceNode<*>>(message("explorer.copy_arn"), icon = AllIcons.Actions.Copy),
+    DumbAware,
+    AwsExplorerActionContributor {
     override fun actionPerformed(selected: AwsExplorerResourceNode<*>, e: AnActionEvent) {
         CopyPasteManager.getInstance().setContents(StringSelection(selected.resourceArn()))
         AwsTelemetry.copyArn(e.project, selected.serviceId)
+    }
+
+    override fun process(group: DefaultActionGroup, node: AwsExplorerNode<*>) {
+        if (node is AwsExplorerResourceNode<*>) {
+            group.add(this)
+        }
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
@@ -5,9 +5,12 @@ package software.aws.toolkits.jetbrains.core.explorer.actions
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.Separator
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAware
 import software.aws.toolkits.jetbrains.core.explorer.DeleteResourceDialog
+import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.jetbrains.utils.notifyInfo
@@ -43,4 +46,15 @@ abstract class DeleteResourceAction<in T : AwsExplorerResourceNode<*>> : SingleR
     }
 
     abstract fun performDelete(selected: T)
+}
+
+class ExplorerActionSorter : AwsExplorerActionContributor {
+    override fun process(group: DefaultActionGroup, node: AwsExplorerNode<*>) {
+        // Ensure the `DeleteResourceAction` is last
+        group.getChildren(null).find { it is DeleteResourceAction<*> }?.let {
+            group.remove(it)
+            group.add(Separator.create())
+            group.add(it)
+        }
+    }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/nodes/ResourceActionNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/nodes/ResourceActionNode.kt
@@ -3,6 +3,11 @@
 
 package software.aws.toolkits.jetbrains.core.explorer.nodes
 
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import software.aws.toolkits.jetbrains.core.explorer.actions.AwsExplorerActionContributor
+
 /**
  * Implemented by explorer resources that have associated actions.
  *
@@ -14,4 +19,13 @@ interface ResourceActionNode {
      * @returns The name of the action group declared in plugin.xml that is associated with this explorer node
      */
     fun actionGroupName(): String
+}
+
+class ResourceActionNodeContributor : AwsExplorerActionContributor {
+    private val actionManager = ActionManager.getInstance()
+
+    override fun process(group: DefaultActionGroup, node: AwsExplorerNode<*>) {
+        if (node !is ResourceActionNode) return
+        (actionManager.getAction(node.actionGroupName()) as? ActionGroup)?.let { group.addAll(it) }
+    }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/explorer/actions/AwsExplorerActionPopupHandlerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/explorer/actions/AwsExplorerActionPopupHandlerTest.kt
@@ -1,0 +1,53 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.explorer.actions
+
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.testFramework.DisposableRule
+import com.intellij.testFramework.ExtensionTestUtil
+import com.intellij.testFramework.ProjectRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import software.aws.toolkits.core.utils.test.notNull
+import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
+import software.aws.toolkits.jetbrains.utils.isInstanceOfSatisfying
+
+class AwsExplorerActionPopupHandlerTest {
+
+    @Rule
+    @JvmField
+    val projectRule = ProjectRule()
+
+    @Rule
+    @JvmField
+    val disposableRule = DisposableRule()
+
+    @Test
+    fun `action contributors add actions to the popup`() {
+        val dummyNode = mock<AwsExplorerNode<String>>()
+        val sut = AwsExplorerActionPopupHandler { dummyNode }
+        val mockExtension = object : AwsExplorerActionContributor {
+            override fun process(group: DefaultActionGroup, node: AwsExplorerNode<*>) {
+                group.add(mock())
+            }
+        }
+
+        ExtensionTestUtil.maskExtensions(AwsExplorerActionContributor.EP_NAME, listOf(mockExtension), disposableRule.disposable)
+
+        assertThat(sut.buildPopup()?.actionGroup).notNull.isInstanceOfSatisfying<DefaultActionGroup> {
+            assertThat(it.childrenCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `popup is null shown when no actions`() {
+        val dummyNode = mock<AwsExplorerNode<String>>()
+        val sut = AwsExplorerActionPopupHandler { dummyNode }
+
+        ExtensionTestUtil.maskExtensions(AwsExplorerActionContributor.EP_NAME, emptyList(), disposableRule.disposable)
+        assertThat(sut.buildPopup()).isNull()
+    }
+}


### PR DESCRIPTION
Moving the action logic from the ExplorerToolWindow into an extension point so that it can be more easily extended (and tested).

