### PR TITLE
Fix local snapshot build versioning

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -122,7 +122,7 @@ tasks.withType<PatchPluginXmlTask>().all {
 if (!project.isCi()){
     val buildMetadata = buildMetadata()
     tasks.withType<PatchPluginXmlTask>().all {
-        version.set(intellij.version.map { "$it+$buildMetadata" })
+        version.set("${project.version}+$buildMetadata")
     }
 
     tasks.buildPlugin {


### PR DESCRIPTION
Local builds were reporting IC-202x.y, which were resulting in "update available" notifications

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
