### PR TITLE
CodeWhisperer: fix read operation is not wrapped in readAction

### DIFF
--- a/.changes/next-release/bugfix-1dc5ae0c-1b75-4665-aaf4-ade0960cddcd.json
+++ b/.changes/next-release/bugfix-1dc5ae0c-1b75-4665-aaf4-ade0960cddcd.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "CodeWhisperer: FileCrawler try read access from non AWT thread"
+}

--- a/.changes/next-release/bugfix-1dc5ae0c-1b75-4665-aaf4-ade0960cddcd.json
+++ b/.changes/next-release/bugfix-1dc5ae0c-1b75-4665-aaf4-ade0960cddcd.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "CodeWhisperer: FileCrawler try read access from non AWT thread"
+  "description" : "CodeWhisperer: Run read operation in the background thread without runReadAction"
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererFileCrawler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererFileCrawler.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer.util
 
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
@@ -69,15 +70,17 @@ abstract class CodeWhispererFileCrawler : FileCrawler {
             val project = target.project
             val targetElements = keywordProducer(target)
 
-            return FileEditorManager.getInstance(project).openFiles
-                .filter { openedFile ->
-                    openedFile.name != target.virtualFile.name && openedFile.extension == target.virtualFile.extension
-                }
-                .mapNotNull { openedFile -> PsiManager.getInstance(project).findFile(openedFile) }
-                .maxByOrNull {
-                    val elementsToCheck = keywordProducer(it)
-                    countSubstringMatches(targetElements, elementsToCheck)
-                }?.virtualFile
+            return runReadAction {
+                FileEditorManager.getInstance(project).openFiles
+                    .filter { openedFile ->
+                        openedFile.name != target.virtualFile.name && openedFile.extension == target.virtualFile.extension
+                    }
+                    .mapNotNull { openedFile -> PsiManager.getInstance(project).findFile(openedFile) }
+                    .maxByOrNull {
+                        val elementsToCheck = keywordProducer(it)
+                        countSubstringMatches(targetElements, elementsToCheck)
+                    }?.virtualFile
+            }
         }
 
         /**

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/JavaCodeWhispererFileCrawler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/JavaCodeWhispererFileCrawler.kt
@@ -112,13 +112,15 @@ object JavaCodeWhispererFileCrawler : CodeWhispererFileCrawler() {
      * check files in editors and pick one which has most substring matches to the target
      */
     private fun findRelevantFileFromEditors(psiFile: PsiFile): VirtualFile? = searchRelevantFileInEditors(psiFile) { myPsiFile ->
-        myPsiFile as PsiClassOwner
-        // (1)
-        val classAndMethod = myPsiFile.classes.mapNotNull { clazz ->
-            // class name itself + its method names
-            listOfNotNull(clazz.name) +
-                clazz.methods.mapNotNull { method -> method.name }
-        }.flatten()
+        if (myPsiFile !is PsiClassOwner) {
+            return@searchRelevantFileInEditors emptyList()
+        }
+
+        val classAndMethod = runReadAction {
+            myPsiFile.classes.mapNotNull { clazz ->
+                listOfNotNull(clazz.name) + clazz.methods.mapNotNull { method -> method.name }
+            }.flatten()
+        }
 
         classAndMethod
     }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

```
java.lang.Throwable: Read access is allowed from inside read-action (or EDT) only (see com.intellij.openapi.application.Application.runReadAction())
Current thread: Thread[ApplicationImpl pooled thread 45,4,main] 2077869169 (EventQueue.isDispatchThread()=false)
SystemEventQueueThread: Thread[AWT-EventQueue-0,6,main] 1230366030
	at com.intellij.openapi.diagnostic.Logger.error([Logger.java:202](http://logger.java:202/))
	at com.intellij.openapi.application.impl.ApplicationImpl.assertReadAccessAllowed([ApplicationImpl.java:1004](http://applicationimpl.java:1004/))
	at com.intellij.psi.impl.source.PsiFileImpl.assertReadAccessAllowed([PsiFileImpl.java:184](http://psifileimpl.java:184/))
	at com.intellij.psi.impl.source.PsiFileImpl.getStubTree([PsiFileImpl.java:626](http://psifileimpl.java:626/))
	at com.intellij.psi.impl.source.PsiFileImpl.getGreenStubTree([PsiFileImpl.java:967](http://psifileimpl.java:967/))
	at com.intellij.psi.impl.source.PsiFileImpl.getGreenStub([PsiFileImpl.java:616](http://psifileimpl.java:616/))
	at com.jetbrains.python.psi.impl.PyFileImpl.getTopLevelClasses([PyFileImpl.java:352](http://pyfileimpl.java:352/))
	at software.aws.toolkits.jetbrains.services.codewhisperer.util.PythonCodeWhispererFileCrawler$findRelevantFileFromEditors$1.invoke(PythonCodeWhispererFileCrawler.kt:56)
	at software.aws.toolkits.jetbrains.services.codewhisperer.util.PythonCodeWhispererFileCrawler$findRelevantFileFromEditors$1.invoke(PythonCodeWhispererFileCrawler.kt:53)
```

## Cause
Coroutine will not gurantee which thread the underlying runnable will be executed, when it's executed in the background thread instead of AWT, the exception will be thrown









## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
