### PR TITLE
Fix: Add jobId to feedback and fix Transform Plan UI alignment

### DIFF
--- a/.changes/next-release/bugfix-c5fe39dc-62e3-4580-8fc4-d1bf7876c1d2.json
+++ b/.changes/next-release/bugfix-c5fe39dc-62e3-4580-8fc4-d1bf7876c1d2.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix Code Transform Plan UI component alignment"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/constants/CodeModernizerUIConstants.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/constants/CodeModernizerUIConstants.kt
@@ -86,7 +86,7 @@ class CodeModernizerUIConstants {
         )
         val TRANSFORMATION_STEPS_INFO_AWSQ_BORDER = BorderFactory.createCompoundBorder(
             BorderFactory.createCompoundBorder(
-                BorderFactory.createEmptyBorder(0, 5, 0, 5),
+                BorderFactory.createEmptyBorder(0, 0, 0, 10),
                 BorderFactory.createLineBorder(Color.GRAY, 1, true)
             ),
             BorderFactory.createEmptyBorder(10, 10, 10, 10)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/feedback/FeedbackDialog.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/feedback/FeedbackDialog.kt
@@ -34,6 +34,7 @@ import software.aws.toolkits.jetbrains.AwsToolkit
 import software.aws.toolkits.jetbrains.core.coroutines.getCoroutineUiContext
 import software.aws.toolkits.jetbrains.core.coroutines.projectCoroutineScope
 import software.aws.toolkits.jetbrains.core.help.HelpIds
+import software.aws.toolkits.jetbrains.services.codemodernizer.state.CodeModernizerSessionState
 import software.aws.toolkits.jetbrains.services.telemetry.ClientMetadata
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.aws.toolkits.jetbrains.utils.notifyInfo
@@ -145,10 +146,12 @@ class FeedbackDialog(
                             mapOf(FEEDBACK_SOURCE to "CodeWhisperer onboarding")
                         )
                     } else if (isAmazonQ()) {
+                        val sessionState = CodeModernizerSessionState.getInstance(project)
+                        val jobId: String = sessionState.currentJobId?.id ?: "None"
                         TelemetryService.getInstance().sendFeedback(
                             sentiment,
                             "Amazon Q onboarding: $commentText",
-                            mapOf(FEEDBACK_SOURCE to "Amazon Q onboarding")
+                            mapOf(FEEDBACK_SOURCE to "Amazon Q onboarding", "JobId" to jobId)
                         )
                     } else {
                         TelemetryService.getInstance().sendFeedback(sentiment, commentText)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
- Feedback sent to Amazon Q now contains jobId in the metadata
- Alignment for the boxes' left edge has been fixed: 
<img width="986" alt="Screenshot 2024-01-04 at 4 23 48 PM" src="https://github.com/aws/aws-toolkit-jetbrains/assets/36546476/afa825d4-254d-4baa-8b81-bceeb105dbe1">



## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
