### PR TITLE
Fixed a few issues with exception handling in the resource cache

### DIFF
--- a/.changes/next-release/bugfix-1d2873f0-5e0a-4e08-bfaf-551dae455e25.json
+++ b/.changes/next-release/bugfix-1d2873f0-5e0a-4e08-bfaf-551dae455e25.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fixed issue with uncaught exception in resource cache (#3098)"
+}

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/AwsResourceCacheTest.kt
@@ -494,6 +494,7 @@ class AwsResourceCacheTest {
         latch.countDown()
         assertThatThrownBy { first.value }.hasCauseWithMessage("Boom")
         assertThatThrownBy { second.value }.hasCauseWithMessage("Boom")
+        verifyResourceCalled(1, mockResource)
     }
 
     @Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/AssertJMatchers.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/AssertJMatchers.kt
@@ -4,6 +4,8 @@
 package software.aws.toolkits.jetbrains.utils
 
 import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.AbstractThrowableAssert
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.CompletableFutureAssert
 import java.time.Duration
 import java.util.concurrent.CompletionStage
@@ -28,6 +30,15 @@ fun <T> CompletableFutureAssert<T>.hasValue(value: T) {
 val <T> CompletionStage<T>.value get() = toCompletableFuture().get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
 
 val <T> CompletableFutureAssert<T>.hasException get() = this.wait().isCompletedExceptionally
+
+fun <SELF : AbstractThrowableAssert<SELF, ACTUAL>, ACTUAL : Throwable> AbstractThrowableAssert<SELF, ACTUAL>.hasCauseWithMessage(
+    message: String
+): AbstractThrowableAssert<SELF, ACTUAL> {
+    satisfies { parentThrowable ->
+        assertThat(parentThrowable.cause).isNotNull.hasMessage(message)
+    }
+    return this
+}
 
 inline fun <reified T> AbstractAssert<*, *>.isInstanceOf() = isInstanceOf(T::class.java)
 inline fun <reified T> AbstractAssert<*, *>.isInstanceOfSatisfying(checker: Consumer<T>) = isInstanceOfSatisfying(T::class.java, checker)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Previously exceptions were getting cached, and bubbled as unhandled exceptions on subsequent calls. This fixes the following:
- exceptions are no longer considered valid "current values" when evaluating whether to return a cached value
- exceptions are pruned from the cache on maintenance runs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->
#3098 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new tests to cover missing scenarios.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
