### PR TITLE
move credential change topic subscription to projectListener

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererServiceNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererServiceNode.kt
@@ -5,19 +5,14 @@ package software.aws.toolkits.jetbrains.services.codewhisperer.explorer
 
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.ide.util.treeView.AbstractTreeNode
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.SimpleTextAttributes
 import com.intellij.util.text.DateTimeFormatManager
 import software.aws.toolkits.core.utils.tryOrNull
-import software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection
-import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
-import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManagerListener
 import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeWhispererConnection
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.AbstractActionTreeNode
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.ActionGroupOnRightClick
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.PinnedConnectionNode
-import software.aws.toolkits.jetbrains.core.explorer.refreshDevToolTree
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererLoginType
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.nodes.CodeWhispererReconnectNode
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.nodes.FreeTierUsageLimitHitNode

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererServiceNode.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/CodeWhispererServiceNode.kt
@@ -60,21 +60,6 @@ class CodeWhispererServiceNode(
     }
     private val learnCodeWhispererNode by lazy { LearnCodeWhispererNode(nodeProject) }
 
-    init {
-        ApplicationManager.getApplication().messageBus.connect().subscribe(
-            ToolkitConnectionManagerListener.TOPIC,
-            object : ToolkitConnectionManagerListener {
-                override fun activeConnectionChanged(newConnection: ToolkitConnection?) {
-                    // TODO: Move this IF block into nullifyAccountlessCredentialIfNeeded()
-                    if (newConnection is AwsBearerTokenConnection) {
-                        CodeWhispererExplorerActionManager.getInstance().nullifyAccountlessCredentialIfNeeded()
-                    }
-                    project.refreshDevToolTree()
-                }
-            }
-        )
-    }
-
     override fun onDoubleClick(event: MouseEvent) {}
 
     override fun getChildren(): Collection<AbstractTreeNode<*>> {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupSettingsListener.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupSettingsListener.kt
@@ -10,9 +10,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
+import software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManagerListener
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
+import software.aws.toolkits.jetbrains.core.explorer.refreshDevToolTree
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.CodeWhispererCodeScanManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererActivationChangedListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
@@ -57,6 +59,12 @@ class CodeWhispererProjectStartupSettingsListener(private val project: Project) 
         } else {
             CodeWhispererCodeScanManager.getInstance(project).removeCodeScanUI()
         }
+
+        // TODO: Move this IF block into nullifyAccountlessCredentialIfNeeded()
+        if (newConnection is AwsBearerTokenConnection) {
+            CodeWhispererExplorerActionManager.getInstance().nullifyAccountlessCredentialIfNeeded()
+        }
+        project.refreshDevToolTree()
     }
 
     override fun onChange(providerId: String) {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Issue 

A new instance of CodeWhispererServiceNode will be created here https://github.com/aws/aws-toolkit-jetbrains/blob/main/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/CodeWhispererExplorerRootNode.kt#L13 everytime we refresh devTool tree and instances not being used will not be disposed/garbage collected immediately by the JVM

## Fix
Moving subscription to project level listener 



https://github.com/aws/aws-toolkit-jetbrains/assets/96078566/576f9095-15e6-465f-936f-fe84819cee67


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
