### PR TITLE
CodeWhisperer: Fix indexOutOfBoundException in reformat

### DIFF
--- a/.changes/next-release/bugfix-05445066-8f16-47fc-be95-503f9a5f0743.json
+++ b/.changes/next-release/bugfix-05445066-8f16-47fc-be95-503f9a5f0743.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "CodeWhisperer: Fix an issue where an IndexOutOfBoundException could be thrown when using CodeWhisperer"
+}


### PR DESCRIPTION
1. Remove adjustLineIndent since it's almost no longer needed, indents from model will be trusted.
2. Keep the reformatReference since reference offset still needs to be updated after right context truncation.
3. Add tests

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
