### PR TITLE
Mark JB 2020.3 as deprecated

### DIFF
--- a/.changes/next-release/deprecation-2bea839a-65ca-433d-80d8-0751de73468e.json
+++ b/.changes/next-release/deprecation-2bea839a-65ca-433d-80d8-0751de73468e.json
@@ -1,0 +1,4 @@
+{
+  "type" : "deprecation",
+  "description" : "An upcoming release will remove support for IDEs based on the 2020.3 platform"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/MinimumVersionChange.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/MinimumVersionChange.kt
@@ -55,8 +55,8 @@ class MinimumVersionChange @JvmOverloads constructor(isUnderTest: Boolean = fals
     }
 
     companion object {
-        const val MIN_VERSION = 203
-        const val MIN_VERSION_HUMAN = "2020.3"
+        const val MIN_VERSION = 211
+        const val MIN_VERSION_HUMAN = "2021.1"
 
         // Used by tests to make sure the prompt never shows up
         const val SKIP_PROMPT = "aws.suppress_deprecation_prompt"


### PR DESCRIPTION
## Description
JB 2020.3 support will be removed in a subsequent release. Notify users that it is now deprecated.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
