### PR TITLE
CodeWhisperer CodeScan - Handle file outside project

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
@@ -65,7 +65,7 @@ sealed class CodeScanSessionConfig(
 
         LOG.debug { "Creating payload. File selected as root for the context truncation: ${selectedFile.path}" }
 
-        val (includedSourceFiles, payloadSize, totalLines, _) = when(selectedFile.path.startsWith(projectRoot.path)) {
+        val (includedSourceFiles, payloadSize, totalLines, _) = when (selectedFile.path.startsWith(projectRoot.path)) {
             true -> includeDependencies()
             false -> {
                 // Set project root as the parent of the selected file.
@@ -89,14 +89,13 @@ sealed class CodeScanSessionConfig(
         return Payload(payloadContext, srcZip)
     }
 
-    open fun includeFileOutsideProjectRoot(): PayloadMetadata {
+    open fun includeFileOutsideProjectRoot(): PayloadMetadata =
         // Handle the case where the selected file is outside the project root.
-        return PayloadMetadata(
+        PayloadMetadata(
             setOf(selectedFile.path),
             selectedFile.length,
             Files.lines(selectedFile.toNioPath()).count().toLong()
         )
-    }
 
     open fun includeDependencies(): PayloadMetadata {
         val includedSourceFiles = mutableSetOf<String>()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
@@ -65,7 +65,7 @@ sealed class CodeScanSessionConfig(
 
         LOG.debug { "Creating payload. File selected as root for the context truncation: ${selectedFile.path}" }
 
-        val (includedSourceFiles, payloadSize, totalLines, _) = when (selectedFile.path.startsWith(projectRoot.path)) {
+        val payloadMetadata = when (selectedFile.path.startsWith(projectRoot.path)) {
             true -> includeDependencies()
             false -> {
                 // Set project root as the parent of the selected file.
@@ -75,14 +75,14 @@ sealed class CodeScanSessionConfig(
         }
 
         // Copy all the included source files to the source zip
-        val srcZip = zipFiles(includedSourceFiles.map { Path.of(it) })
+        val srcZip = zipFiles(payloadMetadata.sourceFiles.map { Path.of(it) })
         val payloadContext = PayloadContext(
             selectedFile.programmingLanguage().toTelemetryType(),
-            totalLines,
-            includedSourceFiles.size,
+            payloadMetadata.linesScanned,
+            payloadMetadata.sourceFiles.size,
             Instant.now().toEpochMilli() - start,
-            includedSourceFiles.mapNotNull { Path.of(it).toFile().toVirtualFile() },
-            payloadSize,
+            payloadMetadata.sourceFiles.mapNotNull { Path.of(it).toFile().toVirtualFile() },
+            payloadMetadata.payloadSize,
             srcZip.length()
         )
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
@@ -33,7 +33,8 @@ sealed class CodeScanSessionConfig(
     private val selectedFile: VirtualFile,
     private val project: Project
 ) {
-    val projectRoot = project.guessProjectDir() ?: error("Cannot guess base directory for project ${project.name}")
+    var projectRoot = project.guessProjectDir() ?: error("Cannot guess base directory for project ${project.name}")
+        private set
 
     abstract val sourceExt: String
 
@@ -64,7 +65,14 @@ sealed class CodeScanSessionConfig(
 
         LOG.debug { "Creating payload. File selected as root for the context truncation: ${selectedFile.path}" }
 
-        val (includedSourceFiles, payloadSize, totalLines, _) = includeDependencies()
+        val (includedSourceFiles, payloadSize, totalLines, _) = when(selectedFile.path.startsWith(projectRoot.path)) {
+            true -> includeDependencies()
+            false -> {
+                // Set project root as the parent of the selected file.
+                projectRoot = selectedFile.parent
+                includeFileOutsideProjectRoot()
+            }
+        }
 
         // Copy all the included source files to the source zip
         val srcZip = zipFiles(includedSourceFiles.map { Path.of(it) })
@@ -79,6 +87,15 @@ sealed class CodeScanSessionConfig(
         )
 
         return Payload(payloadContext, srcZip)
+    }
+
+    open fun includeFileOutsideProjectRoot(): PayloadMetadata {
+        // Handle the case where the selected file is outside the project root.
+        return PayloadMetadata(
+            setOf(selectedFile.path),
+            selectedFile.length,
+            Files.lines(selectedFile.toNioPath()).count().toLong()
+        )
     }
 
     open fun includeDependencies(): PayloadMetadata {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Handle case where the file a user wants to scan is outside the project root. Currently scanned file path relative to the project root is sent for code scan. When this file is outside the project root, relative path contains `..` which fails at CG processing. This is handled in this PR.    

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
* When the file is outside the project root, include just that file in the zip archive. 
* Change project root to the parent of this above file as the file path relative to the project root is included in the zip archive. 
   * This will make sure that the relative path is correct (does not include `..`)
   * The updated project root will be correctly used when displaying the results back in the panel.   

File outside project
https://github.com/aws/aws-toolkit-jetbrains/assets/16646509/54c2ddd7-25b0-42d6-a244-205eb917a129


## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
