### PR TITLE
fix Windows file path in zip entries

### DIFF
--- a/.changes/next-release/bugfix-e16b8891-087a-4164-a9de-1e051a7e66c0.json
+++ b/.changes/next-release/bugfix-e16b8891-087a-4164-a9de-1e051a7e66c0.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix Code Transform uploaded artifact file paths when submitting from Windows machine"
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -130,7 +130,7 @@ data class CodeModernizerSessionContext(
                             var paddedPathString = paddedPath.toPath().toString()
                             // Convert Windows file path to work on Linux
                             if (File.separatorChar != '/') {
-                                paddedPathString = paddedPathString.replace("\\", "/")
+                                paddedPathString = paddedPathString.replace('\\', '/')
                             }
                             it.putNextEntry(paddedPathString, depfile.inputStream())
                         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -127,13 +127,23 @@ data class CodeModernizerSessionContext(
                         dependencyfiles.forEach { depfile ->
                             val relativePath = File(depfile.path).relativeTo(depDirectory.parentFile)
                             val paddedPath = depSources.resolve(relativePath)
-                            it.putNextEntry(paddedPath.toPath().toString(), depfile.inputStream())
+                            var paddedPathString = paddedPath.toPath().toString()
+                            // Convert Windows file path to work on Linux
+                            if (File.separatorChar != '/') {
+                                paddedPathString = paddedPathString.replace("\\", "/")
+                            }
+                            it.putNextEntry(paddedPathString, depfile.inputStream())
                         }
                     }
                     files.forEach { file ->
                         val relativePath = File(file.path).relativeTo(sourceFolder)
                         val paddedPath = zipSources.resolve(relativePath)
-                        it.putNextEntry(paddedPath.toPath().toString(), file.inputStream)
+                        var paddedPathString = paddedPath.toPath().toString()
+                        // Convert Windows file path to work on Linux
+                        if (File.separatorChar != '/') {
+                            paddedPathString = paddedPathString.replace("\\", "/")
+                        }
+                        it.putNextEntry(paddedPathString, file.inputStream)
                     }
                 }.toFile()
                 if (depDirectory != null) ZipCreationResult.Succeeded(outputFile) else ZipCreationResult.Missing1P(outputFile)

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -141,7 +141,7 @@ data class CodeModernizerSessionContext(
                         var paddedPathString = paddedPath.toPath().toString()
                         // Convert Windows file path to work on Linux
                         if (File.separatorChar != '/') {
-                            paddedPathString = paddedPathString.replace("\\", "/")
+                            paddedPathString = paddedPathString.replace('\\', '/')
                         }
                         it.putNextEntry(paddedPathString, file.inputStream)
                     }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
@@ -12,10 +12,12 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.projectRoots.JavaSdkVersion
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.testFramework.common.ThreadLeakTracker
+import com.intellij.testFramework.runInEdtAndGet
 import com.intellij.testFramework.runInEdtAndWait
 import kotlinx.coroutines.runBlocking
 import org.apache.commons.codec.digest.DigestUtils
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.gradle.internal.impldep.com.amazonaws.ResponseMetadata
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -94,7 +96,6 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         val fileText = "Morning"
         projectRule.fixture.addFileToModule(module, "src/tmp.txt", fileText)
 
-        var file: File? = null
         // get project.projectFile because project.projectFile can not be null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
@@ -105,24 +106,23 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         val codeContext = mock(CodeModernizerSessionContext::class.java)
         val mockFile = mock(File::class.java)
         `when`(codeContext.runMavenCommand(mockFile)).thenReturn(mock(File::class.java))
-        runInEdtAndWait {
-            file = context.createZipWithModuleFiles().payload
+        val file = runInEdtAndGet {
+            context.createZipWithModuleFiles().payload
         }
-        assertNotNull(file)
-        val zipFile = ZipFile(file)
-        val entries = zipFile.entries()
-        var numEntries = 0
-        while (entries.hasMoreElements()) {
-            numEntries += 1
-            val entry = entries.nextElement() ?: continue
-            val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
-            when (Path(entry.name)) {
-                Path("manifest.json") -> assertNotNull(fileContent)
-                Path("sources/src/tmp.txt") -> assertEquals(fileText, fileContent)
-                else -> throw AssertionError("Unexpected entry in zip file: $entry")
+        ZipFile(file).use { zipFile ->
+            var numEntries = 0
+            assertThat(zipFile.entries().toList()).allSatisfy { entry ->
+                numEntries += 1
+                val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
+                when (Path(entry.name)) {
+                    Path("manifest.json") -> assertNotNull(fileContent)
+                    Path("sources/src/tmp.txt") -> assertEquals(fileText, fileContent)
+                    else -> fail("Unexpected entry in zip file: $entry")
+                }
             }
+            zipFile.close()
+            assert(numEntries == 2)
         }
-        assert(numEntries == 2)
     }
 
     @Test
@@ -134,7 +134,6 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         projectRule.fixture.addFileToModule(module, "target/somedir/anotherthing.class", fileText)
         projectRule.fixture.addFileToModule(module, "pom.xml", fileText)
 
-        var file: File? = null
         // get project.projectFile because project.projectFile can not be null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
@@ -145,21 +144,20 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         val codeContext = mock(CodeModernizerSessionContext::class.java)
         val mockFile = mock(File::class.java)
         `when`(codeContext.runMavenCommand(mockFile)).thenReturn(mock(File::class.java))
-        runInEdtAndWait {
-            file = context.createZipWithModuleFiles().payload
+        val file = runInEdtAndGet {
+            context.createZipWithModuleFiles().payload
         }
-        assertNotNull(file)
-        val zipFile = ZipFile(file)
-        val entries = zipFile.entries()
-        while (entries.hasMoreElements()) {
-            val entry = entries.nextElement() ?: continue
-            val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
-            when (Path(entry.name)) {
-                Path("manifest.json") -> assertNotNull(fileContent)
-                Path("sources/src/tmp.java") -> assertEquals(fileText, fileContent)
-                Path("sources/pom.xml") -> assertEquals(fileText, fileContent)
-                else -> throw AssertionError("Unexpected entry in zip file: $entry")
+        ZipFile(file).use { zipFile ->
+            assertThat(zipFile.entries().toList()).allSatisfy { entry ->
+                val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
+                when (Path(entry.name)) {
+                    Path("manifest.json") -> assertNotNull(fileContent)
+                    Path("sources/src/tmp.java") -> assertEquals(fileText, fileContent)
+                    Path("sources/pom.xml") -> assertEquals(fileText, fileContent)
+                    else -> fail("Unexpected entry in zip file: $entry")
+                }
             }
+            zipFile.close()
         }
     }
 
@@ -172,7 +170,6 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         projectRule.fixture.addFileToModule(module, "target/somedir/anotherthing.class", fileText)
         projectRule.fixture.addFileToModule(module, "pom.xml", fileText)
 
-        var file: File? = null
         // get project.projectFile because project.projectFile can not be null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
@@ -180,21 +177,20 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
 
         val pom = roots[0].children.first { it.name == "pom.xml" }
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
-        runInEdtAndWait {
-            file = context.createZipWithModuleFiles().payload
+        val file = runInEdtAndGet {
+            context.createZipWithModuleFiles().payload
         }
-        assertNotNull(file)
-        val zipFile = ZipFile(file)
-        val entries = zipFile.entries()
-        while (entries.hasMoreElements()) {
-            val entry = entries.nextElement() ?: continue
-            val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
-            when (Path(entry.name)) {
-                Path("manifest.json") -> assertNotNull(fileContent)
-                Path("sources/src/tmp.java") -> assertEquals(fileText, fileContent)
-                Path("sources/pom.xml") -> assertEquals(fileText, fileContent)
-                else -> throw AssertionError("Unexpected entry in zip file: $entry")
+        ZipFile(file).use { zipFile ->
+            assertThat(zipFile.entries().toList()).allSatisfy { entry ->
+                val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
+                when (Path(entry.name)) {
+                    Path("manifest.json") -> assertNotNull(fileContent)
+                    Path("sources/src/tmp.java") -> assertEquals(fileText, fileContent)
+                    Path("sources/pom.xml") -> assertEquals(fileText, fileContent)
+                    else -> fail("Unexpected entry in zip file: $entry")
+                }
             }
+            zipFile.close()
         }
     }
 
@@ -209,30 +205,28 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
             "someModule/target/smth.class",
             "someModule/src/helloworld.java",
         )
-        var file: File? = null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
         assertFalse(roots.isEmpty() || roots.size > 1)
 
         val pom = roots[0].children.first { it.name == "pom.xml" }
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
-        runInEdtAndWait {
-            file = context.createZipWithModuleFiles().payload
+        val file = runInEdtAndGet {
+            context.createZipWithModuleFiles().payload
         }
-        assertNotNull(file)
-        val zipFile = ZipFile(file)
-        val entries = zipFile.entries()
-        while (entries.hasMoreElements()) {
-            val entry = entries.nextElement() ?: continue
-            val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
-            when (Path(entry.name)) {
-                Path("manifest.json") -> assertNotNull(fileContent)
-                Path("sources/src/tmp.java") -> assertEquals("src/tmp.java", fileContent)
-                Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
-                Path("sources/someModule/src/helloworld.java") -> assertEquals("someModule/src/helloworld.java", fileContent)
-                Path("sources/someModule/pom.xml") -> assertEquals("someModule/pom.xml", fileContent)
-                else -> throw AssertionError("Unexpected entry in zip file: $entry")
+        ZipFile(file).use { zipFile ->
+            assertThat(zipFile.entries().toList()).allSatisfy { entry ->
+                val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
+                when (Path(entry.name)) {
+                    Path("manifest.json") -> assertNotNull(fileContent)
+                    Path("sources/src/tmp.java") -> assertEquals("src/tmp.java", fileContent)
+                    Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
+                    Path("sources/someModule/src/helloworld.java") -> assertEquals("someModule/src/helloworld.java", fileContent)
+                    Path("sources/someModule/pom.xml") -> assertEquals("someModule/pom.xml", fileContent)
+                    else -> fail("Unexpected entry in zip file: $entry")
+                }
             }
+            zipFile.close()
         }
     }
 
@@ -247,31 +241,28 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
             "someModule\\target\\smth.class",
             "someModule\\src\\helloworld.java",
         )
-        var file: File? = null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
         assertFalse(roots.isEmpty() || roots.size > 1)
 
         val pom = roots[0].children.first { it.name == "pom.xml" }
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
-        runInEdtAndWait {
-            file = context.createZipWithModuleFiles().payload
+        val file = runInEdtAndGet {
+            context.createZipWithModuleFiles().payload
         }
-        assertNotNull(file)
-        val zipFile = ZipFile(file)
-        val entries = zipFile.entries()
-        while (entries.hasMoreElements()) {
-            val entry = entries.nextElement() ?: continue
-            val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
-            // Note: file contents are using the original path strings from addFilesToProjectModule.
-            when (Path(entry.name)) {
-                Path("manifest.json") -> assertNotNull(fileContent)
-                Path("sources/src/tmp.java") -> assertEquals("src\\tmp.java", fileContent)
-                Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
-                Path("sources/someModule/src/helloworld.java") -> assertEquals("someModule\\src\\helloworld.java", fileContent)
-                Path("sources/someModule/pom.xml") -> assertEquals("someModule\\pom.xml", fileContent)
-                else -> throw AssertionError("Unexpected entry in zip file: $entry")
+        ZipFile(file).use { zipFile ->
+            assertThat(zipFile.entries().toList()).allSatisfy { entry ->
+                val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
+                when (Path(entry.name)) {
+                    Path("manifest.json") -> assertNotNull(fileContent)
+                    Path("sources/src/tmp.java") -> assertEquals("src\\tmp.java", fileContent)
+                    Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
+                    Path("sources/someModule/src/helloworld.java") -> assertEquals("someModule\\src\\helloworld.java", fileContent)
+                    Path("sources/someModule/pom.xml") -> assertEquals("someModule\\pom.xml", fileContent)
+                    else -> fail("Unexpected entry in zip file: $entry")
+                }
             }
+            zipFile.close()
         }
     }
 
@@ -284,7 +275,6 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
             "someModule/pom.xml",
             "someModule/.idea/smthelse.iml"
         )
-        var file: File? = null
         // get project.projectFile because project.projectFile can not be null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
@@ -292,22 +282,21 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
 
         val pom = roots[0].children.first { it.name == "pom.xml" }
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
-        runInEdtAndWait {
-            file = context.createZipWithModuleFiles().payload
+        val file = runInEdtAndGet {
+            context.createZipWithModuleFiles().payload
         }
-        assertNotNull(file)
-        val zipFile = ZipFile(file)
-        val entries = zipFile.entries()
-        while (entries.hasMoreElements()) {
-            val entry = entries.nextElement() ?: continue
-            val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
-            when (Path(entry.name)) {
-                Path("manifest.json") -> assertNotNull(fileContent)
-                Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
-                Path("sources/src/tmp.java") -> assertEquals("src/tmp.java", fileContent)
-                Path("sources/someModule/pom.xml") -> assertEquals("someModule/pom.xml", fileContent)
-                else -> throw AssertionError("Unexpected entry in zip file: $entry")
+        ZipFile(file).use { zipFile ->
+            assertThat(zipFile.entries().toList()).allSatisfy { entry ->
+                val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
+                when (Path(entry.name)) {
+                    Path("manifest.json") -> assertNotNull(fileContent)
+                    Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
+                    Path("sources/src/tmp.java") -> assertEquals("src/tmp.java", fileContent)
+                    Path("sources/someModule/pom.xml") -> assertEquals("someModule/pom.xml", fileContent)
+                    else -> throw AssertionError("Unexpected entry in zip file: $entry")
+                }
             }
+            zipFile.close()
         }
     }
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

For paths that include "/" on Windows machines, replace them with "\" before zipping.
- Confirmed transformation remained successful on Mac.
- Confirmed transformation for simple Java 8 app worked on Windows. 

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
