### PR TITLE
Don't disable Python Connected Exection when Targets API is enabled

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/execution/PythonAwsConnectionExtension.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/execution/PythonAwsConnectionExtension.kt
@@ -6,7 +6,6 @@ package software.aws.toolkits.jetbrains.core.execution
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.openapi.options.SettingsEditor
-import com.intellij.openapi.util.registry.Registry
 import com.jetbrains.python.run.AbstractPythonRunConfiguration
 import com.jetbrains.python.run.PythonRunConfigurationExtension
 import org.jdom.Element

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/execution/PythonAwsConnectionExtension.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/execution/PythonAwsConnectionExtension.kt
@@ -45,5 +45,5 @@ class PythonAwsConnectionExtension : PythonRunConfigurationExtension() {
         delegate.validateConfiguration(configuration, isExecution)
     }
 
-    private fun isEnabled() = PythonAwsConnectionExperiment.isEnabled() && !Registry.`is`("python.use.targets.api", false)
+    private fun isEnabled() = PythonAwsConnectionExperiment.isEnabled()
 }


### PR DESCRIPTION
#3253
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
