### PR TITLE
Use SAM CLI v1.98.0 for integration tests

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -14,6 +14,8 @@ env:
 phases:
   install:
     commands:
+      - sed -i 's/latest\/download/download\/v1.98.0/g' /usr/local/bin/installSam.sh
+      - installSam.sh --update
       - n install 16
       - startDocker.sh
       # login to DockerHub so we don't get throttled


### PR DESCRIPTION
Test failures begin with v1.99.0
Temporarily downgrade to v1.98.0 to allow for release to continue

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
