### PR TITLE
[CodeWhisperer] Make CodeWhispererEnterHandler override EnterHandler

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
@@ -15,9 +15,6 @@ import software.aws.toolkits.telemetry.CodewhispererTriggerType
 class CodeWhispererEnterHandler(originalHandler: EditorActionHandler) :
     EnterHandler(originalHandler),
     CodeWhispererAutoTriggerHandler {
-    override fun executeInCommand(editor: Editor, dataContext: DataContext?) =
-        originalHandler.executeInCommand(editor, dataContext)
-
     override fun executeWriteAction(editor: Editor, caret: Caret?, dataContext: DataContext?) {
         super.executeWriteAction(editor, caret, dataContext)
         if (!CodeWhispererService.getInstance().canDoInvocation(editor, CodewhispererTriggerType.AutoTrigger)) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
@@ -12,7 +12,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispe
 import software.aws.toolkits.telemetry.CodewhispererAutomatedTriggerType
 import software.aws.toolkits.telemetry.CodewhispererTriggerType
 
-class CodeWhispererEnterHandler(private val originalHandler: EditorActionHandler) :
+class CodeWhispererEnterHandler(originalHandler: EditorActionHandler) :
     EnterHandler(originalHandler),
     CodeWhispererAutoTriggerHandler {
     override fun executeInCommand(editor: Editor, dataContext: DataContext?) =

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer.editor
 
+import com.intellij.codeInsight.editorActions.EnterHandler
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
@@ -12,7 +13,7 @@ import software.aws.toolkits.telemetry.CodewhispererAutomatedTriggerType
 import software.aws.toolkits.telemetry.CodewhispererTriggerType
 
 class CodeWhispererEnterHandler(private val originalHandler: EditorActionHandler) :
-    EditorActionHandler(),
+    EnterHandler(originalHandler),
     CodeWhispererAutoTriggerHandler {
     override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext?) =
         originalHandler.isEnabled(editor, caret, dataContext)
@@ -20,10 +21,8 @@ class CodeWhispererEnterHandler(private val originalHandler: EditorActionHandler
     override fun executeInCommand(editor: Editor, dataContext: DataContext?) =
         originalHandler.executeInCommand(editor, dataContext)
 
-    override fun doExecute(editor: Editor, caret: Caret?, dataContext: DataContext?) {
-        if (originalHandler.isEnabled(editor, caret, dataContext)) {
-            originalHandler.execute(editor, caret, dataContext)
-        }
+    override fun executeWriteAction(editor: Editor, caret: Caret?, dataContext: DataContext?) {
+        super.executeWriteAction(editor, caret, dataContext)
         if (!CodeWhispererService.getInstance().canDoInvocation(editor, CodewhispererTriggerType.AutoTrigger)) {
             return
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
@@ -15,9 +15,6 @@ import software.aws.toolkits.telemetry.CodewhispererTriggerType
 class CodeWhispererEnterHandler(private val originalHandler: EditorActionHandler) :
     EnterHandler(originalHandler),
     CodeWhispererAutoTriggerHandler {
-    override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext?) =
-        originalHandler.isEnabled(editor, caret, dataContext)
-
     override fun executeInCommand(editor: Editor, dataContext: DataContext?) =
         originalHandler.executeInCommand(editor, dataContext)
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestBase.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestBase.kt
@@ -122,7 +122,7 @@ open class CodeWhispererTestBase {
         editorManager = CodeWhispererEditorManager.getInstance()
         settingsManager = CodeWhispererSettings.getInstance()
 
-        projectRule.fixture.configureByText(pythonFileName, pythonTestLeftContext)
+        setPrompt(pythonFileName, pythonTestLeftContext)
 
         originalExplorerActionState = stateManager.state
         originalSettings = settingsManager.state
@@ -139,10 +139,6 @@ open class CodeWhispererTestBase {
                 value[CodeWhispererConfigurationType.IsIncludeCodeWithReference] = true
             }
         )
-
-        runInEdtAndWait {
-            projectRule.fixture.editor.caretModel.primaryCaret.moveToOffset(projectRule.fixture.editor.document.textLength)
-        }
     }
 
     @After
@@ -180,5 +176,12 @@ open class CodeWhispererTestBase {
         val actual = popupManagerSpy.popupComponents.recommendationInfoLabel.text
         val expected = message("codewhisperer.popup.recommendation_info", selected, total, POPUP_DIM_HEX)
         assertThat(actual).isEqualTo(expected)
+    }
+
+    fun setPrompt(filename: String, prompt: String) {
+        projectRule.fixture.configureByText(filename, prompt)
+        runInEdtAndWait {
+            projectRule.fixture.editor.caretModel.primaryCaret.moveToOffset(projectRule.fixture.editor.document.textLength)
+        }
     }
 }


### PR DESCRIPTION
1. Currently it's overriding EditorActionHandler which doesn't have
access to the indents the EnterHandler makes afterwards, so override
the EnterHandler class.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
