### PR TITLE
Disable Builder ID associated tests when running in non-prod infrastructure

### DIFF
--- a/jetbrains-core/it/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderIntegrationTest.kt
+++ b/jetbrains-core/it/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderIntegrationTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_REGION
@@ -25,6 +26,7 @@ import java.time.Instant
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 @ExtendWith(ApplicationExtension::class, SsoLoginExtension::class)
 @SsoLogin("codecatalyst-test-account")
+@DisabledIfEnvironmentVariable(named = "IS_PROD", matches = "false")
 class InteractiveBearerTokenProviderIntegrationTest {
     companion object {
         @JvmStatic

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/sso/MockSsoLoginCallbackProvider.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/credentials/sso/MockSsoLoginCallbackProvider.kt
@@ -84,6 +84,7 @@ internal class TestSsoPrompt(private val secretName: String) : SsoLoginCallback 
         LOG.info {
             """
                 "Auth invocation request ID: ${response.responseMetadata().requestId()}"
+                "Auth function error: ${response.functionError()}
                 "Auth invocation response status code: ${response.statusCode()}"
             """.trimIndent()
         }

--- a/jetbrains-gateway/it/software/aws/toolkits/jetbrains/gateway/DevEnvConnectTest.kt
+++ b/jetbrains-gateway/it/software/aws/toolkits/jetbrains/gateway/DevEnvConnectTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -62,6 +63,7 @@ import kotlin.time.ExperimentalTime
 @OptIn(ExperimentalTime::class)
 @ExtendWith(ApplicationExtension::class)
 @SsoLogin("codecatalyst-test-account")
+@DisabledIfEnvironmentVariable(named = "IS_PROD", matches = "false")
 class DevEnvConnectTest : AfterAllCallback {
     companion object {
         @JvmField


### PR DESCRIPTION

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
