### PR TITLE
Only run dependabot on the main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,6 @@ version: 2
 updates:
   - package-ecosystem: "gradle" 
     directory: "/"
+    target-branch: "main" # Don't run on forks, staging, etc.
     schedule:
       interval: "daily"


### PR DESCRIPTION
Dependabot spams our staging branch with PRs that should be against the main branch instead
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
