### PR TITLE
Move to new 'Confirm' device code flow

### DIFF
--- a/.changes/next-release/bugfix-1fa27aca-6711-45ac-ac1d-d5edd392ce7f.json
+++ b/.changes/next-release/bugfix-1fa27aca-6711-45ac-ac1d-d5edd392ce7f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue displaying SSO code on new UI in Windows"
+}

--- a/.changes/next-release/feature-b4e483d4-59cb-47f4-9a5c-0bb446fce83a.json
+++ b/.changes/next-release/feature-b4e483d4-59cb-47f4-9a5c-0bb446fce83a.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Authentication: When signing in to AWS Builder Id or IAM Identity Center (SSO), verify the device code matches instead of copy-pasting it"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
@@ -36,7 +36,7 @@ object SsoPrompt : SsoLoginCallback {
 
             if (result) {
                 AwsTelemetry.loginWithBrowser(project = null, Result.Succeeded, CredentialType.SsoProfile)
-                BrowserUtil.browse(authorization.verificationUri)
+                BrowserUtil.browse(authorization.verificationUriComplete)
             } else {
                 AwsTelemetry.loginWithBrowser(project = null, Result.Cancelled, CredentialType.SsoProfile)
                 throw ProcessCanceledException(IllegalStateException(message("credentials.sso.login.cancelled")))
@@ -62,7 +62,7 @@ object BearerTokenPrompt : SsoLoginCallback {
 
             if (codeCopied) {
                 AwsTelemetry.loginWithBrowser(project = null, Result.Succeeded, CredentialType.BearerToken)
-                BrowserUtil.browse(authorization.verificationUri)
+                BrowserUtil.browse(authorization.verificationUriComplete)
             } else {
                 AwsTelemetry.loginWithBrowser(project = null, Result.Cancelled, CredentialType.BearerToken)
             }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
@@ -6,7 +6,7 @@ package software.aws.toolkits.jetbrains.core.credentials.sso
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.progress.ProcessCanceledException
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
-import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.CopyUserCodeForLoginDialog
+import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.ConfirmUserCodeLoginDialog
 import software.aws.toolkits.jetbrains.utils.computeOnEdt
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
@@ -28,7 +28,7 @@ class DefaultSsoLoginCallbackProvider : SsoLoginCallbackProvider {
 object SsoPrompt : SsoLoginCallback {
     override fun tokenPending(authorization: Authorization) {
         computeOnEdt {
-            val result = CopyUserCodeForLoginDialog(
+            val result = ConfirmUserCodeLoginDialog(
                 authorization.userCode,
                 message("credentials.sso.login.title"),
                 CredentialType.SsoProfile
@@ -54,7 +54,7 @@ object SsoPrompt : SsoLoginCallback {
 object BearerTokenPrompt : SsoLoginCallback {
     override fun tokenPending(authorization: Authorization) {
         computeOnEdt {
-            val codeCopied = CopyUserCodeForLoginDialog(
+            val codeCopied = ConfirmUserCodeLoginDialog(
                 authorization.userCode,
                 message("credentials.sono.login"),
                 CredentialType.BearerToken

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/ConfirmUserCodeLoginDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/ConfirmUserCodeLoginDialog.kt
@@ -25,7 +25,7 @@ import software.aws.toolkits.telemetry.Result
 import java.awt.datatransfer.StringSelection
 import javax.swing.JComponent
 
-class CopyUserCodeForLoginDialog(
+class ConfirmUserCodeLoginDialog(
     private val authCode: String,
     private val dialogTitle: String,
     private val credentialType: CredentialType
@@ -62,11 +62,6 @@ class CopyUserCodeForLoginDialog(
         title = dialogTitle
         setOKButtonText(message("aws.sso.signing.device.code"))
         super.init()
-    }
-
-    override fun doOKAction() {
-        CopyPasteManager.getInstance().setContents(StringSelection(authCode))
-        super.doOKAction()
     }
 
     override fun doCancelAction() {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/CopyUserCodeForLoginDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/CopyUserCodeForLoginDialog.kt
@@ -9,12 +9,15 @@ import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.impl.ActionButton
+import com.intellij.openapi.editor.colors.EditorColorsUtil
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
+import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.components.BorderLayoutPanel
+import software.aws.toolkits.core.utils.tryOrNull
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
 import software.aws.toolkits.telemetry.CredentialType
@@ -30,19 +33,29 @@ class CopyUserCodeForLoginDialog(
 
     private val pane = panel {
         row {
-            text(message("aws.sso.signing.device.code.copy.dialog.text"), maxLineLength = -1)
+            label(message("aws.sso.signing.device.code.copy.dialog.text"))
         }
 
         row {
             cell(
                 BorderLayoutPanel(5, 0).apply {
                     val action = CopyUserCodeForLogin(authCode)
-                    addToCenter(JBLabel(authCode).setCopyable(true))
+                    addToCenter(
+                        JBLabel(authCode).apply {
+                            tryOrNull {
+                                JBFont.create(JBFont.decode(EditorColorsUtil.getGlobalOrDefaultColorScheme().consoleFontName)).biggerOn(9f).asBold()
+                            }?.let {
+                                font = it
+                            }
+                            setCopyable(true)
+                        }
+                    )
                     addToRight(ActionButton(action, action.templatePresentation.clone(), ActionPlaces.UNKNOWN, ActionToolbar.NAVBAR_MINIMUM_BUTTON_SIZE))
                 }
             ).horizontalAlign(HorizontalAlign.CENTER)
         }
     }
+
     override fun createCenterPanel(): JComponent? = pane
 
     init {

--- a/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -136,9 +136,9 @@ aws.settings.telemetry.option=Send usage metrics to AWS
 aws.settings.telemetry.prompt.message=Usage metrics are collected by default. Click <a href="">here</a> to adjust this behavior.
 aws.settings.telemetry.prompt.title=AWS Toolkit telemetry
 aws.settings.title=AWS
-aws.sso.signing.device.code=Open and Copy Code
+aws.sso.signing.device.code=Proceed To Browser
 aws.sso.signing.device.code.copy=Copy Code
-aws.sso.signing.device.code.copy.dialog.text=To proceed, open the login page and provide this code to confirm the access request from AWS Toolkit:
+aws.sso.signing.device.code.copy.dialog.text=To proceed, open the login page and confirm that the code matches:
 aws.sso.signing.device.waiting=Waiting for browser authorization for code: {0}
 aws.terminal.action=Open AWS local terminal
 aws.terminal.action.tooltip=Start a local terminal with the current AWS connection settings injected as environment variables


### PR DESCRIPTION
Now that Identity has rolled out the relevant browser changes, we have internal approval to return to the "confirm"-based SSO login workflow. This PR also fixes the rendering issue for the device code on Windows when the experimental UI is enabled. 

<img width="437" alt="image" src="https://github.com/aws/aws-toolkit-jetbrains/assets/742829/d0dc65e7-de4c-4d42-8657-1e36ee888812">

<img width="603" alt="image" src="https://github.com/aws/aws-toolkit-jetbrains/assets/742829/4d3356aa-3caa-4fbb-beae-6cf2a16d7580">

![image](https://github.com/aws/aws-toolkit-jetbrains/assets/742829/b087c632-8d5c-4547-94c7-d750b878b4d8)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
