### PR TITLE
codewhisperer: dont send unknown as completion type for empty recos

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -440,7 +440,7 @@ class CodeWhispererService {
                     false,
                     false,
                     "",
-                    CodewhispererCompletionType.Unknown
+                    CodewhispererCompletionType.Line
                 ),
                 -1,
                 CodewhispererSuggestionState.Empty,

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
@@ -209,12 +209,7 @@ class CodeWhispererTelemetryService {
         val classifierThreshold = CodeWhispererAutoTriggerService.getThreshold()
 
         val supplementalContext = requestContext.supplementalContext
-        val completionType = if (recommendationContext.details.any {
-                it.completionType == CodewhispererCompletionType.Block
-            }
-        ) {
-            CodewhispererCompletionType.Block
-        } else CodewhispererCompletionType.Line
+        val completionType = if (recommendationContext.details.isEmpty()) CodewhispererCompletionType.Line else recommendationContext.details[0].completionType
 
         // only send if it's a pro tier user
         projectCoroutineScope(project).launch {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -146,7 +146,7 @@ object CodeWhispererUtil {
         val nonBlankLines = content.split("\n").count { it.isNotBlank() }
 
         return when {
-            content.isEmpty() -> CodewhispererCompletionType.Unknown
+            content.isEmpty() -> CodewhispererCompletionType.Line
             nonBlankLines > 1 -> CodewhispererCompletionType.Block
             else -> CodewhispererCompletionType.Line
         }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryServiceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryServiceTest.kt
@@ -265,7 +265,7 @@ class CodeWhispererTelemetryServiceTest {
                 1,
                 "codewhispererSessionId" to responseContext.sessionId,
                 "codewhispererFirstRequestId" to requestContext.latencyContext.firstRequestId,
-                "codewhispererCompletionType" to CodewhispererCompletionType.Line,
+                "codewhispererCompletionType" to recommendationContext.details[0].completionType,
                 "codewhispererLanguage" to requestContext.fileContextInfo.programmingLanguage.toTelemetryType(),
                 "codewhispererTriggerType" to requestContext.triggerTypeInfo.triggerType,
                 "codewhispererAutomatedTriggerType" to requestContext.triggerTypeInfo.automatedTriggerType.telemetryType,
@@ -467,12 +467,7 @@ class CodeWhispererTelemetryServiceTest {
         val expectedSuggestionReferenceCount = 1
         val expectedGeneratedLineCount = 50
         val expectedCharCount = 100
-        val expectedCompletionType = if (expectedRecommendationContext.details.any {
-                it.completionType == CodewhispererCompletionType.Block
-            }
-        ) {
-            CodewhispererCompletionType.Block
-        } else CodewhispererCompletionType.Line
+        val expectedCompletionType = expectedRecommendationContext.details[0].completionType
         sut.sendUserTriggerDecisionEvent(
             expectedRequestContext,
             expectedResponseContext,

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryServiceTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryServiceTest.kt
@@ -46,7 +46,6 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhis
 import software.aws.toolkits.jetbrains.services.telemetry.NoOpPublisher
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.aws.toolkits.jetbrains.settings.AwsSettings
-import software.aws.toolkits.telemetry.CodewhispererCompletionType
 import software.aws.toolkits.telemetry.CodewhispererPreviousSuggestionState
 import software.aws.toolkits.telemetry.CodewhispererSuggestionState
 import java.time.Duration

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryTest.kt
@@ -819,7 +819,8 @@ class CodeWhispererTelemetryTest : CodeWhispererTestBase() {
                 metricCaptor.allValues,
                 userDecision,
                 numOfEmptyRecommendations,
-                "codewhispererSuggestionState" to CodewhispererSuggestionState.Empty.toString()
+                "codewhispererSuggestionState" to CodewhispererSuggestionState.Empty.toString(),
+                "codewhispererCompletionType" to CodewhispererCompletionType.Line.toString()
             )
         }
     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestUtil.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestUtil.kt
@@ -313,10 +313,10 @@ fun aRecommendationContextAndSessionContext(decisions: List<CodewhispererSuggest
             DetailContext(aString(), completion, completion, Random.nextBoolean(), Random.nextBoolean(), aString(), CodewhispererCompletionType.Line)
         } else if (decision == CodewhispererSuggestionState.Discard) {
             val completion = aCompletion()
-            DetailContext(aString(), completion, completion, true, Random.nextBoolean(), aString(), CodewhispererCompletionType.Unknown)
+            DetailContext(aString(), completion, completion, true, Random.nextBoolean(), aString(), CodewhispererCompletionType.Line)
         } else {
             val completion = aCompletion()
-            DetailContext(aString(), completion, completion, false, Random.nextBoolean(), aString(), CodewhispererCompletionType.Unknown)
+            DetailContext(aString(), completion, completion, false, Random.nextBoolean(), aString(), CodewhispererCompletionType.Line)
         }
 
         details.add(toAdd)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestUtil.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestUtil.kt
@@ -310,7 +310,7 @@ fun aRecommendationContextAndSessionContext(decisions: List<CodewhispererSuggest
     decisions.forEach { decision ->
         val toAdd = if (decision == CodewhispererSuggestionState.Empty) {
             val completion = aCompletion("", true, 0, 0)
-            DetailContext(aString(), completion, completion, Random.nextBoolean(), Random.nextBoolean(), aString(), CodewhispererCompletionType.Unknown)
+            DetailContext(aString(), completion, completion, Random.nextBoolean(), Random.nextBoolean(), aString(), CodewhispererCompletionType.Line)
         } else if (decision == CodewhispererSuggestionState.Discard) {
             val completion = aCompletion()
             DetailContext(aString(), completion, completion, true, Random.nextBoolean(), aString(), CodewhispererCompletionType.Unknown)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
send line as completion type for empty recommendations instead of unknown
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
