### PR TITLE
Use 'InspectionsOK' instead of 'Commit' for CodeWhisperer checkmark in status bar

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
@@ -97,7 +97,7 @@ class CodeWhispererStatusBarWidget(project: Project) :
         } else if (CodeWhispererInvocationStatus.getInstance().hasExistingInvocation()) {
             AnimatedIcon.Default()
         } else {
-            AllIcons.Actions.Commit
+            AllIcons.General.InspectionsOK
         }
 
     companion object {


### PR DESCRIPTION
In NewUI, 'Commit' does not look like a checkmark

![image](https://github.com/aws/aws-toolkit-jetbrains/assets/742829/e66dceb7-0482-4d98-94dd-370d412ec045)
![image](https://github.com/aws/aws-toolkit-jetbrains/assets/742829/621775c5-1890-4b33-8320-fcfe365ada4d)


<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
