### PR TITLE
 Amazon Q Transform: Capture build log to include in uploaded transform artifact

### DIFF
--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ideMaven/TransformMavenRunner.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ideMaven/TransformMavenRunner.kt
@@ -5,10 +5,12 @@ package software.aws.toolkits.jetbrains.services.codemodernizer.ideMaven
 
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.execution.runners.ProgramRunner
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
 import org.jetbrains.idea.maven.execution.MavenRunConfigurationType
 import org.jetbrains.idea.maven.execution.MavenRunnerParameters
 import org.jetbrains.idea.maven.execution.MavenRunnerSettings
@@ -25,8 +27,22 @@ class TransformMavenRunner(val project: Project) {
                 return@Callback
             }
             handler.addProcessListener(object : ProcessAdapter() {
+                var output: String = ""
+
+                override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+                    when (outputType) {
+                        ProcessOutputTypes.STDOUT -> {
+                            output += event.text
+                        }
+                        ProcessOutputTypes.STDERR -> {
+                            output += event.text
+                        }
+                    }
+                }
+
                 override fun processTerminated(event: ProcessEvent) {
                     onComplete.exitCode(event.exitCode)
+                    onComplete.setOutput(output)
                 }
             })
         }

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ideMaven/TransformRunnable.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ideMaven/TransformRunnable.kt
@@ -5,6 +5,7 @@ package software.aws.toolkits.jetbrains.services.codemodernizer.ideMaven
 
 class TransformRunnable : Runnable {
     private var isComplete: Int? = null
+    private var output: String? = null
 
     fun exitCode(i: Int) {
         isComplete = i
@@ -15,4 +16,9 @@ class TransformRunnable : Runnable {
     }
 
     fun isComplete(): Int? = isComplete
+    fun getOutput(): String? = output
+
+    fun setOutput(s: String) {
+        output = s
+    }
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
@@ -27,7 +27,6 @@ import org.junit.Test
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doNothing
@@ -106,7 +105,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         val codeContext = mock(CodeModernizerSessionContext::class.java)
         val mockFile = mock(File::class.java)
         val mockStringBUilder = mock(StringBuilder::class.java)
-        `when`(codeContext.runMavenCommand(mockFile, mockStringBUilder)).thenReturn(mock(File::class.java))
+        whenever(codeContext.runMavenCommand(mockFile, mockStringBUilder)).thenReturn(mock(File::class.java))
         val file = runInEdtAndGet {
             context.createZipWithModuleFiles().payload
         }
@@ -146,7 +145,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         val codeContext = mock(CodeModernizerSessionContext::class.java)
         val mockFile = mock(File::class.java)
         val mockStringBUilder = mock(StringBuilder::class.java)
-        `when`(codeContext.runMavenCommand(mockFile, mockStringBUilder)).thenReturn(mock(File::class.java))
+        whenever(codeContext.runMavenCommand(mockFile, mockStringBUilder)).thenReturn(mock(File::class.java))
         val file = runInEdtAndGet {
             context.createZipWithModuleFiles().payload
         }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
@@ -105,7 +105,8 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         val context = CodeModernizerSessionContext(project, root.children[0], JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
         val codeContext = mock(CodeModernizerSessionContext::class.java)
         val mockFile = mock(File::class.java)
-        `when`(codeContext.runMavenCommand(mockFile)).thenReturn(mock(File::class.java))
+        val mockStringBUilder = mock(StringBuilder::class.java)
+        `when`(codeContext.runMavenCommand(mockFile, mockStringBUilder)).thenReturn(mock(File::class.java))
         val file = runInEdtAndGet {
             context.createZipWithModuleFiles().payload
         }
@@ -117,11 +118,12 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
                 when (Path(entry.name)) {
                     Path("manifest.json") -> assertNotNull(fileContent)
                     Path("sources/src/tmp.txt") -> assertEquals(fileText, fileContent)
+                    Path("build-logs.txt") -> assertNotNull(fileContent)
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
             zipFile.close()
-            assert(numEntries == 2)
+            assert(numEntries == 3)
         }
     }
 
@@ -143,7 +145,8 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
         val codeContext = mock(CodeModernizerSessionContext::class.java)
         val mockFile = mock(File::class.java)
-        `when`(codeContext.runMavenCommand(mockFile)).thenReturn(mock(File::class.java))
+        val mockStringBUilder = mock(StringBuilder::class.java)
+        `when`(codeContext.runMavenCommand(mockFile, mockStringBUilder)).thenReturn(mock(File::class.java))
         val file = runInEdtAndGet {
             context.createZipWithModuleFiles().payload
         }
@@ -154,6 +157,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
                     Path("manifest.json") -> assertNotNull(fileContent)
                     Path("sources/src/tmp.java") -> assertEquals(fileText, fileContent)
                     Path("sources/pom.xml") -> assertEquals(fileText, fileContent)
+                    Path("build-logs.txt") -> assertNotNull(fileContent)
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
@@ -187,6 +191,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
                     Path("manifest.json") -> assertNotNull(fileContent)
                     Path("sources/src/tmp.java") -> assertEquals(fileText, fileContent)
                     Path("sources/pom.xml") -> assertEquals(fileText, fileContent)
+                    Path("build-logs.txt") -> assertNotNull(fileContent)
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
@@ -223,6 +228,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
                     Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
                     Path("sources/someModule/src/helloworld.java") -> assertEquals("someModule/src/helloworld.java", fileContent)
                     Path("sources/someModule/pom.xml") -> assertEquals("someModule/pom.xml", fileContent)
+                    Path("build-logs.txt") -> assertNotNull(fileContent)
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
@@ -259,6 +265,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
                     Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
                     Path("sources/someModule/src/helloworld.java") -> assertEquals("someModule\\src\\helloworld.java", fileContent)
                     Path("sources/someModule/pom.xml") -> assertEquals("someModule\\pom.xml", fileContent)
+                    Path("build-logs.txt") -> assertNotNull(fileContent)
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
@@ -293,6 +300,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
                     Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
                     Path("sources/src/tmp.java") -> assertEquals("src/tmp.java", fileContent)
                     Path("sources/someModule/pom.xml") -> assertEquals("someModule/pom.xml", fileContent)
+                    Path("build-logs.txt") -> assertNotNull(fileContent)
                     else -> throw AssertionError("Unexpected entry in zip file: $entry")
                 }
             }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
1. To ensure code transform can copy necessary dependencies, code transform will first run "mvn install" for the project in case customer had not build the project previously.

2. Code Transform wants to include more details on pre-transformation build information (maven install and copy-dependencies) in the final summary file. To do so, we will capture build informaiton in a temporary `build-logs.txt` file that will be zipped with existing manifest and directories, and uploaded to backend.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
