### PR TITLE
Bug - aws-toolkit-tsconfig.json doesn't escape slashes in path in windows

### DIFF
--- a/.changes/next-release/bugfix-1d15d166-eaad-40a4-a813-a4381c81928f.json
+++ b/.changes/next-release/bugfix-1d15d166-eaad-40a4-a813-a4381c81928f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue when running typescript lamda in windows where paths aren't being escaped"
+}

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilder.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsLambdaBuilder.kt
@@ -22,6 +22,7 @@ import software.aws.toolkits.jetbrains.utils.execution.steps.Context
 import software.aws.toolkits.jetbrains.utils.execution.steps.Step
 import software.aws.toolkits.jetbrains.utils.execution.steps.StepEmitter
 import software.aws.toolkits.resources.message
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -56,6 +57,15 @@ class NodeJsLambdaBuilder : LambdaBuilder() {
                         Files.createFile(tsConfig)
                     }
 
+
+                    fun checkAddSlashes (path: String): String {
+                        var newPath = path;
+                        if(File.separator.equals("\\")) {
+                            newPath = newPath.replace("\\", "\\\\");
+                        }
+                        return newPath;
+                    }
+
                     // TODO: if there's an existing tsconfig file, should we use it as a base?
                     tsConfig.writeText(
                         // language=JSON
@@ -63,16 +73,16 @@ class NodeJsLambdaBuilder : LambdaBuilder() {
                         {
                             "compilerOptions": {
                                 "${TypeScriptConfig.TYPE_ROOTS}": [
-                                  "${sourceRoot.resolve(TypeScriptConfig.DEFAULT_TYPES_DIRECTORY)}"
+                                  "${checkAddSlashes(sourceRoot.resolve(TypeScriptConfig.DEFAULT_TYPES_DIRECTORY).toString())}"
                                 ],
                                 "${TypeScriptConfig.TYPES}": [
                                   "node"
                                 ],
                                 "${TypeScriptConfig.TARGET_OPTION}": "${TypeScriptConfig.LanguageTarget.ES6.libName}",
                                 "${TypeScriptConfig.MODULE}": "${TypeScriptConfig.MODULE_COMMON_JS}",
-                                "${TypeScriptConfig.OUT_DIR}": "$tsOutput",
+                                "${TypeScriptConfig.OUT_DIR}": "${checkAddSlashes(tsOutput)}",
                                 "${TypeScriptConfig.ROOT_DIR}": ".",
-                                "sourceRoot": "$sourceRoot",
+                                "sourceRoot": "${checkAddSlashes(sourceRoot.toString())}",
                                 "${TypeScriptConfig.SOURCE_MAP}": true
                             }
                         }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Before writing to `aws-toolkit-tsconfig.json` we check to see if the path separator is `\`, if it is, we escape the slashes.

## Motivation and Context
In windows, when running a typescript lamda, AWS-toolkit generates `aws-toolkit-tsconfig.json` but it doesn't escape slashes in the path. 
This results in a file like

```
{
    "compilerOptions": {
        "typeRoots": [
          "E:\Development\Code\node_modules\@types"
        ],
        "types": [
          "node"
        ],
        "target": "es6",
        "module": "commonjs",
        "outDir": "E:\Development\Code\aws-toolkit-ts-output",
        "rootDir": ".",
        "sourceRoot": "E:\Development\Code",
        "sourceMap": true
    }
}
```

Which breaks tsc resulting it not being able to transpile and SAM failing to run.

## Testing
- Deleted `aws-toolkit-tsconfig.json`
- Run lambda locally
- Did same in MacOS to ensure it didn't affect Unix based filesystems

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [n/a] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
