### PR TITLE
[CodeWhisperer] Add a document-changed threshold in CodeCoverageTracker

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorListener.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorListener.kt
@@ -3,8 +3,8 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer.editor
 
+import com.intellij.openapi.editor.event.BulkAwareDocumentListener
 import com.intellij.openapi.editor.event.DocumentEvent
-import com.intellij.openapi.editor.event.DocumentListener
 import com.intellij.openapi.editor.event.EditorFactoryEvent
 import com.intellij.openapi.editor.event.EditorFactoryListener
 import com.intellij.openapi.editor.impl.EditorImpl
@@ -24,7 +24,7 @@ class CodeWhispererEditorListener : EditorFactoryListener {
                 if (!CodeWhispererLanguageManager.getInstance().isLanguageSupported(language.toString())) return
                 // If language is supported, install document listener for CodeWhisperer service
                 editor.document.addDocumentListener(
-                    object : DocumentListener {
+                    object : BulkAwareDocumentListener {
                         override fun documentChanged(event: DocumentEvent) {
                             if (!CodeWhispererExplorerActionManager.getInstance().hasAcceptedTermsOfService()) return
                             CodeWhispererInvocationStatus.getInstance().documentChanged()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererExplorerActionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererExplorerActionManager.kt
@@ -26,7 +26,7 @@ import software.aws.toolkits.telemetry.AwsTelemetry
 import java.net.URI
 
 @State(name = "codewhispererStates", storages = [Storage("aws.xml")])
-internal class CodeWhispererExplorerActionManager : PersistentStateComponent<CodeWhispererExploreActionState> {
+class CodeWhispererExplorerActionManager : PersistentStateComponent<CodeWhispererExploreActionState> {
     private val actionState = CodeWhispererExploreActionState()
 
     fun performAction(project: Project, actionId: String) {
@@ -198,7 +198,7 @@ internal class CodeWhispererExplorerActionManager : PersistentStateComponent<Cod
     }
 }
 
-internal class CodeWhispererExploreActionState : BaseState() {
+class CodeWhispererExploreActionState : BaseState() {
     @get:Property
     val value by map<CodeWhispererExploreStateType, Boolean>()
 
@@ -206,7 +206,7 @@ internal class CodeWhispererExploreActionState : BaseState() {
     var token by string()
 }
 
-internal enum class CodeWhispererExploreStateType {
+enum class CodeWhispererExploreStateType {
     IsAutoEnabled,
     IsManualEnabled,
     HasAcceptedTermsOfServices,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
@@ -91,6 +91,8 @@ abstract class CodeWhispererCodeCoverageTracker(
             LOG.debug { "event with isWholeTextReplaced flag: $event" }
             if (event.oldTimeStamp == 0L) return
         }
+        // This case capture IDE reformatting the document, which will be blank string
+        if (isDocumentEventFromReformatting(event)) return
         incrementTotalTokens(event.document, event.newLength - event.oldLength)
     }
 
@@ -146,6 +148,9 @@ abstract class CodeWhispererCodeCoverageTracker(
             if (totalTokens.get() < 0) totalTokens.set(0)
         }
     }
+
+    private fun isDocumentEventFromReformatting(event: DocumentEvent): Boolean =
+        (event.newFragment.toString().isBlank() && event.oldFragment.toString().isBlank()) && (event.oldLength == 0 || event.newLength == 0)
 
     private fun reset() {
         startTime = Instant.now()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.editor.RangeMarker
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
+import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.replaceService
@@ -56,54 +57,49 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.telemetry.NoOpPublisher
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.aws.toolkits.jetbrains.settings.AwsSettings
+import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
 import software.aws.toolkits.telemetry.CodewhispererCompletionType
 import software.aws.toolkits.telemetry.CodewhispererLanguage
 
-class CodeWhispererCodeCoverageTrackerTest {
-    private class TestCodePercentageTracker(
+open class CodeWhispererCodeCoverageTrackerTestBase {
+    protected class TestCodePercentageTracker(
         timeWindowInSec: Long,
         language: CodewhispererLanguage,
         rangeMarkers: MutableList<RangeMarker> = mutableListOf(),
         codeCoverageTokens: MutableMap<Document, CodeCoverageTokens> = mutableMapOf()
     ) : CodeWhispererCodeCoverageTracker(timeWindowInSec, language, rangeMarkers, codeCoverageTokens)
 
-    private class TestTelemetryService(
+    protected class TestTelemetryService(
         publisher: TelemetryPublisher = NoOpPublisher(),
         batcher: TelemetryBatcher
     ) : TelemetryService(publisher, batcher)
 
     @Rule
     @JvmField
-    var projectRule = PythonCodeInsightTestFixtureRule()
+    val pythonProjectRule = PythonCodeInsightTestFixtureRule()
 
     @Rule
     @JvmField
-    val mockClientManagerRule = MockClientManagerRule()
+    val javaProjectRule = JavaCodeInsightTestFixtureRule()
 
     @Rule
     @JvmField
     val disposableRule = DisposableRule()
 
-    private lateinit var project: Project
-    private lateinit var fixture: CodeInsightTestFixture
-    private lateinit var telemetryServiceSpy: TelemetryService
-    private lateinit var batcher: TelemetryBatcher
-    private lateinit var exploreActionManagerMock: CodeWhispererExplorerActionManager
+    @Rule
+    @JvmField
+    val mockClientManagerRule = MockClientManagerRule()
 
-    private lateinit var invocationContext: InvocationContext
-    private lateinit var sessionContext: SessionContext
+    protected lateinit var project: Project
+    protected lateinit var fixture: CodeInsightTestFixture
+    protected lateinit var telemetryServiceSpy: TelemetryService
+    protected lateinit var batcher: TelemetryBatcher
+    protected lateinit var exploreActionManagerMock: CodeWhispererExplorerActionManager
 
     @Before
-    fun setup() {
+    open fun setup() {
         AwsSettings.getInstance().isTelemetryEnabled = true
-        project = projectRule.project
-        fixture = projectRule.fixture
-        fixture.configureByText(pythonFileName, pythonTestLeftContext)
-        runInEdtAndWait {
-            projectRule.fixture.editor.caretModel.primaryCaret.moveToOffset(projectRule.fixture.editor.document.textLength)
-        }
-
         batcher = mock()
         telemetryServiceSpy = spy(TestTelemetryService(batcher = batcher))
         exploreActionManagerMock = mock {
@@ -112,7 +108,34 @@ class CodeWhispererCodeCoverageTrackerTest {
 
         ApplicationManager.getApplication().replaceService(CodeWhispererExplorerActionManager::class.java, exploreActionManagerMock, disposableRule.disposable)
         ApplicationManager.getApplication().replaceService(TelemetryService::class.java, telemetryServiceSpy, disposableRule.disposable)
-        project.replaceService(CodeWhispererCodeReferenceManager::class.java, mock(), disposableRule.disposable)
+    }
+
+    @After
+    fun tearDown() {
+        CodeWhispererCodeCoverageTracker.getInstancesMap().clear()
+    }
+
+    protected companion object {
+        const val CODE_PERCENTAGE = "codewhisperer_codePercentage"
+        const val CWSPR_PERCENTAGE = "codewhispererPercentage"
+        const val CWSPR_Language = "codewhispererLanguage"
+        const val CWSPR_ACCEPTED_TOKENS = "codewhispererAcceptedTokens"
+        const val CWSPR_TOTAL_TOKENS = "codewhispererTotalTokens"
+    }
+}
+
+class CodeWhispererCodeCoverageTrackerTestPython : CodeWhispererCodeCoverageTrackerTestBase() {
+    private lateinit var invocationContext: InvocationContext
+    private lateinit var sessionContext: SessionContext
+    @Before
+    override fun setup() {
+        super.setup()
+        project = pythonProjectRule.project
+        fixture = pythonProjectRule.fixture
+        fixture.configureByText(pythonFileName, pythonTestLeftContext)
+        runInEdtAndWait {
+            pythonProjectRule.fixture.editor.caretModel.primaryCaret.moveToOffset(pythonProjectRule.fixture.editor.document.textLength)
+        }
 
         val requestContext = RequestContext(
             project,
@@ -131,11 +154,9 @@ class CodeWhispererCodeCoverageTrackerTest {
         )
         invocationContext = InvocationContext(requestContext, responseContext, recommendationContext, mock())
         sessionContext = SessionContext()
-    }
 
-    @After
-    fun tearDown() {
-        CodeWhispererCodeCoverageTracker.getInstancesMap().clear()
+        // it is needed because referenceManager is listening to CODEWHISPERER_USER_ACTION_PERFORMED topic
+        project.replaceService(CodeWhispererCodeReferenceManager::class.java, mock(), disposableRule.disposable)
     }
 
     @Test
@@ -205,6 +226,26 @@ class CodeWhispererCodeCoverageTrackerTest {
         }
 
         assertThat(pythonTracker.totalTokensSize).isEqualTo(pythonTestLeftContext.length - 3)
+    }
+
+    @Test
+    fun `test tracker documentChanged - will not increment tokens on blank string of length greater than 1`() {
+        val pythonTracker = TestCodePercentageTracker(
+            TOTAL_SECONDS_IN_MINUTE,
+            CodewhispererLanguage.Python,
+            codeCoverageTokens = mutableMapOf(fixture.editor.document to CodeCoverageTokens(pythonTestLeftContext.length, 0))
+        )
+        CodeWhispererCodeCoverageTracker.getInstancesMap()[CodewhispererLanguage.Python] = pythonTracker
+        pythonTracker.activateTrackerIfNotActive()
+        assertThat(pythonTracker.totalTokensSize).isEqualTo(pythonTestLeftContext.length)
+
+        runInEdtAndWait {
+            WriteCommandAction.runWriteCommandAction(project) {
+                fixture.editor.document.insertString(fixture.editor.caretModel.offset, "\t")
+            }
+        }
+
+        assertThat(pythonTracker.totalTokensSize).isEqualTo(pythonTestLeftContext.length)
     }
 
     @Test
@@ -400,12 +441,72 @@ class CodeWhispererCodeCoverageTrackerTest {
         document.insertString(currentOffset, string)
         caretModel.moveToOffset(currentOffset + string.length)
     }
+}
 
-    private companion object {
-        const val CODE_PERCENTAGE = "codewhisperer_codePercentage"
-        const val CWSPR_PERCENTAGE = "codewhispererPercentage"
-        const val CWSPR_Language = "codewhispererLanguage"
-        const val CWSPR_ACCEPTED_TOKENS = "codewhispererAcceptedTokens"
-        const val CWSPR_TOTAL_TOKENS = "codewhispererTotalTokens"
+class CodeWhispererCodeCoverageTrackerTestJava : CodeWhispererCodeCoverageTrackerTestBase() {
+    @Before
+    override fun setup() {
+        super.setup()
+        project = javaProjectRule.project
+        fixture = javaProjectRule.fixture
+    }
+
+    @Test
+    fun `tracker should not update totalTokens if documentChanged events are fired by code reformatting`() {
+        val codeNeedToBeReformatted = """
+            class Answer {
+                private int knapsack(int[] w, int[] v, int c) {
+                int[][] dp = new int[w.length + 1][c + 1];
+                    for (int i = 0; i < w.length; i++) {for (int j = 0; j <= c; j++) {
+                                   if (j < w[i]) {
+                                dp[i + 1][j] = dp[i][j];
+                        } 
+                            else {
+                      dp[i + 1][j] = Math.max(dp[i][j], dp[i][j - w[i]] + v[i]);
+                            }
+                        }
+                                 }
+                    return                  dp[w.length][c];
+                }
+            }            
+        """.trimIndent()
+        val file = fixture.configureByText("test.java", codeNeedToBeReformatted)
+        val tracker = spy(
+            TestCodePercentageTracker(
+                TOTAL_SECONDS_IN_MINUTE,
+                language = CodewhispererLanguage.Java,
+                codeCoverageTokens = mutableMapOf(fixture.editor.document to CodeCoverageTokens(totalTokens = codeNeedToBeReformatted.length))
+            )
+        )
+        CodeWhispererCodeCoverageTracker.getInstancesMap()[CodewhispererLanguage.Java] = tracker
+        runInEdtAndWait {
+            WriteCommandAction.runWriteCommandAction(project) {
+                println(fixture.editor.document.text)
+                CodeStyleManager.getInstance(project).reformatText(file, 0, fixture.editor.document.textLength)
+                println(fixture.editor.document.text)
+            }
+        }
+        // reformat should fire documentChanged events, but tracker should not update token from these events
+        verify(tracker, atLeastOnce()).documentChanged(any())
+        assertThat(tracker.totalTokensSize).isEqualTo(codeNeedToBeReformatted.length)
+
+        val formatted = """
+            class Answer {
+                private int knapsack(int[] w, int[] v, int c) {
+                    int[][] dp = new int[w.length + 1][c + 1];
+                    for (int i = 0; i < w.length; i++) {
+                        for (int j = 0; j <= c; j++) {
+                            if (j < w[i]) {
+                                dp[i + 1][j] = dp[i][j];
+                            } else {
+                                dp[i + 1][j] = Math.max(dp[i][j], dp[i][j - w[i]] + v[i]);
+                            }
+                        }
+                    }
+                    return dp[w.length][c];
+                }
+            }
+        """.trimIndent()
+        assertThat(fixture.editor.document.text.trimEnd()).isEqualTo(formatted)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
