### PR TITLE
make Toolkit imcompatible on JB Gateway thin client

### DIFF
--- a/jetbrains-core/resources/META-INF/plugin-intellij.xml
+++ b/jetbrains-core/resources/META-INF/plugin-intellij.xml
@@ -4,4 +4,8 @@
 <idea-plugin>
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
+
+    <incompatible-with>com.intellij.cwm.guest</incompatible-with>
+    <incompatible-with>com.intellij.jetbrains.client</incompatible-with>
+    <incompatible-with>com.intellij.gateway</incompatible-with>
 </idea-plugin>


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
