### PR TITLE
fix(CodeTransform): Updating commands for copying dependencies

### DIFF
--- a/.changes/next-release/bugfix-d9747f14-34f4-48f2-9a6d-62caaa7c1897.json
+++ b/.changes/next-release/bugfix-d9747f14-34f4-48f2-9a6d-62caaa7c1897.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "fix(CodeTransform): Updating commands for copying dependencies"
+}


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Using `mvn install` as the primary mechanism to copy dependencies. The order of execution is as follows:
1. Run `dependency:copy-dependencies` to copy any locally persisted dependencies into an empty dependencies directory. We will continue execution even if this step fails as this is just an optimization to avoid downloading any locally available dependencies which can be copied with this command.
2. Run `mvn clean` and `mvn install` with the `-Dmavn.repo.local` arg pointing to the dependencies directory created in step 1. This is the primary command we are going to depend on to gather dependencies. If either of these commands fail, fail the submission.

Also removed the `-q` flag while running the commands to help users see the logs while we run these commands as the `mvn install` can potentially take a long time to run.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes - Hard to test as this class just invokes the maven runner.
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required) - Metrics already present
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
