### PR TITLE
Fix CodeTransform tests that don't actually validate anything

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/clients/FeatureDevClient.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/clients/FeatureDevClient.kt
@@ -48,7 +48,8 @@ class FeatureDevClient(private val project: Project) {
 
     private fun streamingBearerClient() = connection().getConnectionSettings().awsClient<CodeWhispererStreamingAsyncClient>()
 
-    private val amazonQStreamingClient = AmazonQStreamingClient.getInstance(project)
+    private val amazonQStreamingClient
+        get() = AmazonQStreamingClient.getInstance(project)
 
     fun createTaskAssistConversation(): CreateTaskAssistConversationResponse = bearerClient().createTaskAssistConversation(
         CreateTaskAssistConversationRequest.builder().build()

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/client/GumbyClient.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codemodernizer/client/GumbyClient.kt
@@ -43,7 +43,8 @@ class GumbyClient(private val project: Project) {
 
     private fun bearerClient() = connection().getConnectionSettings().awsClient<CodeWhispererRuntimeClient>()
 
-    private val amazonQStreamingClient = AmazonQStreamingClient.getInstance(project)
+    private val amazonQStreamingClient
+        get() = AmazonQStreamingClient.getInstance(project)
 
     fun createGumbyUploadUrl(sha256Checksum: String): CreateUploadUrlResponse {
         val request = CreateUploadUrlRequest.builder()
@@ -123,8 +124,7 @@ class GumbyClient(private val project: Project) {
     suspend fun downloadExportResultArchive(jobId: JobId): MutableList<ByteArray> = amazonQStreamingClient.exportResultArchive(
         jobId.id,
         ExportIntent.TRANSFORMATION,
-        {
-                e ->
+        { e ->
             LOG.error(e) { "${CodeTransformApiNames.ExportResultArchive} failed: ${e.message}" }
             CodetransformTelemetry.logApiError(
                 codeTransformApiNames = CodeTransformApiNames.ExportResultArchive,


### PR DESCRIPTION
When a test is run under `launch`, the test runner does not actually confirm that the assertions within succeed

While `launch { ... }.await()` would work, you would need to put it under a `runBlocking`. `runTest` is a better option as it provides test-specific niceties, such as waiting for child coroutines to finish before reporting test status and automatically timing out children if blocked for too long
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
