### PR TITLE
Fix multiple 'Getting Started' panels open at once

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedVirtualFile.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedVirtualFile.kt
@@ -12,8 +12,6 @@ class GettingStartedVirtualFile : LightVirtualFile(message("gettingstarted.edito
     override fun isWritable() = false
     override fun isDirectory() = false
 
-    override fun hashCode(): Int = toString().hashCode()
-    override fun equals(other: Any?): Boolean {
-        return other is GettingStartedVirtualFile && name == other.name
-    }
+    override fun hashCode() = toString().hashCode()
+    override fun equals(other: Any?) = other is GettingStartedVirtualFile && name == other.name
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedVirtualFile.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedVirtualFile.kt
@@ -7,8 +7,13 @@ import com.intellij.testFramework.LightVirtualFile
 import software.aws.toolkits.resources.message
 
 class GettingStartedVirtualFile : LightVirtualFile(message("gettingstarted.editor.title")) {
-    override fun toString() = getName()
+    override fun toString() = "GettingStartedVirtualFile[${getName()}]"
     override fun getPath() = getName()
     override fun isWritable() = false
     override fun isDirectory() = false
+
+    override fun hashCode(): Int = toString().hashCode()
+    override fun equals(other: Any?): Boolean {
+        return other is GettingStartedVirtualFile && name == other.name
+    }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedVirtualFileTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedVirtualFileTest.kt
@@ -1,3 +1,6 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package software.aws.toolkits.jetbrains.core.gettingstarted.editor
 
 import org.assertj.core.api.Assertions.assertThat

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedVirtualFileTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedVirtualFileTest.kt
@@ -1,0 +1,21 @@
+package software.aws.toolkits.jetbrains.core.gettingstarted.editor
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GettingStartedVirtualFileTest {
+    @Test
+    fun `different GettingStartedVirtualFile instances have the same hashCode`() {
+        assertThat(GettingStartedVirtualFile().hashCode()).isEqualTo(GettingStartedVirtualFile().hashCode())
+    }
+
+    @Test
+    fun `different GettingStartedVirtualFile instances are equal`() {
+        assertThat(GettingStartedVirtualFile()).isEqualTo(GettingStartedVirtualFile())
+    }
+
+    @Test
+    fun `null is not equal to GettingStartedVirtualFile instance`() {
+        assertThat(GettingStartedVirtualFile()).isNotEqualTo(null)
+    }
+}


### PR DESCRIPTION
Invoking the 'Setup' action results in a new editor pane each time. The JetBrains editor dedupes tabs based on the identity (equals/hashCode) of the underyling VirtualFile object, so we can fix this by overriding equals/hashCode appropriately.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
