### PR TITLE
Fix 'Duplicate content roots detected' IDE warning during Gradle import

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -93,9 +93,9 @@ plugins/
 file("plugins").listFiles()?.forEach root@ {
     if (!it.isDirectory) return@root
 
-    val name = it.name
-    include(":$name")
-    project(":$name").projectDir = it
+    val pluginRoot = "plugin-${it.name}"
+    include(":$pluginRoot")
+    project(":$pluginRoot").projectDir = it
 
     val path = ArrayDeque<String>()
     it.walk().maxDepth(2)


### PR DESCRIPTION
settings.gradle.kts was erroneously creating an extra project in the hierarchy, confusing the IDE. For example, 'plugins/toolkit' was creating: ':toolkit' and ':plugin-toolkit'
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
