### PR TITLE
Fix NPE when loading cloudwatch log streams with no last event timestamp

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/TableUtils.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/editor/TableUtils.kt
@@ -54,7 +54,7 @@ class LogStreamsDateColumn(
 
     override fun isCellEditable(item: LogStream?): Boolean = false
     override fun getRenderer(item: LogStream?): TableCellRenderer = renderer
-    override fun getComparator(): Comparator<LogStream>? = if (sortable) Comparator.comparing { it.lastEventTimestamp() } else null
+    override fun getComparator(): Comparator<LogStream>? = if (sortable) Comparator.comparing { it.lastEventTimestamp() ?: Long.MIN_VALUE } else null
 }
 
 class LogStreamDateColumn(private val format: SyncDateFormat? = null) : ColumnInfo<LogStreamEntry, String>(message("general.time")) {


### PR DESCRIPTION
```
java.lang.NullPointerException
	at java.base/java.util.Comparator.lambda$comparing$77a9974f$1(Comparator.java:469)
	at java.desktop/javax.swing.DefaultRowSorter.compare(DefaultRowSorter.java:981)
	at java.desktop/javax.swing.DefaultRowSorter$Row.compareTo(DefaultRowSorter.java:1391)
	at java.desktop/javax.swing.DefaultRowSorter$Row.compareTo(DefaultRowSorter.java:1381)
	at java.base/java.util.ComparableTimSort.countRunAndMakeAscending(ComparableTimSort.java:325)
	at java.base/java.util.ComparableTimSort.sort(ComparableTimSort.java:188)
	at java.base/java.util.Arrays.sort(Arrays.java:1249)
	at java.desktop/javax.swing.DefaultRowSorter.sort(DefaultRowSorter.java:616)
	at java.desktop/javax.swing.DefaultRowSorter.allRowsChanged(DefaultRowSorter.java:863)
	at java.desktop/javax.swing.JTable.notifySorter(JTable.java:4263)
	at java.desktop/javax.swing.JTable.sortedTableChanged(JTable.java:4123)
	at java.desktop/javax.swing.JTable.tableChanged(JTable.java:4400)
	at com.intellij.ui.table.TableView.tableChanged(TableView.java:98)
	at java.desktop/javax.swing.table.AbstractTableModel.fireTableChanged(AbstractTableModel.java:297)
	at java.desktop/javax.swing.table.AbstractTableModel.fireTableDataChanged(AbstractTableModel.java:199)
	at com.intellij.util.ui.ListTableModel.setItems(ListTableModel.java:86)
	at software.aws.toolkits.jetbrains.services.cloudwatch.logs.CloudWatchActor.loadAndPopulate(CloudWatchActor.kt:71)
	at software.aws.toolkits.jetbrains.services.cloudwatch.logs.CloudWatchActor$loadAndPopulate$1.invokeSuspend(CloudWatchActor.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
