### PR TITLE
Move 'Send to Amazon Q' action group after the 'Show Context Actions' action

### DIFF
--- a/.changes/next-release/bugfix-6a224ad6-84f6-4e9f-931e-87c866b2c09b.json
+++ b/.changes/next-release/bugfix-6a224ad6-84f6-4e9f-931e-87c866b2c09b.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Move 'Send to Amazon Q' action group after the 'Show Context Actions' action"
+}

--- a/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
@@ -901,7 +901,8 @@
         >
             <add-to-group
                 group-id="EditorPopupMenu"
-                anchor="first"
+                anchor="after"
+                relative-to-action="ShowIntentionsGroup"
             />
 
             <action id="aws.toolkit.jetbrains.core.services.cwc.commands.ExplainCodeAction"


### PR DESCRIPTION
Negative customer sentiment from current placement 

![image](https://github.com/aws/aws-toolkit-jetbrains/assets/742829/9462b297-7774-446c-831d-ac979c4a68cb)


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
