### PR TITLE
Don't show CodeWhisperer status widget in remote env

### DIFF
--- a/.changes/next-release/bugfix-bc2c5c25-2e62-43fa-a407-76486cfab45d.json
+++ b/.changes/next-release/bugfix-bc2c5c25-2e62-43fa-a407-76486cfab45d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue where the CodeWhisperer status bar widget is visible in a remote development environment"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidgetFactory.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidgetFactory.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.impl.status.widget.StatusBarEditorBasedWidgetFactory
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhispererEnabled
+import software.aws.toolkits.jetbrains.utils.isRunningOnRemoteBackend
 import software.aws.toolkits.resources.message
 
 class CodeWhispererStatusBarWidgetFactory : StatusBarEditorBasedWidgetFactory() {
@@ -17,7 +18,7 @@ class CodeWhispererStatusBarWidgetFactory : StatusBarEditorBasedWidgetFactory() 
     override fun getDisplayName(): String = message("codewhisperer.statusbar.display_name")
 
     override fun isAvailable(project: Project): Boolean =
-        isCodeWhispererEnabled(project)
+        !isRunningOnRemoteBackend() && isCodeWhispererEnabled(project)
 
     override fun createWidget(project: Project): StatusBarWidget = CodeWhispererStatusBarWidget(project)
 


### PR DESCRIPTION
CodeWhisperer doesn't work in remote environments, so the status bar should not be visible either
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
