### PR TITLE
Remove unnecessary state management on RoleInfo ComboBoxRenderer

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialog.kt
@@ -374,10 +374,6 @@ class IdcRolePopup(
             val combo = AsyncComboBox<RoleInfo> { label, value, _ ->
                 value ?: return@AsyncComboBox
                 label.text = "${value.roleName()} (${value.accountId()})"
-                state.roleInfo = RoleInfo.builder()
-                    .roleName(value.roleName())
-                    .accountId(value.accountId())
-                    .build()
             }
 
             Disposer.register(myDisposable, combo)


### PR DESCRIPTION
The value is already bound to the same variable through the UI DSL
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
