### PR TITLE
Fix list of sso scopes used by ProfileSsoSessionProvider

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileCredentialProviderFactory.kt
@@ -220,7 +220,7 @@ class ProfileCredentialProviderFactory(private val ssoCache: SsoCache = diskCach
 
     private fun createAwsCredentialProvider(profile: Profile, region: AwsRegion) = when {
         profile.propertyExists(PROFILE_SSO_SESSION_PROPERTY) -> createSsoSessionProfileProvider(profile)
-        profile.propertyExists(ProfileProperty.SSO_START_URL) -> createSsoProvider(profile)
+        profile.propertyExists(ProfileProperty.SSO_START_URL) -> createLegacySsoProvider(profile)
         profile.propertyExists(ProfileProperty.ROLE_ARN) -> createAssumeRoleProvider(profile, region)
         profile.propertyExists(ProfileProperty.AWS_SESSION_TOKEN) -> createStaticSessionProvider(profile)
         profile.propertyExists(ProfileProperty.AWS_ACCESS_KEY_ID) -> createBasicProvider(profile)
@@ -230,9 +230,9 @@ class ProfileCredentialProviderFactory(private val ssoCache: SsoCache = diskCach
         }
     }
 
-    private fun createSsoProvider(profile: Profile): AwsCredentialsProvider = ProfileSsoProvider(profile)
+    private fun createLegacySsoProvider(profile: Profile): AwsCredentialsProvider = ProfileLegacySsoProvider(ssoCache, profile)
 
-    private fun createSsoSessionProfileProvider(profile: Profile): AwsCredentialsProvider = ProfileSsoSessionProvider(profile)
+    private fun createSsoSessionProfileProvider(profile: Profile): AwsCredentialsProvider = ProfileSsoSessionProvider(ssoCache, profile)
 
     private fun createAssumeRoleProvider(profile: Profile, region: AwsRegion): AwsCredentialsProvider {
         val sourceProfileName = profile.property(ProfileProperty.SOURCE_PROFILE)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileLegacySsoProvider.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileLegacySsoProvider.kt
@@ -13,11 +13,11 @@ import software.amazon.awssdk.services.sso.SsoClient
 import software.amazon.awssdk.services.ssooidc.SsoOidcClient
 import software.amazon.awssdk.utils.SdkAutoCloseable
 import software.aws.toolkits.jetbrains.core.AwsClientManager
-import software.aws.toolkits.jetbrains.core.credentials.diskCache
 import software.aws.toolkits.jetbrains.core.credentials.sso.SsoAccessTokenProvider
+import software.aws.toolkits.jetbrains.core.credentials.sso.SsoCache
 import software.aws.toolkits.jetbrains.core.credentials.sso.SsoCredentialProvider
 
-class ProfileSsoProvider(profile: Profile) : AwsCredentialsProvider, SdkAutoCloseable {
+class ProfileLegacySsoProvider(ssoCache: SsoCache, profile: Profile) : AwsCredentialsProvider, SdkAutoCloseable {
     private val ssoClient: SsoClient
     private val ssoOidcClient: SsoOidcClient
     private val credentialsProvider: SsoCredentialProvider
@@ -32,7 +32,7 @@ class ProfileSsoProvider(profile: Profile) : AwsCredentialsProvider, SdkAutoClos
         val ssoAccessTokenProvider = SsoAccessTokenProvider(
             profile.requiredProperty(ProfileProperty.SSO_START_URL),
             ssoRegion,
-            diskCache,
+            ssoCache,
             ssoOidcClient
         )
 


### PR DESCRIPTION
Scopes were being passed as `"Optional[[scope1,scope2,scope3]]"` instead of `listOf("scope1", "scope2", "scope3")`.
The relevant test was also adjusted to observe that the expected side effects in ProfileSsoSessionProvider were happening rather than the contents of the profile file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
