### PR TITLE
CodeWhisperer: Correct completion type for every completion in user decision events

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorManager.kt
@@ -59,7 +59,8 @@ class CodeWhispererEditorManager {
                     PsiDocumentManager.getInstance(project).getPsiFile(document)?.virtualFile,
                     rangeMarker,
                     remainingRecommendation,
-                    selectedIndex
+                    selectedIndex,
+                    detail.completionType
                 )
 
                 ApplicationManager.getApplication().messageBus.syncPublisher(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/model/CodeWhispererModel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/model/CodeWhispererModel.kt
@@ -16,6 +16,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispe
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.RequestContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.ResponseContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
+import software.aws.toolkits.telemetry.CodewhispererCompletionType
 import software.aws.toolkits.telemetry.CodewhispererTriggerType
 import software.aws.toolkits.telemetry.Result
 import java.util.concurrent.TimeUnit
@@ -63,7 +64,8 @@ data class DetailContext(
     val reformatted: Completion,
     val isDiscarded: Boolean,
     val isTruncatedOnRight: Boolean,
-    val rightOverlap: String = ""
+    val rightOverlap: String = "",
+    val completionType: CodewhispererCompletionType,
 )
 
 data class SessionContext(

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.codewhispererruntime.model.Reference
 import software.amazon.awssdk.services.codewhispererruntime.model.Span
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.DetailContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.RecommendationChunk
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getCompletionType
 import kotlin.math.max
 
 class CodeWhispererRecommendationManager {
@@ -121,7 +122,15 @@ class CodeWhispererRecommendationManager {
         return recommendations.map {
             val isDiscardedByUserInput = !it.content().startsWith(userInput) || it.content() == userInput
             if (isDiscardedByUserInput) {
-                return@map DetailContext(requestId, it, it, isDiscarded = true, isTruncatedOnRight = false, rightOverlap = "")
+                return@map DetailContext(
+                    requestId,
+                    it,
+                    it,
+                    isDiscarded = true,
+                    isTruncatedOnRight = false,
+                    rightOverlap = "",
+                    getCompletionType(it)
+                )
             }
 
             val overlap = findRightContextOverlap(requestContext, it)
@@ -137,7 +146,15 @@ class CodeWhispererRecommendationManager {
                 .build()
             val isDiscardedByUserInputForTruncated = !truncated.content().startsWith(userInput) || truncated.content() == userInput
             if (isDiscardedByUserInputForTruncated) {
-                return@map DetailContext(requestId, it, truncated, isDiscarded = true, isTruncatedOnRight = true, rightOverlap = overlap)
+                return@map DetailContext(
+                    requestId,
+                    it,
+                    truncated,
+                    isDiscarded = true,
+                    isTruncatedOnRight = true,
+                    rightOverlap = overlap,
+                    getCompletionType(it)
+                )
             }
 
             val reformatted = reformat(requestContext, truncated)
@@ -148,7 +165,8 @@ class CodeWhispererRecommendationManager {
                 reformatted,
                 isDiscardedByRightContextTruncationDedupe,
                 truncated.content().length != it.content().length,
-                overlap
+                overlap,
+                getCompletionType(it)
             )
         }
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -109,23 +109,16 @@ fun VirtualFile.toCodeChunk(path: String): Sequence<Chunk> = sequence {
 }
 
 object CodeWhispererUtil {
-    fun checkCompletionType(
-        results: List<Completion>,
-        noRecommendation: Boolean
-    ): CodewhispererCompletionType {
-        if (noRecommendation) {
-            return CodewhispererCompletionType.Unknown
-        }
-        return if (results[0].content().contains("\n")) {
-            CodewhispererCompletionType.Block
-        } else {
-            CodewhispererCompletionType.Line
+    fun getCompletionType(completion: Completion): CodewhispererCompletionType {
+        val content = completion.content()
+        val nonBlankLines = content.split("\n").count { it.isNotBlank() }
+
+        return when {
+            content.isEmpty() -> CodewhispererCompletionType.Unknown
+            nonBlankLines > 1 -> CodewhispererCompletionType.Block
+            else -> CodewhispererCompletionType.Line
         }
     }
-
-    // return true if every recommendation is empty
-    fun checkEmptyRecommendations(recommendations: List<Completion>): Boolean =
-        recommendations.all { it.content().isEmpty() }
 
     fun notifyWarnCodeWhispererUsageLimit(project: Project? = null) {
         notifyWarn(

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererCodeCoverageTrackerTest.kt
@@ -156,9 +156,19 @@ internal class CodeWhispererCodeCoverageTrackerTestPython : CodeWhispererCodeCov
             null,
             mock()
         )
-        val responseContext = ResponseContext("sessionId", CodewhispererCompletionType.Block)
+        val responseContext = ResponseContext("sessionId")
         val recommendationContext = RecommendationContext(
-            listOf(DetailContext("requestId", pythonResponse.completions()[0], pythonResponse.completions()[0], false, false)),
+            listOf(
+                DetailContext(
+                    "requestId",
+                    pythonResponse.completions()[0],
+                    pythonResponse.completions()[0],
+                    false,
+                    false,
+                    "",
+                    CodewhispererCompletionType.Block
+                )
+            ),
             "x, y",
             "x, y",
             mock()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererStateTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererStateTest.kt
@@ -10,7 +10,6 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestU
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonResponse
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutomatedTriggerType
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService
-import software.aws.toolkits.telemetry.CodewhispererCompletionType
 import software.aws.toolkits.telemetry.CodewhispererLanguage
 import software.aws.toolkits.telemetry.CodewhispererTriggerType
 
@@ -52,7 +51,6 @@ class CodeWhispererStateTest : CodeWhispererTestBase() {
             assertThat(listOf(actualResponseContext.sessionId)).isEqualTo(
                 pythonResponse.sdkHttpResponse().headers()[CodeWhispererService.KET_SESSION_ID]
             )
-            assertThat(actualResponseContext.completionType).isEqualTo(CodewhispererCompletionType.Block)
         }
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryServiceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryServiceTest.kt
@@ -252,7 +252,7 @@ class CodeWhispererTelemetryServiceTest {
                 1,
                 "codewhispererSessionId" to responseContext.sessionId,
                 "codewhispererFirstRequestId" to requestContext.latencyContext.firstRequestId,
-                "codewhispererCompletionType" to responseContext.completionType,
+                "codewhispererCompletionType" to CodewhispererCompletionType.Line,
                 "codewhispererLanguage" to requestContext.fileContextInfo.programmingLanguage.toTelemetryType(),
                 "codewhispererTriggerType" to requestContext.triggerTypeInfo.triggerType,
                 "codewhispererAutomatedTriggerType" to requestContext.triggerTypeInfo.automatedTriggerType.telemetryType,
@@ -493,7 +493,17 @@ fun aRecommendationContext(): RecommendationContext {
     val details = mutableListOf<DetailContext>()
     val size = Random.nextInt(1, 5)
     for (i in 1..size) {
-        details.add(DetailContext(aString(), aCompletion(), aCompletion(), listOf(true, false).random(), listOf(true, false).random()))
+        details.add(
+            DetailContext(
+                aString(),
+                aCompletion(),
+                aCompletion(),
+                listOf(true, false).random(),
+                listOf(true, false).random(),
+                aString(),
+                CodewhispererCompletionType.Line
+            )
+        )
     }
 
     return RecommendationContext(
@@ -516,14 +526,14 @@ fun aRecommendationContextAndSessionContext(decisions: List<CodewhispererSuggest
     val details = mutableListOf<DetailContext>()
     decisions.forEach { decision ->
         val toAdd = if (decision == CodewhispererSuggestionState.Empty) {
-            val completion = aCompletion(true, 0, 0)
-            DetailContext(aString(), completion, completion, Random.nextBoolean(), Random.nextBoolean())
+            val completion = aCompletion("", true, 0, 0)
+            DetailContext(aString(), completion, completion, Random.nextBoolean(), Random.nextBoolean(), aString(), CodewhispererCompletionType.Unknown)
         } else if (decision == CodewhispererSuggestionState.Discard) {
             val completion = aCompletion()
-            DetailContext(aString(), completion, completion, true, Random.nextBoolean())
+            DetailContext(aString(), completion, completion, true, Random.nextBoolean(), aString(), CodewhispererCompletionType.Unknown)
         } else {
             val completion = aCompletion()
-            DetailContext(aString(), completion, completion, false, Random.nextBoolean())
+            DetailContext(aString(), completion, completion, false, Random.nextBoolean(), aString(), CodewhispererCompletionType.Unknown)
         }
 
         details.add(toAdd)
@@ -558,7 +568,7 @@ fun aRecommendationContextAndSessionContext(decisions: List<CodewhispererSuggest
     return recommendationContext to sessionContext
 }
 
-fun aCompletion(isEmpty: Boolean = false, referenceCount: Int? = null, importCount: Int? = null): Completion {
+fun aCompletion(content: String? = null, isEmpty: Boolean = false, referenceCount: Int? = null, importCount: Int? = null): Completion {
     val myReferenceCount = referenceCount ?: Random.nextInt(0, 4)
     val myImportCount = importCount ?: Random.nextInt(0, 4)
 
@@ -575,13 +585,13 @@ fun aCompletion(isEmpty: Boolean = false, referenceCount: Int? = null, importCou
     }
 
     return Completion.builder()
-        .content(if (!isEmpty) aString() else "")
+        .content(content ?: if (!isEmpty) aString() else "")
         .references(references)
         .mostRelevantMissingImports(imports)
         .build()
 }
 
-fun aResponseContext(): ResponseContext = ResponseContext(aString(), listOf(CodewhispererCompletionType.Block, CodewhispererCompletionType.Line).random())
+fun aResponseContext(): ResponseContext = ResponseContext(aString())
 
 fun aFileContextInfo(language: CodeWhispererProgrammingLanguage? = null): FileContextInfo {
     val caretContextInfo = CaretContext(aString(), aString(), aString())

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererUtilTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererUtilTest.kt
@@ -9,8 +9,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getCompletionType
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.toCodeChunk
 import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
+import software.aws.toolkits.telemetry.CodewhispererCompletionType
 
 class CodeWhispererUtilTest {
     @JvmField
@@ -135,6 +137,27 @@ class CodeWhispererUtilTest {
         )
         assertThat(result[4].path).isEqualTo("fake/path")
         assertThat(result[4].nextChunk).isEqualTo(result[4].content)
+    }
+
+    @Test
+    fun `test getCompletionType() should give Block completion type to multi-line completions that has at least two non-blank lines`() {
+        assertThat(getCompletionType(aCompletion("test\n\n\t\nanother test"))).isEqualTo(CodewhispererCompletionType.Block)
+        assertThat(getCompletionType(aCompletion("test\ntest\n"))).isEqualTo(CodewhispererCompletionType.Block)
+        assertThat(getCompletionType(aCompletion("\n   \t\r\ntest\ntest"))).isEqualTo(CodewhispererCompletionType.Block)
+    }
+
+    @Test
+    fun `test getCompletionType() should give Line completion type to line completions`() {
+        assertThat(getCompletionType(aCompletion("test"))).isEqualTo(CodewhispererCompletionType.Line)
+        assertThat(getCompletionType(aCompletion("test\n\t   "))).isEqualTo(CodewhispererCompletionType.Line)
+    }
+
+    @Test
+    fun `test getCompletionType() should give Line completion type to multi-line completions that has at most 1 non-blank line`() {
+        assertThat(getCompletionType(aCompletion("test\n\t"))).isEqualTo(CodewhispererCompletionType.Line)
+        assertThat(getCompletionType(aCompletion("test\n    "))).isEqualTo(CodewhispererCompletionType.Line)
+        assertThat(getCompletionType(aCompletion("test\n\r"))).isEqualTo(CodewhispererCompletionType.Line)
+        assertThat(getCompletionType(aCompletion("\n\n\n\ntest"))).isEqualTo(CodewhispererCompletionType.Line)
     }
 }
 


### PR DESCRIPTION
 1. Previously we just use the completion type of the first suggestion,
    as the completion type for all suggestions. Now since this is no longer true,
    plugin side also needs to make the change to compute the completion type
    for every suggestion. Since this is per-suggestion level this will
    be recorded in the userDecision event.

    2. Note that we still have 'completionType' field in other events(
    serviceInvocation, clientComponentLatency, etc) these values no longer
    make sense for analysis.

    3. For actually computing the completionType for each suggestion, the rule
    is:
    If a suggestion has multi-lines and they are non-blank lines, it's a
    block suggestion, otherwise it's a line suggestion.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
