### PR TITLE
Fix python3.6 image debug invokes

### DIFF
--- a/.changes/next-release/bugfix-79c3a93c-68e7-4877-b0e1-835b49e5582b.json
+++ b/.changes/next-release/bugfix-79c3a93c-68e7-4877-b0e1-835b49e5582b.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix image-based Lambda debugging for Python 3.6"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonDebugSupport.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonDebugSupport.kt
@@ -76,7 +76,7 @@ class Python36ImageDebugSupport : PythonImageDebugSupport() {
     override val id: String = LambdaRuntime.PYTHON3_6.toString()
     override fun displayName() = LambdaRuntime.PYTHON3_6.toString().capitalize()
     override val pythonPath: String = "/var/lang/bin/python3.6"
-    override val bootstrapPath: String = "/var/runtime/awslambda/bootstrap.py"
+    override val bootstrapPath: String = "/var/runtime/bootstrap"
 }
 
 class Python37ImageDebugSupport : PythonImageDebugSupport() {


### PR DESCRIPTION

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
