### PR TITLE
Remove build requirement

### DIFF
--- a/.changes/next-release/bugfix-0451fd5a-678f-4947-b678-50fc9ce28eb5.json
+++ b/.changes/next-release/bugfix-0451fd5a-678f-4947-b678-50fc9ce28eb5.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "CodeWhisperer: Security scans for Java no longer require build artifacts"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/JavaCodeScanSessionConfig.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/JavaCodeScanSessionConfig.kt
@@ -16,7 +16,6 @@ import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.exists
 import software.aws.toolkits.core.utils.getLogger
-import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.cannotFindBuildArtifacts
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.fileTooLarge
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.JAVA_CODE_SCAN_TIMEOUT_IN_SECONDS
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.JAVA_PAYLOAD_LIMIT_IN_BYTES
@@ -56,7 +55,6 @@ internal class JavaCodeScanSessionConfig(
         // Include all the dependencies using BFS
         val (sourceFiles, srcPayloadSize, totalLines, buildPaths) = includeDependencies()
 
-        var noClassFilesFound = true
         val outputPaths = CompilerPaths.getOutputPaths(ModuleManager.getInstance(project).modules)
         var totalBuildPayloadSize = 0L
         val buildFiles = buildPaths.mapNotNull { relativePath ->
@@ -64,13 +62,11 @@ internal class JavaCodeScanSessionConfig(
             if (classFile == null) {
                 LOG.debug { "Cannot find class file for $relativePath" }
             } else {
-                noClassFilesFound = false
                 totalBuildPayloadSize += classFile.toFile().length()
             }
             classFile
         }
         LOG.debug { "Total build files sent in payload: ${buildFiles.size}" }
-        if (noClassFilesFound) cannotFindBuildArtifacts()
 
         // Copy all the included source and build files to the source zip
         val srcZip = zipFiles(sourceFiles.mapNotNull { getPath(it) } + buildFiles)

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererJavaCodeScanTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererJavaCodeScanTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.spy
@@ -28,6 +29,7 @@ import org.mockito.kotlin.stub
 import software.aws.toolkits.jetbrains.core.compileProjectAndWait
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.CodeScanSessionConfig
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.JavaCodeScanSessionConfig
+import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.PayloadMetadata
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.addClass
 import software.aws.toolkits.jetbrains.utils.rules.addModule
@@ -151,6 +153,17 @@ class CodeWhispererJavaCodeScanTest : CodeWhispererCodeScanTestBase(HeavyJavaCod
             filesInZip += 1
         }
         assertThat(filesInZip).isEqualTo(4)
+    }
+
+    @Test
+    fun `create payload with no build files does not throw exception`() {
+        sessionConfigSpy.stub {
+            onGeneric { includeDependencies() }.thenReturn(PayloadMetadata(emptySet(), 0, 0, emptySet()))
+        }
+        assertDoesNotThrow {
+            val payload = sessionConfigSpy.createPayload()
+            assertThat(payload.context.buildPayloadSize).isEqualTo(0)
+        }
     }
 
     @Test


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Security scans for Java code throws an error if its not compiled. This requirement should be removed since most detectors don't require compiled code to run a scan.

- Don't throw an error if compilation output path is not set
- Don't throw an error if build files are not found
- If build files are found, still include them in the zip file


## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
