### PR TITLE
Give Rider backend more time to start in tests

### DIFF
--- a/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
+++ b/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
@@ -15,7 +15,6 @@ import com.jetbrains.rider.test.scriptingApi.useCachedTemplates
 import org.testng.annotations.AfterClass
 import org.testng.annotations.BeforeClass
 import java.io.File
-import java.time.Duration
 
 /**
  * Base test class that uses the same solution per test class.

--- a/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
+++ b/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
@@ -39,8 +39,6 @@ abstract class AwsReuseSolutionTestBase : BaseTestWithSolutionBase() {
     protected open fun getCustomSolutionFileName(): String? = null
     protected open fun preprocessTempDirectory(tempDir: File) {}
 
-    override val backendShellLoadTimeout: Duration = backendStartTimeout
-
     override val testCaseNameToTempDir: String
         get() = getSolutionDirectoryName()
 
@@ -79,6 +77,7 @@ abstract class AwsReuseSolutionTestBase : BaseTestWithSolutionBase() {
         GeneralSettings.getInstance().isConfirmExit = false
 
         val params = OpenSolutionParams()
+        params.backendLoadedTimeout = backendStartTimeout
         params.customSolutionName = getCustomSolutionFileName()
         params.preprocessTempDirectory = { preprocessTempDirectory(it) }
         params.persistCaches = persistCaches

--- a/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
+++ b/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
@@ -15,6 +15,7 @@ import com.jetbrains.rider.test.scriptingApi.useCachedTemplates
 import org.testng.annotations.AfterClass
 import org.testng.annotations.BeforeClass
 import java.io.File
+import java.time.Duration
 
 /**
  * Base test class that uses the same solution per test class.
@@ -37,6 +38,8 @@ abstract class AwsReuseSolutionTestBase : BaseTestWithSolutionBase() {
 
     protected open fun getCustomSolutionFileName(): String? = null
     protected open fun preprocessTempDirectory(tempDir: File) {}
+
+    override val backendShellLoadTimeout: Duration = backendStartTimeout
 
     override val testCaseNameToTempDir: String
         get() = getSolutionDirectoryName()

--- a/jetbrains-rider/tst/base/RiderTestFrameworkUtils.kt
+++ b/jetbrains-rider/tst/base/RiderTestFrameworkUtils.kt
@@ -12,6 +12,10 @@ import com.intellij.util.text.SemVer
 import com.jetbrains.rider.test.base.PrepareTestEnvironment
 import java.io.File
 import java.nio.file.Paths
+import java.time.Duration
+
+// sometimes Windows Rider tests time out while starting the backend
+val backendStartTimeout = Duration.ofMinutes(3)
 
 val versions by lazy {
     // would be nice if this were json https://github.com/dotnet/runtime/issues/3049

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/completion/DotNetHandlerCompletionTest.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/completion/DotNetHandlerCompletionTest.kt
@@ -15,8 +15,7 @@ import org.testng.annotations.Test
 import java.time.Duration
 
 class DotNetHandlerCompletionTest : BaseTestWithSolution() {
-
-    override val backendShellLoadTimeout: Duration = backendStartTimeout
+    override val backendLoadedTimeout: Duration = backendStartTimeout
 
     override fun getSolutionDirectoryName(): String = ""
 

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/completion/DotNetHandlerCompletionTest.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/completion/DotNetHandlerCompletionTest.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.lambda.completion
 
 import base.allowCustomDotnetRoots
+import base.backendStartTimeout
 import com.intellij.openapi.util.IconLoader
 import com.jetbrains.rd.ide.model.IconModel
 import com.jetbrains.rider.test.annotations.TestEnvironment
@@ -11,8 +12,11 @@ import com.jetbrains.rider.test.base.BaseTestWithSolution
 import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations.BeforeSuite
 import org.testng.annotations.Test
+import java.time.Duration
 
 class DotNetHandlerCompletionTest : BaseTestWithSolution() {
+
+    override val backendShellLoadTimeout: Duration = backendStartTimeout
 
     override fun getSolutionDirectoryName(): String = ""
 

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
@@ -18,7 +18,7 @@ class LambdaGutterMarkHighlightingTest : BaseTestWithMarkup() {
         private const val LAMBDA_RUN_MARKER_ATTRIBUTE_ID = "AWS Lambda Run Method Gutter Mark"
     }
 
-    override val backendShellLoadTimeout: Duration = backendStartTimeout
+    override val backendLoadedTimeout: Duration = backendStartTimeout
 
     override fun getSolutionDirectoryName(): String = "SamHelloWorldApp"
 

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
@@ -3,18 +3,22 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.dotnet
 
+import base.backendStartTimeout
 import com.jetbrains.rdclient.testFramework.waitForDaemon
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.test.base.BaseTestWithMarkup
 import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 import software.aws.toolkits.jetbrains.protocol.awsSettingModel
+import java.time.Duration
 
 class LambdaGutterMarkHighlightingTest : BaseTestWithMarkup() {
 
     companion object {
         private const val LAMBDA_RUN_MARKER_ATTRIBUTE_ID = "AWS Lambda Run Method Gutter Mark"
     }
+
+    override val backendShellLoadTimeout: Duration = backendStartTimeout
 
     override fun getSolutionDirectoryName(): String = "SamHelloWorldApp"
 


### PR DESCRIPTION
Another attempt to fix Windows test flake
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
