### PR TITLE
bug fix - method calls on disposed components

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/pinning/ConnectionPinningManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/pinning/ConnectionPinningManager.kt
@@ -63,6 +63,7 @@ class DefaultConnectionPinningManager(private val project: Project) :
             BearerTokenProviderListener.TOPIC,
             object : BearerTokenProviderListener {
                 override fun invalidate(providerId: String) {
+                    if (project.isDisposed) return
                     pinnedConnections.entries.removeIf { (_, v) -> v.id == providerId }
                 }
             }
@@ -124,8 +125,7 @@ class DefaultConnectionPinningManager(private val project: Project) :
         )
     }
 
-    override fun dispose() {
-    }
+    override fun dispose() {}
 
     @TestOnly
     internal fun showDialogIfNeeded(oldConnection: ToolkitConnection, newConnection: ToolkitConnection, featuresString: String) = if (!doNotPromptForPinning) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/pinning/ConnectionPinningManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/pinning/ConnectionPinningManager.kt
@@ -63,7 +63,6 @@ class DefaultConnectionPinningManager(private val project: Project) :
             BearerTokenProviderListener.TOPIC,
             object : BearerTokenProviderListener {
                 override fun invalidate(providerId: String) {
-                    if (project.isDisposed) return
                     pinnedConnections.entries.removeIf { (_, v) -> v.id == providerId }
                 }
             }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/RefreshAwsTree.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/RefreshAwsTree.kt
@@ -26,6 +26,7 @@ fun Project.refreshAwsTree(resource: Resource<*>? = null, connectionSettings: Co
 
 fun Project.refreshDevToolTree() {
     runInEdt {
+        if (this.isDisposed) return@runInEdt
         DevToolsToolWindow.getInstance(this).redrawContent()
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarManager.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer.status
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -22,12 +23,12 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhi
  * Manager visibility of CodeWhisperer status bar widget, only display it when CodeWhisperer is connected
  */
 @Service(Service.Level.PROJECT)
-class CodeWhispererStatusBarManager(private val project: Project) {
+class CodeWhispererStatusBarManager(private val project: Project) : Disposable {
     private val widgetsManager = project.getService(StatusBarWidgetsManager::class.java)
     private val settings = ApplicationManager.getApplication().getService(StatusBarWidgetSettings::class.java)
 
     init {
-        ApplicationManager.getApplication().messageBus.connect().subscribe(
+        ApplicationManager.getApplication().messageBus.connect(this).subscribe(
             ToolkitConnectionManagerListener.TOPIC,
             object : ToolkitConnectionManagerListener {
                 override fun activeConnectionChanged(newConnection: ToolkitConnection?) {
@@ -56,6 +57,8 @@ class CodeWhispererStatusBarManager(private val project: Project) {
             widgetsManager.updateWidget(it)
         }
     }
+
+    override fun dispose() {}
 
     companion object {
         fun getInstance(project: Project): CodeWhispererStatusBarManager = project.service()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarManager.kt
@@ -31,6 +31,7 @@ class CodeWhispererStatusBarManager(private val project: Project) {
             ToolkitConnectionManagerListener.TOPIC,
             object : ToolkitConnectionManagerListener {
                 override fun activeConnectionChanged(newConnection: ToolkitConnection?) {
+                    if (project.isDisposed) return
                     updateWidget()
                 }
             }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarManager.kt
@@ -32,7 +32,6 @@ class CodeWhispererStatusBarManager(private val project: Project) : Disposable {
             ToolkitConnectionManagerListener.TOPIC,
             object : ToolkitConnectionManagerListener {
                 override fun activeConnectionChanged(newConnection: ToolkitConnection?) {
-                    if (project.isDisposed) return
                     updateWidget()
                 }
             }


### PR DESCRIPTION
### Before

https://user-images.githubusercontent.com/96078566/211497038-c9608346-e1e4-4333-ae58-ea55ab5d89e9.mov


### After


https://user-images.githubusercontent.com/96078566/211497719-9a3d15eb-e741-4981-ba74-624c8e762327.mov




### Root cause
Due to some project levels components subscribing application level topics, even when the project is disposed, it will still receive the app level message and hence the error.


### LOG

```
om.intellij.serviceContainer.AlreadyDisposedException: Cannot create software.aws.toolkits.jetbrains.core.explorer.devToolsTab.DevToolsToolWindow because container is already disposed (container=Project(name=project_1, containerState=DISPOSE_COMPLETED, componentStore=/Users/xshaohua/Desktop/dev/Projects/project_env1/project_1) (disposed))
	at com.intellij.serviceContainer.ContainerUtilKt.throwAlreadyDisposedError(containerUtil.kt:40)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:695)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:629)
	at software.aws.toolkits.jetbrains.core.explorer.devToolsTab.DevToolsToolWindow$Companion.getInstance(DevToolsToolWindow.kt:168)
	at software.aws.toolkits.jetbrains.core.explorer.RefreshAwsTreeKt$refreshDevToolTree$$inlined$runInEdt$default$1.run(actions.kt:62)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:209)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:21)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:191)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:813)
```
 
```
com.intellij.serviceContainer.AlreadyDisposedException: Cannot create software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager because container is already disposed (container=Project(name=my-react-app, containerState=DISPOSE_COMPLETED, componentStore=/Users/xshaohua/Desktop/dev/Projects/my-react-app) (disposed))
	at com.intellij.serviceContainer.ContainerUtilKt.throwAlreadyDisposedError(containerUtil.kt:34)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:631)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:583)
	at com.intellij.openapi.client.ClientAwareComponentManager.getFromSelfOrCurrentSession(ClientAwareComponentManager.kt:37)
	at com.intellij.openapi.client.ClientAwareComponentManager.getService(ClientAwareComponentManager.kt:22)
	at software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager$Companion.getInstance(ToolkitAuthManager.kt:179)
	at software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager.checkActiveCodeWhispererConnectionType(CodeWhispererExplorerActionManager.kt:109)
	at software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManagerKt.isCodeWhispererEnabled(CodeWhispererExplorerActionManager.kt:179)

```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
