### PR TITLE
[CodeWhisperer] Send empty telemetry events for empty recommendations

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
@@ -570,6 +570,7 @@ class CodeWhispererPopupManager {
 
     private fun isValidRecommendation(detailContext: DetailContext, userInput: String, typeahead: String): Boolean {
         if (detailContext.isDiscarded) return false
+        if (detailContext.recommendation.content().isEmpty()) return false
         val indexOfFirstNonWhiteSpace = typeahead.indexOfFirst { !it.isWhitespace() }
         if (indexOfFirstNonWhiteSpace == -1) return true
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
@@ -75,7 +75,7 @@ class CodeWhispererTelemetryService {
         )
     }
 
-    private fun sendUserDecisionEvent(
+    fun sendUserDecisionEvent(
         requestId: String,
         requestContext: RequestContext,
         responseContext: ResponseContext,
@@ -185,7 +185,8 @@ class CodeWhispererTelemetryService {
                 sessionContext.seen.contains(index),
                 hasUserAccepted,
                 isDiscarded,
-                detail.hasReferences()
+                detail.hasReferences(),
+                detail.content().isEmpty()
             )
             sendUserDecisionEvent(requestId, requestContext, responseContext, detail, index, suggestionState, detailContexts.size)
         }
@@ -197,9 +198,12 @@ class CodeWhispererTelemetryService {
         hasSeen: Boolean,
         hasUserAccepted: Boolean,
         isDiscarded: Boolean,
-        hasReference: Boolean
+        hasReference: Boolean,
+        isEmpty: Boolean
     ): CodewhispererSuggestionState =
-        if (!CodeWhispererSettings.getInstance().isIncludeCodeWithReference() && hasReference) {
+        if (isEmpty) {
+            CodewhispererSuggestionState.Empty
+        } else if (!CodeWhispererSettings.getInstance().isIncludeCodeWithReference() && hasReference) {
             CodewhispererSuggestionState.Filter
         } else if (isDiscarded) {
             CodewhispererSuggestionState.Discard

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestUtil.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestUtil.kt
@@ -65,6 +65,34 @@ object CodeWhispererTestUtil {
         .responseMetadata(metadata)
         .sdkHttpResponse(sdkHttpResponse)
         .build() as ListRecommendationsResponse
+    val emptyListResponse: ListRecommendationsResponse = ListRecommendationsResponse.builder()
+        .recommendations(listOf())
+        .nextToken("")
+        .responseMetadata(metadata)
+        .sdkHttpResponse(sdkHttpResponse)
+        .build() as ListRecommendationsResponse
+    val listOfEmptyRecommendationResponse: ListRecommendationsResponse = ListRecommendationsResponse.builder()
+        .recommendations(
+            generateMockRecommendationDetail(""),
+            generateMockRecommendationDetail(""),
+            generateMockRecommendationDetail(""),
+        )
+        .nextToken("")
+        .responseMetadata(metadata)
+        .sdkHttpResponse(sdkHttpResponse)
+        .build() as ListRecommendationsResponse
+    val listOfMixedEmptyAndNonEmptyRecommendationResponse: ListRecommendationsResponse = ListRecommendationsResponse.builder()
+        .recommendations(
+            generateMockRecommendationDetail(""),
+            generateMockRecommendationDetail("test recommendation 3"),
+            generateMockRecommendationDetail(""),
+            generateMockRecommendationDetail("test recommendation 4"),
+            generateMockRecommendationDetail("test recommendation 5")
+        )
+        .nextToken("")
+        .responseMetadata(metadata)
+        .sdkHttpResponse(sdkHttpResponse)
+        .build() as ListRecommendationsResponse
 
     const val pythonFileName = "test.py"
     const val javaFileName = "test.java"


### PR DESCRIPTION
1. There are two types of empty recommendations server could
return to the client. The first one is an empty list of recommendations.
The second one is a list of recommendations but some recommendations
are empty (strings). Previously we don't send user decision events
for both cases. This is resulting in a discrepancy between serviceInvocation
event and userDecision event per codewhispererSessionId. We decided to send
userDecision events for both. Additionally, for empty list, we just send
the event and stop early, since there isn't additonal things to render.
For empty recommendations, they will be kept in the state but not shown
to the users, and userDecision events for them will be sent later when
we send events for all recommendations we received on session close.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
