### PR TITLE
Amazon Q Transform: Always execute IDE bundled maven whenever maven command fails

### DIFF
--- a/.changes/next-release/bugfix-0cd6cb68-2ee7-4e79-8f6d-18c6a5592731.json
+++ b/.changes/next-release/bugfix-0cd6cb68-2ee7-4e79-8f6d-18c6a5592731.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Transform: Always execute IDE bundled maven whenever maven command fails"
+}

--- a/.changes/next-release/feature-85b6e4d3-97f5-48f6-ab49-bfc270b1de5b.json
+++ b/.changes/next-release/feature-85b6e4d3-97f5-48f6-ab49-bfc270b1de5b.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Amazon Q Transform: Always execute IDE bundled maven whenever maven command fails"
+}

--- a/.changes/next-release/feature-85b6e4d3-97f5-48f6-ab49-bfc270b1de5b.json
+++ b/.changes/next-release/feature-85b6e4d3-97f5-48f6-ab49-bfc270b1de5b.json
@@ -1,4 +1,0 @@
-{
-  "type" : "feature",
-  "description" : "Amazon Q Transform: Always execute IDE bundled maven whenever maven command fails"
-}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -224,7 +224,6 @@ data class CodeModernizerSessionContext(
                         codeTransformMavenBuildCommand = CodeTransformMavenBuildCommand.Mvn,
                         reason = error
                     )
-                    return null
                 } else {
                     shouldTryMvnCommand = false
                     LOG.warn { "Maven executed successfully" }
@@ -244,7 +243,6 @@ data class CodeModernizerSessionContext(
                     reason = e.message
                 )
                 LOG.error(e) { e.message.toString() }
-                throw e
             }
         }
 

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -180,7 +180,9 @@ data class CodeModernizerSessionContext(
         try {
             val mvnw = if (SystemInfo.isWindows) {
                 "./mvnw.cmd"
-            } else  "./mvnw"
+            } else {
+                "./mvnw"
+            }
             val output = runCommand(mvnw)
             if (output.exitCode != 0) {
                 LOG.error { "mvnw command output:\n$output" }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.JavaSdkVersion
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindowManager
@@ -39,7 +40,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
-import java.util.Locale
 import kotlin.io.NoSuchFileException
 import kotlin.io.byteInputStream
 import kotlin.io.deleteRecursively
@@ -178,7 +178,6 @@ data class CodeModernizerSessionContext(
         LOG.warn { "Executing ./mvnw" }
         var shouldTryMvnCommand = true
         try {
-           
             val mvnw = if (SystemInfo.isWindows) {
                 "./mvnw.cmd"
             } else  "./mvnw"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -39,6 +39,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.Locale
 import kotlin.io.NoSuchFileException
 import kotlin.io.byteInputStream
 import kotlin.io.deleteRecursively
@@ -177,7 +178,12 @@ data class CodeModernizerSessionContext(
         LOG.warn { "Executing ./mvnw" }
         var shouldTryMvnCommand = true
         try {
-            val output = runCommand("./mvnw")
+            var mvnw = "./mvnw"
+            val system = System.getProperty("os.name").lowercase(Locale.getDefault())
+            if (system.contains("win")) {
+                mvnw = "./mvnw.cmd"
+            }
+            val output = runCommand(mvnw)
             if (output.exitCode != 0) {
                 LOG.error { "mvnw command output:\n$output" }
                 val error = "The exitCode should be 0 while it was ${output.exitCode}"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -178,11 +178,10 @@ data class CodeModernizerSessionContext(
         LOG.warn { "Executing ./mvnw" }
         var shouldTryMvnCommand = true
         try {
-            var mvnw = "./mvnw"
-            val system = System.getProperty("os.name").lowercase(Locale.getDefault())
-            if (system.contains("win")) {
-                mvnw = "./mvnw.cmd"
-            }
+           
+            val mvnw = if (SystemInfo.isWindows) {
+                "./mvnw.cmd"
+            } else  "./mvnw"
             val output = runCommand(mvnw)
             if (output.exitCode != 0) {
                 LOG.error { "mvnw command output:\n$output" }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Due to a customer's experience that the maven command failed but the IDE bundled maven succeeded, we allow to always execute IDE bundled maven whenever maven command fails
## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
