### PR TITLE
Force all log4j dependencies to be 2.15.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,15 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
     }
+
+    // TODO: remove after https://github.com/JetBrains/intellij-ui-test-robot/pull/136
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.apache.logging.log4j") {
+                useVersion("2.15.0")
+            }
+        }
+    }
 }
 
 tasks.register<GenerateGithubChangeLog>("generateChangeLog") {


### PR DESCRIPTION
Appeas to be only coming in through ui-test fixtures
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
