### PR TITLE
Bump org.eclipse.jgit:org.eclipse.jgit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ intellijGradle = "1.13.2"
 intellijRemoteRobot = "0.11.18"
 jackson = "2.13.3"
 jacoco = "0.8.8"
-jgit = "5.11.0.202103091610-r"
+jgit = "6.5.0.202303070854-r"
 junit4 = "4.13.2"
 junit5 = "5.9.2"
 # https://plugins.jetbrains.com/docs/intellij/kotlin.html#adding-kotlin-support


### PR DESCRIPTION
Bumps org.eclipse.jgit:org.eclipse.jgit from 5.11.0.202103091610-r to 6.5.0.202303070854-r.

---
updated-dependencies:
- dependency-name: org.eclipse.jgit:org.eclipse.jgit dependency-type: direct:production update-type: version-update:semver-major ...


 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
