### PR TITLE
Fix CodeWhisperer client trying to create a client from a null connection

### DIFF
--- a/.changes/next-release/bugfix-c86767c0-255d-4c27-9f8d-b85f0083bb4c.json
+++ b/.changes/next-release/bugfix-c86767c0-255d-4c27-9f8d-b85f0083bb4c.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix 'null' is not a connection when authenticating to CodeWhisperer"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAddConnectionDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAddConnectionDialog.kt
@@ -150,14 +150,7 @@ open class ToolkitAddConnectionDialog(
 
                 val scopes = customizer?.scopes?.nullize() ?: listOf("sso:account:access")
 
-                LOG.info {
-                    """
-                        Try to fetch credential with: 
-                        \t loginType=${modal.loginType}, 
-                        \t region=${modal.region},
-                        \t startUrl=${modal.startUrl}
-                    """.trimIndent()
-                }
+                LOG.info { "Try to fetch credential with: $modal" }
 
                 loginSso(project, startUrl, region, scopes)
             }
@@ -178,20 +171,7 @@ open class ToolkitAddConnectionDialog(
                 }
             }
 
-            LOG.warn(e) {
-                """
-                    Failed to fetch credential with:
-                    \t loginType=${modal.loginType},
-                    \t region=${modal.region},
-                    \t startUrl=${modal.startUrl},
-                    \t message=$message
-                """.trimIndent()
-            }
-
-            if (e is ProcessCanceledException) {
-                // clean up dirty connection
-                ToolkitAuthManager.getInstance().deleteConnection(ToolkitBearerTokenProvider.ssoIdentifier(modal.startUrl, modal.region))
-            }
+            LOG.warn(e) { "Failed to fetch credential with: $modal; reason: $message" }
 
             runInEdt(ModalityState.any()) {
                 ToolkitAddConnectionDialog(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAddConnectionDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAddConnectionDialog.kt
@@ -32,7 +32,6 @@ import software.amazon.awssdk.services.ssooidc.model.InvalidGrantException
 import software.amazon.awssdk.services.ssooidc.model.InvalidRequestException
 import software.amazon.awssdk.services.ssooidc.model.SsoOidcException
 import software.aws.toolkits.core.credentials.DEFAULT_SSO_REGION
-import software.aws.toolkits.core.credentials.ToolkitBearerTokenProvider
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.core.utils.warn


### PR DESCRIPTION
```
2023-05-11 08:54:15,359 [156012507] SEVERE - #c.i.o.a.i.ApplicationImpl - Cannot invoke (class=, method=activeConnectionChanged, topic=ToolkitConnectionManagerListener active connection change)
java.lang.RuntimeException: Cannot invoke (class=, method=activeConnectionChanged, topic=ToolkitConnectionManagerListener active connection change)
    at com.intellij.util.messages.impl.MessageBusImplKt.invokeListener(MessageBusImpl.kt:657)
    at com.intellij.util.messages.impl.MessageBusImplKt.deliverMessage(MessageBusImpl.kt:415)
    at com.intellij.util.messages.impl.MessageBusImplKt.pumpWaiting(MessageBusImpl.kt:394)
    at com.intellij.util.messages.impl.MessageBusImplKt.access$pumpWaiting(MessageBusImpl.kt:1)
    at com.intellij.util.messages.impl.MessagePublisher.invoke(MessageBusImpl.kt:454)
    at jdk.proxy8/jdk.proxy8.$Proxy260.activeConnectionChanged(Unknown Source)
    at software.aws.toolkits.jetbrains.core.credentials.DefaultToolkitConnectionManager.switchConnection(DefaultToolkitConnectionManager.kt:121)
    at software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt.reauthConnection(ToolkitAuthManager.kt:180)
    at software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt.loginSso(ToolkitAuthManager.kt:169)
    at software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt.loginSso$default(ToolkitAuthManager.kt:107)
    at software.aws.toolkits.jetbrains.core.credentials.sono.SonoCredentialManager$getProviderAndPromptAuth$1.invoke(SonoCredentialManager.kt:72)
    at software.aws.toolkits.jetbrains.core.credentials.sono.SonoCredentialManager$getProviderAndPromptAuth$1.invoke(SonoCredentialManager.kt:71)
    at software.aws.toolkits.jetbrains.utils.ThreadingUtilsKt.runUnderProgressIfNeeded(ThreadingUtils.kt:30)
    at software.aws.toolkits.jetbrains.core.credentials.sono.SonoCredentialManager.getProviderAndPromptAuth(SonoCredentialManager.kt:71)
    at software.aws.toolkits.jetbrains.core.credentials.sono.SonoCredentialManager$Companion.loginSono(SonoCredentialManager.kt:87)
    at software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.actions.SonoLogin.actionPerformed$lambda$0(SonoLogin.kt:16)
    at com.intellij.openapi.application.impl.ApplicationImpl$1.run(ApplicationImpl.java:252)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:702)
    at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:699)
    at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
    at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:699)
    at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.IllegalStateException: null is not a bearer token connection
    at software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererClientAdaptorImpl.getBearerClient(CodeWhispererClientAdaptor.kt:162)
    at software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererClientAdaptorImpl$initClientUpdateListener$1.activeConnectionChanged(CodeWhispererClientAdaptor.kt:94)
    at com.intellij.util.messages.impl.MessageBusImplKt.invokeMethod(MessageBusImpl.kt:680)
    at com.intellij.util.messages.impl.MessageBusImplKt.invokeListener(MessageBusImpl.kt:640)
    ... 25 more
```
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
