### PR TITLE
Make 'Getting Started' panel background darker in dark mode

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
@@ -17,6 +17,7 @@ import com.intellij.openapi.project.DefaultProjectFactory
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.Balloon
+import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
 import com.intellij.ui.GotItTooltip
 import com.intellij.ui.IdeBorderFactory
 import com.intellij.ui.components.JBLabel
@@ -73,6 +74,8 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
     private val featureSetPanel = FeatureColumns()
     private val alarm = Alarm()
     init {
+        background = WelcomeScreenUIManager.getMainAssociatedComponentBackground()
+
         ApplicationManager.getApplication().messageBus.connect(this).subscribe(
             BearerTokenProviderListener.TOPIC,
             object : BearerTokenProviderListener {
@@ -215,6 +218,8 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
                         }
                     }
                 }
+            }.apply {
+                isOpaque = false
             }
         )
 
@@ -420,6 +425,8 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
                             }
                         }.visible(checkBearerConnectionValidity(project, BearerTokenFeatureSet.CODECATALYST) is ActiveConnection.ExpiredBearer)
                     }
+                }.apply {
+                    isOpaque = false
                 }
             )
         }
@@ -573,6 +580,8 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
                             }
                         }.visible(checkIamConnectionValidity(project) is ActiveConnection.ExpiredIam)
                     }
+                }.apply {
+                    isOpaque = false
                 }
             )
         }
@@ -738,6 +747,8 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
                             )
                         }.visible(checkBearerConnectionValidity(project, BearerTokenFeatureSet.CODEWHISPERER) is ActiveConnection.ExpiredBearer)
                     }
+                }.apply {
+                    isOpaque = false
                 }
             )
         }
@@ -764,7 +775,6 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
             addToCenter(
                 panel {
                     indent {
-
                         row {
                             label(panelTitle).applyToComponent {
                                 font = PANEL_TITLE_FONT
@@ -782,6 +792,8 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
                             }
                         }
                     }
+                }.apply {
+                    isOpaque = false
                 }
             )
         }
@@ -794,6 +806,8 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
             border = IdeBorderFactory.createRoundedBorder().apply {
                 setColor(UIUtil.getLabelForeground())
             }
+
+            isOpaque = false
         }
     }
 
@@ -809,6 +823,7 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
             }
         }
     }
+
     private class ConnectionInfoBanner : BorderLayoutPanel(10, 0) {
         private val wrapper = Wrapper()
         init {
@@ -887,6 +902,8 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
     private inner class FeatureColumns : BorderLayoutPanel(10, 0) {
         private val wrapper = Wrapper()
         init {
+            isOpaque = false
+
             addToCenter(wrapper)
         }
 
@@ -901,6 +918,8 @@ class GettingStartedPanel(private val project: Project) : BorderLayoutPanel(), D
                         // CodeCatalyst Panel
                         cell(CodeCatalystPanel())
                     }
+                }.apply {
+                    isOpaque = false
                 }
             )
         }


### PR DESCRIPTION
Per UX mocks, background should be darker

<img width="1494" alt="Screenshot 2023-10-23 at 4 56 51 PM" src="https://github.com/aws/aws-toolkit-jetbrains/assets/742829/e6d685a4-e118-499c-a4e8-1fda0b3d0390">
<img width="1387" alt="Screenshot 2023-10-23 at 4 51 29 PM" src="https://github.com/aws/aws-toolkit-jetbrains/assets/742829/b9bfc427-a01b-4c1d-98a8-2e8300a7767a">


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
