### PR TITLE
Update active connection on unlinking

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/UnpinConnectionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/UnpinConnectionAction.kt
@@ -6,13 +6,16 @@ package software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.actions
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.UpdateInBackground
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAware
+import com.intellij.util.messages.Topic
 import software.aws.toolkits.jetbrains.core.credentials.pinning.ConnectionPinningManager
 import software.aws.toolkits.jetbrains.core.credentials.pinning.FeatureWithPinnedConnection
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.DevToolsToolWindow
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.DevToolsToolWindowDataKeys
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.PinnedConnectionNode
 import software.aws.toolkits.resources.message
+import java.util.EventListener
 
 class UnpinConnectionAction : AnAction(), DumbAware, UpdateInBackground {
     override fun update(e: AnActionEvent) {
@@ -28,7 +31,7 @@ class UnpinConnectionAction : AnAction(), DumbAware, UpdateInBackground {
         val project = e.project ?: return
         val feature = feature(e) ?: return
         ConnectionPinningManager.getInstance().setPinnedConnection(feature, null)
-
+        ApplicationManager.getApplication().messageBus.syncPublisher(UnpinConnectionListener.TOPIC).onChange()
         DevToolsToolWindow.getInstance(project).redrawContent()
     }
 
@@ -40,5 +43,14 @@ class UnpinConnectionAction : AnAction(), DumbAware, UpdateInBackground {
 
         val node = nodes.firstOrNull() as? PinnedConnectionNode ?: return null
         return node.feature()
+    }
+}
+
+interface UnpinConnectionListener : EventListener {
+    fun onChange() {}
+
+    companion object {
+        @Topic.AppLevel
+        val TOPIC = Topic.create("Connection unpinned from panel", UnpinConnectionListener::class.java)
     }
 }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/UnpinConnectionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/UnpinConnectionAction.kt
@@ -28,7 +28,7 @@ class UnpinConnectionAction : AnAction(), DumbAware, UpdateInBackground {
         val project = e.project ?: return
         val feature = feature(e) ?: return
         ConnectionPinningManager.getInstance().setPinnedConnection(feature, null)
-        
+
         DevToolsToolWindow.getInstance(project).redrawContent()
     }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/UnpinConnectionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/UnpinConnectionAction.kt
@@ -6,16 +6,13 @@ package software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.actions
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.UpdateInBackground
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAware
-import com.intellij.util.messages.Topic
 import software.aws.toolkits.jetbrains.core.credentials.pinning.ConnectionPinningManager
 import software.aws.toolkits.jetbrains.core.credentials.pinning.FeatureWithPinnedConnection
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.DevToolsToolWindow
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.DevToolsToolWindowDataKeys
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.PinnedConnectionNode
 import software.aws.toolkits.resources.message
-import java.util.EventListener
 
 class UnpinConnectionAction : AnAction(), DumbAware, UpdateInBackground {
     override fun update(e: AnActionEvent) {
@@ -31,6 +28,7 @@ class UnpinConnectionAction : AnAction(), DumbAware, UpdateInBackground {
         val project = e.project ?: return
         val feature = feature(e) ?: return
         ConnectionPinningManager.getInstance().setPinnedConnection(feature, null)
+        
         DevToolsToolWindow.getInstance(project).redrawContent()
     }
 
@@ -44,4 +42,3 @@ class UnpinConnectionAction : AnAction(), DumbAware, UpdateInBackground {
         return node.feature()
     }
 }
-

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/UnpinConnectionAction.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/UnpinConnectionAction.kt
@@ -31,7 +31,6 @@ class UnpinConnectionAction : AnAction(), DumbAware, UpdateInBackground {
         val project = e.project ?: return
         val feature = feature(e) ?: return
         ConnectionPinningManager.getInstance().setPinnedConnection(feature, null)
-        ApplicationManager.getApplication().messageBus.syncPublisher(UnpinConnectionListener.TOPIC).onChange()
         DevToolsToolWindow.getInstance(project).redrawContent()
     }
 
@@ -46,11 +45,3 @@ class UnpinConnectionAction : AnAction(), DumbAware, UpdateInBackground {
     }
 }
 
-interface UnpinConnectionListener : EventListener {
-    fun onChange() {}
-
-    companion object {
-        @Topic.AppLevel
-        val TOPIC = Topic.create("Connection unpinned from panel", UnpinConnectionListener::class.java)
-    }
-}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
@@ -56,6 +56,7 @@ import software.aws.toolkits.jetbrains.core.explorer.AwsToolkitExplorerToolWindo
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.DevToolsToolWindow
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.CawsServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.CodeWhispererExplorerRootNode
+import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.actions.UnpinConnectionListener
 import software.aws.toolkits.jetbrains.core.gettingstarted.SourceOfEntry
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel.PanelConstants.BULLET_PANEL_HEIGHT
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel.PanelConstants.GOT_IT_ID_PREFIX
@@ -112,6 +113,16 @@ class GettingStartedPanel(
                 }
             }
         )
+
+        ApplicationManager.getApplication().messageBus.connect(this).subscribe(
+            UnpinConnectionListener.TOPIC,
+            object : UnpinConnectionListener {
+                override fun onChange() {
+                    connectionUpdated()
+                }
+            }
+        )
+
         addToCenter(
             panel {
                 indent {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
@@ -48,6 +48,8 @@ import software.aws.toolkits.jetbrains.core.credentials.loginSso
 import software.aws.toolkits.jetbrains.core.credentials.logoutFromSsoConnection
 import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeCatalystConnection
 import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeWhispererConnection
+import software.aws.toolkits.jetbrains.core.credentials.pinning.ConnectionPinningManagerListener
+import software.aws.toolkits.jetbrains.core.credentials.pinning.FeatureWithPinnedConnection
 import software.aws.toolkits.jetbrains.core.credentials.sono.CODECATALYST_SCOPES
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_REGION
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
@@ -56,7 +58,6 @@ import software.aws.toolkits.jetbrains.core.explorer.AwsToolkitExplorerToolWindo
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.DevToolsToolWindow
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.CawsServiceNode
 import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.CodeWhispererExplorerRootNode
-import software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.actions.UnpinConnectionListener
 import software.aws.toolkits.jetbrains.core.gettingstarted.SourceOfEntry
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel.PanelConstants.BULLET_PANEL_HEIGHT
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel.PanelConstants.GOT_IT_ID_PREFIX
@@ -115,11 +116,12 @@ class GettingStartedPanel(
         )
 
         ApplicationManager.getApplication().messageBus.connect(this).subscribe(
-            UnpinConnectionListener.TOPIC,
-            object : UnpinConnectionListener {
-                override fun onChange() {
+            ConnectionPinningManagerListener.TOPIC,
+            object : ConnectionPinningManagerListener {
+                override fun pinnedConnectionChanged(feature: FeatureWithPinnedConnection, newConnection: ToolkitConnection?) {
                     connectionUpdated()
                 }
+
             }
         )
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/editor/GettingStartedPanel.kt
@@ -121,7 +121,6 @@ class GettingStartedPanel(
                 override fun pinnedConnectionChanged(feature: FeatureWithPinnedConnection, newConnection: ToolkitConnection?) {
                     connectionUpdated()
                 }
-
             }
         )
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
If a user is connected using one type of connection(eg Builder Id) and then logs in using another(eg Idc) for the same feature, the user will see the original connection type until they unpin their current connection to use the new one

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
