### PR TITLE
Make CW auto-reconnect on startup

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
@@ -58,6 +58,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.listeners
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.CodeScanSessionConfig
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.overlaps
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
+import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhispererEnabled
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CodeScanTelemetryEvent
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererColorUtil.INACTIVE_TEXT_COLOR
@@ -126,14 +127,12 @@ class CodeWhispererCodeScanManager(val project: Project) {
      * Triggers a code scan and displays results in the new tab in problems view panel.
      */
     fun runCodeScan() {
+        if (!isCodeWhispererEnabled(project)) return
+
         // Return if a scan is already in progress.
         if (isCodeScanInProgress.getAndSet(true)) return
-        if (CodeWhispererUtil.isConnectionExpired(project)) {
-            promptReAuth(project) {
-                isCodeScanInProgress.set(false)
-            }
-            return
-        }
+        if (promptReAuth(project)) return
+
         // Prepare for a code scan
         beforeCodeScan()
         // launch code scan coroutine

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererExplorerActionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererExplorerActionManager.kt
@@ -20,7 +20,8 @@ import software.aws.toolkits.jetbrains.core.explorer.refreshDevToolTree
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererLoginType
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getConnectionStartUrl
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.isConnectionExpired
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.isAccessTokenExpired
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.isRefreshTokenExpired
 import software.aws.toolkits.telemetry.AwsTelemetry
 import java.time.LocalDateTime
 
@@ -119,7 +120,7 @@ class CodeWhispererExplorerActionManager : PersistentStateComponent<CodeWhispere
 
     fun checkActiveCodeWhispererConnectionType(project: Project) = when {
         actionState.token != null -> CodeWhispererLoginType.Accountless
-        isConnectionExpired(project) -> CodeWhispererLoginType.Expired
+        isAccessTokenExpired(project) || isRefreshTokenExpired(project) -> CodeWhispererLoginType.Expired
         else -> {
             val conn = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeWhispererConnection.getInstance())
             if (conn != null) {
@@ -197,4 +198,8 @@ interface CodeWhispererActivationChangedListener {
 
 fun isCodeWhispererEnabled(project: Project) = with(CodeWhispererExplorerActionManager.getInstance()) {
     checkActiveCodeWhispererConnectionType(project) != CodeWhispererLoginType.Logout
+}
+
+fun isCodeWhispererExpired(project: Project) = with(CodeWhispererExplorerActionManager.getInstance()) {
+    checkActiveCodeWhispererConnectionType(project) == CodeWhispererLoginType.Expired
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/nodes/CodeWhispererReconnectNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/nodes/CodeWhispererReconnectNode.kt
@@ -4,13 +4,8 @@
 package software.aws.toolkits.jetbrains.services.codewhisperer.explorer.nodes
 
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
-import software.aws.toolkits.jetbrains.core.credentials.BearerSsoConnection
-import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
-import software.aws.toolkits.jetbrains.core.credentials.loginSso
-import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeWhispererConnection
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getConnectionStartUrl
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.reconnectCodeWhisperer
 import software.aws.toolkits.resources.message
 import java.awt.event.MouseEvent
 
@@ -21,12 +16,6 @@ class CodeWhispererReconnectNode(nodeProject: Project) : CodeWhispererActionNode
     AllIcons.Actions.Execute
 ) {
     override fun onDoubleClick(event: MouseEvent) {
-        val connection = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeWhispererConnection.getInstance())
-        if (connection !is BearerSsoConnection) return
-        ApplicationManager.getApplication().executeOnPooledThread {
-            getConnectionStartUrl(connection)?.let { startUrl ->
-                loginSso(project, startUrl, scopes = connection.scopes)
-            }
-        }
+        reconnectCodeWhisperer(project)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
@@ -19,6 +19,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.status.CodeWhisper
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.notifyErrorAccountless
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.notifyWarnAccountless
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.promptReAuth
 import java.time.LocalDateTime
 import java.util.Date
 import java.util.Timer
@@ -39,6 +40,9 @@ class CodeWhispererProjectStartupActivity : StartupActivity.DumbAware {
         }
         if (!isCodeWhispererEnabled(project)) return
         if (runOnce) return
+
+        // Reconnect CodeWhisperer on startup
+        promptReAuth(project)
 
         CodeWhispererAutoTriggerService.getInstance().determineUserGroupIfNeeded()
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
@@ -13,16 +13,11 @@ import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.impl.status.EditorBasedWidget
 import com.intellij.ui.AnimatedIcon
 import com.intellij.util.Consumer
-import software.aws.toolkits.jetbrains.core.credentials.BearerSsoConnection
-import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
-import software.aws.toolkits.jetbrains.core.credentials.loginSso
-import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeWhispererConnection
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
-import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererLoginType
-import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
+import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhispererExpired
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStateChangeListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStatus
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.reconnectCodeWhisperer
 import software.aws.toolkits.resources.message
 import java.awt.event.MouseEvent
 import javax.swing.Icon
@@ -59,39 +54,23 @@ class CodeWhispererStatusBarWidget(project: Project) :
 
     override fun getClickConsumer(): Consumer<MouseEvent>? = null
 
-    override fun getPopupStep(): ListPopup? {
-        val connectionType = CodeWhispererExplorerActionManager.getInstance().checkActiveCodeWhispererConnectionType(project)
-        return if (connectionType == CodeWhispererLoginType.Expired) {
-            JBPopupFactory.getInstance().createConfirmation(message("codewhisperer.statusbar.popup.title"), ::reconnect, 0)
+    override fun getPopupStep(): ListPopup? =
+        if (isCodeWhispererExpired(project)) {
+            JBPopupFactory.getInstance().createConfirmation(message("codewhisperer.statusbar.popup.title"), { reconnectCodeWhisperer(project) }, 0)
         } else {
             null
         }
-    }
-
-    private fun reconnect() {
-        val connection = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeWhispererConnection.getInstance())
-        if (connection !is BearerSsoConnection) {
-            return
-        }
-        ApplicationManager.getApplication().executeOnPooledThread {
-            CodeWhispererUtil.getConnectionStartUrl(connection)?.let { startUrl ->
-                loginSso(project, startUrl, scopes = connection.scopes)
-            }
-        }
-    }
 
     override fun getSelectedValue(): String = message("codewhisperer.statusbar.display_name")
 
-    override fun getIcon(): Icon {
-        val connectionType = CodeWhispererExplorerActionManager.getInstance().checkActiveCodeWhispererConnectionType(project)
-        return if (connectionType == CodeWhispererLoginType.Expired) {
+    override fun getIcon(): Icon =
+        if (isCodeWhispererExpired(project)) {
             AllIcons.General.BalloonWarning
         } else if (CodeWhispererInvocationStatus.getInstance().hasExistingInvocation()) {
             AnimatedIcon.Default()
         } else {
             AllIcons.Actions.Commit
         }
-    }
 
     companion object {
         const val ID = "aws.codewhisperer.statusWidget"


### PR DESCRIPTION
This fixes the issue when CW does not auto-reconnect on IDE startup. CW will try to auto-connect when the connection(accessToken is expired) It will first try to use the refresh token to refresh, if failed, it will prompt a notification for people to re-auth(go through the browser login flow again).
Also did some refactors to ensure:
1. CW actions are not performed when CW is logged out, or CW needs to re-auth, for the case when CW needs to refresh, refresh the token and continue with the CW action.
2. Reuse helpers for serveral parts for reconnect, refresh, showing expiry notification and expiry check.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
