### PR TITLE
Q Code Transform refactor: Add CodeTransformTelemetryManager to centralize CodeTransform telemetry emission.

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ArtifactHandler.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ArtifactHandler.kt
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 data class DownloadArtifactResult(val artifact: CodeModernizerArtifact?, val zipPath: String)
 class ArtifactHandler(private val project: Project, private val clientAdaptor: GumbyClient) {
-    private val telemetry = CodeModernizerTelemetryManager.getInstance(project)
+    private val telemetry = CodeTransformTelemetryManager.getInstance(project)
     private val downloadedArtifacts = mutableMapOf<JobId, Path>()
     private val downloadedSummaries = mutableMapOf<JobId, TransformationSummary>()
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerManager.kt
@@ -71,7 +71,7 @@ const val AMAZON_Q_FEEDBACK_DIALOG_KEY = "Amazon Q"
 
 @State(name = "codemodernizerStates", storages = [Storage("aws.xml", roamingType = RoamingType.PER_OS)])
 class CodeModernizerManager(private val project: Project) : PersistentStateComponent<CodeModernizerState>, Disposable {
-    private val telemetry = CodeModernizerTelemetryManager.getInstance(project)
+    private val telemetry = CodeTransformTelemetryManager.getInstance(project)
     private var managerState = CodeModernizerState()
     val codeModernizerBottomWindowPanelManager by lazy { CodeModernizerBottomWindowPanelManager(project) }
     private val codeModernizerBottomWindowPanelContent by lazy {

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
@@ -53,7 +53,7 @@ class CodeModernizerSession(
     private val state = CodeModernizerSessionState.getInstance(sessionContext.project)
     private val isDisposed = AtomicBoolean(false)
     private val shouldStop = AtomicBoolean(false)
-    private val telemetry = CodeModernizerTelemetryManager.getInstance(sessionContext.project)
+    private val telemetry = CodeTransformTelemetryManager.getInstance(sessionContext.project)
 
     /**
      * Note that this function makes network calls and needs to be run from a background thread.

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
@@ -35,7 +35,7 @@ import software.aws.toolkits.telemetry.CodeTransformApiNames
 import java.io.File
 import java.io.FileInputStream
 import java.time.Instant
-import java.util.*
+import java.util.Base64
 import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicBoolean
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformTelemetryManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformTelemetryManager.kt
@@ -29,7 +29,7 @@ import java.util.Base64
 /**
  * CodeModernizerTelemetry contains helper functions for common operations that require telemetry.
  */
-class CodeModernizerTelemetryManager(private val project: Project) {
+class CodeTransformTelemetryManager(private val project: Project) {
     private val sessionId get() = CodeTransformTelemetryState.instance.getSessionId()
     private val currentJobStatus get() = CodeModernizerSessionState.getInstance(project).currentJobStatus.toString()
     fun sendUserClickedTelemetry(srcStartComponent: CodeTransformStartSrcComponents) {
@@ -186,6 +186,6 @@ class CodeModernizerTelemetryManager(private val project: Project) {
     fun jobIsStartedFromChatPrompt() = CodetransformTelemetry.jobIsStartedFromChatPrompt(codeTransformSessionId = sessionId)
 
     companion object {
-        fun getInstance(project: Project): CodeModernizerTelemetryManager = project.service()
+        fun getInstance(project: Project): CodeTransformTelemetryManager = project.service()
     }
 }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformUtils.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformUtils.kt
@@ -155,7 +155,7 @@ suspend fun JobId.pollTransformationStatusAndPlan(
     maxDuration: Duration = Duration.ofSeconds(604800),
     onStateChange: (previousStatus: TransformationStatus?, currentStatus: TransformationStatus, transformationPlan: TransformationPlan?) -> Unit,
 ): PollingResult {
-    val telemetry = CodeModernizerTelemetryManager.getInstance(project)
+    val telemetry = CodeTransformTelemetryManager.getInstance(project)
     var state = TransformationStatus.UNKNOWN_TO_SDK_VERSION
     var transformationResponse: GetTransformationResponse? = null
     var transformationPlan: TransformationPlan? = null

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/actions/CodeModernizerStopModernizerAction.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/actions/CodeModernizerStopModernizerAction.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
 import software.aws.toolkits.jetbrains.services.codemodernizer.CodeModernizerManager
-import software.aws.toolkits.jetbrains.services.codemodernizer.CodeModernizerTelemetryManager
+import software.aws.toolkits.jetbrains.services.codemodernizer.CodeTransformTelemetryManager
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CodeTransformCancelSrcComponents
 
@@ -31,7 +31,7 @@ class CodeModernizerStopModernizerAction :
     override fun actionPerformed(event: AnActionEvent) {
         val project = event.project ?: return
         CodeModernizerManager.getInstance(project).userInitiatedStopCodeModernization()
-        CodeModernizerTelemetryManager.getInstance(project)
+        CodeTransformTelemetryManager.getInstance(project)
             .jobIsCancelledByUser(CodeTransformCancelSrcComponents.BottomPanelSideNavButton)
     }
 }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/client/GumbyClient.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/client/GumbyClient.kt
@@ -36,7 +36,7 @@ import software.aws.toolkits.jetbrains.services.amazonq.CONTENT_SHA256
 import software.aws.toolkits.jetbrains.services.amazonq.SERVER_SIDE_ENCRYPTION
 import software.aws.toolkits.jetbrains.services.amazonq.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID
 import software.aws.toolkits.jetbrains.services.amazonq.clients.AmazonQStreamingClient
-import software.aws.toolkits.jetbrains.services.codemodernizer.CodeModernizerTelemetryManager
+import software.aws.toolkits.jetbrains.services.codemodernizer.CodeTransformTelemetryManager
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.JobId
 import software.aws.toolkits.telemetry.CodeTransformApiNames
 import java.io.File
@@ -45,7 +45,7 @@ import java.time.Instant
 
 @Service(Service.Level.PROJECT)
 class GumbyClient(private val project: Project) {
-    private val telemetry = CodeModernizerTelemetryManager.getInstance(project)
+    private val telemetry = CodeTransformTelemetryManager.getInstance(project)
     private fun connection() = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())
         ?: error("Attempted to use connection while one does not exist")
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ideMaven/MavenRunnerUtils.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ideMaven/MavenRunnerUtils.kt
@@ -11,14 +11,14 @@ import org.jetbrains.idea.maven.execution.MavenRunnerSettings
 import org.slf4j.Logger
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.info
-import software.aws.toolkits.jetbrains.services.codemodernizer.CodeModernizerTelemetryManager
+import software.aws.toolkits.jetbrains.services.codemodernizer.CodeTransformTelemetryManager
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.MavenCopyCommandsResult
 import software.aws.toolkits.telemetry.CodeTransformMavenBuildCommand
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 
-private fun emitMavenFailure(error: String, logger: Logger, telemetry: CodeModernizerTelemetryManager, throwable: Throwable? = null) {
+private fun emitMavenFailure(error: String, logger: Logger, telemetry: CodeTransformTelemetryManager, throwable: Throwable? = null) {
     if (throwable != null) logger.error(throwable) { error } else logger.error { error }
     telemetry.mvnBuildFailed(CodeTransformMavenBuildCommand.IDEBundledMaven, error)
 }
@@ -26,7 +26,7 @@ private fun emitMavenFailure(error: String, logger: Logger, telemetry: CodeModer
 fun runMavenCopyCommands(sourceFolder: File, buildlogBuilder: StringBuilder, logger: Logger, project: Project): MavenCopyCommandsResult {
     val currentTimestamp = System.currentTimeMillis()
     val destinationDir = Files.createTempDirectory("transformation_dependencies_temp_$currentTimestamp")
-    val telemetry = CodeModernizerTelemetryManager.getInstance(project)
+    val telemetry = CodeTransformTelemetryManager.getInstance(project)
     logger.info { "Executing IntelliJ bundled Maven" }
     try {
         // Create shared parameters
@@ -86,7 +86,7 @@ private fun runMavenCopyDependencies(
     transformMavenRunner: TransformMavenRunner,
     destinationDir: Path,
     logger: Logger,
-    telemetry: CodeModernizerTelemetryManager,
+    telemetry: CodeTransformTelemetryManager,
 ): TransformRunnable {
     buildlogBuilder.appendLine("Command Run: IntelliJ bundled Maven dependency:copy-dependencies")
     val copyCommandList = listOf(
@@ -125,7 +125,7 @@ private fun runMavenClean(
     mvnSettings: MavenRunnerSettings,
     transformMavenRunner: TransformMavenRunner,
     logger: Logger,
-    telemetry: CodeModernizerTelemetryManager,
+    telemetry: CodeTransformTelemetryManager,
     destinationDir: Path
 ): TransformRunnable {
     buildlogBuilder.appendLine("Command Run: IntelliJ bundled Maven clean")
@@ -157,7 +157,7 @@ private fun runMavenInstall(
     mvnSettings: MavenRunnerSettings,
     transformMavenRunner: TransformMavenRunner,
     logger: Logger,
-    telemetry: CodeModernizerTelemetryManager,
+    telemetry: CodeTransformTelemetryManager,
     destinationDir: Path
 ): TransformRunnable {
     buildlogBuilder.appendLine("Command Run: IntelliJ bundled Maven install")

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerSessionContext.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.core.utils.createTemporaryZipFile
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.putNextEntry
-import software.aws.toolkits.jetbrains.services.codemodernizer.CodeModernizerTelemetryManager
+import software.aws.toolkits.jetbrains.services.codemodernizer.CodeTransformTelemetryManager
 import software.aws.toolkits.jetbrains.services.codemodernizer.ideMaven.runMavenCopyCommands
 import software.aws.toolkits.jetbrains.services.codemodernizer.panels.managers.CodeModernizerBottomWindowPanelManager
 import software.aws.toolkits.jetbrains.services.codemodernizer.toolwindow.CodeModernizerBottomToolWindowFactory
@@ -28,15 +28,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
-import kotlin.io.NoSuchFileException
-import kotlin.io.byteInputStream
-import kotlin.io.deleteRecursively
-import kotlin.io.inputStream
 import kotlin.io.path.Path
-import kotlin.io.relativeTo
-import kotlin.io.resolve
-import kotlin.io.resolveSibling
-import kotlin.io.walkTopDown
 
 const val MANIFEST_PATH = "manifest.json"
 const val ZIP_SOURCES_PATH = "sources"
@@ -82,7 +74,7 @@ data class CodeModernizerSessionContext(
     fun executeMavenCopyCommands(sourceFolder: File, buildLogBuilder: StringBuilder) = runMavenCopyCommands(sourceFolder, buildLogBuilder, LOG, project)
 
     fun createZipWithModuleFiles(): ZipCreationResult {
-        val telemetry = CodeModernizerTelemetryManager.getInstance(project)
+        val telemetry = CodeTransformTelemetryManager.getInstance(project)
         val root = configurationFile.parent
         val sourceFolder = File(root.path)
         val buildLogBuilder = StringBuilder("Starting Build Log...\n")

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ui/components/PreCodeTransformUserDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/ui/components/PreCodeTransformUserDialog.kt
@@ -20,7 +20,7 @@ import com.intellij.ui.dsl.builder.TopGap
 import com.intellij.ui.dsl.builder.columns
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.toMutableProperty
-import software.aws.toolkits.jetbrains.services.codemodernizer.CodeModernizerTelemetryManager
+import software.aws.toolkits.jetbrains.services.codemodernizer.CodeTransformTelemetryManager
 import software.aws.toolkits.jetbrains.services.codemodernizer.getSupportedJavaMappings
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.CustomerSelection
 import software.aws.toolkits.jetbrains.services.codemodernizer.tryGetJdk
@@ -48,7 +48,7 @@ class PreCodeTransformUserDialog(
         lateinit var dialogPanel: DialogPanel
         lateinit var buildFileComboBox: ComboBox<String>
 
-        val telemetry = CodeModernizerTelemetryManager.getInstance(project)
+        val telemetry = CodeTransformTelemetryManager.getInstance(project)
         val buildfiles = supportedBuildFilesInProject
         var focusedModuleIndex = 0
         var chosenBuildFile = buildfiles.firstOrNull()

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cwc/controller/ChatController.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cwc/controller/ChatController.kt
@@ -41,7 +41,7 @@ import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublishe
 import software.aws.toolkits.jetbrains.services.amazonq.onboarding.OnboardingPageInteraction
 import software.aws.toolkits.jetbrains.services.amazonq.onboarding.OnboardingPageInteractionType
 import software.aws.toolkits.jetbrains.services.codemodernizer.CodeModernizerManager
-import software.aws.toolkits.jetbrains.services.codemodernizer.CodeModernizerTelemetryManager
+import software.aws.toolkits.jetbrains.services.codemodernizer.CodeTransformTelemetryManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererUserModificationTracker
 import software.aws.toolkits.jetbrains.services.cwc.InboundAppMessagesHandler
 import software.aws.toolkits.jetbrains.services.cwc.clients.chat.exceptions.ChatApiException
@@ -144,7 +144,7 @@ class ChatController private constructor(
                 } else {
                     manager.getBottomToolWindow().show()
                 }
-                CodeModernizerTelemetryManager.getInstance(context.project).jobIsStartedFromChatPrompt()
+                CodeTransformTelemetryManager.getInstance(context.project).jobIsStartedFromChatPrompt()
             }
         }
         TelemetryHelper.recordTelemetryChatRunCommand(CwsprChatCommandType.Transform, startUrl = getStartUrl(context.project))


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Description
Previously our telemetry emission made the code unnecessarily messy and long and the `CodeTransformTelemetryState` was accessed directly by different parts of the `CodeTransform` flow. This pr decouples the telemetry state handling from the core `CodeTransform` flow by only accessing the state from a new manager `CodeTransformTelemetryManager`.

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
