### PR TITLE
Fix Windows unit test environment

### DIFF
--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -7,18 +7,10 @@ env:
 
 phases:
   install:
+    runtime-versions:
+      java: corretto17
+
     commands:
-      - |
-        $url = 'https://corretto.aws/downloads/latest/amazon-corretto-17-x64-windows-jdk.msi';
-        Write-Host ('Downloading from {0}' -f $url);
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
-        Invoke-WebRequest -Uri $url -OutFile 'corretto_jdk_build.msi';
-        Start-Process 'corretto_jdk_build.msi' -PassThru | Wait-Process
-      - |
-        $javaName = "C:\Program Files\Amazon Corretto" | ForEach-Object {
-          ls $_ | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name
-        }
-        $JAVA_HOME = "C:\Program Files\Amazon Corretto\$javaName"
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
@@ -41,7 +33,6 @@ phases:
         # See https://github.com/NuGet/NuGet.Client/pull/4259
         $Env:NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY = "3,1000"
 
-        $Env:JAVA_HOME = $JAVA_HOME
         if ($Env:CODEARTIFACT_DOMAIN_NAME -and $Env:CODEARTIFACT_REPO_NAME) {
           $Env:CODEARTIFACT_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format maven --query repositoryEndpoint --output text
           $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text


### PR DESCRIPTION
CodeBuild fixed the issue where `corretto17` did nothing and Corretto team released a new version of JDK17 which the existing logic is unable to find for some reason
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
