### PR TITLE
Fixed bug in the Deploy Serverless Application (SAM) dialogue where it wouldn't update the stack tags and parameters on update.

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/deploy/DeployServerlessApplicationDialog.kt
@@ -186,7 +186,10 @@ class DeployServerlessApplicationDialog(
                     ).toolTipText(message("serverless.application.deploy.tooltip.createStack"))
 
                     createStackButton.selected.addListener {
-                        refreshTemplateParametersAndTags()
+                        if (it && deployType != DeployType.CREATE) {
+                            deployType = DeployType.CREATE
+                            refreshTemplateParametersAndTags()
+                        }
                     }
 
                     textField(::newStackName)
@@ -211,7 +214,10 @@ class DeployServerlessApplicationDialog(
                     ).toolTipText(message("serverless.application.deploy.tooltip.updateStack"))
 
                     updateStackButton.selected.addListener {
-                        refreshTemplateParametersAndTags()
+                        if (it && deployType != DeployType.UPDATE) {
+                            deployType = DeployType.UPDATE
+                            refreshTemplateParametersAndTags()
+                        }
                     }
 
                     stackSelector()


### PR DESCRIPTION
Fixed bug in the Deploy Serverless Application (SAM) dialogue where it wouldn't update the stack tags and parameters on update.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
The code wouldn't fetch the tags and parameters from the existing stack
Added logic to prevent updates on mouse-over the radio button.

## Motivation and Context
The code wouldn't fetch the tags and parameters from the existing stack.

## Related Issue(s)
Couldn't find any existing bug issues.

## Testing
Run multiple debug sessions, until the expected behaviour was achieved.

## Screenshots (if appropriate)
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
