### PR TITLE
Wildcard .NET Framework assembly references to allow plugin to be built with .NET 8

### DIFF
--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Daemon/AWS.Daemon.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Daemon/AWS.Daemon.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.2" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Localization/AWS.Localization.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Localization/AWS.Localization.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.2" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Project/AWS.Project.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Project/AWS.Project.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.2" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.*" />
     </ItemGroup>
 
 </Project>

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Psi/AWS.Psi.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Psi/AWS.Psi.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.2" />
+      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.*" />
     </ItemGroup>
 
 </Project>

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Settings/AWS.Settings.csproj
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Settings/AWS.Settings.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Rider.SDK" Version="$(RiderSDKVersion)" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.2" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.$(NetFrameworkTarget)" Version="1.0.*" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
```
         /app/aws-toolkit-jetbrains/jetbrains-rider/ReSharper.AWS/src/AWS.Daemon/AWS.Daemon.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.NETFramework.ReferenceAssemblies.net472 from 1.0.3 to 1.0.2. Reference the package directly from the project to select a different version.  [/app/aws-toolkit-jetbrains/jetbrains-rider/ReSharper.AWS/ReSharper.AWS.sln]
       /app/aws-toolkit-jetbrains/jetbrains-rider/ReSharper.AWS/src/AWS.Daemon/AWS.Daemon.csproj : error NU1605:  AWS.Daemon -> Microsoft.NETFramework.ReferenceAssemblies 1.0.3 -> Microsoft.NETFramework.ReferenceAssemblies.net472 (>= 1.0.3)  [/app/aws-toolkit-jetbrains/jetbrains-rider/ReSharper.AWS/ReSharper.AWS.sln]
       /app/aws-toolkit-jetbrains/jetbrains-rider/ReSharper.AWS/src/AWS.Daemon/AWS.Daemon.csproj : error NU1605:  AWS.Daemon -> Microsoft.NETFramework.ReferenceAssemblies.net472 (>= 1.0.2) [/app/aws-toolkit-jetbrains/jetbrains-rider/ReSharper.AWS/ReSharper.AWS.sln]
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
