### PR TITLE
Fix Explorer-based UI tests

### DIFF
--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -19,8 +19,8 @@ fun IdeaFrame.awsExplorer(
     val locator = byXpath("//div[@accessiblename='AWS Toolkit Tool Window']")
 
     step("AWS toolkit tool window") {
-        val explorer = try {
-            find<AwsExplorer>(locator)
+        try {
+            find<ComponentFixture>(locator)
         } catch (e: Exception) {
             step("Open tool window") {
                 // Click the tool window stripe
@@ -28,7 +28,8 @@ fun IdeaFrame.awsExplorer(
                 find(locator, timeout)
             }
         }
-
+        find<ComponentFixture>(byXpath("//div[@class='TabContainer']//div[@text='Explorer']")).click()
+        val explorer = find<AwsExplorer>(byXpath("//div[@class='ExplorerToolWindow']"))
         explorer.apply(function)
     }
 }


### PR DESCRIPTION
Tests assume that the 'Explorer' tab is always selected by default, which is no longer true

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
