### PR TITLE
Fix missing `/` in CODEOWNERS for Q Transform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 codewhisperer/ @aws/codewhisperer-team
 amazonq/ @aws/aws-mynah
 cwc/ @aws/aws-mynah
-codemodernizer @aws/elastic-gumby
+codemodernizer/ @aws/elastic-gumby


### PR DESCRIPTION
Needs `/` or wont match files in the subdirectory
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
