### PR TITLE
codewhisperer: enable UTG(Unit test generator) for java/python

### DIFF
--- a/.changes/next-release/feature-581591a9-066f-4696-bc5c-1eb8cd01b642.json
+++ b/.changes/next-release/feature-581591a9-066f-4696-bc5c-1eb8cd01b642.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "CodeWhisperer: Improve file context fetching logic"
+}

--- a/.changes/next-release/feature-581591a9-066f-4696-bc5c-1eb8cd01b642.json
+++ b/.changes/next-release/feature-581591a9-066f-4696-bc5c-1eb8cd01b642.json
@@ -1,4 +1,4 @@
 {
   "type" : "feature",
-  "description" : "CodeWhisperer: Improve file context fetching logic"
+  "description" : "CodeWhisperer: Improve suggestion quality with enhanced file context fetching"
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/languages/CodeWhispererJava.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/languages/CodeWhispererJava.kt
@@ -23,6 +23,8 @@ class CodeWhispererJava private constructor() : CodeWhispererProgrammingLanguage
 
     override fun isSupplementalContextSupported() = true
 
+    override fun isUTGSupported() = true
+
     companion object {
         const val ID = "java"
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/languages/CodeWhispererPython.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/languages/CodeWhispererPython.kt
@@ -21,6 +21,8 @@ class CodeWhispererPython private constructor() : CodeWhispererProgrammingLangua
 
     override fun isAllClassifier(): Boolean = true
 
+    override fun isUTGSupported() = true
+
     companion object {
         const val ID = "python"
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -512,7 +512,7 @@ class CodeWhispererService {
         // 2. supplemental context
         val startFetchingTimestamp = System.currentTimeMillis()
         val isTstFile = FileContextProvider.getInstance(project).isTestFile(psiFile)
-        val supplementalContext = if (CodeWhispererUserGroupSettings.getInstance().getUserGroup() == CodeWhispererUserGroup.CrossFile && !isTstFile) {
+        val supplementalContext = if (CodeWhispererUserGroupSettings.getInstance().getUserGroup() == CodeWhispererUserGroup.CrossFile) {
             runBlocking {
                 try {
                     withTimeout(SUPPLEMENTAL_CONTEXT_TIMEOUT) {
@@ -530,13 +530,18 @@ class CodeWhispererService {
                             targetFileName = fileContext.filename
                         )
                     } else {
-                        LOG.error(e) { "Run into unexpected error when fetching supplemental context" }
+                        LOG.debug { "Run into unexpected error when fetching supplemental context, error: ${e.message}" }
                         null
                     }
                 }
             }
         } else {
-            null
+            SupplementalContextInfo(
+                isUtg = isTstFile,
+                contents = emptyList(),
+                latency = 0,
+                targetFileName = fileContext.filename
+            )
         }
 
         // 3. caret position

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -37,7 +37,6 @@ import software.amazon.awssdk.services.codewhispererruntime.model.Recommendation
 import software.amazon.awssdk.services.codewhispererruntime.model.SupplementalContext
 import software.amazon.awssdk.services.codewhispererruntime.model.ThrottlingException
 import software.aws.toolkits.core.utils.debug
-import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.jetbrains.core.coroutines.disposableCoroutineScope

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererServiceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererServiceTest.kt
@@ -86,7 +86,7 @@ class CodeWhispererServiceTest {
     }
 
     @Test
-    fun `getRequestContext - cross file context should be null for non-cross-file user group`() {
+    fun `getRequestContext - cross file context should be empty for non-cross-file user group`() {
         whenever(userGroupSetting.getUserGroup()).thenReturn(CodeWhispererUserGroup.Control)
         val file = projectRule.fixture.addFileToProject("main.java", "public class Main {}")
 
@@ -102,6 +102,8 @@ class CodeWhispererServiceTest {
             LatencyContext()
         )
 
-        assertThat(actual.supplementalContext).isNull()
+        assertThat(actual.supplementalContext).isNotNull
+        assertThat(actual.supplementalContext?.contents).isEmpty()
+        assertThat(actual.supplementalContext?.contentLength).isEqualTo(0)
     }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

* Enable UTG (unit test generator) feature flag for CrossFile userGroup
* Make changes to ensure supplemental context telemetry being sent regardless the userGroup it belongs (we need `metadata.codewhispererSupplementalContextIsUtg` field to differentiate UTG feature acceptance rate vs. CrossFile feature)
## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
