### PR TITLE
Fix the issue when CodeWhisperer invocation is not set to complete when editor is disposed

### DIFF
--- a/.changes/next-release/bugfix-6bbbb228-bbb0-4707-8117-5171de1add3e.json
+++ b/.changes/next-release/bugfix-6bbbb228-bbb0-4707-8117-5171de1add3e.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "CodeWhisperer: Fix an issue where CodeWhisperer would stuck in the invocation state indefinitely"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererInvocationStatus.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererInvocationStatus.kt
@@ -40,6 +40,7 @@ class CodeWhispererInvocationStatus {
         if (isInvokingCodeWhisperer.compareAndSet(true, false)) {
             ApplicationManager.getApplication().messageBus.syncPublisher(CODEWHISPERER_INVOCATION_STATE_CHANGED).invocationStateChanged(false)
             LOG.debug { "Ending CodeWhisperer invocation" }
+            invokingSessionId = null
         }
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererInvocationStatus.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererInvocationStatus.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class CodeWhispererInvocationStatus {
     private val isInvokingCodeWhisperer: AtomicBoolean = AtomicBoolean(false)
+    private var invokingSessionId: String? = null
     private var timeAtLastInvocationComplete: Instant? = null
     var timeAtLastDocumentChanged: Instant = Instant.now()
         private set
@@ -25,7 +26,7 @@ class CodeWhispererInvocationStatus {
 
     fun checkExistingInvocationAndSet(): Boolean =
         if (isInvokingCodeWhisperer.getAndSet(true)) {
-            LOG.debug { "Have existing CodeWhisperer invocation" }
+            LOG.debug { "Have existing CodeWhisperer invocation, sessionId: $invokingSessionId" }
             true
         } else {
             ApplicationManager.getApplication().messageBus.syncPublisher(CODEWHISPERER_INVOCATION_STATE_CHANGED).invocationStateChanged(true)
@@ -73,6 +74,11 @@ class CodeWhispererInvocationStatus {
 
     fun setInvocationStart() {
         timeAtLastInvocationStart = Instant.now()
+    }
+
+    fun setInvocationSessionId(sessionId: String?) {
+        LOG.debug { "Set current CodeWhisperer invocation sessionId: $sessionId" }
+        invokingSessionId = sessionId
     }
 
     fun hasEnoughDelayToInvokeCodeWhisperer(): Boolean {


### PR DESCRIPTION
This will result in CodeWhisperer not able to set the invocation end boolean flag since the coroutine is still active. Will dispose the popup so it triggers the disposal chain to set the flag to false.

Before:

https://github.com/aws/aws-toolkit-jetbrains/assets/89420755/340c36e3-c8e2-4e22-bf18-eff810806d7b


After:


https://github.com/aws/aws-toolkit-jetbrains/assets/89420755/82f2987e-98f0-4015-9766-76a56fac6fc9


<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
