### PR TITLE
Enable SendTelemetryEvent to Builder ID users

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
@@ -71,7 +71,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.ISSUE_HIGHLIGHT_TEXT_ATTRIBUTES
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.promptReAuth
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIamIdentityCenterConnection
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIdcConnectionOrTelemetryEnabled
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.Result
 import java.time.Duration
@@ -404,7 +404,7 @@ class CodeWhispererCodeScanManager(val project: Project) {
         programmingLanguage: CodeWhispererProgrammingLanguage,
         codeScanJobId: String?
     ) {
-        runIfIamIdentityCenterConnection(project) {
+        runIfIdcConnectionOrTelemetryEnabled(project) {
             try {
                 val response = CodeWhispererClientAdaptor.getInstance(project)
                     .sendCodeScanTelemetry(programmingLanguage, codeScanJobId)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/credentials/CodeWhispererClientAdaptor.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/credentials/CodeWhispererClientAdaptor.kt
@@ -38,6 +38,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhisp
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhispererProgrammingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.RequestContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.ResponseContext
+import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.isTelemetryEnabled
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.transform
 import software.aws.toolkits.jetbrains.settings.AwsSettings
@@ -76,7 +77,7 @@ interface CodeWhispererClientAdaptor : Disposable {
         isSigv4: Boolean = shouldUseSigv4Client(project)
     ): ListCodeScanFindingsResponse
 
-    fun putUserTriggerDecisionTelemetry(
+    fun sendUserTriggerDecisionTelemetry(
         requestContext: RequestContext,
         responseContext: ResponseContext,
         completionType: CodewhispererCompletionType,
@@ -85,7 +86,7 @@ interface CodeWhispererClientAdaptor : Disposable {
         lineCount: Int
     ): SendTelemetryEventResponse
 
-    fun putCodePercentageTelemetry(
+    fun sendCodePercentageTelemetry(
         language: CodeWhispererProgrammingLanguage,
         acceptedTokenCount: Int,
         totalTokenCount: Int
@@ -180,7 +181,7 @@ open class CodeWhispererClientAdaptorImpl(override val project: Project) : CodeW
             bearerClient().listCodeAnalysisFindings(request.transform()).transform()
         }
 
-    override fun putUserTriggerDecisionTelemetry(
+    override fun sendUserTriggerDecisionTelemetry(
         requestContext: RequestContext,
         responseContext: ResponseContext,
         completionType: CodewhispererCompletionType,
@@ -217,7 +218,7 @@ open class CodeWhispererClientAdaptorImpl(override val project: Project) : CodeW
         }
     }
 
-    override fun putCodePercentageTelemetry(
+    override fun sendCodePercentageTelemetry(
         language: CodeWhispererProgrammingLanguage,
         acceptedTokenCount: Int,
         totalTokenCount: Int

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
@@ -30,7 +30,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispe
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererUserGroupSettings
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.TOTAL_SECONDS_IN_MINUTE
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIamIdentityCenterConnection
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIdcConnectionOrTelemetryEnabled
 import software.aws.toolkits.telemetry.CodewhispererTelemetry
 import java.time.Duration
 import java.time.Instant
@@ -203,9 +203,9 @@ abstract class CodeWhispererCodeCoverageTracker(
             }
         }
 
-        runIfIamIdentityCenterConnection(project) {
+        runIfIdcConnectionOrTelemetryEnabled(project) {
             try {
-                val response = CodeWhispererClientAdaptor.getInstance(project).putCodePercentageTelemetry(
+                val response = CodeWhispererClientAdaptor.getInstance(project).sendCodePercentageTelemetry(
                     language,
                     acceptedTokensSize,
                     totalTokensSize

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
@@ -33,7 +33,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.service.ResponseCo
 import software.aws.toolkits.jetbrains.services.codewhisperer.settings.CodeWhispererSettings
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getConnectionStartUrl
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getGettingStartedTaskType
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIamIdentityCenterConnection
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIdcConnectionOrTelemetryEnabled
 import software.aws.toolkits.jetbrains.settings.AwsSettings
 import software.aws.toolkits.telemetry.CodewhispererCompletionType
 import software.aws.toolkits.telemetry.CodewhispererGettingStartedTask
@@ -188,6 +188,7 @@ class CodeWhispererTelemetryService {
         suggestionReferenceCount: Int,
         generatedLineCount: Int
     ) {
+        val project = requestContext.project
         val totalImportCount = recommendationContext.details.fold(0) { grandTotal, detail ->
             grandTotal + detail.recommendation.mostRelevantMissingImports().size
         }
@@ -225,11 +226,11 @@ class CodeWhispererTelemetryService {
         } else CodewhispererCompletionType.Line
 
         // only send if it's a pro tier user
-        projectCoroutineScope(requestContext.project).launch {
-            runIfIamIdentityCenterConnection(requestContext.project) {
+        projectCoroutineScope(project).launch {
+            runIfIdcConnectionOrTelemetryEnabled(project) {
                 try {
-                    val response = CodeWhispererClientAdaptor.getInstance(requestContext.project)
-                        .putUserTriggerDecisionTelemetry(
+                    val response = CodeWhispererClientAdaptor.getInstance(project)
+                        .sendUserTriggerDecisionTelemetry(
                             requestContext,
                             responseContext,
                             completionType,
@@ -250,7 +251,7 @@ class CodeWhispererTelemetryService {
         }
 
         CodewhispererTelemetry.userTriggerDecision(
-            project = requestContext.project,
+            project = project,
             codewhispererSessionId = responseContext.sessionId,
             codewhispererFirstRequestId = requestContext.latencyContext.firstRequestId,
             credentialStartUrl = getConnectionStartUrl(requestContext.connection),

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererClientAdaptorTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererClientAdaptorTest.kt
@@ -255,9 +255,9 @@ class CodeWhispererClientAdaptorTest {
     }
 
     @Test
-    fun `sendTelemetryEvent for userTriggerDecision respects telemetry optin status`() {
+    fun `sendTelemetryEvent for userTriggerDecision respects telemetry optin status, for SSO users`() {
         sendTelemetryEventOptOutCheckHelper {
-            sut.putUserTriggerDecisionTelemetry(
+            sut.sendUserTriggerDecisionTelemetry(
                 aRequestContext(projectRule.project),
                 aResponseContext(),
                 aCompletionType(),
@@ -271,7 +271,7 @@ class CodeWhispererClientAdaptorTest {
     @Test
     fun `sendTelemetryEvent for codePercentage respects telemetry optin status`() {
         sendTelemetryEventOptOutCheckHelper {
-            sut.putCodePercentageTelemetry(aProgrammingLanguage(), 0, 1)
+            sut.sendCodePercentageTelemetry(aProgrammingLanguage(), 0, 1)
         }
     }
 

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererUtilTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererUtilTest.kt
@@ -19,7 +19,7 @@ import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_REGION
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
 import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getCompletionType
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIamIdentityCenterConnection
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIdcConnectionOrTelemetryEnabled
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.toCodeChunk
 import software.aws.toolkits.jetbrains.utils.rules.JavaCodeInsightTestFixtureRule
 import software.aws.toolkits.telemetry.CodewhispererCompletionType
@@ -53,7 +53,7 @@ class CodeWhispererUtilTest {
         val oldCount = modificationTracker.modificationCount
 
         val ssoConn = ManagedBearerSsoConnection(startUrl = "fake url", region = "us-east-1", scopes = CODEWHISPERER_SCOPES)
-        runIfIamIdentityCenterConnection(ssoConn) { modificationTracker.incModificationCount() }
+        runIfIdcConnectionOrTelemetryEnabled(ssoConn) { modificationTracker.incModificationCount() }
 
         val newCount = modificationTracker.modificationCount
         assertThat(newCount).isEqualTo(oldCount + 1L)
@@ -65,7 +65,7 @@ class CodeWhispererUtilTest {
         val oldCount = modificationTracker.modificationCount
 
         val builderIdConn = ManagedBearerSsoConnection(startUrl = SONO_URL, region = SONO_REGION, scopes = CODEWHISPERER_SCOPES)
-        runIfIamIdentityCenterConnection(builderIdConn) { modificationTracker.incModificationCount() }
+        runIfIdcConnectionOrTelemetryEnabled(builderIdConn) { modificationTracker.incModificationCount() }
 
         val newCount = modificationTracker.modificationCount
         assertThat(newCount).isEqualTo(oldCount)


### PR DESCRIPTION
1. Only send the telemetry if Builder ID users optin telemetry sharing

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
