### PR TITLE
[CodeWhisperer] UX Change: Reference panel to use absolute path

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -101,6 +101,8 @@ object CodeWhispererEditorUtil {
             }
         }
 
+    fun getFileAbsolutePath(editor: Editor): String? = FileDocumentManager.getInstance().getFile(editor.document)?.path
+
     fun getPopupPositionAboveText(editor: Editor, popup: JBPopup, offset: Int): Point {
         val textAbsolutePosition = editor.offsetToXY(offset)
         val editorLocation = editor.component.locationOnScreen

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceManager.kt
@@ -24,8 +24,8 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.awt.RelativePoint
 import software.amazon.awssdk.services.codewhisperer.model.Reference
+import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.getPopupPositionAboveText
-import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.getRelativePathToContentRoot
 import software.aws.toolkits.jetbrains.services.codewhisperer.layout.CodeWhispererLayoutConfig.horizontalPanelConstraints
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererColorUtil.EDITOR_CODE_REFERENCE_HOVER
@@ -68,7 +68,7 @@ class CodeWhispererCodeReferenceManager(private val project: Project) {
         val (_, detail, reformattedDetail) = recommendationContext.details[selectedIndex]
         val userInput = recommendationContext.userInputSinceInvocation
         val startOffset = caretPosition.offset
-        val relativePath = getRelativePathToContentRoot(editor)
+        val absolutePath = CodeWhispererEditorUtil.getFileAbsolutePath(editor)
         reformattedDetail.references().forEachIndexed { i, reference ->
             // start and end could intersect with the userInput, we do not want to show reference for the
             // userInput part, so we truncate the range to exclude userInput here if there's an overlap.
@@ -97,7 +97,7 @@ class CodeWhispererCodeReferenceManager(private val project: Project) {
 
             codeReferenceComponents.contentPanel.apply {
                 add(
-                    codeReferenceComponents.codeReferenceRecordPanel(reference, relativePath, lineNums),
+                    codeReferenceComponents.codeReferenceRecordPanel(reference, absolutePath, lineNums),
                     horizontalPanelConstraints, components.size - 1
                 )
 


### PR DESCRIPTION
Change from `path from content root` to `absolute path` to get aligned with VSC's behavior
Before:
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/96078566/186215118-57468adf-8d76-48b2-9429-ef76cef9e880.png">



After:
<img width="1759" alt="image" src="https://user-images.githubusercontent.com/96078566/186214845-779195a8-1d3a-43b3-9229-8de318e2f3fa.png">




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
