### PR TITLE
[CodeWhisperer] Not sending telemetry when users are not editing the file

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
@@ -111,6 +111,7 @@ abstract class CodeWhispererCodeCoverageTracker(
             addAndGetAcceptedTokens(it.endOffset - it.startOffset)
         }
 
+        // percentage == 0 means totalTokens == 0 and users are not editing the document, thus we shouldn't emit telemetry for this
         percentage?.let { percentage ->
             CodewhispererTelemetry.codePercentage(
                 project = null,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
@@ -111,7 +111,7 @@ abstract class CodeWhispererCodeCoverageTracker(
             addAndGetAcceptedTokens(it.endOffset - it.startOffset)
         }
 
-        percentage?.let {percentage ->
+        percentage?.let { percentage ->
             CodewhispererTelemetry.codePercentage(
                 project = null,
                 acceptedTokensSize,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
@@ -33,8 +33,8 @@ abstract class CodeWhispererCodeCoverageTracker(
     private val totalTokens: AtomicInteger,
     private val rangeMarkers: MutableList<RangeMarker>
 ) : Disposable {
-    val percentage: Int
-        get() = if (totalTokensSize != 0) calculatePercentage(acceptedTokensSize, totalTokensSize) else 0
+    val percentage: Int?
+        get() = if (totalTokensSize != 0) calculatePercentage(acceptedTokensSize, totalTokensSize) else null
     val acceptedTokensSize: Int
         get() = acceptedTokens.get()
     val totalTokensSize: Int
@@ -111,14 +111,16 @@ abstract class CodeWhispererCodeCoverageTracker(
             addAndGetAcceptedTokens(it.endOffset - it.startOffset)
         }
 
-        CodewhispererTelemetry.codePercentage(
-            project = null,
-            acceptedTokensSize,
-            language,
-            percentage,
-            startTime.toString(),
-            totalTokensSize
-        )
+        percentage?.let {percentage ->
+            CodewhispererTelemetry.codePercentage(
+                project = null,
+                acceptedTokensSize,
+                language,
+                percentage,
+                startTime.toString(),
+                totalTokensSize
+            )
+        }
     }
 
     @TestOnly

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
@@ -111,7 +111,7 @@ abstract class CodeWhispererCodeCoverageTracker(
             addAndGetAcceptedTokens(it.endOffset - it.startOffset)
         }
 
-        // percentage == 0 means totalTokens == 0 and users are not editing the document, thus we shouldn't emit telemetry for this
+        // percentage == null means totalTokens == 0 and users are not editing the document, thus we shouldn't emit telemetry for this
         percentage?.let { percentage ->
             CodewhispererTelemetry.codePercentage(
                 project = null,

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
@@ -220,7 +220,7 @@ class CodeWhispererCodeCoverageTrackerTest {
         fixture.configureByText("/emptyFile.java", "")
         val javaTracker = spy(TestCodePercentageTracker(TOTAL_SECONDS_IN_MINUTE, language = CodewhispererLanguage.Java))
         CodeWhispererCodeCoverageTracker.getInstancesMap()[CodewhispererLanguage.Java] = javaTracker
-        assertThat(javaTracker.percentage).isEqualTo(0)
+        assertThat(javaTracker.percentage).isNull()
     }
 
     @Test
@@ -314,6 +314,14 @@ class CodeWhispererCodeCoverageTrackerTest {
     fun `test flush() won't emit telemetry event when users not enabling telemetry`() {
         AwsSettings.getInstance().isTelemetryEnabled = false
         val pythonTracker = TestCodePercentageTracker(TOTAL_SECONDS_IN_MINUTE, CodewhispererLanguage.Python, AtomicInteger(10), AtomicInteger(20))
+        pythonTracker.forceTrackerFlush()
+        verify(batcher, Times(0)).enqueue(any())
+    }
+
+    @Test
+    fun `test flush() won't emit telemetry when users are not editing the document`() {
+        val pythonTracker = TestCodePercentageTracker(TOTAL_SECONDS_IN_MINUTE, CodewhispererLanguage.Python, AtomicInteger(0), AtomicInteger(0))
+        assertThat(pythonTracker.activeRequestCount()).isEqualTo(1)
         pythonTracker.forceTrackerFlush()
         verify(batcher, Times(0)).enqueue(any())
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Since we add documentListeners when the editor instance is created, when users are switching to another, the %code tracker is still sending %code telemetry, which will be 0 and it increase a lot of noise for reading these metric.

This PR aims to block these scenario from sending telemetry.





## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
