### PR TITLE
Add deprecation messages for IDE 223 / Gateway 232

### DIFF
--- a/.changes/next-release/deprecation-2c7d6d91-a8c1-41bc-a17f-024b045c7704.json
+++ b/.changes/next-release/deprecation-2c7d6d91-a8c1-41bc-a17f-024b045c7704.json
@@ -1,0 +1,4 @@
+{
+  "type" : "deprecation",
+  "description" : "An upcoming release will remove support for JetBrains Gateway version 2023.2 and for for IDEs based on the 2022.3 platform"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/MinimumVersionChange.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/MinimumVersionChange.kt
@@ -55,8 +55,8 @@ class MinimumVersionChange @JvmOverloads constructor(isUnderTest: Boolean = fals
     }
 
     companion object {
-        const val MIN_VERSION = 223
-        const val MIN_VERSION_HUMAN = "2022.3"
+        const val MIN_VERSION = 231
+        const val MIN_VERSION_HUMAN = "2023.1"
 
         // Used by tests to make sure the prompt never shows up
         const val SKIP_PROMPT = "aws.suppress_deprecation_prompt"

--- a/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/GatewayDeprecationNotice.kt
+++ b/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/GatewayDeprecationNotice.kt
@@ -29,7 +29,7 @@ class GatewayDeprecationNotice : AppLifecycleListener {
     }
 
     companion object {
-        const val MIN_VERSION = 232
-        const val MIN_VERSION_HUMAN = "2023.2"
+        const val MIN_VERSION = 233
+        const val MIN_VERSION_HUMAN = "2023.3"
     }
 }


### PR DESCRIPTION
This is earlier than we would normally do this, and we likely will not do this immediately. However, we want the agility in case we need to drop these builds last minute.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
