### PR TITLE
(refactor codewhisperer) use cwsprProgrammingLanguage type in codescan payload instead of string

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
@@ -31,13 +31,13 @@ import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.CodeScanSessionConfig
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.PayloadContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererClientManager
+import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererUnknownLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CodeScanResponseContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CodeScanServiceInvocationContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.CODE_SCAN_POLLING_INTERVAL_IN_SECONDS
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.TOTAL_BYTES_IN_KB
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.TOTAL_MILLIS_IN_SECOND
 import software.aws.toolkits.jetbrains.utils.assertIsNonDispatchThread
-import software.aws.toolkits.telemetry.CodewhispererLanguage
 import java.io.File
 import java.io.FileInputStream
 import java.io.IOException
@@ -83,7 +83,7 @@ internal class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionC
                     "Total number of lines scanned: ${payloadContext.totalLines} \n" +
                     "Total number of files included in payload: ${payloadContext.totalFiles} \n" +
                     "Total time taken for creating payload: ${payloadContext.totalTimeInMilliseconds * 1.0 / TOTAL_MILLIS_IN_SECOND} seconds\n" +
-                    "Payload context language: ${payloadContext.language}"
+                    "Payload context language: ${payloadContext.language.languageId}"
             }
             codeScanResponseContext = codeScanResponseContext.copy(payloadContext = payloadContext)
 
@@ -113,9 +113,9 @@ internal class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionC
             )
 
             // 4. Call createCodeScan to start a code scan
-            LOG.debug { "Requesting security scan for the uploaded artifacts, language: ${payloadContext.language}" }
+            LOG.debug { "Requesting security scan for the uploaded artifacts, language: ${payloadContext.language.languageId}" }
             val serviceInvocationStartTime = now()
-            val createCodeScanResponse = createCodeScan(payloadContext.language.toString())
+            val createCodeScanResponse = createCodeScan(payloadContext.language.languageId)
             LOG.debug {
                 "Successfully created security scan with " +
                     "status: ${createCodeScanResponse.status()} " +
@@ -346,7 +346,7 @@ internal data class CodeScanSessionContext(
     val sessionConfig: CodeScanSessionConfig
 )
 
-internal fun defaultPayloadContext() = PayloadContext(CodewhispererLanguage.Unknown, 0, 0, 0, 0, 0)
+internal fun defaultPayloadContext() = PayloadContext(CodeWhispererUnknownLanguage.INSTANCE, 0, 0, 0, 0, 0)
 
 internal fun defaultServiceInvocationContext() = CodeScanServiceInvocationContext(0, 0)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
@@ -17,6 +17,7 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.putNextEntry
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.fileFormatNotSupported
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.fileTooLarge
+import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhispererProgrammingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.programmingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.CODE_SCAN_CREATE_PAYLOAD_TIMEOUT_IN_SECONDS
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.TOTAL_BYTES_IN_KB
@@ -60,7 +61,7 @@ internal sealed class CodeScanSessionConfig(
         // Copy all the included source files to the source zip
         val srcZip = zipFiles(includedSourceFiles.map { Path.of(it) })
         val payloadContext = PayloadContext(
-            selectedFile.programmingLanguage().toTelemetryType(),
+            selectedFile.programmingLanguage(),
             totalLines,
             includedSourceFiles.size,
             Instant.now().toEpochMilli() - start,
@@ -189,7 +190,7 @@ data class Payload(
 )
 
 data class PayloadContext(
-    val language: CodewhispererLanguage,
+    val language: CodeWhispererProgrammingLanguage,
     val totalLines: Long,
     val totalFiles: Int,
     val totalTimeInMilliseconds: Long,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/JavaCodeScanSessionConfig.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/JavaCodeScanSessionConfig.kt
@@ -18,6 +18,7 @@ import software.aws.toolkits.core.utils.exists
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.cannotFindBuildArtifacts
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.fileTooLarge
+import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererJava
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.JAVA_CODE_SCAN_TIMEOUT_IN_SECONDS
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.JAVA_PAYLOAD_LIMIT_IN_BYTES
 import software.aws.toolkits.resources.message
@@ -80,7 +81,7 @@ internal class JavaCodeScanSessionConfig(
         val buildZip = zipFiles(buildFiles)
 
         val payloadContext = PayloadContext(
-            CodewhispererLanguage.Java,
+            CodeWhispererJava.INSTANCE,
             totalLines,
             sourceFiles.size,
             Instant.now().toEpochMilli() - start,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/JavaCodeScanSessionConfig.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/JavaCodeScanSessionConfig.kt
@@ -22,7 +22,6 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.JAVA_CODE_SCAN_TIMEOUT_IN_SECONDS
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.JAVA_PAYLOAD_LIMIT_IN_BYTES
 import software.aws.toolkits.resources.message
-import software.aws.toolkits.telemetry.CodewhispererLanguage
 import java.io.IOException
 import java.lang.IndexOutOfBoundsException
 import java.nio.file.Files

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
@@ -138,7 +138,7 @@ class CodeWhispererTelemetryService {
             codewhispererCodeScanSrcZipFileBytes = payloadContext.srcZipFileSize.toInt(),
             codewhispererCodeScanBuildZipFileBytes = payloadContext.buildZipFileSize?.toInt(),
             codewhispererCodeScanTotalIssues = totalIssues,
-            codewhispererLanguage = payloadContext.language,
+            codewhispererLanguage = payloadContext.language.toTelemetryType(),
             duration = codeScanEvent.duration,
             contextTruncationDuration = payloadContext.totalTimeInMilliseconds.toInt(),
             artifactsUploadDuration = serviceInvocationContext.artifactsUploadDuration.toInt(),

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanTest.kt
@@ -29,6 +29,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionco
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.Payload
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.PayloadContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.PythonCodeScanSessionConfig
+import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererPython
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.TOTAL_MILLIS_IN_SECOND
 import software.aws.toolkits.jetbrains.utils.isInstanceOf
 import software.aws.toolkits.telemetry.CodewhispererLanguage
@@ -41,7 +42,7 @@ class CodeWhispererCodeScanTest : CodeWhispererCodeScanTestBase() {
     internal lateinit var psifile: PsiFile
     internal lateinit var file: File
     private lateinit var sessionConfigSpy: PythonCodeScanSessionConfig
-    private val payloadContext = PayloadContext(CodewhispererLanguage.Python, 1, 1, 10, 600, 200)
+    private val payloadContext = PayloadContext(CodeWhispererPython.INSTANCE, 1, 1, 10, 600, 200)
     private lateinit var codeScanSessionContext: CodeScanSessionContext
     private lateinit var codeScanSessionSpy: CodeWhispererCodeScanSession
 


### PR DESCRIPTION
 ## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
