### PR TITLE
[CodeWhisperer] fix and remove incorrect support of .tsx file

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
@@ -16,6 +16,7 @@ class CodeWhispererLanguageManager {
     )
 
     fun isLanguageSupported(language: ProgrammingLanguage): Boolean = supportedLanguage.contains(language.languageName)
+
     /**
      * This should be called to map some language dialect to their mother language
      * e.g. JSX -> JavaScript, TypeScript -> JavaScript etc.

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
@@ -11,14 +11,11 @@ class CodeWhispererLanguageManager {
     private val supportedLanguage = setOf(
         CodewhispererLanguage.Java.toString(),
         CodewhispererLanguage.Python.toString(),
-        CodewhispererLanguage.Javascript.toString()
+        CodewhispererLanguage.Javascript.toString(),
+        "jsx harmony"
     )
 
-    fun isLanguageSupported(language: ProgrammingLanguage): Boolean {
-        val mappedLanguage = getParentLanguage(language)
-        return supportedLanguage.contains(mappedLanguage.languageName)
-    }
-
+    fun isLanguageSupported(language: ProgrammingLanguage): Boolean = supportedLanguage.contains(language.languageName)
     /**
      * This should be called to map some language dialect to their mother language
      * e.g. JSX -> JavaScript, TypeScript -> JavaScript etc.

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
@@ -8,14 +8,10 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.model.ProgrammingL
 import software.aws.toolkits.telemetry.CodewhispererLanguage
 
 class CodeWhispererLanguageManager {
-    private val supportedLanguage = setOf(
-        CodewhispererLanguage.Java.toString(),
-        CodewhispererLanguage.Python.toString(),
-        CodewhispererLanguage.Javascript.toString(),
-        "jsx harmony"
-    )
-
-    fun isLanguageSupported(language: ProgrammingLanguage): Boolean = supportedLanguage.contains(language.languageName)
+    fun isLanguageSupported(language: ProgrammingLanguage): Boolean {
+        val cwsprLanguage = language.toCodeWhispererLanguage()
+        return cwsprLanguage != CodewhispererLanguage.Unknown && cwsprLanguage != CodewhispererLanguage.Plaintext
+    }
 
     /**
      * This should be called to map some language dialect to their mother language
@@ -36,7 +32,7 @@ fun ProgrammingLanguage.toCodeWhispererLanguage() = when {
     languageName.contains("python") -> CodewhispererLanguage.Python
     languageName.contains("javascript") -> CodewhispererLanguage.Javascript
     languageName.contains("java") -> CodewhispererLanguage.Java
-    languageName.contains("jsx") -> CodewhispererLanguage.Jsx
+    languageName.contains("jsx harmony") -> CodewhispererLanguage.Jsx
     languageName.contains("plain_text") -> CodewhispererLanguage.Plaintext
     else -> CodewhispererLanguage.Unknown
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
@@ -8,9 +8,14 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.model.ProgrammingL
 import software.aws.toolkits.telemetry.CodewhispererLanguage
 
 class CodeWhispererLanguageManager {
+    private val supportedLanguage = setOf(
+        CodewhispererLanguage.Java.toString(),
+        CodewhispererLanguage.Python.toString(),
+        CodewhispererLanguage.Javascript.toString()
+    )
     fun isLanguageSupported(language: ProgrammingLanguage): Boolean {
-        val cwsprLanguage = language.toCodeWhispererLanguage()
-        return cwsprLanguage != CodewhispererLanguage.Unknown && cwsprLanguage != CodewhispererLanguage.Plaintext
+        val mappedLanguage = getParentLanguage(language)
+        return supportedLanguage.contains(mappedLanguage.languageName)
     }
 
     /**
@@ -19,7 +24,7 @@ class CodeWhispererLanguageManager {
      */
     internal fun getParentLanguage(language: ProgrammingLanguage): ProgrammingLanguage =
         when {
-            language.languageName.contains("jsx") -> ProgrammingLanguage(CodewhispererLanguage.Javascript)
+            language.languageName.contains("jsx harmony") -> ProgrammingLanguage(CodewhispererLanguage.Javascript)
             else -> language
         }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
@@ -81,8 +81,8 @@ class CodeWhispererLanguageManagerTest {
         assertThat(ProgrammingLanguage("javascript").toCodeWhispererLanguage()).isEqualTo(CodewhispererLanguage.Javascript)
         assertThat(ProgrammingLanguage("JavaScript").toCodeWhispererLanguage()).isEqualTo(CodewhispererLanguage.Javascript)
 
-        assertThat(ProgrammingLanguage("jsx").toCodeWhispererLanguage()).isEqualTo(CodewhispererLanguage.Jsx)
-        assertThat(ProgrammingLanguage("JSX").toCodeWhispererLanguage()).isEqualTo(CodewhispererLanguage.Jsx)
+        assertThat(ProgrammingLanguage("Jsx harmony").toCodeWhispererLanguage()).isEqualTo(CodewhispererLanguage.Jsx)
+        assertThat(ProgrammingLanguage("JSX").toCodeWhispererLanguage()).isEqualTo(CodewhispererLanguage.Unknown)
     }
 
     @Test

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
@@ -113,7 +113,7 @@ class CodeWhispererLanguageManagerTest {
         val javaLang = ProgrammingLanguage(CodewhispererLanguage.Java)
         val pythonLang = ProgrammingLanguage(CodewhispererLanguage.Python)
         val javascriptLang = ProgrammingLanguage(CodewhispererLanguage.Javascript)
-        val jsxLang = ProgrammingLanguage(CodewhispererLanguage.Jsx)
+        val jsxLang = ProgrammingLanguage("Jsx harmony")
         val plainText = ProgrammingLanguage(CodewhispererLanguage.Plaintext)
         val unknown = ProgrammingLanguage(CodewhispererLanguage.Unknown)
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
@@ -55,8 +55,8 @@ class CodeWhispererLanguageManagerTest {
         assertThat(manager.isLanguageSupported(ProgrammingLanguage("python"))).isTrue
         assertThat(manager.isLanguageSupported(ProgrammingLanguage("Python"))).isTrue
 
-        assertThat(manager.isLanguageSupported(ProgrammingLanguage("jsx"))).isTrue
-        assertThat(manager.isLanguageSupported(ProgrammingLanguage("JSX"))).isTrue
+        assertThat(manager.isLanguageSupported(ProgrammingLanguage("jsx harmony"))).isTrue
+        assertThat(manager.isLanguageSupported(ProgrammingLanguage("JSX harmony"))).isTrue
 
         assertThat(manager.isLanguageSupported(ProgrammingLanguage("javascript"))).isTrue
         assertThat(manager.isLanguageSupported(ProgrammingLanguage("JavaScript"))).isTrue
@@ -66,6 +66,8 @@ class CodeWhispererLanguageManagerTest {
 
         assertThat(manager.isLanguageSupported(ProgrammingLanguage("cpp"))).isFalse
         assertThat(manager.isLanguageSupported(ProgrammingLanguage("unknown"))).isFalse
+
+        assertThat(manager.isLanguageSupported(ProgrammingLanguage("typescript jsx"))).isFalse
     }
 
     @Test


### PR DESCRIPTION
## Problem
`.tsx` file type is wrongly supported

## Solution
TSX file type name: `TypeScript JSX`
JSX file type name: `JSX harmony`

Ad-hoc fix: Update `CodeWhispererLanguageManager.isLanguageSupported()`
(another refactor PR which will use declarative way for languages supported by CodeWhisperer #3300 will reduce the string coversion back and forward)

## Screenshots After fix

#### .tsx

<img width="1385" alt="image" src="https://user-images.githubusercontent.com/96078566/192888916-4a503fad-bf7f-405e-936a-01694791af65.png">

#### .jsx

<img width="1385" alt="image" src="https://user-images.githubusercontent.com/96078566/192888967-1e9569b4-69f3-4ea5-a6aa-4d0d8261dff4.png">


 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
