### PR TITLE
Add back Python Console support for CodeWhisperer

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
@@ -33,7 +33,12 @@ class CodeWhispererLanguageManager {
     // plugin features when developing CodeWhisperer features.
     fun getLanguage(vFile: VirtualFile): CodeWhispererProgrammingLanguage {
         val fileTypeName = vFile.fileType.name.lowercase()
-        val fileExtension = vFile.extension?.lowercase() ?: return CodeWhispererUnknownLanguage.INSTANCE
+        val fileExtension = vFile.extension?.lowercase()
+
+        // We want to support Python Console which does not have a file extension
+        if (fileExtension == null && fileTypeName.contains("python")) {
+            return CodeWhispererUnknownLanguage.INSTANCE
+        }
         return when {
             fileTypeName.contains("python") -> CodeWhispererPython.INSTANCE
             fileTypeName.contains("javascript") -> CodeWhispererJavaScript.INSTANCE

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
@@ -36,7 +36,7 @@ class CodeWhispererLanguageManager {
         val fileExtension = vFile.extension?.lowercase()
 
         // We want to support Python Console which does not have a file extension
-        if (fileExtension == null && fileTypeName.contains("python")) {
+        if (fileExtension == null && !fileTypeName.contains("python")) {
             return CodeWhispererUnknownLanguage.INSTANCE
         }
         return when {

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
@@ -100,6 +100,7 @@ class CodeWhispererLanguageManagerTest {
         testGetProgrammingLanguageUtil(listOf("c++"), languageExtensionsMap[CodeWhispererC.INSTANCE], CodeWhispererC::class.java)
         testGetProgrammingLanguageUtil(listOf("Shell Script"), languageExtensionsMap[CodeWhispererShell.INSTANCE], CodeWhispererShell::class.java)
         testGetProgrammingLanguageUtil(listOf("Rust"), languageExtensionsMap[CodeWhispererRust.INSTANCE], CodeWhispererRust::class.java)
+        testGetProgrammingLanguageUtil(listOf("Python Console"), listOf(null), CodeWhispererPython::class.java)
     }
 
     @Test
@@ -113,7 +114,7 @@ class CodeWhispererLanguageManagerTest {
 
     private fun <T : CodeWhispererProgrammingLanguage> testGetProgrammingLanguageUtil(
         fileTypeNames: List<String>,
-        fileExtensions: List<String>?,
+        fileExtensions: List<String?>?,
         expectedLanguage: Class<T>
     ) {
         fileExtensions?.forEach { fileExtension ->


### PR DESCRIPTION
Will also test on PyCharm
Tested on PyCharm, confirmed it's working.


https://user-images.githubusercontent.com/89420755/231879452-ade0f6e3-e160-4331-ad28-1a4d643bacb0.mov


<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
