### PR TITLE
fix(codewhisperer): prompt pinning on new connection

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitConnectionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitConnectionManager.kt
@@ -105,10 +105,17 @@ class DefaultToolkitConnectionManager : ToolkitConnectionManager, PersistentStat
             this.connection = newConnection
 
             val pinningManager = pinningManager
-            if (oldConnection != null && newConnection != null && pinningManager != null) {
+            if (newConnection != null && pinningManager != null) {
                 val featuresToPin = mutableListOf<FeatureWithPinnedConnection>()
                 FeatureWithPinnedConnection.EP_NAME.forEachExtensionSafe {
-                    if (!pinningManager.isFeaturePinned(it) && (it.supportsConnectionType(oldConnection) != it.supportsConnectionType(newConnection))) {
+                    if (!pinningManager.isFeaturePinned(it) &&
+
+                        (
+                            (oldConnection == null && it.supportsConnectionType(newConnection)) ||
+                                (oldConnection != null && it.supportsConnectionType(oldConnection) != it.supportsConnectionType(newConnection))
+                            )
+
+                    ) {
                         featuresToPin.add(it)
                     }
                 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/pinning/ConnectionPinningManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/pinning/ConnectionPinningManager.kt
@@ -43,7 +43,7 @@ interface ConnectionPinningManager {
     fun getPinnedConnection(feature: FeatureWithPinnedConnection): ToolkitConnection?
     fun setPinnedConnection(feature: FeatureWithPinnedConnection, newConnection: ToolkitConnection?)
 
-    fun maybePinFeatures(oldConnection: ToolkitConnection, newConnection: ToolkitConnection, features: List<FeatureWithPinnedConnection>)
+    fun maybePinFeatures(oldConnection: ToolkitConnection?, newConnection: ToolkitConnection, features: List<FeatureWithPinnedConnection>)
 
     companion object {
         fun getInstance(): ConnectionPinningManager = service()
@@ -90,7 +90,7 @@ class DefaultConnectionPinningManager :
         ApplicationManager.getApplication().messageBus.syncPublisher(ConnectionPinningManagerListener.TOPIC).pinnedConnectionChanged(feature, newConnection)
     }
 
-    override fun maybePinFeatures(oldConnection: ToolkitConnection, newConnection: ToolkitConnection, features: List<FeatureWithPinnedConnection>) {
+    override fun maybePinFeatures(oldConnection: ToolkitConnection?, newConnection: ToolkitConnection, features: List<FeatureWithPinnedConnection>) {
         val featuresString = if (features.size == 1) {
             features.first().featureName
         } else {
@@ -127,7 +127,7 @@ class DefaultConnectionPinningManager :
     override fun dispose() {}
 
     @TestOnly
-    internal fun showDialogIfNeeded(oldConnection: ToolkitConnection, newConnection: ToolkitConnection, featuresString: String, project: Project? = null) =
+    internal fun showDialogIfNeeded(oldConnection: ToolkitConnection?, newConnection: ToolkitConnection, featuresString: String, project: Project? = null) =
         if (!doNotPromptForPinning) {
             val bearerTokenConnectionName = bearerTokenConnectionString(oldConnection, newConnection)
 
@@ -157,7 +157,7 @@ class DefaultConnectionPinningManager :
             false
         }
 
-    private fun bearerTokenConnectionString(oldConnection: ToolkitConnection, newConnection: ToolkitConnection): String {
+    private fun bearerTokenConnectionString(oldConnection: ToolkitConnection?, newConnection: ToolkitConnection): String {
         val connection = if (oldConnection is AwsBearerTokenConnection) oldConnection else newConnection
         return if (connection.isSono()) message("aws_builder_id.service_name") else message("iam_identity_center.name")
     }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
also prompt the user to pin connection on new supported connections

https://github.com/aws/aws-toolkit-jetbrains/assets/60411978/bf16c921-1486-4c06-9e38-f03daa5fbe95


## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
