### PR TITLE
Temporarily disable python3.6 integ

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
@@ -43,7 +43,7 @@ class PythonLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runt
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
         fun data(): Collection<Array<Runtime>> = listOf(
-            arrayOf(Runtime.PYTHON3_6),
+//            arrayOf(Runtime.PYTHON3_6),
             arrayOf(Runtime.PYTHON3_7),
             arrayOf(Runtime.PYTHON3_8),
             arrayOf(Runtime.PYTHON3_9)


### PR DESCRIPTION

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
