### PR TITLE
Remove unncessary test compilation when not running test-related tasks

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -244,7 +244,7 @@ tasks.withType<RunIdeForUiTestTask>().all {
 // weird implicit dependency issue, maybe with how the task graph works?
 // or because tests are on the ide classpath for some reason?
 tasks.named("classpathIndexCleanup") {
-    dependsOn(tasks.named("compileIntegrationTestKotlin"))
+    mustRunAfter(tasks.named("compileIntegrationTestKotlin"))
 }
 
 configurations.instrumentedJar.configure {


### PR DESCRIPTION
Implicit task dependency resolution was incorrectly resolved with `dependsOn` rather than `mustRunAfter`, which introduced a task dependency rather than task ordering

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
