### PR TITLE
fix(codewhisperer): Show re-auth prompt when invoking Cwspr APIs while connection expires

### DIFF
--- a/.changes/next-release/bugfix-78561cf0-b3ff-4121-a4ff-5f690cbdf1b0.json
+++ b/.changes/next-release/bugfix-78561cf0-b3ff-4121-a4ff-5f690cbdf1b0.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Show re-authenticate prompt when invoking CodeWhisperer APIs while connection expired"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
@@ -41,7 +41,7 @@ class CodeWhispererProjectStartupActivity : StartupActivity.DumbAware {
         if (runOnce) return
 
         // Reconnect CodeWhisperer on startup
-        promptReAuth(project)
+        promptReAuth(project, true)
 
         // install intellsense autotrigger listener, this only need to be executed 1 time
         project.messageBus.connect().subscribe(LookupManagerListener.TOPIC, CodeWhispererIntelliSenseAutoTriggerListener)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
@@ -41,7 +41,7 @@ class CodeWhispererProjectStartupActivity : StartupActivity.DumbAware {
         if (runOnce) return
 
         // Reconnect CodeWhisperer on startup
-        promptReAuth(project, true)
+        promptReAuth(project, isPluginStarting = true)
 
         // install intellsense autotrigger listener, this only need to be executed 1 time
         project.messageBus.connect().subscribe(LookupManagerListener.TOPIC, CodeWhispererIntelliSenseAutoTriggerListener)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -186,16 +186,21 @@ object CodeWhispererUtil {
     // This will be called only when there's a CW connection, but it has expired(either accessToken or refreshToken)
     // 1. If connection is expired, try to refresh
     // 2. If not able to refresh, requesting re-login by showing a notification
-    // 3. The notification will be shown at most once per IDE session
+    // 3. The notification will be shown
+    //   3.1 At most once per IDE restarts.
+    //   3.2 At most once after IDE restarts,
+    //   for example, when user performs security scan or fetch code completion for the first time
     // Return true if need to re-auth, false otherwise
-    fun promptReAuth(project: Project): Boolean {
+    fun promptReAuth(project: Project, isPluginStarting: Boolean=false): Boolean {
         if (CodeWhispererService.hasReAuthPromptBeenShown()) return false
         if (!isCodeWhispererExpired(project)) return false
         val tokenProvider = tokenProvider(project) ?: return false
         return maybeReauthProviderIfNeeded(project, tokenProvider) {
             runInEdt {
                 notifyConnectionExpiredRequestReauth(project)
-                CodeWhispererService.markReAuthPromptShown()
+                if (!isPluginStarting) {
+                    CodeWhispererService.markReAuthPromptShown()
+                }
             }
         }
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -191,7 +191,7 @@ object CodeWhispererUtil {
     //   3.2 At most once after IDE restarts,
     //   for example, when user performs security scan or fetch code completion for the first time
     // Return true if need to re-auth, false otherwise
-    fun promptReAuth(project: Project, isPluginStarting: Boolean=false): Boolean {
+    fun promptReAuth(project: Project, isPluginStarting: Boolean = false): Boolean {
         if (CodeWhispererService.hasReAuthPromptBeenShown()) return false
         if (!isCodeWhispererExpired(project)) return false
         val tokenProvider = tokenProvider(project) ?: return false


### PR DESCRIPTION
Show re-auth prompt when invoking Cwspr APIs while connection expires


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
This PR is to let CodeWhisperer show re-authentication prompt when user invokes CodeWhisperer APIs with an expired connection. Previously, it only shows when user restarts the IDE. 

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
