### PR TITLE
Emit Kotlin build reports

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,6 @@ org.gradle.jvmargs=-Xmx2048m
 
 # prefer non-enterprise variant of test-retry
 systemProp.gradle.enterprise.testretry.enabled=false
+
+# outputs to build/reports/kotlin-build
+kotlin.build.report.output=file


### PR DESCRIPTION
Need a baseline to see how much time we save with [K2](https://github.com/aws/aws-toolkit-jetbrains/pull/4170)

https://kotlinlang.org/docs/gradle-compilation-and-caches.html#build-reports

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
