### PR TITLE
Make sure dev tools nodes are expanded on 'Got it' popup

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/DevToolsToolWindow.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/DevToolsToolWindow.kt
@@ -110,8 +110,7 @@ class DevToolsToolWindow(private val project: Project) : SimpleToolWindowPanel(t
 
         redrawContent()
 
-        // TODO: does this expansion need to be conditional?
-        TreeUtil.expand(tree, 2)
+        makeServiceChildrenVisible()
     }
 
     override fun dispose() {}
@@ -153,6 +152,10 @@ class DevToolsToolWindow(private val project: Project) : SimpleToolWindowPanel(t
         val state = TreeState.createOn(tree)
         treeModel.invalidate()
         state.applyTo(tree)
+    }
+
+    fun makeServiceChildrenVisible() {
+        TreeUtil.expand(tree, 2)
     }
 
     companion object {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
@@ -35,6 +35,7 @@ import software.aws.toolkits.jetbrains.core.credentials.sono.CODECATALYST_SCOPES
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_REGION
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
 import software.aws.toolkits.jetbrains.core.explorer.AwsToolkitExplorerToolWindow
+import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.DevToolsToolWindow
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel.PanelConstants.BULLET_PANEL_HEIGHT
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel.PanelConstants.GOT_IT_ID_PREFIX
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel.PanelConstants.PANEL_HEIGHT
@@ -193,6 +194,9 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel() {
     private fun showGotIt(tabName: String, tooltip: GotItTooltip) {
         AwsToolkitExplorerToolWindow.toolWindow(project).activate {
             AwsToolkitExplorerToolWindow.getInstance(project).selectTab(tabName)?.let {
+                if (tabName == AwsToolkitExplorerToolWindow.DEVTOOLS_TAB_ID) {
+                    DevToolsToolWindow.getInstance(project).makeServiceChildrenVisible()
+                }
                 tooltip.show(it as JComponent, GotItTooltip.TOP_MIDDLE)
             }
         }


### PR DESCRIPTION
If a user has previously opened the Dev Tools tool window, but collapsed the nodes, it may be confusing because there are no immediate actions available

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
