### PR TITLE
Fix debugger failure in Rider 2022.1.1

### DIFF
--- a/.changes/next-release/bugfix-e70966c5-80d9-4ab8-84d5-bd2526dc6b33.json
+++ b/.changes/next-release/bugfix-e70966c5-80d9-4ab8-84d5-bd2526dc6b33.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix .NET debugger regression in 2022.1.1"
+}

--- a/.changes/next-release/bugfix-e70966c5-80d9-4ab8-84d5-bd2526dc6b33.json
+++ b/.changes/next-release/bugfix-e70966c5-80d9-4ab8-84d5-bd2526dc6b33.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Fix .NET debugger regression in 2022.1.1"
+  "description" : "Fix .NET Lambda debugging regression in 2022.1.1"
 }


### PR DESCRIPTION
Reported in #1399

Rider 2022.1.1 seems to have removed dotnet binaries that are not relevant to the platform
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
