### PR TITLE
Mark generated SDK directory as generated sources

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-generate-sdks.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-generate-sdks.gradle.kts
@@ -9,10 +9,15 @@ val sdkGenerator = project.extensions.create<GenerateSdkExtension>("sdkGenerator
 
 plugins {
     java
+    id("org.jetbrains.gradle.plugin.idea-ext")
 }
 
 sourceSets {
     main {
+        resources {
+            setSrcDirs(listOf(sdkGenerator.c2jFolder))
+        }
+
         java {
             setSrcDirs(listOf(sdkGenerator.srcDir()))
         }
@@ -38,4 +43,12 @@ tasks.withType<JavaCompile>().configureEach {
 val generateTask = tasks.register<GenerateSdk>("generateSdks")
 tasks.named("compileJava") {
     dependsOn(generateTask)
+}
+
+idea {
+    module {
+        afterEvaluate {
+            generatedSourceDirs = sourceDirs
+        }
+    }
 }


### PR DESCRIPTION
Conveys more context to IDE during search
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
