### PR TITLE
Fix IDE deadlock when logging into Builder ID / SSO

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
@@ -90,7 +90,7 @@ interface ToolkitConnectionManager : Disposable {
 
     fun activeConnectionForFeature(feature: FeatureWithPinnedConnection): ToolkitConnection?
 
-    fun switchConnection(connection: ToolkitConnection?)
+    fun switchConnection(newConnection: ToolkitConnection?)
 
     override fun dispose() {}
 


### PR DESCRIPTION
* Caused by connection switch lock on pooled thread waiting for dialog pinning prompt (on EDT), while status bar widget update waiting for lock release on EDT
* Causes subsequent warning on unsafe actions holding write lock, fix by setting modality state appropriately
* No tests because unit tests have a different thread model than a running IDE

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
