### PR TITLE
Support for RDS MariaDB instances

### DIFF
--- a/.changes/next-release/feature-33017f7e-c362-4d52-b344-ae66f2742bee.json
+++ b/.changes/next-release/feature-33017f7e-c362-4d52-b344-ae66f2742bee.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Support for RDS MariaDB instances"
+}

--- a/.changes/next-release/feature-33017f7e-c362-4d52-b344-ae66f2742bee.json
+++ b/.changes/next-release/feature-33017f7e-c362-4d52-b344-ae66f2742bee.json
@@ -1,4 +1,4 @@
 {
   "type" : "feature",
-  "description" : "Support for RDS MariaDB instances"
+  "description" : "Support for RDS MariaDB instances (#3530)"
 }

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/datagrip/DatagripUtils.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/datagrip/DatagripUtils.kt
@@ -13,9 +13,11 @@ import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.services.rds.AuroraMySql
 import software.aws.toolkits.jetbrains.services.rds.AuroraPostgres
+import software.aws.toolkits.jetbrains.services.rds.JDBC_MARIADB
 import software.aws.toolkits.jetbrains.services.rds.JDBC_MYSQL
 import software.aws.toolkits.jetbrains.services.rds.JDBC_MYSQL_AURORA
 import software.aws.toolkits.jetbrains.services.rds.JDBC_POSTGRES
+import software.aws.toolkits.jetbrains.services.rds.Maria
 import software.aws.toolkits.jetbrains.services.rds.MySql
 import software.aws.toolkits.jetbrains.services.rds.Postgres
 import software.aws.toolkits.jetbrains.services.redshift.RedshiftResources.JDBC_REDSHIFT
@@ -46,6 +48,7 @@ fun ProtoConnection.getAwsConnectionSettings(): ConnectionSettings {
 fun jdbcAdapterFromRuntime(runtime: String?): String? = when (runtime) {
     in Postgres.engines -> JDBC_POSTGRES
     in MySql.engines -> JDBC_MYSQL
+    in Maria.engines -> JDBC_MARIADB
     in AuroraMySql.engines -> JDBC_MYSQL_AURORA
     in AuroraPostgres.engines -> JDBC_POSTGRES
     REDSHIFT_ENGINE_TYPE -> JDBC_REDSHIFT
@@ -54,11 +57,11 @@ fun jdbcAdapterFromRuntime(runtime: String?): String? = when (runtime) {
 
 fun secretsManagerIsApplicable(dataSource: LocalDataSource): Boolean {
     val dbms = dataSource.dbms
-    return dbms == Dbms.MYSQL || dbms == Dbms.POSTGRES || dbms == Dbms.REDSHIFT || dbms == Dbms.MYSQL_AURORA
+    return dbms == Dbms.MYSQL || dbms == Dbms.MARIA || dbms == Dbms.POSTGRES || dbms == Dbms.REDSHIFT || dbms == Dbms.MYSQL_AURORA
 }
 
 fun iamIsApplicable(dataSource: LocalDataSource): Boolean =
-    dataSource.dbms == Dbms.MYSQL || dataSource.dbms == Dbms.POSTGRES || dataSource.dbms == Dbms.MYSQL_AURORA
+    dataSource.dbms == Dbms.MYSQL || dataSource.dbms == Dbms.MARIA || dataSource.dbms == Dbms.POSTGRES || dataSource.dbms == Dbms.MYSQL_AURORA
 
 fun validateIamConfiguration(connection: ProtoConnection) {
     // MariaDB/Mysql aurora will never work if SSL is turned off, so validate and give

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/RdsEngine.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/RdsEngine.kt
@@ -52,7 +52,6 @@ abstract class PostgresBase(engine: Set<String>, additionalInfo: String? = null)
     override fun iamUsername(username: String) = username.lowercase()
 }
 
-// TODO: Verify the IDE provided icon won't cause issues
 object Maria : RdsEngine(setOf("mariadb"), AllIcons.Providers.Mariadb, null) {
     override fun sslConfig(): DataSourceSslConfiguration = RequireSsl
     override fun connectionStringUrl(endpoint: String) = "jdbc:$JDBC_MARIADB://$endpoint/"

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/RdsEngine.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/RdsEngine.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.rds
 
 import com.intellij.database.dataSource.DataSourceSslConfiguration
+import com.intellij.icons.AllIcons
 import icons.AwsIcons
 import software.aws.toolkits.jetbrains.datagrip.RequireSsl
 import software.aws.toolkits.resources.message
@@ -32,7 +33,7 @@ sealed class RdsEngine(val engines: Set<String>, val icon: Icon, val additionalI
     open fun sslConfig(): DataSourceSslConfiguration? = null
 
     companion object {
-        fun values(): Set<RdsEngine> = setOf(MySql, AuroraMySql, Postgres, AuroraPostgres)
+        fun values(): Set<RdsEngine> = setOf(Maria, MySql, AuroraMySql, Postgres, AuroraPostgres)
         fun fromEngine(engine: String) = values().find { it.engines.contains(engine) } ?: throw IllegalArgumentException("Unknown RDS engine $engine")
     }
 }
@@ -49,6 +50,12 @@ abstract class PostgresBase(engine: Set<String>, additionalInfo: String? = null)
      * IAM role "Admin", it is inserted to the db as "admin"
      */
     override fun iamUsername(username: String) = username.lowercase()
+}
+
+// TODO: Verify the IDE provided icon won't cause issues
+object Maria : RdsEngine(setOf("mariadb"), AllIcons.Providers.Mariadb, null) {
+    override fun sslConfig(): DataSourceSslConfiguration = RequireSsl
+    override fun connectionStringUrl(endpoint: String) = "jdbc:$JDBC_MARIADB://$endpoint/"
 }
 
 object MySql : MySqlBase(setOf("mysql")) {

--- a/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/RdsResources.kt
+++ b/jetbrains-ultimate/src/software/aws/toolkits/jetbrains/services/rds/RdsResources.kt
@@ -9,6 +9,7 @@ const val POSTGRES_ENGINE_TYPE = "postgres"
 
 const val JDBC_MYSQL = "mysql"
 const val JDBC_MYSQL_AURORA = "mysql:aurora"
+const val JDBC_MARIADB = "mariadb"
 const val JDBC_POSTGRES = "postgresql"
 
 object RdsResources {

--- a/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/DatagripUtilsTest.kt
+++ b/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/datagrip/DatagripUtilsTest.kt
@@ -72,6 +72,7 @@ class DatagripUtilsTest {
     fun `jdbcAdapterFromRuntime works`() {
         assertThat(jdbcAdapterFromRuntime("postgres")).isEqualTo("postgresql")
         assertThat(jdbcAdapterFromRuntime("mysql")).isEqualTo("mysql")
+        assertThat(jdbcAdapterFromRuntime("mariadb")).isEqualTo("mariadb")
         assertThat(jdbcAdapterFromRuntime("redshift")).isEqualTo("redshift")
         assertThat(jdbcAdapterFromRuntime("mongo")).isNull()
     }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
MariaDB instances will now show up under the RDS node in the explorer. I was able to verify IAM and Secrets Manager authentication against an active AWS account.
![image](https://user-images.githubusercontent.com/48898064/228032570-955baa26-dcad-4098-8ed6-085ee3a755a1.png)
I have not added any significant tests specifically for MariaDB aside from a simple assertion (which was the only per-engine tests I could find).

Fixes #3530 

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
