### PR TITLE
[CodeWhisperer] UX fix: reference panel should not count surfix newline character

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
@@ -78,7 +78,6 @@ class CodeWhispererRecommendationManager {
                 spanEndOffset -= 1
                 lastChar = runReadAction { currentRange.document.getText(TextRange(spanEndOffset - 1, spanEndOffset)) }
             }
-//            val endOffset = if (lastChar == "\n") currentRange.endOffset - 1 else currentRange.endOffset
             originalReference
                 .toBuilder()
                 .recommendationContentSpan(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
@@ -83,12 +83,9 @@ class CodeWhispererRecommendationManager {
     fun reformatReference(originalReference: Reference, rangeMarker: RangeMarker, invocationStartOffset: Int): Reference {
         rangeMarker.apply {
             val documentContent = runReadAction { document.charsSequence }
-            var spanEndOffset = endOffset
-            var lastChar = documentContent.subSequence(spanEndOffset - 1, spanEndOffset).toString()
-            while (lastChar == "\n") {
-                spanEndOffset -= 1
-                lastChar = documentContent.subSequence(spanEndOffset - 1, spanEndOffset).toString()
-            }
+
+            // has to plus 1 because right boundary is exclusive
+            val spanEndOffset = documentContent.subSequence(0, endOffset).indexOfLast { char -> char != '\n' } + 1
             return originalReference
                 .toBuilder()
                 .recommendationContentSpan(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer.service
 
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.RangeMarker
@@ -82,7 +81,7 @@ class CodeWhispererRecommendationManager {
      */
     fun reformatReference(originalReference: Reference, rangeMarker: RangeMarker, invocationStartOffset: Int): Reference {
         rangeMarker.apply {
-            val documentContent = runReadAction { document.charsSequence }
+            val documentContent = document.charsSequence
 
             // has to plus 1 because right boundary is exclusive
             val spanEndOffset = documentContent.subSequence(0, endOffset).indexOfLast { char -> char != '\n' } + 1

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceManager.kt
@@ -103,6 +103,7 @@ class CodeWhispererCodeReferenceManager(private val project: Project) {
 
                 // add each line of the original reference a JPanel to the tool window content panel
                 originalContentLines.forEach { line ->
+                    if (line.isEmpty()) return@forEach
                     add(
                         codeReferenceComponents.codeContentPanel(line),
                         horizontalPanelConstraints, components.size - 1

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.codewhisperer
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
@@ -393,6 +394,18 @@ class CodeWhispererCodeCoverageTrackerTest {
         assertThat(pythonTracker.activeRequestCount()).isEqualTo(1)
         pythonTracker.forceTrackerFlush()
         verify(batcher, Times(0)).enqueue(any())
+    }
+
+    @Test
+    fun `test`() {
+        fixture.configureByText("test.py", "abcde")
+        runInEdtAndWait {
+            fixture.editor.caretModel.moveToOffset(4)
+            val offset = fixture.editor.caretModel.offset
+            assertThat(offset).isEqualTo(4)
+            val c = runInEdtAndGet { runReadAction { fixture.editor.document.charsSequence.subSequence(offset, offset + 1) } }
+            println(c)
+        }
     }
 
     private fun Editor.appendString(string: String) {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.codewhisperer
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
@@ -394,18 +393,6 @@ class CodeWhispererCodeCoverageTrackerTest {
         assertThat(pythonTracker.activeRequestCount()).isEqualTo(1)
         pythonTracker.forceTrackerFlush()
         verify(batcher, Times(0)).enqueue(any())
-    }
-
-    @Test
-    fun `test`() {
-        fixture.configureByText("test.py", "abcde")
-        runInEdtAndWait {
-            fixture.editor.caretModel.moveToOffset(4)
-            val offset = fixture.editor.caretModel.offset
-            assertThat(offset).isEqualTo(4)
-            val c = runInEdtAndGet { runReadAction { fixture.editor.document.charsSequence.subSequence(offset, offset + 1) } }
-            println(c)
-        }
     }
 
     private fun Editor.appendString(string: String) {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererRecommendationManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererRecommendationManagerTest.kt
@@ -46,15 +46,15 @@ class CodeWhispererRecommendationManagerTest {
     }
 
     @Test
-    fun `test reformatReference() should generate new a new reference with span based on rangeMarker and no surfix newline char`() {
+    fun `test reformatReference() should generate a new reference with span based on rangeMarker and no surfix newline char`() {
         // invocationOffset and markerStartOffset is of our choice as long as invocationOffset <= markerStartOffset
         val recommendationManager = CodeWhispererRecommendationManager()
-        testReforMatReferenceUtil(recommendationManager, documentContentSurfix = "", invocationOffset = 2, markerStartOffset = 5)
-        testReforMatReferenceUtil(recommendationManager, documentContentSurfix = "\n", invocationOffset = 2, markerStartOffset = 5)
-        testReforMatReferenceUtil(recommendationManager, documentContentSurfix = "\n\n", invocationOffset = 1, markerStartOffset = 4)
+        testReformatReferenceUtil(recommendationManager, documentContentSurfix = "", invocationOffset = 2, markerStartOffset = 5)
+        testReformatReferenceUtil(recommendationManager, documentContentSurfix = "\n", invocationOffset = 2, markerStartOffset = 5)
+        testReformatReferenceUtil(recommendationManager, documentContentSurfix = "\n\n", invocationOffset = 1, markerStartOffset = 4)
     }
 
-    private fun testReforMatReferenceUtil(
+    private fun testReformatReferenceUtil(
         recommendationManager: CodeWhispererRecommendationManager,
         documentContentSurfix: String,
         invocationOffset: Int,

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererRecommendationManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererRecommendationManagerTest.kt
@@ -1,0 +1,85 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.codewhisperer
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.DisposableRule
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.runInEdtAndGet
+import com.intellij.testFramework.runInEdtAndWait
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.awssdk.services.codewhisperer.model.Reference
+import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererRecommendationManager
+import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
+
+class CodeWhispererRecommendationManagerTest {
+    @Rule
+    @JvmField
+    var projectRule = PythonCodeInsightTestFixtureRule()
+
+    @Rule
+    @JvmField
+    val disposableRule = DisposableRule()
+
+    private val documentContentContent = "012345678"
+    private lateinit var fixture: CodeInsightTestFixture
+    private lateinit var project: Project
+    private val originalReference = Reference.builder()
+        .licenseName("test_license")
+        .repository("test_repo")
+        .build()
+
+    @Before
+    fun setup() {
+        fixture = projectRule.fixture
+        project = projectRule.project
+
+        fixture.configureByText("test.py", documentContentContent)
+        runInEdtAndWait {
+            fixture.editor.caretModel.moveToOffset(documentContentContent.length)
+        }
+    }
+
+    @Test
+    fun `test reformatReference() should generate new a new reference with span based on rangeMarker and no surfix newline char`() {
+        // invocationOffset and markerStartOffset is of our choice as long as invocationOffset <= markerStartOffset
+        val recommendationManager = CodeWhispererRecommendationManager()
+        testReforMatReferenceUtil(recommendationManager, documentContentSurfix = "", invocationOffset = 2, markerStartOffset = 5)
+        testReforMatReferenceUtil(recommendationManager, documentContentSurfix = "\n", invocationOffset = 2, markerStartOffset = 5)
+        testReforMatReferenceUtil(recommendationManager, documentContentSurfix = "\n\n", invocationOffset = 1, markerStartOffset = 4)
+    }
+
+    private fun testReforMatReferenceUtil(
+        recommendationManager: CodeWhispererRecommendationManager,
+        documentContentSurfix: String,
+        invocationOffset: Int,
+        markerStartOffset: Int
+    ) {
+        // insert newline characters
+        WriteCommandAction.runWriteCommandAction(project) {
+            fixture.editor.document.insertString(fixture.editor.caretModel.offset, documentContentSurfix)
+        }
+
+        val rangeMarker =
+            runInEdtAndGet { fixture.editor.document.createRangeMarker(markerStartOffset, documentContentContent.length + documentContentSurfix.length) }
+
+        val reformattedReference = runInEdtAndGet { recommendationManager.reformatReference(originalReference, rangeMarker, invocationOffset) }
+        assertThat(reformattedReference.licenseName()).isEqualTo("test_license")
+        assertThat(reformattedReference.repository()).isEqualTo("test_repo")
+        assertThat(reformattedReference.recommendationContentSpan().start()).isEqualTo(rangeMarker.startOffset - invocationOffset)
+        assertThat(reformattedReference.recommendationContentSpan().end()).isEqualTo(rangeMarker.endOffset - invocationOffset - documentContentSurfix.length)
+        val span = runInEdtAndGet {
+            fixture.editor.document.charsSequence.subSequence(
+                reformattedReference.recommendationContentSpan().start(),
+                reformattedReference.recommendationContentSpan().end()
+            )
+        }
+        // span should not include newline char
+        assertThat(span.last()).isNotEqualTo('\n')
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As title, reference panel now will count newline character, thus incorrect line number where cwspr recommendation is inserted is shown.

Before:
<img width="1524" alt="line_number_before" src="https://user-images.githubusercontent.com/96078566/186520976-a7116237-ed2d-436f-8559-e528bb609af3.png">


After:

<img width="1402" alt="line_number_after" src="https://user-images.githubusercontent.com/96078566/186520957-06973b8a-03d6-47e2-8384-065a0992a39e.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
