### PR TITLE
Fix Go tests

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/steps/SamRunnerStep.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/steps/SamRunnerStep.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.services.lambda.steps
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.io.FileUtil
 import software.aws.toolkits.core.credentials.toEnvironmentVariables
 import software.aws.toolkits.core.utils.AttributeBagKey
@@ -32,6 +33,10 @@ class SamRunnerStep(val environment: ExecutionEnvironment, val settings: LocalLa
             .withParameters("local")
             .withParameters("invoke")
             .apply {
+                if (ApplicationManager.getApplication().isUnitTestMode) {
+                    withParameters("--debug")
+                }
+
                 if (settings is TemplateSettings) {
                     withParameters(settings.logicalId)
                 }

--- a/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/lambda/go/GoLocalRunConfigurationIntegrationTest.kt
+++ b/jetbrains-ultimate/it/software/aws/toolkits/jetbrains/services/lambda/go/GoLocalRunConfigurationIntegrationTest.kt
@@ -272,7 +272,7 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: LambdaRuntime)
     fun samIsExecutedImage(): Unit = samImageRunDebugTest(
         projectRule = projectRule,
         relativePath = "samProjects/image/$runtime",
-        templatePatches = mapOf("[GoVersion]" to (compatibleGoForIde() ?: "1")),
+        templatePatches = mapOf("[GoVersion]" to (compatibleGoForIde())),
         sourceFileName = "main.go",
         runtime = runtime,
         mockCredentialsId = mockId,
@@ -285,7 +285,7 @@ class GoLocalRunConfigurationIntegrationTest(private val runtime: LambdaRuntime)
         samImageRunDebugTest(
             projectRule = projectRule,
             relativePath = "samProjects/image/$runtime",
-            templatePatches = mapOf("[GoVersion]" to (compatibleGoForIde() ?: "1")),
+            templatePatches = mapOf("[GoVersion]" to (compatibleGoForIde())),
             sourceFileName = "main.go",
             runtime = runtime,
             mockCredentialsId = mockId,

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/GoCodeInsightTestFixtureRule.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/GoCodeInsightTestFixtureRule.kt
@@ -100,9 +100,13 @@ fun runGoModTidy(goModFile: VirtualFile) {
     }
 }
 
-fun compatibleGoForIde() = when (ApplicationInfo.getInstance().build.baselineVersion) {
-    211 -> "1.16.6" // TODO: FIX_WHEN_MIN_IS_212
-    else -> null
+fun compatibleGoForIde(): String {
+    val baseline = ApplicationInfo.getInstance().build.baselineVersion
+    return when {
+        baseline == 211 -> "1.16.6" // TODO: FIX_WHEN_MIN_IS_212
+        baseline < 221 -> "1.17.8" // TODO: FIX_WHEN_MIN_IS_221
+        else -> "1.18.0"
+    }
 }
 
 fun CodeInsightTestFixture.ensureCorrectGoVersion(disposable: Disposable) {

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/GoCodeInsightTestFixtureRule.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/GoCodeInsightTestFixtureRule.kt
@@ -120,7 +120,7 @@ fun CodeInsightTestFixture.ensureCorrectGoVersion(disposable: Disposable) {
     }
 
     val goVersionOverride = compatibleGoForIde()
-    goVersionOverride?.let {
+    goVersionOverride.let {
         val overrideLocation = this.tempDirPath
 
         installGoSdk(overrideLocation, it)


### PR DESCRIPTION
1.18.0 just came out which our tests defaulted to, but Delve in 212 and 213 don't support that

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
