### PR TITLE
Adding CFN information to Explorer Nodes

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/apprunner/AppRunnerExplorerNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/apprunner/AppRunnerExplorerNode.kt
@@ -12,7 +12,9 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNo
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
 import software.aws.toolkits.jetbrains.services.apprunner.resources.AppRunnerResources
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.utils.toHumanReadable
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class AppRunnerNode(project: Project, service: AwsExplorerServiceNode) :
@@ -29,11 +31,14 @@ class AppRunnerServiceNode(
     AppRunnerClient.SERVICE_NAME,
     service.serviceName(),
     AwsIcons.Resources.APPRUNNER_SERVICE
-) {
+),
+    CloudFormationResource {
     override fun resourceType(): String = "service"
     override fun resourceArn(): String = service.serviceArn()
     override fun statusText(): String = service.status().toString().toHumanReadable()
 
     override fun isAlwaysShowPlus(): Boolean = false
     override fun isAlwaysLeaf(): Boolean = true
+    override val resourceType = AWS.AppRunner.Service
+    override val cfnPhysicalIdentifier: String = service.serviceArn()
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationExplorerNodes.kt
@@ -15,6 +15,7 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplore
 import software.aws.toolkits.jetbrains.services.cloudformation.resources.CloudFormationResources
 import software.aws.toolkits.jetbrains.services.cloudformation.stack.StackWindowManager
 import software.aws.toolkits.jetbrains.utils.toHumanReadable
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class CloudFormationServiceNode(project: Project, service: AwsExplorerServiceNode) : CacheBackedAwsExplorerServiceRootNode<StackSummary>(
@@ -36,7 +37,8 @@ class CloudFormationStackNode(
     CloudFormationClient.SERVICE_NAME,
     stackName,
     AwsIcons.Resources.CLOUDFORMATION_STACK
-) {
+),
+    CloudFormationResource {
     override fun resourceType() = "stack"
 
     override fun resourceArn() = stackId
@@ -48,4 +50,7 @@ class CloudFormationStackNode(
     override fun onDoubleClick() {
         StackWindowManager.getInstance(nodeProject).openStack(stackName, stackId)
     }
+
+    override val resourceType = AWS.CloudFormation.Stack
+    override val cfnPhysicalIdentifier = stackId
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationResource.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormationResource.kt
@@ -1,0 +1,14 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cloudformation
+
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
+
+/**
+ * Marker interface used for filtering now, but in the future can also be used by CloudAPI
+ */
+interface CloudFormationResource {
+    val resourceType: CloudFormationResourceType
+    val cfnPhysicalIdentifier: String
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/IndexedResources.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/IndexedResources.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.cloudformation
 
 import software.aws.toolkits.jetbrains.services.cloudformation.IndexedResource.Companion.from
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 import java.io.DataInput
 import java.io.DataOutput
@@ -106,6 +107,6 @@ internal val INDEXED_RESOURCE_MAPPINGS = mapOf<String,
         (String, Map<String, String>, Map<String, String>) -> IndexedResource,
         (Resource) -> IndexedResource>
     >(
-    LAMBDA_FUNCTION_TYPE to Pair(::IndexedFunction, ::IndexedFunction),
+    AWS.Lambda.Function.fullName to Pair(::IndexedFunction, ::IndexedFunction),
     SERVERLESS_FUNCTION_TYPE to Pair(::IndexedFunction, ::IndexedFunction)
 )

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/Resources.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/Resources.kt
@@ -5,6 +5,7 @@ package software.aws.toolkits.jetbrains.services.cloudformation
 
 import software.amazon.awssdk.services.lambda.model.PackageType
 import software.aws.toolkits.jetbrains.services.cloudformation.yaml.YamlCloudFormationTemplate.Companion.getTextValues
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 interface Function : Resource {
@@ -22,8 +23,6 @@ interface Function : Resource {
     fun timeout(): Int? = getOptionalScalarProperty("Timeout")?.toInt()
     fun memorySize(): Int? = getOptionalScalarProperty("MemorySize")?.toInt()
 }
-
-const val LAMBDA_FUNCTION_TYPE = "AWS::Lambda::Function"
 
 class LambdaFunction(private val delegate: Resource) : Resource by delegate, Function {
     override fun setCodeLocation(location: String) {
@@ -62,6 +61,6 @@ class SamFunction(private val delegate: Resource) : Resource by delegate, Functi
 }
 
 internal val RESOURCE_MAPPINGS = mapOf<String, (Resource) -> Resource>(
-    LAMBDA_FUNCTION_TYPE to ::LambdaFunction,
+    AWS.Lambda.Function.fullName to ::LambdaFunction,
     SERVERLESS_FUNCTION_TYPE to ::SamFunction
 )

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogsServiceNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudwatch/logs/CloudWatchLogsServiceNode.kt
@@ -11,7 +11,9 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.cloudwatch.logs.resources.CloudWatchResources
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class CloudWatchLogsServiceNode(project: Project, service: AwsExplorerServiceNode) : CacheBackedAwsExplorerServiceRootNode<LogGroup>(
@@ -32,7 +34,8 @@ class CloudWatchLogsNode(
     CloudWatchLogsClient.SERVICE_NAME,
     logGroupName,
     AwsIcons.Resources.CloudWatch.LOG_GROUP
-) {
+),
+    CloudFormationResource {
     override fun resourceType() = "group"
 
     override fun resourceArn() = arn
@@ -42,4 +45,7 @@ class CloudWatchLogsNode(
     override fun onDoubleClick() {
         CloudWatchLogWindow.getInstance(nodeProject).showLogGroup(logGroupName)
     }
+
+    override val resourceType = AWS.Logs.LogGroup
+    override val cfnPhysicalIdentifier = logGroupName
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/DynamicResourceSchemaMapping.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/DynamicResourceSchemaMapping.kt
@@ -8,9 +8,10 @@ import com.intellij.openapi.project.Project
 import com.jetbrains.jsonSchema.JsonSchemaMappingsProjectConfiguration
 import com.jetbrains.jsonSchema.ide.JsonSchemaService
 import org.jetbrains.annotations.TestOnly
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 
 class DynamicResourceSchemaMapping {
-    private val currentlyActiveResourceTypes: MutableSet<String> = mutableSetOf()
+    private val currentlyActiveResourceTypes: MutableSet<CloudFormationResourceType> = mutableSetOf()
 
     fun addResourceSchemaMapping(
         project: Project,
@@ -23,7 +24,7 @@ class DynamicResourceSchemaMapping {
         }
     }
 
-    fun getCurrentlyActiveResourceTypes(): Set<String> = currentlyActiveResourceTypes
+    fun getCurrentlyActiveResourceTypes(): Set<CloudFormationResourceType> = currentlyActiveResourceTypes
 
     @TestOnly
     fun removeCurrentlyActiveResourceTypes(project: Project) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/DynamicResourceStateChangedNotificationHandler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/DynamicResourceStateChangedNotificationHandler.kt
@@ -37,7 +37,7 @@ class DynamicResourceStateChangedNotificationHandler(private val project: Projec
             DynamicresourceTelemetry.mutateResource(
                 project,
                 Result.Succeeded,
-                state.resourceType,
+                state.resourceType.fullName,
                 addOperationToTelemetry(state.operation),
                 ChronoUnit.MILLIS.between(state.startTime, DynamicResourceTelemetryResources.getCurrentTime()).toDouble()
             )
@@ -65,7 +65,7 @@ class DynamicResourceStateChangedNotificationHandler(private val project: Projec
             DynamicresourceTelemetry.mutateResource(
                 project,
                 Result.Failed,
-                state.resourceType,
+                state.resourceType.fullName,
                 addOperationToTelemetry(state.operation),
                 ChronoUnit.MILLIS.between(state.startTime, DynamicResourceTelemetryResources.getCurrentTime()).toDouble()
             )

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/DynamicResourcesProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/DynamicResourcesProvider.kt
@@ -8,10 +8,11 @@ import kotlinx.coroutines.withContext
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.amazon.awssdk.services.cloudformation.model.ProvisioningType
 import software.amazon.awssdk.services.cloudformation.model.Visibility
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 import kotlin.coroutines.coroutineContext
 
 class DynamicResourcesProvider(private val cfnClient: CloudFormationClient) {
-    suspend fun listSupportedTypes(): List<ResourceType> = withContext(coroutineContext) {
+    suspend fun listSupportedTypes(): List<CloudFormationResourceType> = withContext(coroutineContext) {
         val mutable = async {
             cfnClient.listTypesPaginator {
                 it.visibility(Visibility.PUBLIC)
@@ -29,11 +30,10 @@ class DynamicResourcesProvider(private val cfnClient: CloudFormationClient) {
 
         types.flatMap { resp ->
             resp.typeSummaries().map { summary ->
-                CloudControlApiResources.resourceTypeFromResourceTypeName(summary.typeName())
+                CloudFormationResourceType(summary.typeName())
             }
         }
     }
 }
 
-data class ResourceType(val fullName: String, val service: String, val name: String)
-data class DynamicResource(val type: ResourceType, val identifier: String)
+data class DynamicResource(val type: CloudFormationResourceType, val identifier: String)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceServiceNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceServiceNode.kt
@@ -17,6 +17,7 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceActionNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceParentNode
 import software.aws.toolkits.jetbrains.core.getResourceNow
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.dynamic.CloudControlApiResources
 import software.aws.toolkits.jetbrains.services.dynamic.DynamicResource
 import software.aws.toolkits.jetbrains.services.dynamic.DynamicResourceIdentifier
@@ -24,6 +25,7 @@ import software.aws.toolkits.jetbrains.services.dynamic.DynamicResourceUpdateMan
 import software.aws.toolkits.jetbrains.services.dynamic.DynamicResourceUpdateManager.Companion.isTerminal
 import software.aws.toolkits.jetbrains.services.dynamic.OpenViewEditableDynamicResourceVirtualFile
 import software.aws.toolkits.jetbrains.services.dynamic.ViewEditableDynamicResourceVirtualFile
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.DynamicresourceTelemetry
 import software.aws.toolkits.telemetry.Result
@@ -69,7 +71,8 @@ class UnavailableDynamicResourceTypeNode(project: Project, resourceType: String)
 
 class DynamicResourceNode(project: Project, val resource: DynamicResource) :
     AwsExplorerNode<DynamicResource>(project, resource, null),
-    ResourceActionNode {
+    ResourceActionNode,
+    CloudFormationResource {
 
     override fun actionGroupName() = "aws.toolkit.explorer.dynamic.resource"
     override fun displayName(): String = CloudControlApiResources.getResourceDisplayName(resource.identifier)
@@ -125,6 +128,9 @@ class DynamicResourceNode(project: Project, val resource: DynamicResource) :
     private companion object {
         val LOG = getLogger<DynamicResourceNode>()
     }
+
+    override val resourceType = CloudFormationResourceType(resource.type.fullName)
+    override val cfnPhysicalIdentifier = resource.identifier
 }
 
 enum class OpenResourceModelSourceAction {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceServiceNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceServiceNode.kt
@@ -30,8 +30,8 @@ import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.DynamicresourceTelemetry
 import software.aws.toolkits.telemetry.Result
 
-class DynamicResourceResourceTypeNode(project: Project, val resourceType: String) :
-    AwsExplorerNode<String>(project, resourceType, null),
+open class DynamicResourceResourceTypeNode(project: Project, val resourceType: CloudFormationResourceType) :
+    AwsExplorerNode<CloudFormationResourceType>(project, resourceType, null),
     ResourceParentNode,
     ResourceActionNode {
 
@@ -46,15 +46,15 @@ class DynamicResourceResourceTypeNode(project: Project, val resourceType: String
     override fun getChildrenInternal(): List<AwsExplorerNode<*>> = try {
         nodeProject.getResourceNow(CloudControlApiResources.listResources(resourceType))
             .map { DynamicResourceNode(nodeProject, it) }
-            .also { DynamicresourceTelemetry.listResource(project = nodeProject, success = true, resourceType = resourceType) }
+            .also { DynamicresourceTelemetry.listResource(project = nodeProject, success = true, resourceType = resourceType.fullName) }
     } catch (e: Exception) {
         when (e) {
             is UnsupportedActionException -> {
-                DynamicresourceTelemetry.listResource(project = nodeProject, result = Result.Cancelled, resourceType = resourceType)
+                DynamicresourceTelemetry.listResource(project = nodeProject, result = Result.Cancelled, resourceType = resourceType.fullName)
                 listOf(AwsExplorerEmptyNode(nodeProject, message("dynamic_resources.unavailable_in_region", region.id)))
             }
             else -> {
-                DynamicresourceTelemetry.listResource(project = nodeProject, success = false, resourceType = resourceType)
+                DynamicresourceTelemetry.listResource(project = nodeProject, success = false, resourceType = resourceType.fullName)
                 throw e
             }
         }
@@ -79,7 +79,7 @@ class DynamicResourceNode(project: Project, val resource: DynamicResource) :
 
     override fun statusText(): String? {
         val state = DynamicResourceUpdateManager.getInstance(nodeProject)
-            .getUpdateStatus(DynamicResourceIdentifier(nodeProject.getConnectionSettingsOrThrow(), resource.type.fullName, resource.identifier))?.takeIf {
+            .getUpdateStatus(DynamicResourceIdentifier(nodeProject.getConnectionSettingsOrThrow(), resource.type, resource.identifier))?.takeIf {
                 !it.status.isTerminal()
             }
             ?: return null
@@ -92,7 +92,7 @@ class DynamicResourceNode(project: Project, val resource: DynamicResource) :
     override fun onDoubleClick() = openResourceModelInEditor(OpenResourceModelSourceAction.READ)
 
     fun openResourceModelInEditor(sourceAction: OpenResourceModelSourceAction) {
-        val dynamicResourceIdentifier = DynamicResourceIdentifier(nodeProject.getConnectionSettingsOrThrow(), resource.type.fullName, resource.identifier)
+        val dynamicResourceIdentifier = DynamicResourceIdentifier(nodeProject.getConnectionSettingsOrThrow(), resource.type, resource.identifier)
         val openFiles = FileEditorManager.getInstance(nodeProject).openFiles.filter {
             it is ViewEditableDynamicResourceVirtualFile && it.dynamicResourceIdentifier == dynamicResourceIdentifier
         }
@@ -103,7 +103,7 @@ class DynamicResourceNode(project: Project, val resource: DynamicResource) :
                     val model = OpenViewEditableDynamicResourceVirtualFile.getResourceModel(
                         nodeProject,
                         nodeProject.awsClient(),
-                        resource.type.fullName,
+                        resource.type,
                         resource.identifier
                     ) ?: return
                     val file = ViewEditableDynamicResourceVirtualFile(
@@ -112,7 +112,7 @@ class DynamicResourceNode(project: Project, val resource: DynamicResource) :
                     )
 
                     indicator.text = message("dynamic_resources.fetch.open")
-                    OpenViewEditableDynamicResourceVirtualFile.openFile(nodeProject, file, sourceAction, resource.type.fullName)
+                    OpenViewEditableDynamicResourceVirtualFile.openFile(nodeProject, file, sourceAction, resource.type)
                 }
             }.queue()
         } else {
@@ -129,7 +129,7 @@ class DynamicResourceNode(project: Project, val resource: DynamicResource) :
         val LOG = getLogger<DynamicResourceNode>()
     }
 
-    override val resourceType = CloudFormationResourceType(resource.type.fullName)
+    override val resourceType = resource.type
     override val cfnPhysicalIdentifier = resource.identifier
 }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/explorer/actions/DynamicResourceDeleteResourceAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamic/explorer/actions/DynamicResourceDeleteResourceAction.kt
@@ -29,7 +29,7 @@ class DynamicResourceDeleteResourceAction :
         if (response) {
             val dynamicResourceIdentifier = DynamicResourceIdentifier(
                 selected.nodeProject.getConnectionSettingsOrThrow(),
-                selected.resource.type.fullName, selected.resource.identifier
+                selected.resource.type, selected.resource.identifier
             )
             val fileEditorManager = FileEditorManager.getInstance(selected.nodeProject)
             fileEditorManager.openFiles.forEach {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamodb/explorer/DynamoDbExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/dynamodb/explorer/DynamoDbExplorerNodes.kt
@@ -13,9 +13,11 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNo
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
 import software.aws.toolkits.jetbrains.core.getResourceIfPresent
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.dynamodb.DynamoDbResources
 import software.aws.toolkits.jetbrains.services.dynamodb.editor.DynamoDbTableEditorProvider
 import software.aws.toolkits.jetbrains.services.sts.StsResources
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class DynamoDbServiceNode(project: Project, service: AwsExplorerServiceNode) :
@@ -25,7 +27,8 @@ class DynamoDbServiceNode(project: Project, service: AwsExplorerServiceNode) :
 }
 
 class DynamoDbTableNode(project: Project, private val tableName: String) :
-    AwsExplorerResourceNode<String>(project, DynamoDbClient.SERVICE_METADATA_ID, tableName, AwsIcons.Resources.DynamoDb.TABLE) {
+    AwsExplorerResourceNode<String>(project, DynamoDbClient.SERVICE_METADATA_ID, tableName, AwsIcons.Resources.DynamoDb.TABLE),
+    CloudFormationResource {
     private val arn = run {
         val account = tryOrNull { nodeProject.getResourceIfPresent(StsResources.ACCOUNT) } ?: ""
         "arn:${nodeProject.activeRegion().partitionId}:dynamodb:${nodeProject.activeRegion().id}:$account:table/$tableName"
@@ -38,4 +41,7 @@ class DynamoDbTableNode(project: Project, private val tableName: String) :
     override fun onDoubleClick() {
         DynamoDbTableEditorProvider.openViewer(nodeProject, resourceArn())
     }
+
+    override val resourceType = AWS.DynamoDB.Table
+    override val cfnPhysicalIdentifier = tableName
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecr/EcrExplorerNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecr/EcrExplorerNode.kt
@@ -14,8 +14,10 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceRoo
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceActionNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceParentNode
 import software.aws.toolkits.jetbrains.core.getResourceNow
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.ecr.resources.EcrResources
 import software.aws.toolkits.jetbrains.services.ecr.resources.Repository
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class EcrServiceNode(project: Project, service: AwsExplorerServiceNode) : AwsExplorerServiceRootNode(project, service) {
@@ -34,7 +36,8 @@ class EcrRepositoryNode(
         repository.repositoryName,
         AwsIcons.Resources.ECR_REPOSITORY
     ),
-    ResourceParentNode {
+    ResourceParentNode,
+    CloudFormationResource {
 
     override fun resourceType(): String = "repository"
 
@@ -47,6 +50,9 @@ class EcrRepositoryNode(
     override fun getChildrenInternal(): List<AwsExplorerNode<*>> = nodeProject
         .getResourceNow(EcrResources.listTags(repository.repositoryName))
         .map { EcrTagNode(nodeProject, repository, it) }
+
+    override val resourceType = AWS.ECR.Repository
+    override val cfnPhysicalIdentifier = repository.repositoryName
 }
 
 class EcrTagNode(project: Project, val repository: Repository, val tag: String) : AwsExplorerNode<String>(project, tag, null), ResourceActionNode {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/EcsExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecs/EcsExplorerNodes.kt
@@ -15,7 +15,9 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceRoo
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceLocationNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceParentNode
 import software.aws.toolkits.jetbrains.core.getResourceNow
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.ecs.resources.EcsResources
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class EcsParentNode(project: Project, service: AwsExplorerServiceNode) : AwsExplorerServiceRootNode(project, service) {
@@ -39,7 +41,8 @@ class EcsClusterParentNode(project: Project) :
 
 class EcsClusterNode(project: Project, private val clusterArn: String) :
     AwsExplorerResourceNode<String>(project, EcsClient.SERVICE_NAME, clusterArn, AwsIcons.Resources.Ecs.ECS_CLUSTER),
-    ResourceParentNode {
+    ResourceParentNode,
+    CloudFormationResource {
 
     override fun resourceType(): String = "cluster"
     override fun resourceArn(): String = clusterArn
@@ -52,15 +55,21 @@ class EcsClusterNode(project: Project, private val clusterArn: String) :
         .getResourceNow(EcsResources.listServiceArns(clusterArn))
         .map { nodeProject.getResourceNow(EcsResources.describeService(clusterArn, it)) }
         .map { EcsServiceNode(nodeProject, it, clusterArn) }
+
+    override val resourceType = AWS.ECS.Cluster
+    override val cfnPhysicalIdentifier = displayName()
 }
 
 class EcsServiceNode(project: Project, private val service: Service, private val clusterArn: String) :
     AwsExplorerResourceNode<Service>(project, EcsClient.SERVICE_NAME, service, AwsIcons.Resources.Ecs.ECS_SERVICE),
-    ResourceLocationNode {
+    ResourceLocationNode,
+    CloudFormationResource {
 
     override fun resourceType() = "service"
     override fun resourceArn(): String = value.serviceArn()
     override fun displayName(): String = value.serviceName()
     fun executeCommandEnabled() = value.enableExecuteCommand()
     fun clusterArn(): String = clusterArn
+    override val resourceType = AWS.ECS.Service
+    override val cfnPhysicalIdentifier = "${value.serviceArn()}|$clusterArn"
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/LambdaExplorerNodes.kt
@@ -13,8 +13,10 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNo
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceLocationNode
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.lambda.execution.remote.RemoteLambdaLocation
 import software.aws.toolkits.jetbrains.services.lambda.resources.LambdaResources
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class LambdaServiceNode(project: Project, service: AwsExplorerServiceNode) :
@@ -32,11 +34,14 @@ open class LambdaFunctionNode(
     function,
     AwsIcons.Resources.LAMBDA_FUNCTION
 ),
-    ResourceLocationNode {
+    ResourceLocationNode,
+    CloudFormationResource {
 
     override fun resourceType() = "function"
 
     override fun resourceArn() = value.arn
+    override val resourceType = AWS.Lambda.Function
+    override val cfnPhysicalIdentifier: String = functionName()
 
     override fun toString(): String = functionName()
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/S3ExplorerNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/S3ExplorerNode.kt
@@ -12,7 +12,9 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class S3ServiceNode(project: Project, service: AwsExplorerServiceNode) :
@@ -22,7 +24,8 @@ class S3ServiceNode(project: Project, service: AwsExplorerServiceNode) :
 }
 
 class S3BucketNode(project: Project, val bucket: Bucket) :
-    AwsExplorerResourceNode<String>(project, S3Client.SERVICE_NAME, bucket.name(), AwsIcons.Resources.S3_BUCKET) {
+    AwsExplorerResourceNode<String>(project, S3Client.SERVICE_NAME, bucket.name(), AwsIcons.Resources.S3_BUCKET),
+    CloudFormationResource {
 
     override fun resourceType(): String = "bucket"
 
@@ -35,4 +38,6 @@ class S3BucketNode(project: Project, val bucket: Bucket) :
     }
 
     override fun displayName(): String = bucket.name()
+    override val resourceType = AWS.S3.Bucket
+    override val cfnPhysicalIdentifier: String = bucket.name()
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/SchemasExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/SchemasExplorerNodes.kt
@@ -14,7 +14,9 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNod
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceParentNode
 import software.aws.toolkits.jetbrains.core.getResourceNow
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class SchemasServiceNode(project: Project, service: AwsExplorerServiceNode) :
@@ -32,10 +34,13 @@ open class SchemaRegistryNode(
     registry,
     AwsIcons.Resources.SCHEMA_REGISTRY
 ),
-    ResourceParentNode {
+    ResourceParentNode,
+    CloudFormationResource {
     override fun resourceType() = "registry"
 
     override fun resourceArn(): String = value.registryArn() ?: value.registryName()
+    override val resourceType = AWS.EventSchemas.Registry
+    override val cfnPhysicalIdentifier: String = registry.registryArn()
 
     override fun toString(): String = value.registryName()
 
@@ -69,10 +74,13 @@ open class SchemaNode(
     SchemasClient.SERVICE_NAME,
     schema,
     AwsIcons.Resources.SCHEMA
-) {
+),
+    CloudFormationResource {
     override fun resourceType() = "schema"
 
-    override fun resourceArn() = value.arn ?: value.name
+    override fun resourceArn() = cfnPhysicalIdentifier
+    override val resourceType = AWS.EventSchemas.Schema
+    override val cfnPhysicalIdentifier = value.arn ?: value.name
 
     override fun toString(): String = value.name
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/SqsExplorerNodes.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/sqs/SqsExplorerNodes.kt
@@ -11,8 +11,10 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.sqs.resources.SqsResources
 import software.aws.toolkits.jetbrains.services.sqs.toolwindow.SqsWindow
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class SqsServiceNode(project: Project, service: AwsExplorerServiceNode) :
@@ -29,8 +31,11 @@ class SqsQueueNode(
     SqsClient.SERVICE_NAME,
     queueUrl,
     AwsIcons.Resources.Sqs.SQS_QUEUE
-) {
+),
+    CloudFormationResource {
     val queue = Queue(queueUrl, nodeProject.activeRegion())
+    override val resourceType = AWS.SQS.Queue
+    override val cfnPhysicalIdentifier = queueUrl
 
     override fun resourceType() = "queue"
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/DynamicResourcesConfigurable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/DynamicResourcesConfigurable.kt
@@ -25,6 +25,7 @@ import software.aws.toolkits.jetbrains.services.dynamic.explorer.OtherResourcesN
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.aws.toolkits.jetbrains.ui.feedback.FEEDBACK_SOURCE
 import software.aws.toolkits.jetbrains.utils.notifyError
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.FeedbackTelemetry
 import javax.swing.ListSelectionModel
@@ -32,9 +33,9 @@ import javax.swing.ListSelectionModel
 class DynamicResourcesConfigurable : BoundConfigurable(message("aws.settings.dynamic_resources_configurable.title")) {
 
     private val coroutineScope = applicationCoroutineScope()
-    private val checklist = CheckBoxList<String>()
-    private val allResources = mutableSetOf<String>()
-    private val selected = mutableSetOf<String>()
+    private val checklist = CheckBoxList<CloudFormationResourceType>()
+    private val allResources = mutableSetOf<CloudFormationResourceType>()
+    private val selected = mutableSetOf<CloudFormationResourceType>()
     private val filter = object : FilterComponent("filter", 5) {
         override fun filter() {
             updateCheckboxList()
@@ -119,7 +120,9 @@ class DynamicResourcesConfigurable : BoundConfigurable(message("aws.settings.dyn
 
     private fun updateCheckboxList() {
         checklist.clear()
-        allResources.filter { it.contains(filter.filter, ignoreCase = true) }.sorted().forEach { checklist.addItem(it, it, it in selected) }
+        allResources.filter { it.fullName.contains(filter.filter, ignoreCase = true) }
+            .sortedBy { it.fullName }
+            .forEach { checklist.addItem(it, it.fullName, it in selected) }
     }
 
     private fun checkboxStateHandler(idx: Int, state: Boolean) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/DynamicResourcesSettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/DynamicResourcesSettings.kt
@@ -10,9 +10,10 @@ import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.annotations.Property
 import software.aws.toolkits.core.utils.replace
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 
 interface DynamicResourcesSettings {
-    var selected: Set<String>
+    var selected: Set<CloudFormationResourceType>
 
     companion object {
         fun getInstance(): DynamicResourcesSettings = service()
@@ -23,10 +24,12 @@ interface DynamicResourcesSettings {
 internal class DefaultDynamicResourcesSettings :
     DynamicResourcesSettings,
     SimplePersistentStateComponent<DynamicResourcesConfiguration>(DynamicResourcesConfiguration()) {
-    override var selected: Set<String>
-        get() = state.selected.toSet()
+    override var selected: Set<CloudFormationResourceType>
+        get() {
+            return state.selected.map { CloudFormationResourceType(it) }.toSet()
+        }
         set(value) {
-            state.selected.replace(value)
+            state.selected.replace(value.map { it.fullName })
         }
 }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/TestUtils.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/TestUtils.kt
@@ -33,6 +33,7 @@ import software.aws.toolkits.jetbrains.services.lambda.resources.LambdaResources
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
 import software.aws.toolkits.jetbrains.services.sqs.resources.SqsResources
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
@@ -64,7 +65,7 @@ fun MockResourceCacheRule.fillResourceCache(project: Project) {
     this.addEntry(
         project,
         CloudControlApiResources.listTypes(),
-        CompletableFuture.completedFuture(listOf("Aws::Sample::Resource"))
+        CompletableFuture.completedFuture(listOf(CloudFormationResourceType("Aws::Sample::Resource")))
     )
 
     this.addEntry(

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/CopyServiceUrlActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/CopyServiceUrlActionTest.kt
@@ -9,7 +9,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
-import software.amazon.awssdk.services.apprunner.model.ServiceSummary
 import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.jetbrains.services.apprunner.AppRunnerServiceNode
 import java.awt.datatransfer.DataFlavor
@@ -24,7 +23,7 @@ class CopyServiceUrlActionTest {
     @Test
     fun `Copy Service Url copies correct field`() {
         val action = CopyServiceUrlAction()
-        action.actionPerformed(AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(aString()).serviceUrl(url).build()), mock())
+        action.actionPerformed(AppRunnerServiceNode(projectRule.project, aServiceSummary { serviceUrl(url) }), mock())
         val data = CopyPasteManager.getInstance().getContents<String>(DataFlavor.stringFlavor)
         assertThat(data).isEqualTo("https://$url")
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/DeleteServiceActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/DeleteServiceActionTest.kt
@@ -14,7 +14,6 @@ import org.mockito.kotlin.verify
 import software.amazon.awssdk.services.apprunner.AppRunnerClient
 import software.amazon.awssdk.services.apprunner.model.DeleteServiceRequest
 import software.amazon.awssdk.services.apprunner.model.DeleteServiceResponse
-import software.amazon.awssdk.services.apprunner.model.ServiceSummary
 import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.services.apprunner.AppRunnerServiceNode
@@ -37,7 +36,7 @@ class DeleteServiceActionTest {
         client.stub {
             on { deleteService(any<DeleteServiceRequest>()) } doAnswer { DeleteServiceResponse.builder().build() }
         }
-        val node = AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(aString()).serviceArn(arn).build())
+        val node = AppRunnerServiceNode(projectRule.project, aServiceSummary { serviceArn(arn) })
         action.performDelete(node)
         verify(client, times(1)).deleteService(DeleteServiceRequest.builder().serviceArn(arn).build())
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/DeployActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/DeployActionTest.kt
@@ -23,7 +23,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import software.amazon.awssdk.services.apprunner.AppRunnerClient
-import software.amazon.awssdk.services.apprunner.model.ServiceSummary
 import software.amazon.awssdk.services.apprunner.model.StartDeploymentRequest
 import software.amazon.awssdk.services.apprunner.model.StartDeploymentResponse
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient
@@ -85,7 +84,7 @@ class DeployActionTest : BaseCoroutineTest(30) {
 
         runBlockingTest {
             action.deploy(
-                AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(aString()).serviceArn(aString()).build()),
+                AppRunnerServiceNode(projectRule.project, aServiceSummary()),
                 appRunnerClient,
                 cloudwatchClient
             )
@@ -114,7 +113,7 @@ class DeployActionTest : BaseCoroutineTest(30) {
 
         runBlockingTest {
             action.deploy(
-                AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(aString()).serviceArn(aString()).build()),
+                AppRunnerServiceNode(projectRule.project, aServiceSummary()),
                 appRunnerClient,
                 cloudwatchClient
             )
@@ -141,7 +140,7 @@ class DeployActionTest : BaseCoroutineTest(30) {
 
         runBlocking {
             action.deploy(
-                AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(aString()).serviceArn(aString()).build()),
+                AppRunnerServiceNode(projectRule.project, aServiceSummary()),
                 appRunnerClient,
                 cloudwatchClient
             )

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/OpenServiceUrlActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/OpenServiceUrlActionTest.kt
@@ -5,13 +5,13 @@ package software.aws.toolkits.jetbrains.services.apprunner.actions
 
 import com.intellij.ide.browsers.BrowserLauncher
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.ProjectRule
 import com.intellij.testFramework.replaceService
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import software.amazon.awssdk.services.apprunner.model.ServiceSummary
 import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.jetbrains.services.apprunner.AppRunnerServiceNode
 
@@ -20,6 +20,10 @@ class OpenServiceUrlActionTest {
     @Rule
     val projectRule = ProjectRule()
 
+    @JvmField
+    @Rule
+    val disposableRule = DisposableRule()
+
     private val url = aString()
 
     @Test
@@ -27,8 +31,8 @@ class OpenServiceUrlActionTest {
         val launcher = mock<BrowserLauncher>()
         val action = OpenServiceUrlAction()
 
-        ApplicationManager.getApplication().replaceService(BrowserLauncher::class.java, launcher, projectRule.project)
-        action.actionPerformed(AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(aString()).serviceUrl(url).build()), mock())
+        ApplicationManager.getApplication().replaceService(BrowserLauncher::class.java, launcher, disposableRule.disposable)
+        action.actionPerformed(AppRunnerServiceNode(projectRule.project, aServiceSummary { serviceUrl(url) }), mock())
 
         verify(launcher).browse("https://$url", project = projectRule.project)
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/PauseServiceActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/PauseServiceActionTest.kt
@@ -24,7 +24,6 @@ import software.amazon.awssdk.services.apprunner.model.AppRunnerException
 import software.amazon.awssdk.services.apprunner.model.PauseServiceRequest
 import software.amazon.awssdk.services.apprunner.model.PauseServiceResponse
 import software.amazon.awssdk.services.apprunner.model.ServiceStatus
-import software.amazon.awssdk.services.apprunner.model.ServiceSummary
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.services.apprunner.AppRunnerServiceNode
@@ -48,7 +47,7 @@ class PauseServiceActionTest {
 
     private val serviceName = RuleUtils.randomName()
     private val serviceArn = "arn::$serviceName"
-    private val serviceSummary = ServiceSummary.builder().serviceName(serviceName).serviceArn(serviceArn).build()
+    private val serviceSummary = aServiceSummary { serviceName(serviceName).serviceArn(serviceArn) }
 
     @Before
     fun setup() {
@@ -117,9 +116,9 @@ class PauseServiceActionTest {
 
     @Test
     fun `Hides node if service is not running`() {
-        ServiceStatus.knownValues().filter { it != ServiceStatus.RUNNING }.forEach {
+        ServiceStatus.knownValues().filter { it != ServiceStatus.RUNNING }.forEach { status ->
             val actionEvent = TestActionEvent()
-            action.update(AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(serviceName).status(it).build()), actionEvent)
+            action.update(AppRunnerServiceNode(projectRule.project, serviceSummary.copy { it.status(status) }), actionEvent)
             assertThat(actionEvent.presentation.isVisible).isFalse
         }
     }
@@ -128,7 +127,7 @@ class PauseServiceActionTest {
     fun `Shows node if service is running`() {
         val actionEvent = TestActionEvent()
         action.update(
-            AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(serviceName).status(ServiceStatus.RUNNING).build()),
+            AppRunnerServiceNode(projectRule.project, serviceSummary.copy { it.status(ServiceStatus.RUNNING) }),
             actionEvent
         )
         assertThat(actionEvent.presentation.isVisible).isTrue

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/ResumeServiceActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/ResumeServiceActionTest.kt
@@ -24,7 +24,6 @@ import software.amazon.awssdk.services.apprunner.model.AppRunnerException
 import software.amazon.awssdk.services.apprunner.model.ResumeServiceRequest
 import software.amazon.awssdk.services.apprunner.model.ResumeServiceResponse
 import software.amazon.awssdk.services.apprunner.model.ServiceStatus
-import software.amazon.awssdk.services.apprunner.model.ServiceSummary
 import software.aws.toolkits.core.utils.RuleUtils
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.services.apprunner.AppRunnerServiceNode
@@ -48,7 +47,7 @@ class ResumeServiceActionTest {
 
     private val serviceName = RuleUtils.randomName()
     private val serviceArn = "arn::$serviceName"
-    private val serviceSummary = ServiceSummary.builder().serviceName(serviceName).serviceArn(serviceArn).build()
+    private val serviceSummary = aServiceSummary { serviceName(serviceName).serviceArn(serviceArn) }
 
     @Before
     fun setup() {
@@ -117,9 +116,9 @@ class ResumeServiceActionTest {
 
     @Test
     fun `Hides node if service is not paused`() {
-        ServiceStatus.knownValues().filter { it != ServiceStatus.PAUSED }.forEach {
+        ServiceStatus.knownValues().filter { it != ServiceStatus.PAUSED }.forEach { status ->
             val actionEvent = TestActionEvent()
-            action.update(AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(serviceName).status(it).build()), actionEvent)
+            action.update(AppRunnerServiceNode(projectRule.project, serviceSummary.copy { it.status(status) }), actionEvent)
             assertThat(actionEvent.presentation.isVisible).isFalse
         }
     }
@@ -128,7 +127,7 @@ class ResumeServiceActionTest {
     fun `Shows node if service is paused`() {
         val actionEvent = TestActionEvent()
         action.update(
-            AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(serviceName).status(ServiceStatus.PAUSED).build()),
+            AppRunnerServiceNode(projectRule.project, serviceSummary.copy { it.status(ServiceStatus.PAUSED) }),
             actionEvent
         )
         assertThat(actionEvent.presentation.isVisible).isTrue

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/ViewLogsActionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/apprunner/actions/ViewLogsActionTest.kt
@@ -56,7 +56,7 @@ class ViewLogsActionTest {
         (ToolWindowManager.getInstance(projectRule.project) as ToolWindowHeadlessManagerImpl)
             .doRegisterToolWindow(CloudWatchLogsToolWindowFactory.TOOLWINDOW_ID)
         toolWindow = CloudWatchLogWindow.getInstance(projectRule.project)
-        node = AppRunnerServiceNode(projectRule.project, ServiceSummary.builder().serviceName(aString()).serviceId(aString()).build())
+        node = AppRunnerServiceNode(projectRule.project, aServiceSummary())
     }
 
     @After
@@ -127,3 +127,10 @@ class ViewLogsActionTest {
         }
     }
 }
+
+fun aServiceSummary(block: ServiceSummary.Builder.() -> Unit = {}) = ServiceSummary.builder()
+    .serviceName(aString())
+    .serviceId(aString())
+    .serviceArn(aString())
+    .apply(block)
+    .build()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/CreateResourceFileStatusHandlerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/CreateResourceFileStatusHandlerTest.kt
@@ -28,8 +28,8 @@ import software.aws.toolkits.jetbrains.services.dynamic.CreateDynamicResourceVir
 import software.aws.toolkits.jetbrains.services.dynamic.CreateResourceFileStatusHandler
 import software.aws.toolkits.jetbrains.services.dynamic.DynamicResource
 import software.aws.toolkits.jetbrains.services.dynamic.ResourceMutationState
-import software.aws.toolkits.jetbrains.services.dynamic.ResourceType
 import software.aws.toolkits.jetbrains.services.dynamic.ViewEditableDynamicResourceVirtualFile
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 import java.time.Instant
 
 class CreateResourceFileStatusHandlerTest {
@@ -45,7 +45,7 @@ class CreateResourceFileStatusHandlerTest {
     private lateinit var createResourceHandler: CreateResourceFileStatusHandler
     private lateinit var connectionSettings: ConnectionSettings
     private lateinit var fileEditorManager: FileEditorManager
-    private val resource = DynamicResource(ResourceType("AWS::SampleService::Type", "SampleService", "Type"), "sampleIdentifier")
+    private val resource = DynamicResource(CloudFormationResourceType("AWS::SampleService::Type"), "sampleIdentifier")
 
     @Before
     fun setup() {
@@ -70,7 +70,7 @@ class CreateResourceFileStatusHandlerTest {
                     .build()
             }
         }
-        val sampleFile = CreateDynamicResourceVirtualFile(connectionSettings, resource.type.fullName)
+        val sampleFile = CreateDynamicResourceVirtualFile(connectionSettings, resource.type)
         runInEdtAndWait {
             fileEditorManager.openFile(sampleFile, false)
         }
@@ -81,7 +81,7 @@ class CreateResourceFileStatusHandlerTest {
             connectionSettings,
             "sampleToken",
             Operation.CREATE,
-            resource.type.fullName,
+            resource.type,
             OperationStatus.SUCCESS,
             resource.identifier,
             "",

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceResourceTypeNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceResourceTypeNodeTest.kt
@@ -15,6 +15,7 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerErrorNode
 import software.aws.toolkits.jetbrains.core.id
 import software.aws.toolkits.jetbrains.services.dynamic.CloudControlApiResources
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 import software.aws.toolkits.resources.message
 
 class DynamicResourceResourceTypeNodeTest {
@@ -29,7 +30,7 @@ class DynamicResourceResourceTypeNodeTest {
 
     @Test
     fun returnsListFromProvider() {
-        val type = "AWS::${aString()}::${aString()}"
+        val type = CloudFormationResourceType("AWS::${aString()}::${aString()}")
         val identifier = aString()
         resourceCache.addEntry(projectRule.project, CloudControlApiResources.listResources(type).id, listOf(identifier))
 
@@ -42,7 +43,7 @@ class DynamicResourceResourceTypeNodeTest {
 
     @Test
     fun unsupportedExceptionResultsInEmptyNode() {
-        val type = aString()
+        val type = CloudFormationResourceType(aString())
         resourceCache.addEntry(projectRule.project, CloudControlApiResources.listResources(type).id, throws = UnsupportedActionException.builder().build())
 
         val sut = DynamicResourceResourceTypeNode(projectRule.project, type)
@@ -54,7 +55,7 @@ class DynamicResourceResourceTypeNodeTest {
 
     @Test
     fun otherExceptionsBubble() {
-        val type = aString()
+        val type = CloudFormationResourceType(aString())
         resourceCache.addEntry(projectRule.project, CloudControlApiResources.listResources(type).id, throws = RuntimeException())
 
         val sut = DynamicResourceResourceTypeNode(projectRule.project, type)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceUpdateManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/DynamicResourceUpdateManagerTest.kt
@@ -35,8 +35,7 @@ import software.aws.toolkits.jetbrains.services.dynamic.DynamicResourceIdentifie
 import software.aws.toolkits.jetbrains.services.dynamic.DynamicResourceStateMutationHandler
 import software.aws.toolkits.jetbrains.services.dynamic.DynamicResourceUpdateManager
 import software.aws.toolkits.jetbrains.services.dynamic.ResourceMutationState
-import software.aws.toolkits.jetbrains.services.dynamic.ResourceType
-import software.aws.toolkits.resources.message
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -56,7 +55,7 @@ class DynamicResourceUpdateManagerTest {
     private lateinit var cloudControlClient: CloudControlClient
     private lateinit var dynamicResourceUpdateManager: DynamicResourceUpdateManager
     private lateinit var connectionSettings: ConnectionSettings
-    private val resource = DynamicResource(ResourceType("AWS::SampleService::Type", "SampleService", "Type"), "sampleIdentifier")
+    private val resource = DynamicResource(CloudFormationResourceType("AWS::SampleService::Type"), "sampleIdentifier")
 
     @Before
     fun setup() {
@@ -106,7 +105,7 @@ class DynamicResourceUpdateManagerTest {
                 }
             )
 
-        dynamicResourceUpdateManager.deleteResource(DynamicResourceIdentifier(connectionSettings, resource.type.fullName, resource.identifier))
+        dynamicResourceUpdateManager.deleteResource(DynamicResourceIdentifier(connectionSettings, resource.type, resource.identifier))
         CountDownLatch(1).await(400, TimeUnit.MILLISECONDS)
         assertThat(testOperationState.size).isEqualTo(1)
         assertThat(testOperationState.first().message).isEqualTo("Completed successfully")
@@ -155,7 +154,7 @@ class DynamicResourceUpdateManagerTest {
                     }
                 }
             )
-        dynamicResourceUpdateManager.deleteResource(DynamicResourceIdentifier(connectionSettings, resource.type.fullName, resource.identifier))
+        dynamicResourceUpdateManager.deleteResource(DynamicResourceIdentifier(connectionSettings, resource.type, resource.identifier))
         CountDownLatch(1).await(400, TimeUnit.MILLISECONDS)
         assertThat(testOperationStatus.size).isEqualTo(1)
         assertThat(testOperationStatus.first()).isEqualTo(OperationStatus.SUCCESS)
@@ -164,7 +163,7 @@ class DynamicResourceUpdateManagerTest {
     @Test
     fun `Notifies user if request token is invalid and stops polling for it`() {
         val notificationMock = mock<Notifications>()
-        val dynamicResourceIdentifier = DynamicResourceIdentifier(connectionSettings, resource.type.fullName, resource.identifier)
+        val dynamicResourceIdentifier = DynamicResourceIdentifier(connectionSettings, resource.type, resource.identifier)
 
         projectRule.project.messageBus.connect(disposableRule.disposable).subscribe(Notifications.TOPIC, notificationMock)
         dynamicResourceUpdateManager = DynamicResourceUpdateManager.getInstance(projectRule.project)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/ResourceSchemaProviderFactoryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/ResourceSchemaProviderFactoryTest.kt
@@ -18,9 +18,9 @@ import software.aws.toolkits.jetbrains.services.dynamic.CloudControlApiResources
 import software.aws.toolkits.jetbrains.services.dynamic.DynamicResource
 import software.aws.toolkits.jetbrains.services.dynamic.DynamicResourceIdentifier
 import software.aws.toolkits.jetbrains.services.dynamic.DynamicResourceSchemaMapping
-import software.aws.toolkits.jetbrains.services.dynamic.ResourceType
 import software.aws.toolkits.jetbrains.services.dynamic.ViewEditableDynamicResourceVirtualFile
 import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 import java.util.concurrent.CompletableFuture
 
 class ResourceSchemaProviderFactoryTest {
@@ -72,12 +72,12 @@ class ResourceSchemaProviderFactoryTest {
 
         val schemaFile = LightVirtualFile("AWSLogLogGroupSchema.json", schema)
         resourceCache.addEntry(
-            projectRule.project, CloudControlApiResources.getResourceSchema(resource.type.fullName),
+            projectRule.project, CloudControlApiResources.getResourceSchema(resource.type),
             CompletableFuture.completedFuture(schemaFile)
         )
     }
 
-    private val resource = DynamicResource(ResourceType("AWS::Log::LogGroup", "Log", "LogGroup"), "sampleIdentifier")
+    private val resource = DynamicResource(CloudFormationResourceType("AWS::Log::LogGroup"), "sampleIdentifier")
 
     @Test
     fun `Check whether schema is applied`() {
@@ -87,7 +87,7 @@ class ResourceSchemaProviderFactoryTest {
         try {
             fixture.enableInspections(jsonSchemaComplianceInspection)
             val file = ViewEditableDynamicResourceVirtualFile(
-                DynamicResourceIdentifier(ConnectionSettings(aToolkitCredentialsProvider(), anAwsRegion()), resource.type.fullName, resource.identifier),
+                DynamicResourceIdentifier(ConnectionSettings(aToolkitCredentialsProvider(), anAwsRegion()), resource.type, resource.identifier),
                 """
                 {"RetentionInDays":<warning descr="Value should be one of: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653">18</warning>}
                 """.trimIndent()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemaRegistryNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemaRegistryNodeTest.kt
@@ -9,6 +9,7 @@ import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.schemas.model.RegistrySummary
 import software.amazon.awssdk.services.schemas.model.SchemaSummary
+import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
@@ -49,7 +50,8 @@ class SchemaRegistryNodeTest {
         assertThat(node.children.map { it.displayName() }).contains(schema1, schema2)
     }
 
-    private fun aSchemaRegistryNode(registry: String) = SchemaRegistryNode(projectRule.project, RegistrySummary.builder().registryName(registry).build())
+    private fun aSchemaRegistryNode(registry: String) =
+        SchemaRegistryNode(projectRule.project, RegistrySummary.builder().registryName(registry).registryArn(aString()).build())
 
     private fun registryWithSchemas(registryName: String, schemas: List<String>) {
         resourceCache.addEntry(

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasServiceNodeTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/schemas/SchemasServiceNodeTest.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.schemas.model.RegistrySummary
+import software.aws.toolkits.core.utils.test.aString
 import software.aws.toolkits.jetbrains.core.MockResourceCacheRule
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerEmptyNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.SchemasExplorerRootNode
@@ -54,6 +55,7 @@ class SchemasServiceNodeTest {
                 names.map {
                     RegistrySummary.builder()
                         .registryName(it)
+                        .registryArn(aString())
                         .build()
                 }
             )

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/settings/DynamicResourcesSettingsTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/settings/DynamicResourcesSettingsTest.kt
@@ -7,13 +7,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import software.aws.toolkits.jetbrains.utils.deserializeState
 import software.aws.toolkits.jetbrains.utils.serializeState
+import software.aws.toolkits.resources.cloudformation.CloudFormationResourceType
 
 class DynamicResourcesSettingsTest {
     @Test
     fun `can round trip settings`() {
         val sut = DefaultDynamicResourcesSettings()
 
-        sut.selected = setOf("a", "b", "c")
+        sut.selected = setOf(CloudFormationResourceType("a"), CloudFormationResourceType("b"), CloudFormationResourceType("c"))
 
         val serialized = serializeState("settings", sut)
         val newSut = DefaultDynamicResourcesSettings()

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodes.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/RdsExplorerNodes.kt
@@ -11,8 +11,10 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNod
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceRootNode
 import software.aws.toolkits.jetbrains.core.getResourceNow
 import software.aws.toolkits.jetbrains.core.utils.buildMap
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
 import software.aws.toolkits.jetbrains.services.rds.resources.LIST_SUPPORTED_CLUSTERS
 import software.aws.toolkits.jetbrains.services.rds.resources.LIST_SUPPORTED_INSTANCES
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class RdsExplorerParentNode(project: Project, service: AwsExplorerServiceNode) : AwsExplorerServiceRootNode(project, service) {
@@ -27,14 +29,18 @@ class RdsExplorerParentNode(project: Project, service: AwsExplorerServiceNode) :
     }
 }
 
-class RdsNode(project: Project, val database: RdsDatabase, private val rdsEngine: RdsEngine = database.rdsEngine()) : AwsExplorerResourceNode<String>(
-    project,
-    RdsClient.SERVICE_NAME,
-    database.arn,
-    rdsEngine.icon
-) {
+class RdsNode(project: Project, val database: RdsDatabase, private val rdsEngine: RdsEngine = database.rdsEngine()) :
+    AwsExplorerResourceNode<String>(
+        project,
+        RdsClient.SERVICE_NAME,
+        database.arn,
+        rdsEngine.icon
+    ),
+    CloudFormationResource {
     override fun displayName(): String = database.identifier
     override fun resourceArn(): String = database.arn
     override fun resourceType(): String = "instance"
     override fun statusText(): String? = rdsEngine.additionalInfo
+    override val resourceType = AWS.RDS.DBInstance
+    override val cfnPhysicalIdentifier = database.identifier
 }

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/redshift/RedshiftExplorerNodes.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/redshift/RedshiftExplorerNodes.kt
@@ -11,6 +11,8 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.nodes.CacheBackedAwsExplorerServiceRootNode
+import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationResource
+import software.aws.toolkits.resources.cloudformation.AWS
 import software.aws.toolkits.resources.message
 
 class RedshiftExplorerParentNode(project: Project, service: AwsExplorerServiceNode) :
@@ -19,13 +21,17 @@ class RedshiftExplorerParentNode(project: Project, service: AwsExplorerServiceNo
     override fun toNode(child: Cluster): AwsExplorerNode<*> = RedshiftExplorerNode(nodeProject, child)
 }
 
-class RedshiftExplorerNode(project: Project, val cluster: Cluster) : AwsExplorerResourceNode<Cluster>(
-    project,
-    RedshiftClient.SERVICE_NAME,
-    cluster,
-    AwsIcons.Resources.REDSHIFT
-) {
+class RedshiftExplorerNode(project: Project, val cluster: Cluster) :
+    AwsExplorerResourceNode<Cluster>(
+        project,
+        RedshiftClient.SERVICE_NAME,
+        cluster,
+        AwsIcons.Resources.REDSHIFT
+    ),
+    CloudFormationResource {
     override fun displayName(): String = cluster.clusterIdentifier()
     override fun resourceType(): String = "cluster"
     override fun resourceArn(): String = nodeProject.clusterArn(cluster, region)
+    override val resourceType = AWS.Redshift.Cluster
+    override val cfnPhysicalIdentifier: String = cluster.clusterIdentifier()
 }

--- a/resources/build.gradle.kts
+++ b/resources/build.gradle.kts
@@ -1,6 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
 import de.undercouch.gradle.tasks.download.Download
 import software.aws.toolkits.gradle.resources.ValidateMessages
 
@@ -13,6 +16,7 @@ plugins {
 sourceSets {
     main {
         resources.srcDir("$buildDir/downloaded-resources")
+        java.srcDir("${project.buildDir}/generated-src")
     }
 }
 
@@ -35,8 +39,54 @@ val download = tasks.register<Download>("downloadResources") {
     }
 }
 
+val downloadCfnSpec = tasks.register<Download>("downloadCfnSpec") {
+    dest(buildDir)
+    onlyIfModified(true)
+    useETag(true)
+    src(listOf("https://d201a2mn26r7lk.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json"))
+}
+
+val generateCfnResourceTypes = tasks.register("generateCfnResourceTypes") {
+    val inputFile = file("${project.buildDir}/CloudFormationResourceSpecification.json")
+    val outputFile = file("${project.buildDir}/generated-src/software/aws/toolkits/resources/cloudformation/CloudFormationResourceTypes.kt")
+    inputs.file(inputFile)
+    outputs.file(outputFile)
+    doLast {
+        data class CfnResourceSpec(@JsonProperty("ResourceTypes") val resourceTypes: Map<String, Any>)
+        val cfnSpec = ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).readValue(inputFile, CfnResourceSpec::class.java)
+
+        val grouped = cfnSpec.resourceTypes.keys.groupBy { it.split("::")[0] }.mapValues { v -> v.value.groupBy { it.split("::")[1] } }
+
+        outputFile.bufferedWriter().use {
+            it.appendLine("// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.")
+            it.appendLine("// SPDX-License-Identifier: Apache-2.0")
+            it.appendLine()
+            it.appendLine("@file:Suppress(\"MaximumLineLength\")")
+            it.appendLine("package software.aws.toolkits.resources.cloudformation")
+            it.appendLine()
+            grouped.forEach { (domain, services) ->
+                it.appendLine("object $domain {")
+                services.toList().sortedBy { (key, _) -> key }.forEach { (service, resourceTypes) ->
+                    it.appendLine("    object $service {")
+                    resourceTypes.sorted().forEach { resourceType ->
+                        val type = resourceType.split("::")[2]
+                        it.appendLine("        val $type = CloudFormationResourceType(\"$resourceType\")")
+                    }
+                    it.appendLine("    }")
+                }
+                it.appendLine("}")
+            }
+        }
+    }
+    dependsOn(downloadCfnSpec)
+}
+
 tasks.processResources {
     dependsOn(download)
+}
+
+tasks.compileKotlin {
+    dependsOn(generateCfnResourceTypes)
 }
 
 val validateLocalizedMessages = tasks.register<ValidateMessages>("validateLocalizedMessages") {

--- a/resources/src/software/aws/toolkits/resources/cloudformation/CloudFormationResourceType.kt
+++ b/resources/src/software/aws/toolkits/resources/cloudformation/CloudFormationResourceType.kt
@@ -1,0 +1,7 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.resources.cloudformation
+
+@JvmInline
+value class CloudFormationResourceType(val fullName: String)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

Adding CFN information to explorer nodes - this is useful for at least two things:
1) being able to open a CloudAPI representation of the node
2) being able to filter by cloud-formation stack (see #3470)
