### PR TITLE
Fix issue loading project into IDE

### DIFF
--- a/kotlinResolution.settings.gradle.kts
+++ b/kotlinResolution.settings.gradle.kts
@@ -6,7 +6,7 @@ dependencyResolutionManagement {
         maybeCreate("libs").apply {
             // pull value from IJ library list: https://github.com/JetBrains/intellij-community/blob/<mv>/.idea/libraries/kotlinx_coroutines_jdk8.xml
             //                              or: https://github.com/JetBrains/intellij-community/blob/<mv>/.idea/libraries/kotlinx_coroutines_core.xml
-            val version = when (providers.gradleProperty("ideProfileName").get()) {
+            val version = when (providers.gradleProperty("ideProfileName").getOrNull() ?: return@apply) {
                 "2022.3" -> {
                     // binary compat issue in tests, but detekt requries at least kotlin 1.8
                     version("kotlin", "1.8.20")


### PR DESCRIPTION
`ideProfileName` is not defined during IDE Gradle import. This might be better resolved by using an alternate property provider but no-op provides the same behavior

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
