### PR TITLE
Don't send empty userDecision events when client receives some recommendations

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -303,10 +303,10 @@ class CodeWhispererService {
 
         val hasAtLeastOneValid = checkRecommendationsValidity(nextStates, response.nextToken().isEmpty())
 
-        // If there are no recommendations in this response, we need to manually send the user decision event here
+        // If there are no recommendations at all in this session, we need to manually send the user decision event here
         // since it won't be sent automatically later
-        if (response.recommendations().isEmpty()) {
-            LOG.debug { "Received an empty list from response, requestId: $requestId" }
+        if (nextStates.recommendationContext.details.isEmpty() && response.nextToken().isEmpty()) {
+            LOG.debug { "Received just an empty list from this session, requestId: $requestId" }
             CodeWhispererTelemetryService.getInstance().sendUserDecisionEvent(
                 requestId,
                 requestContext,

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryTest.kt
@@ -24,6 +24,7 @@ import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doReturnConsecutively
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
@@ -42,6 +43,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestU
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.listOfEmptyRecommendationResponse
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.listOfMixedEmptyAndNonEmptyRecommendationResponse
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonResponse
+import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonResponseWithToken
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonTestLeftContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.testCodeWhispererException
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.testRequestId
@@ -666,7 +668,6 @@ class CodeWhispererTelemetryTest : CodeWhispererTestBase() {
         val totalTokensSize = "$pythonTestLeftContext(".length + acceptedTokensSize
         val metricCaptor = argumentCaptor<MetricEvent>()
         verify(batcher, atLeastOnce()).enqueue(metricCaptor.capture())
-        metricCaptor.allValues.forEach { println(it) }
         assertEventsContainsFieldsAndCount(
             metricCaptor.allValues,
             codePercentage,
@@ -697,6 +698,43 @@ class CodeWhispererTelemetryTest : CodeWhispererTestBase() {
                 userDecision,
                 1,
                 "codewhispererSuggestionState" to CodewhispererSuggestionState.Empty.toString()
+            )
+        }
+    }
+
+    @Test
+    fun `test getting some recommendations and a final empty list of recommendations at session end should not sent empty userDecision events`() {
+        mockClient.stub {
+            on {
+                mockClient.listRecommendations(any<ListRecommendationsRequest>())
+            } doReturnConsecutively(
+                listOf(pythonResponseWithToken, emptyListResponse)
+            )
+        }
+
+        withCodeWhispererServiceInvokedAndWait { }
+
+        runInEdtAndWait {
+            val metricCaptor = argumentCaptor<MetricEvent>()
+            // 2 serviceInvocation + 5 userDecision
+            verify(batcher, atLeast(pythonResponseWithToken.recommendations().size + 2)).enqueue(metricCaptor.capture())
+            assertEventsContainsFieldsAndCount(
+                metricCaptor.allValues,
+                userDecision,
+                0,
+                "codewhispererSuggestionState" to CodewhispererSuggestionState.Empty.toString()
+            )
+            assertEventsContainsFieldsAndCount(
+                metricCaptor.allValues,
+                userDecision,
+                1,
+                "codewhispererSuggestionState" to CodewhispererSuggestionState.Accept.toString()
+            )
+            assertEventsContainsFieldsAndCount(
+                metricCaptor.allValues,
+                userDecision,
+                4,
+                "codewhispererSuggestionState" to CodewhispererSuggestionState.Unseen.toString()
             )
         }
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestUtil.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestUtil.kt
@@ -21,6 +21,7 @@ object CodeWhispererTestUtil {
     const val testRequestIdForCodeWhispererException = "test_request_id_for_codewhispererException"
     const val codeWhispererRecommendationActionId = "CodeWhispererRecommendationAction"
     const val testValidAccessToken = "test_valid_access_token"
+    const val testNextToken = "test_next_token"
     private val testReferenceInfoPair = listOf(
         Pair("MIT", "testRepo1"),
         Pair("Apache-2.0", "testRepo2"),
@@ -53,6 +54,7 @@ object CodeWhispererTestUtil {
         .responseMetadata(metadata)
         .sdkHttpResponse(sdkHttpResponse)
         .build() as ListRecommendationsResponse
+    val pythonResponseWithToken: ListRecommendationsResponse = pythonResponse.toBuilder().nextToken(testNextToken).build()
     val javaResponse: ListRecommendationsResponse = ListRecommendationsResponse.builder()
         .recommendations(
             generateMockRecommendationDetail("(x, y) {\n        return x + y\n    }"),


### PR DESCRIPTION
1. We only want to send userDecision with state empty and index=-1 when we receive an empty list during the entire pagination session. If we receive an empty list after we already have some recommendations, don't send this event.

Corresponding VSC PR: https://github.com/aws/aws-toolkit-vscode/pull/2921
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `gradlew check` succeeds
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if change is customer facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
