### PR TITLE
Limit changelog size by entry count instead of total size

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/JetBrainsWriter.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/JetBrainsWriter.kt
@@ -13,14 +13,14 @@ import java.lang.Math.min
 
 class JetBrainsWriter(private val changeNotesFile: File, repoUrl: String? = null) : ChangeLogWriter(repoUrl) {
     private val sb = StringBuilder()
-    private var isMaxLength = false
+    private var entryCount = 0
 
     override fun append(entry: String) {
-        if (isMaxLength) return
-
+        // if there are too many entries, we fail validation:
         // Invalid plugin descriptor 'plugin.xml'. The value of the '<change-notes>' parameter is too long. Its length is 65573 which is more than maximum 65535 characters long.
-        if ((sb.length + entry.length) > 65000) {
-            isMaxLength = true
+        // HtmlRenderer is not that flexible, so do the simple thing instead of trying to backtrack and maximize the size of the bundled changelog
+        if (entryCount > 10) return
+        if (++entryCount > 10) {
             // language=Markdown
             repoUrl?.let {
                 sb.append("""

--- a/buildSrc/src/test/kotlin/software/aws/toolkits/gradle/changelog/JetBrainsWriterTest.kt
+++ b/buildSrc/src/test/kotlin/software/aws/toolkits/gradle/changelog/JetBrainsWriterTest.kt
@@ -166,31 +166,61 @@ class JetBrainsWriterTest {
         val file = folder.newFile()
         val sut = JetBrainsWriter(file, "https://github.com/org/repo")
 
-        sut.writeEntry(
-            renderEntry(
-                ReleaseEntry(
-                    LocalDate.of(2017, 2, 1),
-                    "2.0.0-preview-3",
-                    listOf(Entry(ChangeType.FEATURE, "Third feature"))
+        repeat(1000) {
+            sut.writeEntry(
+                renderEntry(
+                    ReleaseEntry(
+                        LocalDate.of(2017 + it, 2, 1),
+                        "2.0.0-preview-$it",
+                        listOf(Entry(ChangeType.FEATURE, "Feature $it"))
+                    )
                 )
             )
-        )
-        sut.writeEntry(
-            renderEntry(
-                ReleaseEntry(
-                    LocalDate.of(2017, 1, 3),
-                    "2.0.0-preview-2",
-                    generateSequence { Entry(ChangeType.BUGFIX, "Some bugfix") }.take(10000).toList()
-                )
-            )
-        )
+        }
+
         sut.close()
 
         assertThat(file.readText().trim()).isEqualToIgnoringWhitespace(
             """
-            <h3><em>2.0.0-preview-3</em> (2017-02-01)</h3>
+            <h3><em>2.0.0-preview-0</em> (2017-02-01)</h3>
             <ul>
-            <li><strong>(Feature)</strong> Third feature</li>
+            <li><strong>(Feature)</strong> Feature 0</li>
+            </ul>
+            <h3><em>2.0.0-preview-1</em> (2018-02-01)</h3>
+            <ul>
+            <li><strong>(Feature)</strong> Feature 1</li>
+            </ul>
+            <h3><em>2.0.0-preview-2</em> (2019-02-01)</h3>
+            <ul>
+            <li><strong>(Feature)</strong> Feature 2</li>
+            </ul>
+            <h3><em>2.0.0-preview-3</em> (2020-02-01)</h3>
+            <ul>
+            <li><strong>(Feature)</strong> Feature 3</li>
+            </ul>
+            <h3><em>2.0.0-preview-4</em> (2021-02-01)</h3>
+            <ul>
+            <li><strong>(Feature)</strong> Feature 4</li>
+            </ul>
+            <h3><em>2.0.0-preview-5</em> (2022-02-01)</h3>
+            <ul>
+            <li><strong>(Feature)</strong> Feature 5</li>
+            </ul>
+            <h3><em>2.0.0-preview-6</em> (2023-02-01)</h3>
+            <ul>
+            <li><strong>(Feature)</strong> Feature 6</li>
+            </ul>
+            <h3><em>2.0.0-preview-7</em> (2024-02-01)</h3>
+            <ul>
+            <li><strong>(Feature)</strong> Feature 7</li>
+            </ul>
+            <h3><em>2.0.0-preview-8</em> (2025-02-01)</h3>
+            <ul>
+            <li><strong>(Feature)</strong> Feature 8</li>
+            </ul>
+            <h3><em>2.0.0-preview-9</em> (2026-02-01)</h3>
+            <ul>
+            <li><strong>(Feature)</strong> Feature 9</li>
             </ul>
             <hr />
             <p>Full plugin changelog available on <a href="https://github.com/org/repo/blob/main/CHANGELOG.md">GitHub</a></p>


### PR DESCRIPTION
Previous attempt capped the changelog length by markdown, but the limit may be exceeded when rendered as HTML The HTML renderer doesn't make it easy to stop rendering once we hit a certain size, so limit by entry count instead
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
