### PR TITLE
codewhisperer: suppress token infilling for auto-trigger

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -16,6 +16,8 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.language.programmi
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretPosition
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.FileContextInfo
+import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererUserGroup
+import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererUserGroupSettings
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.LEFT_CONTEXT_ON_CURRENT_LINE
 import java.awt.Point
@@ -88,6 +90,17 @@ object CodeWhispererEditorUtil {
             editorLocation.y + textAbsolutePosition.y - editor.scrollingModel.verticalScrollOffset -
                 (popup as AbstractPopup).preferredContentSize.height
         )
+    }
+
+    fun shouldSkipInvokingBasedOnRightContext(editor: Editor): Boolean {
+        val caretContext = runReadAction { CodeWhispererEditorUtil.extractCaretContext(editor) }
+        val rightContextLines = caretContext.rightFileContext.split(Regex("\r?\n"))
+        val rightContextCurrentLine = if (rightContextLines.isEmpty()) "" else rightContextLines[0]
+
+        return CodeWhispererUserGroupSettings.getInstance().getUserGroup() == CodeWhispererUserGroup.RightContext &&
+            rightContextCurrentLine.isNotEmpty() &&
+            !rightContextCurrentLine.startsWith(" ") &&
+            rightContextCurrentLine.trim() != ("}")
     }
 
     /**

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
@@ -9,12 +9,17 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.shouldSkipInvokingBasedOnRightContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutoTriggerService
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutomatedTriggerType
 
 class CodeWhispererEnterHandler(private val originalHandler: EditorActionHandler) : EnterHandler(originalHandler) {
     override fun executeWriteAction(editor: Editor, caret: Caret?, dataContext: DataContext?) {
         originalHandler.execute(editor, caret, dataContext)
+
+        if (shouldSkipInvokingBasedOnRightContext(editor)) {
+            return
+        }
 
         ApplicationManager.getApplication().executeOnPooledThread {
             CodeWhispererAutoTriggerService.getInstance().tryInvokeAutoTrigger(editor, CodeWhispererAutomatedTriggerType.Enter())

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererTypedHandler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererTypedHandler.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import kotlinx.coroutines.Job
+import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.shouldSkipInvokingBasedOnRightContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutoTriggerService
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutomatedTriggerType
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
@@ -16,6 +17,11 @@ class CodeWhispererTypedHandler : TypedHandlerDelegate() {
     private var triggerOnIdle: Job? = null
     override fun charTyped(c: Char, project: Project, editor: Editor, psiFiles: PsiFile): Result {
         triggerOnIdle?.cancel()
+
+        if (shouldSkipInvokingBasedOnRightContext(editor)
+        ) {
+            return Result.CONTINUE
+        }
 
         // Special Char
         if (CodeWhispererConstants.SPECIAL_CHARACTERS_LIST.contains(c.toString())) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererUserGroupSettings.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererUserGroupSettings.kt
@@ -78,7 +78,10 @@ class CodeWhispererUserGroupSettings : PersistentStateComponent<CodeWhispererUse
 
     @VisibleForTesting
     fun determineUserGroup(): CodeWhispererUserGroup {
-        val group = CodeWhispererUserGroup.Control
+        val randomNum = Math.random()
+        val group = if (randomNum < 1 / 2.0) {
+            CodeWhispererUserGroup.Control
+        } else CodeWhispererUserGroup.RightContext
 
         settings[USER_GROUP_KEY] = group.name
         version = AwsToolkit.PLUGIN_VERSION
@@ -125,7 +128,8 @@ interface CodeWhispererGroup
 enum class CodeWhispererUserGroup : CodeWhispererGroup {
     Control,
     CrossFile,
-    Classifier
+    Classifier,
+    RightContext,
 }
 
 enum class CodeWhispererExpThresholdGroup : CodeWhispererGroup {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
We don't want to invoke when there is immediate right context on the same line with a single '}' as exception
This is an A/B test

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
