### PR TITLE
switch to default model when receiving ResourceNotFoundException

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -259,7 +259,6 @@ class CodeWhispererService {
                 val displayMessage: String
 
                 if (
-                    CodeWhispererConstants.Customization.customizationNotFoundExceptionPredicate(e) ||
                     CodeWhispererConstants.Customization.invalidCustomizationExceptionPredicate(e) ||
                     e is ResourceNotFoundException
                 ) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -36,6 +36,7 @@ import software.amazon.awssdk.services.codewhispererruntime.model.GenerateComple
 import software.amazon.awssdk.services.codewhispererruntime.model.GenerateCompletionsResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.ProgrammingLanguage
 import software.amazon.awssdk.services.codewhispererruntime.model.RecommendationsWithReferencesPreference
+import software.amazon.awssdk.services.codewhispererruntime.model.ResourceNotFoundException
 import software.amazon.awssdk.services.codewhispererruntime.model.SupplementalContext
 import software.amazon.awssdk.services.codewhispererruntime.model.ThrottlingException
 import software.aws.toolkits.core.utils.debug
@@ -259,7 +260,8 @@ class CodeWhispererService {
 
                 if (
                     CodeWhispererConstants.Customization.customizationNotFoundExceptionPredicate(e) ||
-                    CodeWhispererConstants.Customization.invalidCustomizationExceptionPredicate(e)
+                    CodeWhispererConstants.Customization.invalidCustomizationExceptionPredicate(e) ||
+                    e is ResourceNotFoundException
                 ) {
                     (e as CodeWhispererRuntimeException)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
@@ -93,7 +93,6 @@ object CodeWhispererConstants {
     object Customization {
         private const val noAccessToCustomizationMessage = "Your account is not authorized to use CodeWhisperer Enterprise."
         private const val invalidCustomizationMessage = "You are not authorized to access"
-        private const val customizationNotFoundMessage = "not found"
 
         val noAccessToCustomizationExceptionPredicate: (e: Exception) -> Boolean = { e ->
             if (e !is CodeWhispererRuntimeException) {
@@ -108,14 +107,6 @@ object CodeWhispererConstants {
                 false
             } else {
                 e is AccessDeniedException && (e.message?.contains(invalidCustomizationMessage, ignoreCase = true) ?: false)
-            }
-        }
-
-        val customizationNotFoundExceptionPredicate: (e: Exception) -> Boolean = { e ->
-            if (e !is CodeWhispererRuntimeException) {
-                false
-            } else {
-                e is AccessDeniedException && (e.message?.contains(customizationNotFoundMessage, ignoreCase = true) ?: false)
             }
         }
     }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

https://github.com/aws/aws-toolkit-jetbrains/assets/96078566/06c63ea9-cfe4-435f-9e0d-6857d48785e1



```
2023-10-24 14:40:03,124 [3605204]   INFO - #c.i.w.i.i.j.s.JpsGlobalModelSynchronizerImpl - Saving global entities to files
2023-10-24 14:40:09,452 [3611532]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.util.DefaultCodeWhispererFileContextProvider - Crossfile is not supporting kotlin
2023-10-24 14:40:09,456 [3611536]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService - Calling CodeWhisperer service, trigger type: OnDemand
2023-10-24 14:40:09,458 [3611538]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStatus - Starting CodeWhisperer invocation
2023-10-24 14:40:10,034 [3612114]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService - The provided customization arn:aws:codewhisperer:us-east-1:419795008606:customization/GW99HG749UPH is not found, will fallback to the default and retry generate completion
2023-10-24 14:40:10,042 [3612122]   INFO - software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService - SessionId: 98dbd276-277c-48cc-932f-1c9896a3dbcf, RequestId: 98dbd276-277c-48cc-932f-1c9896a3dbcf, Jetbrains IDE: IntelliJ IDEA 2023.2.2, IDE version: IU-232.9921.47, Filename: SsoSupport.kt, Left context of current line: fun getCredential, Cursor line: 26, Caret offset: 1073, Exception Type: AccessDeniedException, Recommendations: 
None
2023-10-24 14:40:10,045 [3612125]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStatus - Ending CodeWhisperer invocation
2023-10-24 14:40:10,045 [3612125]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator - Invalidate customization arn: arn:aws:codewhisperer:us-east-1:419795008606:customization/GW99HG749UPH
2023-10-24 14:40:10,047 [3612127]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.util.DefaultCodeWhispererFileContextProvider - Crossfile is not supporting kotlin
2023-10-24 14:40:10,047 [3612127]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService - Calling CodeWhisperer service, trigger type: OnDemand
2023-10-24 14:40:10,047 [3612127]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStatus - Starting CodeWhisperer invocation
2023-10-24 14:40:10,828 [3612908]   FINE - software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStatus - Set current CodeWhisperer invocation sessionId: 126f6166-7a5c-4ae1-ac80-5c12b264276c
2023-10-24 14:40:10,830 [3612910]   INFO - software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService - SessionId: 126f6166-7a5c-4ae1-ac80-5c12b264276c, RequestId: 91e70bf0-56c3-445c-890f-4950a47ee599, Jetbrains IDE: IntelliJ IDEA 2023.2.2, IDE version: IU-232.9921.47, Filename: SsoSupport.kt, Left context of current line: fun getCredential, Cursor line: 26, Caret offset: 1073, Latency: 779.0, Recommendations: 
(credentialsProvider: CredentialProvider): Credential? {
    return credentialsProvider.getCredential()
}

```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
