### PR TITLE
Add retries to InvalidGrantException

### DIFF
--- a/.changes/next-release/bugfix-d8eac730-1924-4ea8-a4b2-7a08976dbb0d.json
+++ b/.changes/next-release/bugfix-d8eac730-1924-4ea8-a4b2-7a08976dbb0d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "CodeWhisperer: user is sometimes required to re-login before token expiration"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/BearerTokenProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/BearerTokenProvider.kt
@@ -9,6 +9,7 @@ import com.intellij.util.containers.orNull
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
 import software.amazon.awssdk.auth.token.credentials.SdkToken
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.core.retry.conditions.OrRetryCondition
 import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition
 import software.amazon.awssdk.regions.Region
@@ -209,27 +210,31 @@ class ProfileSdkTokenProviderWrapper(private val sessionName: String, region: St
 internal val DEFAULT_STALE_DURATION = Duration.ofMinutes(15)
 internal val DEFAULT_PREFETCH_DURATION = Duration.ofMinutes(20)
 
-private fun buildUnmanagedSsoOidcClient(region: String): SsoOidcClient =
+val ssoOidcClientConfigurationBuilder: (ClientOverrideConfiguration.Builder) -> ClientOverrideConfiguration.Builder = { configuration ->
+    configuration.nullDefaultProfileFile()
+
+    // Get the existing RetryPolicy
+    val existingRetryPolicy = configuration.retryPolicy()
+
+    // Add InvalidGrantException to the RetryOnExceptionsCondition
+    val updatedRetryPolicy = existingRetryPolicy.toBuilder()
+        .retryCondition(
+            OrRetryCondition.create(
+                existingRetryPolicy.retryCondition(),
+                RetryOnExceptionsCondition.create(setOf(InvalidGrantException::class.java)),
+            )
+        ).build()
+
+    // Update the RetryPolicy in the configuration
+    configuration.retryPolicy(updatedRetryPolicy)
+}
+
+fun buildUnmanagedSsoOidcClient(region: String): SsoOidcClient =
     AwsClientManager.getInstance()
         .createUnmanagedClient(
             AnonymousCredentialsProvider.create(),
             Region.of(region),
             clientCustomizer = ToolkitClientCustomizer { _, _, _, _, configuration ->
-                configuration.nullDefaultProfileFile()
-
-                // Get the existing RetryPolicy
-                val existingRetryPolicy = configuration.retryPolicy()
-
-                // Add InvalidGrantException to the RetryOnExceptionsCondition
-                val updatedRetryPolicy = existingRetryPolicy.toBuilder()
-                    .retryCondition(
-                        OrRetryCondition.create(
-                            existingRetryPolicy.retryCondition(),
-                            RetryOnExceptionsCondition.create(setOf(InvalidGrantException::class.java)),
-                        )
-                    ).build()
-
-                // Update the RetryPolicy in the configuration
-                configuration.retryPolicy(updatedRetryPolicy)
+                ssoOidcClientConfigurationBuilder(configuration)
             }
         )


### PR DESCRIPTION
The retries are added to all InvalidGrantException that makes sure that all the transient issues that are causing InvalidGrantException should be resolved by this retry. Using default retry stragegy with 2 retries(as the AWSSDK standard)
 that is 3 max attempts. With exponential backoff

Tested with making a request to throw InvalidGrantException and logs showing there are 3 attempts (1st initial attempt + 2 more retries)

The added test does real network calls, although it's designed to return InvalidGrantExceptions, this is actually an integration test so we can if we want to put it outside of unit tests. Mocking this is non-trivial since the retry logic is something deep inside the sdk.

related VSC change:
https://github.com/aws/aws-toolkit-vscode/pull/3498
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
