### PR TITLE
Add retry clicks due to UI test race condition on 233

### DIFF
--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -19,15 +19,18 @@ fun IdeaFrame.awsExplorer(
     val locator = byXpath("//div[@accessiblename='AWS Toolkit Tool Window']")
 
     step("AWS toolkit tool window") {
-        try {
-            find<ComponentFixture>(locator)
-        } catch (e: Exception) {
-            step("Open tool window") {
-                // Click the tool window stripe
-                find(ComponentFixture::class.java, byXpath("//div[@accessiblename='AWS Toolkit' and @class='StripeButton' and @text='AWS Toolkit']")).click()
-                find(locator, timeout)
+        repeat(5) {
+            try {
+                find<ComponentFixture>(locator)
+                return@repeat
+            } catch (e: Exception) {
+                step("Open tool window") {
+                    // Click the tool window stripe
+                    find(ComponentFixture::class.java, byXpath("//div[@accessiblename='AWS Toolkit' and @class='StripeButton' and @text='AWS Toolkit']")).click()
+                }
             }
         }
+
         find<ComponentFixture>(byXpath("//div[@class='TabContainer']//div[@text='Explorer']")).click()
         val explorer = find<AwsExplorer>(byXpath("//div[@class='ExplorerToolWindow']"))
         explorer.apply(function)

--- a/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
+++ b/ui-tests/tst/software/aws/toolkits/jetbrains/uitests/fixtures/AwsExplorer.kt
@@ -21,12 +21,18 @@ fun IdeaFrame.awsExplorer(
     step("AWS toolkit tool window") {
         repeat(5) {
             try {
-                find<ComponentFixture>(locator)
+                if (it == 0) {
+                    find<ComponentFixture>(locator)
+                } else {
+                    // longer timeout on subsequent tries
+                    find<ComponentFixture>(locator, timeout)
+                }
+
                 return@repeat
             } catch (e: Exception) {
                 step("Open tool window") {
                     // Click the tool window stripe
-                    find(ComponentFixture::class.java, byXpath("//div[@accessiblename='AWS Toolkit' and @class='StripeButton' and @text='AWS Toolkit']")).click()
+                    find<ComponentFixture>(byXpath("//div[@accessiblename='AWS Toolkit' and @class='StripeButton' and @text='AWS Toolkit']")).click()
                 }
             }
         }


### PR DESCRIPTION
A model progress indicator may occur before we manage to click the tool window stripe
<img width="1920" alt="image" src="https://github.com/aws/aws-toolkit-jetbrains/assets/742829/c6c2b1c3-f5f8-4cbe-9c01-c927777c0744">

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
