### PR TITLE
Ban Gson

### DIFF
--- a/detekt-rules/src/software/aws/toolkits/gradle/detekt/rules/BannedImportsRule.kt
+++ b/detekt-rules/src/software/aws/toolkits/gradle/detekt/rules/BannedImportsRule.kt
@@ -69,6 +69,16 @@ class BannedImportsRule : Rule() {
                     )
                 )
             }
+
+            if (importedFqName == "com.google.gson.Gson") {
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.from(element),
+                        message = "Use jacksonObjectMapper() insted of Gson"
+                    )
+                )
+            }
         }
     }
 }

--- a/detekt-rules/tst/software/aws/toolkits/gradle/detekt/rules/BannedImportsRuleTest.kt
+++ b/detekt-rules/tst/software/aws/toolkits/gradle/detekt/rules/BannedImportsRuleTest.kt
@@ -25,6 +25,13 @@ class BannedImportsRuleTest {
     }
 
     @Test
+    fun `Importing Gson fails`() {
+        assertThat(rule.lint("import com.google.gson.Gson"))
+            .singleElement()
+            .matches { it.id == "BannedImports" && it.message == "Use jacksonObjectMapper() insted of Gson" }
+    }
+
+    @Test
     fun `Importing Kotlin test assert fails`() {
         assertThat(rule.lint("import kotlin.test.assertTrue"))
             .singleElement()

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryTest.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer
 
-import com.google.gson.Gson
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
@@ -379,6 +379,7 @@ class CodeWhispererTelemetryTest : CodeWhispererTestBase() {
     fun `test user Decision events record CodeWhisperer reference info`() {
         val userGroup = CodeWhispererUserGroupSettings.getInstance().getUserGroup()
         withCodeWhispererServiceInvokedAndWait {}
+        val mapper = jacksonObjectMapper()
         argumentCaptor<MetricEvent>().apply {
             verify(batcher, atLeastOnce()).enqueue(capture())
             pythonResponse.completions().forEach {
@@ -386,7 +387,7 @@ class CodeWhispererTelemetryTest : CodeWhispererTestBase() {
                     allValues,
                     userDecision,
                     1,
-                    "codewhispererSuggestionReferences" to Gson().toJson(it.references().map { ref -> ref.licenseName() }.toSet()),
+                    "codewhispererSuggestionReferences" to mapper.writeValueAsString(it.references().map { ref -> ref.licenseName() }.toSet()),
                     "codewhispererSuggestionReferenceCount" to it.references().size.toString(),
                     "codewhispererUserGroup" to userGroup.name,
                     atLeast = true


### PR DESCRIPTION
Gson is currently on the classpath, but the rest of the repo uses Jackson ObjectMapper.
Gson is also in maintenance mode.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
