### PR TITLE
Disable :jetbrains-gateway:inspectClassesForKotlinIC

### DIFF
--- a/jetbrains-gateway/build.gradle.kts
+++ b/jetbrains-gateway/build.gradle.kts
@@ -122,3 +122,12 @@ tasks.integrationTest {
     val testToken = RandomString.make(32)
     environment("CWM_HOST_STATUS_OVER_HTTP_TOKEN", testToken)
 }
+
+tasks.inspectClassesForKotlinIC {
+    // > Task :jetbrains-gateway:inspectClassesForKotlinIC FAILED
+    // * What went wrong:
+    // Execution failed for task ':jetbrains-gateway:inspectClassesForKotlinIC'.
+    // > Cannot access input property 'sourceSetOutputClassesDir$kotlin_gradle_plugin_common' of task ':jetbrains-gateway:inspectClassesForKotlinIC'. Accessing unreadable inputs or outputs is not supported. Declare the task as untracked by using Task.doNotTrackState(). See https://docs.gradle.org/8.0.2/userguide/incremental_build.html#disable-state-tracking for more details.
+    //    > Failed to normalize content of 'C:\codebuild\tmp\output\src284282039\src\github.com\aws\aws-toolkit-jetbrains\jetbrains-gateway\build\classes\kotlin\main\classpath.index'.
+    enabled = false
+}


### PR DESCRIPTION

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
