### PR TITLE
fix(codewhisperer): revise condition for refresh token expiration in CW node

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
@@ -207,7 +207,7 @@ fun AwsBearerTokenConnection.lazyIsUnauthedBearerConnection(): Boolean {
         }
 
         // or state is not authorized
-        return provider.state() != BearerTokenAuthState.AUTHORIZED
+        return provider.state() == BearerTokenAuthState.NOT_AUTHENTICATED
     }
 
     // not a bearer token provider

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererExplorerActionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererExplorerActionManager.kt
@@ -120,7 +120,7 @@ class CodeWhispererExplorerActionManager : PersistentStateComponent<CodeWhispere
 
     fun checkActiveCodeWhispererConnectionType(project: Project) = when {
         actionState.token != null -> CodeWhispererLoginType.Accountless
-        isAccessTokenExpired(project) || isRefreshTokenExpired(project) -> CodeWhispererLoginType.Expired
+        isRefreshTokenExpired(project) -> CodeWhispererLoginType.Expired
         else -> {
             val conn = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeWhispererConnection.getInstance())
             if (conn != null) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererExplorerActionManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererExplorerActionManager.kt
@@ -20,7 +20,6 @@ import software.aws.toolkits.jetbrains.core.explorer.refreshDevToolTree
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererLoginType
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getConnectionStartUrl
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.isAccessTokenExpired
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.isRefreshTokenExpired
 import software.aws.toolkits.telemetry.AwsTelemetry
 import java.time.LocalDateTime


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

After 1 hour of AWS Builder ID login, if the IDE is not restarted, the AWS Toolkit will show a yellow warning icon, claiming the connection is invalid & expired. 

But the connection is actually in needs refresh state and it can be automatically refreshed. 


## Analysis 

In the AWS Toolkit node, the connection expiration icon is shown based on the return from`lazyIsUnauthedBearerConnection`, which ultimately converts to `provider.state() != BearerTokenAuthState.AUTHORIZED or provider.currentToken() == null`.


However, this is not aligned with the connection expiration state condition CodeWhisperer node. 
In CW node, `checkActiveCodeWhispererConnectionType` is the check for connection expiration. 

```
val connectionType = CodeWhispererExplorerActionManager.getInstance().checkActiveCodeWhispererConnectionType(project)
        when (connectionType) { CodeWhispererLoginType.Sono -> {
                presentation.addText(message("codewhisperer.explorer.root_node.login_type.aws_builder_id"), SimpleTextAttributes.GRAY_ATTRIBUTES)
            }
        }
```

It then depends on 

```
isAccessTokenExpired(project) || isRefreshTokenExpired(project) -> CodeWhispererLoginType.Expired
```

while 

```
fun isRefreshTokenExpired(project: Project): Boolean {
        val tokenProvider = tokenProvider(project) ?: return false
        val state = tokenProvider.state()
        return state == BearerTokenAuthState.NOT_AUTHENTICATED
    }
```

## The Fix 

The desired behavior is: When access token needs a refresh, it should refresh by itself. 

When the state becomes NEEDS_REFRESH, the AWS Toolkit node should still show valid connection. 

In the latest commit, before the toolkit node is about to show connection expired, we ran a refresh in the background thread, if the state is still not authorized after the refresh, then the warning icon is showed.




## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
