### PR TITLE
Always grab rider logs from running containers on test failure

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -36,17 +36,7 @@ phases:
 
       - chmod +x gradlew
       - ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME integrationTest coverageReport --info --console plain
-      - |
-        if [ $(docker ps -q | wc -l) -gt 0 ]; then
-            echo 'Docker containers were not completely cleaned up!';
-            docker ps;
-            for container in $(docker ps -q); do
-                echo $container;
-                docker exec -i $container sh -c 'tail -n +1 /tmp/logs/*';
-            done;
-            
-            exit 1;
-        fi
+      - if [ $(docker ps -q | wc -l) -gt 0 ]; then echo 'Docker containers were not completely cleaned up!'; docker ps; exit 1; fi
       - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
       - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
       - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"
@@ -57,6 +47,10 @@ phases:
     commands:
       - TEST_ARTIFACTS="/tmp/testArtifacts"
       - mkdir -p $TEST_ARTIFACTS/test-reports
+      - |
+        for container in $(docker ps -q); do
+            docker cp ${container}:/tmp/logs/ ${container}-logs || true
+        done;
       - rsync -rmq --include='*/' --include '**/build/idea-sandbox/system*/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true

--- a/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
+++ b/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
@@ -5,6 +5,8 @@ package base
 
 import com.intellij.ide.GeneralSettings
 import com.intellij.openapi.project.Project
+import com.intellij.testFramework.runInEdtAndWait
+import com.jetbrains.rd.platform.diagnostics.LogTraceScenariosRegistry
 import com.jetbrains.rider.projectView.solutionDirectory
 import com.jetbrains.rider.test.base.BaseTestWithSolutionBase
 import com.jetbrains.rider.test.debugger.XDebuggerTestHelper
@@ -51,6 +53,9 @@ abstract class AwsReuseSolutionTestBase : BaseTestWithSolutionBase() {
 
     @BeforeClass(alwaysRun = true)
     fun enableToolkitDebugLogging() {
+        runInEdtAndWait {
+            LogTraceScenariosRegistry.getInstance().save(listOf("Debugger"))
+        }
         // TODO: output formatting needs to be cleaned up bit it'll do the job for now
         Logger.getLogger("software.aws.toolkits").apply {
             level = Level.DEBUG


### PR DESCRIPTION

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
