### PR TITLE
feat: handle canned errors during code generation

### DIFF
--- a/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
+++ b/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
@@ -489,6 +489,11 @@
                 "currentStage":{"shape":"CodeGenerationWorkflowStage"}
             }
         },
+        "CodeGenerationStatusDetail": {
+            "type": "string",
+            "documentation": "<p>Detailed message about the code generation status</p>",
+            "sensitive": true
+        },
         "CodeGenerationWorkflowStage":{
             "type":"string",
             "enum":[
@@ -916,6 +921,9 @@
                 },
                 "codeGenerationStatus": {
                     "shape": "CodeGenerationStatus"
+                },
+                "codeGenerationStatusDetail": {
+                    "shape": "CodeGenerationStatusDetail"
                 }
             }
         },

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevExceptions.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevExceptions.kt
@@ -31,7 +31,7 @@ internal fun apiError(message: String?, cause: Throwable?): Nothing =
 internal fun exportParseError(): Nothing =
     throw FeatureDevException(message("amazonqFeatureDev.exception.export_parsing_error"))
 
-internal fun InvalidCodeGenStateError(): Nothing =
+internal fun invalidCodeGenStateError(): Nothing =
     throw FeatureDevException(message("amazonqFeatureDev.exception.invalid_code_generation_state_error"))
 
 val denyListedErrors = arrayOf("Deserialization error", "Inaccessible host", "UnknownHost")

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevExceptions.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevExceptions.kt
@@ -31,6 +31,9 @@ internal fun apiError(message: String?, cause: Throwable?): Nothing =
 internal fun exportParseError(): Nothing =
     throw FeatureDevException(message("amazonqFeatureDev.exception.export_parsing_error"))
 
+internal fun InvalidCodeGenStateError(): Nothing =
+    throw FeatureDevException(message("amazonqFeatureDev.exception.invalid_code_generation_state_error"))
+
 val denyListedErrors = arrayOf("Deserialization error", "Inaccessible host", "UnknownHost")
 fun createUserFacingErrorMessage(message: String?): String? =
     if (message != null && denyListedErrors.any { message.contains(it) }) "$FEATURE_NAME API request failed" else message

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessagePublisherExtensions.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessagePublisherExtensions.kt
@@ -206,7 +206,7 @@ suspend fun MessagePublisher.sendFailedCodeGeneration(
 
     this.sendSystemPrompt(
         tabId = tabId,
-        followUp = if ( retryable && session.retriesRemaining() > 0) {
+        followUp = if (retryable && session.retriesRemaining() > 0) {
             listOf(
                 FollowUp(
                     pillText = message("amazonqFeatureDev.follow_up.retry"),

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
@@ -48,8 +48,8 @@ class CodeGenerationState(
             amazonqGenerateCodeIteration = currentIteration.toDouble(),
             amazonqGenerateCodeResponseLatency = (System.currentTimeMillis() - startTime).toDouble(),
             amazonqRepositorySize = repositorySize,
-            amazonqNumberOfFilesGenerated = if (codeGenerationResult is CodeGenerationComplete ) codeGenerationResult.newFiles.size.toDouble() else null,
-            amazonqNumberOfReferences = if (codeGenerationResult is CodeGenerationComplete ) codeGenerationResult.references.size.toDouble() else null,
+            amazonqNumberOfFilesGenerated = if (codeGenerationResult is CodeGenerationComplete) codeGenerationResult.newFiles.size.toDouble() else null,
+            amazonqNumberOfReferences = if (codeGenerationResult is CodeGenerationComplete) codeGenerationResult.references.size.toDouble() else null,
         )
 
         val nextState = PrepareCodeGenerationState(
@@ -97,14 +97,14 @@ private suspend fun CodeGenerationState.generateCode(codeGenerationId: String): 
                 )
             }
             CodeGenerationWorkflowStatus.FAILED -> {
-                if ( codeGenerationResult.codeGenerationStatusDetail().isNullOrEmpty() ) {
+                if (codeGenerationResult.codeGenerationStatusDetail().isNullOrEmpty()) {
                     codeGenerationFailedError()
                 }
 
                 // Canned errors are not retryable, the error above on the contrary will let the user retry code generation.
                 return CodeGenerationFailed(
-                   message=codeGenerationResult.codeGenerationStatusDetail(),
-                   retryable=false
+                    message = codeGenerationResult.codeGenerationStatusDetail(),
+                    retryable = false
                 )
             }
             else -> error("Unknown status: ${codeGenerationResult.codeGenerationStatus().status()}")

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationState.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationState.kt
@@ -8,7 +8,6 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendA
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.createUploadUrl
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.deleteUploadArtifact
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.uploadArtifactToS3
-import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AmazonqTelemetry
 import software.aws.toolkits.telemetry.AmazonqUploadIntent
@@ -17,9 +16,7 @@ class PrepareCodeGenerationState(
     override var tabID: String,
     override var approach: String,
     private var config: SessionStateConfig,
-    val filePaths: List<NewFileZipInfo>,
-    val deletedFiles: List<String>,
-    val references: List<CodeReference>,
+    val codeGenerationResult: CodeGenerationResult,
     var uploadId: String,
     private val currentIteration: Int,
     private var messenger: MessagePublisher

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -180,8 +180,7 @@ class Session(val tabID: String, val project: Project) {
 }
 
 fun Session?.retriesRemaining(): Int {
-    if ( this == null ) return DEFAULT_RETRY_LIMIT
+    if (this == null) return DEFAULT_RETRY_LIMIT
 
     return this.retries
 }
-

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.vfs.VfsUtil
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.APPROACH_RETRY_LIMIT
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CODE_GENERATION_RETRY_LIMIT
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.DEFAULT_RETRY_LIMIT
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.conversationIdNotFound
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAsyncEventProgress
@@ -78,10 +79,8 @@ class Session(val tabID: String, val project: Project) {
             tabID = sessionState.tabID,
             approach = sessionState.approach,
             config = getSessionStateConfig(),
-            filePaths = emptyList(),
-            deletedFiles = emptyList(),
-            references = emptyList(),
-            currentIteration = 0, // first code gen iteration
+            codeGenerationResult = CodeGenerationNotStarted(),
+            currentIteration = 0, // First code gen iteration
             uploadId = "", // There is no code gen uploadId so far
             messenger = messenger,
         )
@@ -179,3 +178,10 @@ class Session(val tabID: String, val project: Project) {
         }
     }
 }
+
+fun Session?.retriesRemaining(): Int {
+    if ( this == null ) return DEFAULT_RETRY_LIMIT
+
+    return this.retries
+}
+

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionStateTypes.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionStateTypes.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session
 
 import com.fasterxml.jackson.annotation.JsonValue
+import software.amazon.awssdk.services.codewhispererruntime.model.CodeGenerationWorkflowStatus
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
 import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
 
@@ -41,11 +42,29 @@ data class NewFileZipInfo(
     val fileContent: String,
 )
 
-data class CodeGenerationResult(
+sealed interface CodeGenerationResult {
+    val status: CodeGenerationWorkflowStatus
+}
+
+data class CodeGenerationNotStarted(
+    override val status: CodeGenerationWorkflowStatus = CodeGenerationWorkflowStatus.IN_PROGRESS, // Status as a placeholder before code generation starts
+    var newFiles: List<NewFileZipInfo> = emptyList(),
+    var deletedFiles: List<String> = emptyList(),
+    var references: List<CodeReference> = emptyList(),
+) : CodeGenerationResult
+
+data class CodeGenerationComplete(
+    override val status: CodeGenerationWorkflowStatus = CodeGenerationWorkflowStatus.COMPLETE,
     var newFiles: List<NewFileZipInfo>,
     var deletedFiles: List<String>, // The string is the path of the file to be deleted
     var references: List<CodeReference>,
-)
+) : CodeGenerationResult
+
+data class CodeGenerationFailed(
+    override val status: CodeGenerationWorkflowStatus = CodeGenerationWorkflowStatus.FAILED,
+    var message: String,
+    var retryable: Boolean
+) : CodeGenerationResult
 
 @Suppress("ConstructorParameterNaming") // Unfortunately, this is exactly how the string json is received and is needed for parsing.
 data class CodeGenerationStreamResult(

--- a/plugins/toolkit/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/plugins/toolkit/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -60,6 +60,7 @@ amazonqFeatureDev.example_text=You can use /dev to:\n- Add a new feature or logi
 amazonqFeatureDev.exception.conversation_not_found=Conversation id must exist before continuing
 amazonqFeatureDev.exception.export_parsing_error=Downloaded code results could not be parsed
 amazonqFeatureDev.exception.insert_code_failed=Failed to insert code changes
+amazonqFeatureDev.exception.invalid_code_generation_state_error=Code generation reached an invalid state
 amazonqFeatureDev.exception.message_not_found=Message was not found
 amazonqFeatureDev.exception.open_diff_failed=Failed to open diff
 amazonqFeatureDev.exception.request_failed=Request failed


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description

There are errors during /dev code generation that are non retryable, these are called canned errors. This means that the user will have to write a new prompt to retry the operation, effectively nullifying the previous interaction. This commit is handling this cases. At the moment, the canned errors are Responsible AI errors which may appear for different reasons during this stage.

## Checklist
- [x] My code follows the code style of this project
- [n/a] I have added tests to cover my changes
- [n/a] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
