### PR TITLE
Modify setup auth page login text for builder id and sso 

### DIFF
--- a/plugins/toolkit/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/plugins/toolkit/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -184,7 +184,7 @@ aws.onboarding.getstarted.panel.comment_link_github=Join us on GitHub
 aws.onboarding.getstarted.panel.group_title=Select a feature to setup authentication
 aws.onboarding.getstarted.panel.iam_row_comment_text=Long-term programmatic access
 aws.onboarding.getstarted.panel.idc_row_comment_text=Successor to AWS Single Sign-on
-aws.onboarding.getstarted.panel.login_with_iam=<a>Login with IAM Identity Center</a>
+aws.onboarding.getstarted.panel.login_with_iam=<a>Use Professional License</a>
 aws.onboarding.getstarted.panel.share_feedback=<a>Share Feedback</a>
 aws.onboarding.getstarted.panel.signup_iam_text=Sign up for free
 aws.onboarding.getstarted.panel.title=Authenticate with AWS Toolkit
@@ -755,7 +755,7 @@ codewhisperer.gettingstarted.panel.comment=Build, maintain and transform applica
 codewhisperer.gettingstarted.panel.learn_more=Learn more
 codewhisperer.gettingstarted.panel.learn_more.with.q=Learn more about <a href = "https://aws.amazon.com/q/">Amazon Q</a> and <a href ="https://aws.amazon.com/codewhisperer">Codewhisperer  </a>
 codewhisperer.gettingstarted.panel.licence_comment=Already have a license?
-codewhisperer.gettingstarted.panel.login_button=Use for free with AWS Builder ID
+codewhisperer.gettingstarted.panel.login_button=Use for free, no AWS account required
 codewhisperer.language.error={0} is currently not supported by CodeWhisperer
 codewhisperer.learn_page.banner.dismiss=Dismiss
 codewhisperer.learn_page.banner.message.new_user=You can always return to this page by clicking "Learn" in Developer Tools > CodeWhisperer
@@ -1206,7 +1206,7 @@ gettingstarted.explorer.new.setup.info=To get started with the Explorer, setup a
 gettingstarted.explorer.open.menu=Open Resource Explorer
 gettingstarted.iam.description=Long-term programmatic access
 gettingstarted.panel.learn_more=Learn more
-gettingstarted.panel.login_button=Use for free with AWS Builder ID
+gettingstarted.panel.login_button=Use for free, no AWS account required
 gettingstarted.setup.auth.failure.body=We are unable to connect or the process was cancelled. Please try again, <a href='https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/auth-access.html'>visit documentation</a>, or <a href='https://github.com/aws/aws-toolkit-jetbrains/issues/new'>file an issue on GitHub</a> to troubleshoot
 gettingstarted.setup.auth.failure.title=Authentication Failed
 gettingstarted.setup.auth.no_iam=CodeWhisperer and Amazon Q do not support authentication with IAM Credentials


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Change text for sign in within the setup auth page
<img width="362" alt="Screenshot 2024-03-18 at 11 23 03 AM" src="https://github.com/aws/aws-toolkit-jetbrains/assets/66754471/cd0959e5-1b8a-426b-81ba-0c03c6375ba5">



 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
