### PR TITLE
CodeWhisperer: fix learn more click telemetry issue

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/learn/LearnCodeWhispererUIComponents.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/learn/LearnCodeWhispererUIComponents.kt
@@ -319,7 +319,9 @@ object LearnCodeWhispererUIComponents {
                 message("codewhisperer.learn_page.examples.description.part_2"),
                 CODEWHISPERER_SUPPORTED_LANG_URI
             ).apply {
-                UiTelemetry.click(null as Project?, "codewhisperer_GenerateSuggestions_LearnMore")
+                addActionListener {
+                    UiTelemetry.click(null as Project?, "codewhisperer_GenerateSuggestions_LearnMore")
+                }
             },
             inlineLabelConstraints
         )


### PR DESCRIPTION
1. it was wrongly sent for every BrowserLink creation, it should only be sent when there's actually a click.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
