### PR TITLE
fix: align transform user click telemetry behavior with VSCode implem…

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerManager.kt
@@ -606,7 +606,7 @@ class CodeModernizerManager(private val project: Project) : PersistentStateCompo
                     // Code successfully stopped toast will display when post job is run after this
                     CodetransformTelemetry.totalRunTime(
                         codeTransformSessionId = CodeTransformTelemetryState.instance.getSessionId(),
-                        codeTransformResultStatusMessage = "User initiated stop",
+                        codeTransformResultStatusMessage = "JobCanceled",
                         codeTransformRunTimeLatency = calculateTotalLatency(CodeTransformTelemetryState.instance.getStartTime(), Instant.now())
                     )
                 }
@@ -615,7 +615,7 @@ class CodeModernizerManager(private val project: Project) : PersistentStateCompo
                 notifyTransformationFailedToStop(e.localizedMessage)
                 CodetransformTelemetry.totalRunTime(
                     codeTransformSessionId = CodeTransformTelemetryState.instance.getSessionId(),
-                    codeTransformResultStatusMessage = "User initiated stop",
+                    codeTransformResultStatusMessage = "JobCanceled",
                     codeTransformRunTimeLatency = calculateTotalLatency(CodeTransformTelemetryState.instance.getStartTime(), Instant.now())
                 )
             }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
@@ -14,7 +14,6 @@ import software.amazon.awssdk.services.codewhispererruntime.model.Transformation
 import software.amazon.awssdk.services.codewhispererruntime.model.TransformationLanguage
 import software.amazon.awssdk.services.codewhispererruntime.model.TransformationPlan
 import software.amazon.awssdk.services.codewhispererruntime.model.TransformationStatus
-import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.AwsClientManager

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
@@ -94,9 +94,9 @@ class CodeModernizerSession(
                 codeTransformRunTimeLatency = calculateTotalLatency(startTime, Instant.now())
             )
         } catch (e: Exception) {
-            LOG.error(e) { e.message.toString() }
+            val errorMessage = "Failed to upload archive"
             CodetransformTelemetry.logGeneralError(
-                codeTransformApiErrorMessage = e.message.toString(),
+                codeTransformApiErrorMessage = errorMessage,
                 codeTransformSessionId = CodeTransformTelemetryState.instance.getSessionId(),
             )
             state.currentJobStatus = TransformationStatus.FAILED
@@ -124,11 +124,11 @@ class CodeModernizerSession(
             LOG.warn { e.localizedMessage }
             return CodeModernizerStartJobResult.Disposed
         } catch (e: Exception) {
-            LOG.warn { e.message.toString() }
+            val errorMessage = "Failed to start job"
             state.putJobHistory(sessionContext, "FAILED TO START")
             state.currentJobStatus = TransformationStatus.FAILED
             CodetransformTelemetry.logGeneralError(
-                codeTransformApiErrorMessage = e.message.toString(),
+                codeTransformApiErrorMessage = errorMessage,
                 codeTransformSessionId = CodeTransformTelemetryState.instance.getSessionId(),
             )
             CodeModernizerStartJobResult.UnableToStartJob(e.message.toString())

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -137,10 +137,10 @@ data class CodeModernizerSessionContext(
                 }.toFile()
                 if (depDirectory != null) ZipCreationResult.Succeeded(outputFile) else ZipCreationResult.Missing1P(outputFile)
             } catch (e: NoSuchFileException) {
-                throw CodeModernizerException("Source folder not found: ${root.path}")
+                throw CodeModernizerException("Source folder not found")
             } catch (e: Exception) {
                 LOG.error(e) { e.message.toString() }
-                throw CodeModernizerException("Unknown exception occurred ${root.path}")
+                throw CodeModernizerException("Unknown exception occurred")
             } finally {
                 depDirectory?.deleteRecursively()
             }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

1. In AWS Toolkit for VSCode, the `isDoubleClickedToTriggerUserModal` metric for code transform is always emitted when customer click on the Transform button, regardless of project validity. However, in IntelliJ, the metric is only emitted if the project is valid. We should align the implementation with VSCode and use it to represent total count of user interaction with Transform Hub/Button. 
2. For consistency in `codeTransformResultStatusMessage`, change "User Initiated Stop" to "JobCanceled" 
3. Some logs include {root.path} which can contain PII, so removing them.

Validated that `isDoubleClickedToTriggerUserModal` is already emitted after user click regardless of project validity.
```
// Tested using invalid project

...
DefaultMetricEvent(createTime=2023-12-22T21:13:24.594822Z, awsAccount=not-set, awsRegion=us-west-2, data=[DefaultDatum(name=ui_click, value=1.0, unit=None, passive=false, metadata={elementId=amazonq_transform})])
// TriggerUserModal emitted
DefaultMetricEvent(createTime=2023-12-22T21:13:24.597080Z, awsAccount=n/a, awsRegion=n/a, data=[DefaultDatum(name=codeTransform_isDoubleClickedToTriggerUserModal, value=1.0, unit=None, passive=false, metadata={codeTransformStartSrcComponents=devToolsStartButton, codeTransformSessionId=c44ff08d-0170-443e-9c45-5a5c3443dd7c})])
DefaultMetricEvent(createTime=2023-12-22T21:13:24.698306Z, awsAccount=n/a, awsRegion=n/a, data=[DefaultDatum(name=amazonq_openChat, value=1.0, unit=None, passive=true, metadata={})])
// InvalidProject emitted
DefaultMetricEvent(createTime=2023-12-22T21:13:24.700987Z, awsAccount=n/a, awsRegion=n/a, data=[DefaultDatum(name=codeTransform_isDoubleClickedToTriggerInvalidProject, value=1.0, unit=None, passive=false, metadata={result=Failed, reason=other build, codeTransformPreValidationError=NonMavenProject, codeTransformSessionId=1c7cec31-5f5f-4de5-9dd9-233c1e0b11ff})])
...
```



## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
