### PR TITLE
Promote CodeWhisperer popup actions to be the first to be executed

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -322,6 +322,7 @@ with what features/services are supported.
         <typedHandler implementation="software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererTypedHandler"/>
         <editorFactoryListener implementation="software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorListener"/>
         <editorActionHandler action="EditorEnter" implementationClass="software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEnterHandler"/>
+        <actionPromoter order="last" implementation="software.aws.toolkits.jetbrains.services.codewhisperer.actions.CodeWhispererActionPromoter"/>
     </extensions>
 
     <extensions defaultExtensionNs="JavaScript.JsonSchema">

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/actions/CodeWhispererActionPromoter.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/actions/CodeWhispererActionPromoter.kt
@@ -1,0 +1,36 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.codewhisperer.actions
+
+import com.intellij.openapi.actionSystem.ActionPromoter
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.actionSystem.EditorAction
+import software.aws.toolkits.jetbrains.services.codewhisperer.popup.handlers.CodeWhispererPopupLeftArrowHandler
+import software.aws.toolkits.jetbrains.services.codewhisperer.popup.handlers.CodeWhispererPopupRightArrowHandler
+import software.aws.toolkits.jetbrains.services.codewhisperer.popup.handlers.CodeWhispererPopupTabHandler
+
+class CodeWhispererActionPromoter : ActionPromoter {
+    override fun promote(actions: MutableList<out AnAction>, context: DataContext): MutableList<AnAction> {
+        val results = actions.toMutableList()
+        results.sortWith { a, b ->
+            if (isCodeWhispererPopupAction(a)) return@sortWith -1
+            else if (isCodeWhispererPopupAction(b)) return@sortWith 1
+            else 0
+        }
+        return results
+    }
+
+    private fun isCodeWhispererAcceptAction(action: AnAction): Boolean =
+        action is EditorAction && action.handler is CodeWhispererPopupTabHandler
+
+    private fun isCodeWhispererNavigateAction(action: AnAction): Boolean =
+        action is EditorAction && (
+            action.handler is CodeWhispererPopupRightArrowHandler ||
+                action.handler is CodeWhispererPopupLeftArrowHandler
+            )
+
+    private fun isCodeWhispererPopupAction(action: AnAction): Boolean =
+        isCodeWhispererAcceptAction(action) || isCodeWhispererNavigateAction(action)
+}


### PR DESCRIPTION
1. When CodeWhisperer popup is showing, we want to force CodeWhisperer's
action to be executed, which are accept and navigate recommendation actions.
so use an actionPromoter to order them to the beginning of the action list.
2. This will solve the problem when CodeWhisperer actions are not working when IdeaVim plugin is installed.
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
