### PR TITLE
feature(QTransform): Detect and add telemetry for 1p dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ slf4j = "1.7.36"
 sshd = "2.11.0"
 wiremock = "2.35.0"
 zjsonpatch = "0.4.11"
+jsoup = "1.14.3"
 
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertJ" }
@@ -99,6 +100,8 @@ sshd-scp = { module = "org.apache.sshd:sshd-scp", version.ref = "sshd" }
 sshd-sftp = { module = "org.apache.sshd:sshd-sftp", version.ref = "sshd" }
 wiremock = { module = "com.github.tomakehurst:wiremock-jre8", version.ref = "wiremock" }
 zjsonpatch = { module = "com.flipkart.zjsonpatch:zjsonpatch", version.ref = "zjsonpatch" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+
 
 [bundles]
 jackson = ["jackson-datetime", "jackson-kotlin", "jackson-yaml", "jackson-xml"]

--- a/jetbrains-core/build.gradle.kts
+++ b/jetbrains-core/build.gradle.kts
@@ -139,9 +139,11 @@ dependencies {
 
     implementation(project(":mynah-ui"))
     implementation(libs.aws.crt)
+    implementation(libs.aws.crt)
     implementation(libs.bundles.jackson)
     implementation(libs.zjsonpatch)
     implementation(libs.commonmark)
+    implementation(libs.jsoup)
 
     testImplementation(project(path = ":core", configuration = "testArtifacts"))
     testImplementation(libs.mockk)

--- a/jetbrains-core/build.gradle.kts
+++ b/jetbrains-core/build.gradle.kts
@@ -139,7 +139,6 @@ dependencies {
 
     implementation(project(":mynah-ui"))
     implementation(libs.aws.crt)
-    implementation(libs.aws.crt)
     implementation(libs.bundles.jackson)
     implementation(libs.zjsonpatch)
     implementation(libs.commonmark)

--- a/jetbrains-core/resources/telemetryOverride.json
+++ b/jetbrains-core/resources/telemetryOverride.json
@@ -207,6 +207,11 @@
                 "q",
                 "codewhispererQ"
             ]
+        },
+        {
+            "name": "has1pdependency",
+            "type": "boolean",
+            "description": "Project contains at least 1 dependency not available in maven central"
         }
     ],
     "metrics": [
@@ -505,6 +510,24 @@
                 {
                     "type": "cwsprChatCommandName",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "codeTransform_projectContains1pDependencies",
+            "description": "When a project contains dependencies not available on maven central",
+            "metadata": [
+                {
+                    "type": "codeTransformSessionId",
+                    "required": true
+                },
+                {
+                    "type": "codeTransformJobId",
+                    "required": true
+                },
+                {
+                    "type": "has1pdependency",
+                    "required": true
                 }
             ]
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerManager.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerManager.kt
@@ -73,6 +73,15 @@ import java.io.File
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.Icon
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import kotlinx.serialization.json.Json;
+import kotlinx.serialization.json.JsonObject;
 
 @State(name = "codemodernizerStates", storages = [Storage("aws.xml", roamingType = RoamingType.PER_OS)])
 class CodeModernizerManager(private val project: Project) : PersistentStateComponent<CodeModernizerState>, Disposable {
@@ -373,6 +382,113 @@ class CodeModernizerManager(private val project: Project) : PersistentStateCompo
     }
 
     /**
+    helper function to generate 1p dependency metrics
+    makes GET requests to maven central to check for 1p dependencies for a small subset of the project's
+    dependencies
+     */
+    private fun makeGETRequests(groupId: String, artifactId: String, version: String, jobId: JobId): Boolean {
+        val httpClient = HttpClient.newHttpClient();
+        val request =  HttpRequest.newBuilder()
+            .uri(URI.create("https://search.maven.org/solrsearch/select?q=g:$groupId%20AND%20a:$artifactId%20AND%20v:$version%20AND%20p:jar&rows=20&wt=json"))
+            .GET()
+            .build();
+
+        try{
+            val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if(response.statusCode() == 200){
+                val jsonResponse = response.body();
+                try {
+                    val json: JsonObject = Json.parseToJsonElement(jsonResponse) as JsonObject;
+                    val responses = json["response"] as? JsonObject;
+                    val numFound = responses?.get("numFound");
+
+
+                    if(numFound.toString() == "0"){
+                        CodetransformTelemetry.projectContains1pDependencies(
+                            codeTransformSessionId = CodeTransformTelemetryState.instance.getSessionId(),
+                            codeTransformJobId = jobId.id,
+                            has1pdependency = true
+                        )
+                        return true;
+                    }
+                } catch (e: Exception){
+                    LOG.warn{"Error parsing JSON response from GET request to maven central: ${e.printStackTrace()}"}
+                }
+            } else {
+                LOG.warn{"Error making request to maven central. Response code: ${response.statusCode()}"}
+            }
+        } catch(e: Exception){
+            LOG.warn{"Exception while making GET request to maven central: ${e.printStackTrace()}"}
+        }
+        return false;
+    }
+
+
+    /**
+     * Coroutine to find and generate metrics on 1p dependencies (dependencies
+     * not available in maven central)
+     */
+    fun generate1pDependencyMetrics(jobId: JobId, session: CodeModernizerSession) = projectCoroutineScope(project).launch {
+        val dir = project.basePath;
+        val commandList = listOf(
+            "versions:dependency-updates-aggregate-report",
+            "-DonlyProjectDependencies=true"
+        )
+
+        try{
+            session.sessionContext.runMavenShellCommand(File(dir), commandList);
+
+            val successImgSrc = "images/icon_success_sml.gif";
+            var aggregateReport = Jsoup.parse(File("$dir/target/site/dependency-updates-aggregate-report.html"), "UTF-8");
+
+            // delete everything after dependency updates <h2> to reduce parsing size
+            val text = "Dependency Updates";
+            val h2 = aggregateReport.select("h2:contains($text)");
+
+            if(h2 != null){
+                val elementsAfterH2 = h2.nextAll();
+                elementsAfterH2.remove();
+            }
+
+            val imgElements: Elements = aggregateReport.select("td img[src=$successImgSrc]");
+            var found1pDependency = false;
+
+            for(img: Element in imgElements){
+                var td = img.parent()?.parent();
+
+                if (td != null){
+                    if(td.childrenSize() > 3){
+                        val followingElements = td.children().subList(1,4);
+
+                        val groupId = followingElements[0].text();
+                        val artifactId = followingElements[1].text();
+                        val version = followingElements[2].text();
+                        found1pDependency = makeGETRequests(groupId, artifactId, version, jobId);
+
+                        if(found1pDependency){
+                            break; // break once one 1p dependency is found to emit metric
+                        }
+                    }
+                }
+            }
+
+            if(!found1pDependency){
+                CodetransformTelemetry.projectContains1pDependencies(
+                    codeTransformSessionId = CodeTransformTelemetryState.instance.getSessionId(),
+                    codeTransformJobId = jobId.id,
+                    has1pdependency = false
+                )
+            }
+        } catch (e: Exception){
+            CodetransformTelemetry.logGeneralError(
+                codeTransformApiErrorMessage = "Failed to run maven command and parse 1p dependencies",
+                codeTransformSessionId = CodeTransformTelemetryState.instance.getSessionId(),
+            )
+        }
+
+    }
+    /**
      *Start the modernization job and return the reference
      */
     internal suspend fun initModernizationJob(session: CodeModernizerSession): CodeModernizerJobCompletedResult {
@@ -413,6 +529,9 @@ class CodeModernizerManager(private val project: Project) : PersistentStateCompo
         ApplicationManager.getApplication().invokeLater {
             codeModernizerBottomWindowPanelManager.setJobRunningUI()
         }
+
+        // start coroutine to generate 1p dependency metrics
+        generate1pDependencyMetrics(jobId, session);
 
         return session.pollUntilJobCompletion(jobId) { new, plan ->
             codeModernizerBottomWindowPanelManager.handleJobTransition(new, plan, session.sessionContext.sourceJavaVersion)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
This PR adds detection for 1p dependencies (private dependencies not available on maven central) and creates new telemetry to help the Q Transform team get more granulated information on the types of dependencies in applications submitted through the transformation. 

This change includes: 
- Running a new maven command that generates a report on dependencies that have newer versions available in maven central. This report is parsed for dependencies that are reported to be on the latest version (which can be available on maven but being used in the application at the latest version available, or be a private dependency). The small subset of dependencies parsed from this report are then checked against maven central. 
    - A few notes on latency: 
        - This approach adds about 3-5 seconds of latency for large multi-module applications tested. The `-DonlyProjectDependencies=true` flag reduced this number from ~1 minute and 40 seconds to only a few seconds. 
        - This logic runs in a new coroutine to ensure that the overall transformation time is not impacted on the customer's end. 
- This change also refactors the `runMavenCommand` function, which was strictly running the `mvn copy-dependencies` command, to generalize it and allow for passing in any `commandList`

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes (tests conducted for this change consisted of end-to-end transformations on the IntelliJ IDE, and tested telemetry generation locally)
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
