### PR TITLE
Fix CW clientComponentLatency event is emitted multiple times for a session

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/model/CodeWhispererModel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/model/CodeWhispererModel.kt
@@ -44,7 +44,8 @@ data class SessionContext(
     val typeahead: String = "",
     val typeaheadOriginal: String = "",
     val selectedIndex: Int = 0,
-    val seen: MutableSet<Int> = mutableSetOf()
+    val seen: MutableSet<Int> = mutableSetOf(),
+    val isFirstTimeShowingPopup: Boolean = true
 )
 
 data class RecommendationChunk(


### PR DESCRIPTION
clientComponenLatency event should not be emitted when user is just navigating recommendations or typing according to what the recommendation shows.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
