### PR TITLE
[CodeWhisperer] Add reference URL in the CWSPR reference panel if present

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceComponents.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceComponents.kt
@@ -64,25 +64,33 @@ class CodeWhispererCodeReferenceComponents(private val project: Project) {
         BrowserUtil.browse(CodeWhispererLicenseInfoManager.getInstance().getLicenseLink(licenseName))
     }.asCodeReferencePanelFont()
 
-    private fun acceptRecommendationSuffixText(repoName: String, path: String?, line: String, url: String) = JLabel().apply {
+    private fun repoNameLink(repo: String, url: String) = ActionLink(repo) {
+        BrowserUtil.browse(url)
+    }.asCodeReferencePanelFont()
+
+    private fun acceptRecommendationSuffixText(repo: String, path: String?, line: String) = JLabel().apply {
         val choice = if (path != null) 1 else 0
-        val repo = if (url.isEmpty()) repoName else message("codewhisperer.toolwindow.entry.urlLink", repoName, url)
-        text = message("codewhisperer.toolwindow.entry.suffix", repo, path ?: "", choice, line)
+        text = message("codewhisperer.toolwindow.entry.suffix", path ?: "", choice, line)
     }.asCodeReferencePanelFont()
 
     fun codeReferenceRecordPanel(ref: Reference, relativePath: String?, lineNums: String) = JPanel(GridBagLayout()).apply {
         background = EditorColorsManager.getInstance().globalScheme.defaultBackground
         border = BorderFactory.createEmptyBorder(5, 0, 0, 0)
         add(acceptRecommendationPrefixText, inlineLabelConstraints)
-        if (ref.url().isEmpty()) {
-            // if url to source package/repo is missing, we still present the hyperlink to SPDX from the license name
+
+        // if url to source package/repo is missing, the UX remains the same as we have for now
+        // if url to source package/repo is present, the url pointing to the source will be present and remove the hyperlink to SPDX
+        if (ref.url().isNullOrEmpty()) {
             add(licenseNameLink(ref.licenseName()), inlineLabelConstraints)
+            add(JLabel(" from ").asCodeReferencePanelFont(), inlineLabelConstraints)
+            add(JLabel(ref.repository()), inlineLabelConstraints)
         } else {
-            // if url to source package/repo is present, the url pointing to the source will be present and remove the hyperlink to SPDX
-            add(JLabel(ref.licenseName()).asCodeReferencePanelFont(), inlineLabelConstraints)
+            add(JLabel(ref.licenseName()), inlineLabelConstraints)
+            add(JLabel(" from ").asCodeReferencePanelFont(), inlineLabelConstraints)
+            add(repoNameLink(ref.repository(), ref.url()), inlineLabelConstraints)
         }
-        add(JLabel(" ").asCodeReferencePanelFont(), inlineLabelConstraints)
-        add(acceptRecommendationSuffixText(ref.repository(), relativePath, lineNums, ref.url()), inlineLabelConstraints)
+
+        add(acceptRecommendationSuffixText(ref.repository(), relativePath, lineNums), inlineLabelConstraints)
         addHorizontalGlue()
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceComponents.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceComponents.kt
@@ -74,7 +74,13 @@ class CodeWhispererCodeReferenceComponents(private val project: Project) {
         background = EditorColorsManager.getInstance().globalScheme.defaultBackground
         border = BorderFactory.createEmptyBorder(5, 0, 0, 0)
         add(acceptRecommendationPrefixText, inlineLabelConstraints)
-        add(licenseNameLink(ref.licenseName()), inlineLabelConstraints)
+        if (ref.url().isEmpty()) {
+            // if url to source package/repo is missing, we still present the hyperlink to SPDX from the license name
+            add(licenseNameLink(ref.licenseName()), inlineLabelConstraints)
+        } else {
+            // if url to source package/repo is present, the url pointing to the source will be present and remove the hyperlink to SPDX
+            add(JLabel(ref.licenseName()).asCodeReferencePanelFont(), inlineLabelConstraints)
+        }
         add(JLabel(" ").asCodeReferencePanelFont(), inlineLabelConstraints)
         add(acceptRecommendationSuffixText(ref.repository(), relativePath, lineNums, ref.url()), inlineLabelConstraints)
         addHorizontalGlue()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceComponents.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceComponents.kt
@@ -64,8 +64,9 @@ class CodeWhispererCodeReferenceComponents(private val project: Project) {
         BrowserUtil.browse(CodeWhispererLicenseInfoManager.getInstance().getLicenseLink(licenseName))
     }.asCodeReferencePanelFont()
 
-    private fun acceptRecommendationSuffixText(repo: String, path: String?, line: String) = JLabel().apply {
+    private fun acceptRecommendationSuffixText(repoName: String, path: String?, line: String, url: String) = JLabel().apply {
         val choice = if (path != null) 1 else 0
+        val repo = if (url.isEmpty()) repoName else message("codewhisperer.toolwindow.entry.urlLink", repoName, url)
         text = message("codewhisperer.toolwindow.entry.suffix", repo, path ?: "", choice, line)
     }.asCodeReferencePanelFont()
 
@@ -75,7 +76,7 @@ class CodeWhispererCodeReferenceComponents(private val project: Project) {
         add(acceptRecommendationPrefixText, inlineLabelConstraints)
         add(licenseNameLink(ref.licenseName()), inlineLabelConstraints)
         add(JLabel(" ").asCodeReferencePanelFont(), inlineLabelConstraints)
-        add(acceptRecommendationSuffixText(ref.repository(), relativePath, lineNums), inlineLabelConstraints)
+        add(acceptRecommendationSuffixText(ref.repository(), relativePath, lineNums, ref.url()), inlineLabelConstraints)
         addHorizontalGlue()
     }
 

--- a/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -311,8 +311,7 @@ codewhisperer.settings.show.label=Show CodeWhisperer Settings
 codewhisperer.statusbar.display_name=CodeWhisperer
 codewhisperer.statusbar.tooltip=CodeWhisperer status
 codewhisperer.toolwindow.entry.prefix=[{0}] ACCEPTED recommendation with the following code provided with reference under 
-codewhisperer.toolwindow.entry.suffix=from repository {0}{2, choice, 0#|1#. Added to {1}} at line {3}
-codewhisperer.toolwindow.entry.urlLink=<html><a href="{1}">{0}</a></html>
+codewhisperer.toolwindow.entry.suffix= {1, choice, 0#|1#. Added to {0}} at line {2}
 codewhisperer.toolwindow.popup.text=Reference code under the {0} license from repository {1}
 codewhisperer.toolwindow.settings=CodeWhisperer Settings
 codewhisperer.toolwindow.settings.prefix=Don't want suggestions that include code with references? Edit in 

--- a/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -312,6 +312,7 @@ codewhisperer.statusbar.display_name=CodeWhisperer
 codewhisperer.statusbar.tooltip=CodeWhisperer status
 codewhisperer.toolwindow.entry.prefix=[{0}] ACCEPTED recommendation with the following code provided with reference under 
 codewhisperer.toolwindow.entry.suffix=from repository {0}{2, choice, 0#|1#. Added to {1}} at line {3}
+codewhisperer.toolwindow.entry.urlLink=<html><a href="{1}">{0}</a></html>
 codewhisperer.toolwindow.popup.text=Reference code under the {0} license from repository {1}
 codewhisperer.toolwindow.settings=CodeWhisperer Settings
 codewhisperer.toolwindow.settings.prefix=Don't want suggestions that include code with references? Edit in 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As Codewhisperer service will return URL pointing to the source package/repo if possible, 
- when the URL is present, client side will show the hyperlink to the src package/repo instead of hyperlink to SPDX per license name
<img width="1383" alt="OT_UX_2" src="https://user-images.githubusercontent.com/96078566/183311196-4d78f23b-e456-4e1e-8248-d30e2bc1b560.png">



- when the URL is missing, client side will remain the same behavior as before: to show the hyperlink to SPDX per license name and no hyperlink with repo name.

<img width="1383" alt="OT_UX_1" src="https://user-images.githubusercontent.com/96078566/183311197-4cfcd234-10cb-4e63-8749-5969e3db88dd.png">


### Coressponding VSC change: https://github.com/aws/aws-toolkit-vscode/pull/2803

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
