### PR TITLE
fix codewhispererUtil.isConnectionExpired return true when the state is "NEEDS_REFRESH"

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitConnectionImpls.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitConnectionImpls.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
 import software.aws.toolkits.core.TokenConnectionSettings
 import software.aws.toolkits.core.credentials.ToolkitBearerTokenProvider
+import software.aws.toolkits.jetbrains.core.credentials.sso.DiskCache
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProvider
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.ProfileSdkTokenProviderWrapper
@@ -16,6 +17,7 @@ class ManagedBearerSsoConnection(
     val startUrl: String,
     val region: String,
     override val scopes: List<String>,
+    cache: DiskCache = diskCache
 ) : BearerSsoConnection, Disposable {
     override val id: String = ToolkitBearerTokenProvider.ssoIdentifier(startUrl, region)
     override val label: String = ToolkitBearerTokenProvider.ssoDisplayName(startUrl)
@@ -25,7 +27,8 @@ class ManagedBearerSsoConnection(
             InteractiveBearerTokenProvider(
                 startUrl,
                 region,
-                scopes
+                scopes,
+                cache
             ),
             region
         )

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -259,7 +259,6 @@ class CodeWhispererService {
                 val displayMessage: String
 
                 if (
-                    CodeWhispererConstants.Customization.customizationNotFoundExceptionPredicate(e) ||
                     CodeWhispererConstants.Customization.invalidCustomizationExceptionPredicate(e) ||
                     e is ResourceNotFoundException
                 ) {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -36,6 +36,7 @@ import software.amazon.awssdk.services.codewhispererruntime.model.GenerateComple
 import software.amazon.awssdk.services.codewhispererruntime.model.GenerateCompletionsResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.ProgrammingLanguage
 import software.amazon.awssdk.services.codewhispererruntime.model.RecommendationsWithReferencesPreference
+import software.amazon.awssdk.services.codewhispererruntime.model.ResourceNotFoundException
 import software.amazon.awssdk.services.codewhispererruntime.model.SupplementalContext
 import software.amazon.awssdk.services.codewhispererruntime.model.ThrottlingException
 import software.aws.toolkits.core.utils.debug
@@ -259,7 +260,8 @@ class CodeWhispererService {
 
                 if (
                     CodeWhispererConstants.Customization.customizationNotFoundExceptionPredicate(e) ||
-                    CodeWhispererConstants.Customization.invalidCustomizationExceptionPredicate(e)
+                    CodeWhispererConstants.Customization.invalidCustomizationExceptionPredicate(e) ||
+                    e is ResourceNotFoundException
                 ) {
                     (e as CodeWhispererRuntimeException)
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -97,7 +97,7 @@ class CodeWhispererService {
 
         if (promptReAuth(project)) return
 
-        if (isCodeWhispererExpired(project)) return
+        if (isCodeWhispererExpired(project) != false) return
 
         latencyContext.credentialFetchingEnd = System.nanoTime()
         val psiFile = runReadAction { PsiDocumentManager.getInstance(project).getPsiFile(editor.document) }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
@@ -52,7 +52,7 @@ class CodeWhispererProjectStartupActivity : StartupActivity.DumbAware {
         // show notification to accountless users
         showAccountlessNotificationIfNeeded(project)
 
-        if (!CodeWhispererExplorerActionManager.getInstance().hasShownNewOnboardingPage() && !isCodeWhispererExpired(project)) {
+        if (!CodeWhispererExplorerActionManager.getInstance().hasShownNewOnboardingPage() && isCodeWhispererExpired(project) == false) {
             showOnboardingPage(project)
         }
         runOnce = true

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupSettingsListener.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupSettingsListener.kt
@@ -74,7 +74,7 @@ class CodeWhispererProjectStartupSettingsListener(private val project: Project) 
     }
 
     override fun onChange(providerId: String) {
-        if (CodeWhispererExplorerActionManager.getInstance().hasShownNewOnboardingPage() || isCodeWhispererExpired(project)) {
+        if (CodeWhispererExplorerActionManager.getInstance().hasShownNewOnboardingPage() || isCodeWhispererExpired(project) != false) {
             return
         }
         LearnCodeWhispererEditorProvider.openEditor(project)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
@@ -77,7 +77,7 @@ class CodeWhispererStatusBarWidget(project: Project) :
     override fun getClickConsumer(): Consumer<MouseEvent>? = null
 
     override fun getPopupStep(): ListPopup? =
-        if (isCodeWhispererExpired(project)) {
+        if (isCodeWhispererExpired(project) == true) {
             JBPopupFactory.getInstance().createConfirmation(message("codewhisperer.statusbar.popup.title"), { reconnectCodeWhisperer(project) }, 0)
         } else {
             null
@@ -92,7 +92,7 @@ class CodeWhispererStatusBarWidget(project: Project) :
     }
 
     override fun getIcon(): Icon =
-        if (isCodeWhispererExpired(project)) {
+        if (isCodeWhispererExpired(project) == true) {
             AllIcons.General.BalloonWarning
         } else if (CodeWhispererInvocationStatus.getInstance().hasExistingInvocation()) {
             AnimatedIcon.Default()

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
@@ -93,7 +93,6 @@ object CodeWhispererConstants {
     object Customization {
         private const val noAccessToCustomizationMessage = "Your account is not authorized to use CodeWhisperer Enterprise."
         private const val invalidCustomizationMessage = "You are not authorized to access"
-        private const val customizationNotFoundMessage = "not found"
 
         val noAccessToCustomizationExceptionPredicate: (e: Exception) -> Boolean = { e ->
             if (e !is CodeWhispererRuntimeException) {
@@ -108,14 +107,6 @@ object CodeWhispererConstants {
                 false
             } else {
                 e is AccessDeniedException && (e.message?.contains(invalidCustomizationMessage, ignoreCase = true) ?: false)
-            }
-        }
-
-        val customizationNotFoundExceptionPredicate: (e: Exception) -> Boolean = { e ->
-            if (e !is CodeWhispererRuntimeException) {
-                false
-            } else {
-                e is AccessDeniedException && (e.message?.contains(customizationNotFoundMessage, ignoreCase = true) ?: false)
             }
         }
     }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -21,7 +21,6 @@ import software.aws.toolkits.jetbrains.core.credentials.loginSso
 import software.aws.toolkits.jetbrains.core.credentials.maybeReauthProviderIfNeeded
 import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeWhispererConnection
 import software.aws.toolkits.jetbrains.core.credentials.sono.isSono
-import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenAuthState
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProvider
 import software.aws.toolkits.jetbrains.core.explorer.refreshDevToolTree
 import software.aws.toolkits.jetbrains.services.codewhisperer.actions.CodeWhispererLoginLearnMoreAction
@@ -196,18 +195,6 @@ object CodeWhispererUtil {
         listOf(CodeWhispererSsoLearnMoreAction(), ConnectWithAwsToContinueActionError(), DoNotShowAgainActionError())
     )
 
-    fun isAccessTokenExpired(project: Project): Boolean {
-        val tokenProvider = tokenProvider(project) ?: return false
-        val state = tokenProvider.state()
-        return state == BearerTokenAuthState.NEEDS_REFRESH
-    }
-
-    fun isRefreshTokenExpired(project: Project): Boolean {
-        val tokenProvider = tokenProvider(project) ?: return false
-        val state = tokenProvider.state()
-        return state == BearerTokenAuthState.NOT_AUTHENTICATED
-    }
-
     // This will be called only when there's a CW connection, but it has expired(either accessToken or refreshToken)
     // 1. If connection is expired, try to refresh
     // 2. If not able to refresh, requesting re-login by showing a notification
@@ -259,7 +246,7 @@ object CodeWhispererUtil {
         return connection.startUrl
     }
 
-    private fun tokenProvider(project: Project) = (
+    fun tokenProvider(project: Project) = (
         ToolkitConnectionManager
             .getInstance(project)
             .activeConnectionForFeature(CodeWhispererConnection.getInstance()) as? AwsBearerTokenConnection

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -204,7 +204,7 @@ object CodeWhispererUtil {
     //   for example, when user performs security scan or fetch code completion for the first time
     // Return true if need to re-auth, false otherwise
     fun promptReAuth(project: Project, isPluginStarting: Boolean = false): Boolean {
-        if (!isCodeWhispererExpired(project)) return false
+        if (isCodeWhispererExpired(project) == false) return false
         val tokenProvider = tokenProvider(project) ?: return false
         return maybeReauthProviderIfNeeded(project, tokenProvider) {
             runInEdt {
@@ -246,7 +246,7 @@ object CodeWhispererUtil {
         return connection.startUrl
     }
 
-    fun tokenProvider(project: Project) = (
+    private fun tokenProvider(project: Project) = (
         ToolkitConnectionManager
             .getInstance(project)
             .activeConnectionForFeature(CodeWhispererConnection.getInstance()) as? AwsBearerTokenConnection

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererExplorerActionManagerTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererExplorerActionManagerTest.kt
@@ -3,9 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
-import com.intellij.testFramework.ApplicationRule
 import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.ProjectRule
 import com.intellij.testFramework.replaceService
@@ -13,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
@@ -23,16 +22,31 @@ import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 import software.aws.toolkits.jetbrains.core.credentials.ManagedBearerSsoConnection
 import software.aws.toolkits.jetbrains.core.credentials.MockToolkitAuthManagerRule
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
+import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeWhispererConnection
+import software.aws.toolkits.jetbrains.core.credentials.pinning.ConnectionPinningManager
+import software.aws.toolkits.jetbrains.core.credentials.sono.CODEWHISPERER_SCOPES
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
+import software.aws.toolkits.jetbrains.core.credentials.sso.AccessToken
+import software.aws.toolkits.jetbrains.core.credentials.sso.AccessTokenCacheKey
+import software.aws.toolkits.jetbrains.core.credentials.sso.DiskCache
+import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenAuthState
+import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererLoginType
-import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExploreActionState
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhispererEnabled
+import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhispererExpired
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 
 class CodeWhispererExplorerActionManagerTest {
     @JvmField
     @Rule
-    val applicationRule = ApplicationRule()
+    val tempFolder = TemporaryFolder()
 
     @JvmField
     @Rule
@@ -50,17 +64,24 @@ class CodeWhispererExplorerActionManagerTest {
     @Rule
     val mockClientManager = MockClientManagerRule()
 
+    private val now = Instant.now()
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
+
     private lateinit var mockManager: CodeWhispererExplorerActionManager
     private lateinit var project: Project
-    private lateinit var connectionManager: ToolkitConnectionManager
+    private lateinit var cacheRoot: Path
+    private lateinit var cacheLocation: Path
+    private lateinit var testDiskCache: DiskCache
 
     @Before
     fun setup() {
+        cacheRoot = tempFolder.root.toPath().toAbsolutePath()
+        cacheLocation = Paths.get(cacheRoot.toString(), "fakehome", ".aws", "sso", "cache")
+        Files.createDirectories(cacheLocation)
+        testDiskCache = DiskCache(cacheLocation, clock)
+
         mockClientManager.create<SsoOidcClient>()
         project = projectRule.project
-        connectionManager = mock()
-
-        project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposableRule.disposable)
     }
 
     /**
@@ -69,49 +90,12 @@ class CodeWhispererExplorerActionManagerTest {
     @Test
     fun `when there is no connection, should return logout`() {
         mockManager = spy()
-        whenever(connectionManager.activeConnectionForFeature(any())).thenReturn(null)
+        val mockConnectionManager = mock<ToolkitConnectionManager>()
+        whenever(mockConnectionManager.activeConnectionForFeature(any())).thenReturn(null)
+        project.replaceService(ToolkitConnectionManager::class.java, mockConnectionManager, disposableRule.disposable)
 
         val actual = mockManager.checkActiveCodeWhispererConnectionType(project)
         assertThat(actual).isEqualTo(CodeWhispererLoginType.Logout)
-    }
-
-    @Test
-    fun `when ToS accepted and there is an accountless token, should return accountless`() {
-        mockManager = spy()
-        mockManager.loadState(
-            // set up accountless token
-            CodeWhispererExploreActionState().apply {
-                this.token = "foo"
-            }
-        )
-
-        val actual = mockManager.checkActiveCodeWhispererConnectionType(project)
-        assertThat(actual).isEqualTo(CodeWhispererLoginType.Accountless)
-    }
-
-    @Test
-    fun `when ToS accepted, no accountless token and there is an AWS Builder ID connection, should return Sono`() {
-        assertLoginType(SONO_URL, CodeWhispererLoginType.Sono)
-    }
-
-    @Test
-    fun `when ToS accepted, no accountless token and there is an SSO connection, should return SSO`() {
-        assertLoginType(aString(), CodeWhispererLoginType.SSO)
-    }
-
-    @Test
-    fun `test nullifyAccountlessCredentialIfNeeded`() {
-        mockManager = CodeWhispererExplorerActionManager()
-        mockManager.loadState(CodeWhispererExploreActionState().apply { this.token = "foo" })
-
-        assertThat(mockManager.state.token)
-            .isNotNull
-            .isEqualTo("foo")
-
-        mockManager.nullifyAccountlessCredentialIfNeeded()
-
-        assertThat(mockManager.state.token)
-            .isNull()
     }
 
     /**
@@ -120,31 +104,113 @@ class CodeWhispererExplorerActionManagerTest {
      * - should return true if loginType == Accountless || Sono || SSO
      */
     @Test
-    fun `test isCodeWhispererEnabled`() {
-        mockManager = mock()
-        ApplicationManager.getApplication().replaceService(CodeWhispererExplorerActionManager::class.java, mockManager, disposableRule.disposable)
+    fun `test connection state`() {
+        assertConnectionState(
+            startUrl = SONO_URL,
+            refreshToken = aString(),
+            expirationTime = now.plus(1, ChronoUnit.DAYS),
+            expectedState = BearerTokenAuthState.AUTHORIZED,
+            expectedLoginType = CodeWhispererLoginType.Sono,
+            expectedIsCwEnabled = true,
+            expectedIsCwExpired = false
+        )
+        assertThat(ConnectionPinningManager.getInstance().isFeaturePinned(CodeWhispererConnection.getInstance())).isFalse
 
-        whenever(mockManager.checkActiveCodeWhispererConnectionType(project)).thenReturn(CodeWhispererLoginType.Logout)
-        assertThat(isCodeWhispererEnabled(project)).isFalse
+        assertConnectionState(
+            startUrl = SONO_URL,
+            refreshToken = aString(),
+            expirationTime = now.minus(1, ChronoUnit.DAYS),
+            expectedState = BearerTokenAuthState.NEEDS_REFRESH,
+            expectedLoginType = CodeWhispererLoginType.Expired,
+            expectedIsCwEnabled = true,
+            expectedIsCwExpired = true
+        )
+        assertThat(ConnectionPinningManager.getInstance().isFeaturePinned(CodeWhispererConnection.getInstance())).isFalse
 
-        whenever(mockManager.checkActiveCodeWhispererConnectionType(project)).thenReturn(CodeWhispererLoginType.Accountless)
-        assertThat(isCodeWhispererEnabled(project)).isTrue
+        assertConnectionState(
+            startUrl = SONO_URL,
+            refreshToken = null,
+            expirationTime = now.minus(1, ChronoUnit.DAYS),
+            expectedState = BearerTokenAuthState.NOT_AUTHENTICATED,
+            expectedLoginType = CodeWhispererLoginType.Logout,
+            expectedIsCwEnabled = false,
+            expectedIsCwExpired = true
+        )
+        assertThat(ConnectionPinningManager.getInstance().isFeaturePinned(CodeWhispererConnection.getInstance())).isFalse
 
-        whenever(mockManager.checkActiveCodeWhispererConnectionType(project)).thenReturn(CodeWhispererLoginType.Sono)
-        assertThat(isCodeWhispererEnabled(project)).isTrue
+        assertConnectionState(
+            startUrl = aString(),
+            refreshToken = aString(),
+            expirationTime = now.plus(1, ChronoUnit.DAYS),
+            expectedState = BearerTokenAuthState.AUTHORIZED,
+            expectedLoginType = CodeWhispererLoginType.SSO,
+            expectedIsCwEnabled = true,
+            expectedIsCwExpired = false
+        )
+        assertThat(ConnectionPinningManager.getInstance().isFeaturePinned(CodeWhispererConnection.getInstance())).isFalse
 
-        whenever(mockManager.checkActiveCodeWhispererConnectionType(project)).thenReturn(CodeWhispererLoginType.SSO)
-        assertThat(isCodeWhispererEnabled(project)).isTrue
+        assertConnectionState(
+            startUrl = aString(),
+            refreshToken = aString(),
+            expirationTime = now.minus(1, ChronoUnit.DAYS),
+            expectedState = BearerTokenAuthState.NEEDS_REFRESH,
+            expectedLoginType = CodeWhispererLoginType.Expired,
+            expectedIsCwEnabled = true,
+            expectedIsCwExpired = true
+        )
+        assertThat(ConnectionPinningManager.getInstance().isFeaturePinned(CodeWhispererConnection.getInstance())).isFalse
+
+        assertConnectionState(
+            startUrl = aString(),
+            refreshToken = null,
+            expirationTime = now.minus(1, ChronoUnit.DAYS),
+            expectedState = BearerTokenAuthState.NOT_AUTHENTICATED,
+            expectedLoginType = CodeWhispererLoginType.Logout,
+            expectedIsCwEnabled = false,
+            expectedIsCwExpired = true
+        )
+        assertThat(ConnectionPinningManager.getInstance().isFeaturePinned(CodeWhispererConnection.getInstance())).isFalse
     }
 
-    private fun assertLoginType(startUrl: String, expectedType: CodeWhispererLoginType) {
-        mockManager = spy()
-        val conn: ManagedBearerSsoConnection = mock()
-        whenever(connectionManager.activeConnectionForFeature(any())).thenReturn(conn)
-        whenever(conn.startUrl).thenReturn(startUrl)
-        whenever(conn.getConnectionSettings()).thenReturn(null)
+    private fun assertConnectionState(
+        startUrl: String,
+        refreshToken: String?,
+        expirationTime: Instant,
+        expectedState: BearerTokenAuthState,
+        expectedLoginType: CodeWhispererLoginType,
+        expectedIsCwEnabled: Boolean,
+        expectedIsCwExpired: Boolean
+    ) {
+        testDiskCache.saveAccessToken(
+            AccessTokenCacheKey(
+                connectionId = "us-east-1",
+                startUrl = startUrl,
+                scopes = CODEWHISPERER_SCOPES
+            ),
+            AccessToken(
+                startUrl = startUrl,
+                region = "us-east-1",
+                accessToken = aString(),
+                refreshToken = refreshToken,
+                expiresAt = expirationTime
+            )
+        )
 
-        val actual = mockManager.checkActiveCodeWhispererConnectionType(project)
-        assertThat(actual).isEqualTo(expectedType)
+        val myConnection = ManagedBearerSsoConnection(
+            startUrl,
+            "us-east-1",
+            CODEWHISPERER_SCOPES,
+            testDiskCache
+        )
+
+        ToolkitConnectionManager.getInstance(project).switchConnection(myConnection)
+        val activeCwConn = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeWhispererConnection.getInstance())
+        val myTokenProvider = myConnection.getConnectionSettings().tokenProvider.delegate as InteractiveBearerTokenProvider
+
+        assertThat(activeCwConn).isEqualTo(myConnection)
+        assertThat(myTokenProvider.state()).isEqualTo(expectedState)
+        assertThat(CodeWhispererExplorerActionManager.getInstance().checkActiveCodeWhispererConnectionType(project)).isEqualTo(expectedLoginType)
+        assertThat(isCodeWhispererEnabled(project)).isEqualTo(expectedIsCwEnabled)
+        assertThat(isCodeWhispererExpired(project)).isEqualTo(expectedIsCwExpired)
     }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


![token_expired](https://github.com/aws/aws-toolkit-jetbrains/assets/96078566/e7d2cff0-dc79-47a6-94ea-0c944be89907)

## Result
The unexpected behavior will result in"promptReauth" returning early and will not try refresh the token


## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
