### PR TITLE
fix: [Amazon Q] handle exceptions in service request

### DIFF
--- a/.changes/next-release/bugfix-2f848e2b-d35e-40a9-a89e-59e5bb8df212.json
+++ b/.changes/next-release/bugfix-2f848e2b-d35e-40a9-a89e-59e5bb8df212.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q: Service exceptions are not suppressed and displayed to the user."
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/messenger/ChatPromptHandler.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/messenger/ChatPromptHandler.kt
@@ -52,6 +52,9 @@ class ChatPromptHandler(private val telemetryHelper: TelemetryHelper) {
                 // Don't emit any other responses if we cancelled the collection
                 if (error is CancellationException) {
                     return@onCompletion
+                } // for any other exception, let the `catch` operator handle it.
+                else if (error != null) {
+                    throw error
                 }
 
                 // Send the gathered suggestions in a final answer-part message


### PR DESCRIPTION
Currently, most exceptions that occur when the amazon Q API is invoked
are suppressed and are not surfaced to the user (For ex,
`AccessDeniedException`).

The plugin proceeds like the call succeeded, and subsequently makes another
call to add a telemetry event that also fails due to an improperly formed
request (from not having a conversationId), and the user is shown this error
instead of the original error.

This change fixed that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Before the change:
<img width="630" alt="image" src="https://github.com/aws/aws-toolkit-jetbrains/assets/15814203/1b48be0b-7656-4cf6-90db-a375fd7c0311">

After the change: 
<img width="365" alt="image" src="https://github.com/aws/aws-toolkit-jetbrains/assets/15814203/56d88e1c-86d4-4e08-961f-0ac13b431b84">

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
