### PR TITLE
Disposing of Swing timers in Run Configuration integration tests

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -17,6 +17,7 @@ phases:
     commands:
       - alternatives --set java ${JAVA_HOME}/bin/java
       - alternatives --set javac ${JAVA_HOME}/bin/javac
+      - n install 16
       - startDocker.sh
       # login to DockerHub so we don't get throttled
       - export DOCKER_USERNAME=`echo $DOCKER_HUB_TOKEN | jq -r '.username'`


### PR DESCRIPTION
Several Run Configuration integration tests fail due to an unrelated disposal of Swing Timers - pulling up the utility added to #3344 to a common location so that it can be used across run configs (e.g. in #3345)