### PR TITLE
Disable Builder ID login test

### DIFF
--- a/plugins/toolkit/jetbrains-core/it/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderIntegrationTest.kt
+++ b/plugins/toolkit/jetbrains-core/it/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.ApplicationExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assumptions.assumeThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -27,6 +28,7 @@ import java.time.Instant
 @ExtendWith(ApplicationExtension::class, SsoLoginExtension::class)
 @SsoLogin("codecatalyst-test-account")
 @DisabledIfEnvironmentVariable(named = "IS_PROD", matches = "false")
+@Disabled("Login Lambda is broken")
 class InteractiveBearerTokenProviderIntegrationTest {
     companion object {
         @JvmStatic


### PR DESCRIPTION
Lambda that completes the login is broken
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
