### PR TITLE
feat(featureDev): use buffer instead of temporal folder for uploading…

### DIFF
--- a/plugins/toolkit/core/src/software/aws/toolkits/core/utils/ZipUtils.kt
+++ b/plugins/toolkit/core/src/software/aws/toolkits/core/utils/ZipUtils.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.core.utils
 
+import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
@@ -39,4 +40,17 @@ fun createTemporaryZipFile(block: (ZipOutputStream) -> Unit): Path {
     val file = Files.createTempFile(null, ".zip")
     ZipOutputStream(Files.newOutputStream(file)).use(block)
     return file
+}
+
+/**
+ * Create a zip file in a temporary location.
+ *
+ * Statements included in [block] populate the zip file with entries.
+ *
+ * @return the [Path] of the temporary file
+ */
+fun createZipByteArray(block: (ZipOutputStream) -> Unit): ByteArrayOutputStream {
+    val outputStream = ByteArrayOutputStream()
+    ZipOutputStream(outputStream).use(block)
+    return outputStream
 }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/model/ZipCreationResult.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/model/ZipCreationResult.kt
@@ -3,6 +3,4 @@
 
 package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.model
 
-import java.io.File
-
-data class ZipCreationResult(val payload: File, val checksum: String, val contentLength: Long)
+data class ZipCreationResult(val payload: ByteArray, val checksum: String, val contentLength: Long)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/FeatureDevSessionContext.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/FeatureDevSessionContext.kt
@@ -9,12 +9,14 @@ import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import org.apache.commons.codec.digest.DigestUtils
-import software.aws.toolkits.core.utils.createTemporaryZipFile
 import software.aws.toolkits.core.utils.putNextEntry
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.model.ZipCreationResult
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
-import java.io.FileInputStream
+import java.nio.file.Path
 import java.util.Base64
+import java.util.zip.ZipOutputStream
 import kotlin.io.path.Path
 import kotlin.io.path.relativeTo
 
@@ -46,8 +48,8 @@ class FeatureDevSessionContext(val project: Project) {
 
     fun getProjectZip(): ZipCreationResult {
         val zippedProject = runReadAction { zipFiles(projectRoot) }
-        val checkSum256: String = Base64.getEncoder().encodeToString(DigestUtils.sha256(FileInputStream(zippedProject)))
-        return ZipCreationResult(zippedProject, checkSum256, zippedProject.length())
+        val checkSum256: String = Base64.getEncoder().encodeToString(DigestUtils.sha256(ByteArrayInputStream(zippedProject)))
+        return ZipCreationResult(zippedProject, checkSum256, zippedProject.size.toLong())
     }
 
     private fun ignoreFile(file: File): Boolean {
@@ -55,14 +57,20 @@ class FeatureDevSessionContext(val project: Project) {
         return ignorePatternsWithGitIgnore.any { p -> p.containsMatchIn(file.path) }
     }
 
-    private fun zipFiles(projectRoot: VirtualFile): File = createTemporaryZipFile {
-        VfsUtil.collectChildrenRecursively(projectRoot).map { virtualFile -> File(virtualFile.path) }.forEach { file ->
-            if (file.isFile() && !ignoreFile(file)) {
-                val relativePath = Path(file.path).relativeTo(projectRoot.toNioPath())
-                it.putNextEntry(relativePath.toString(), Path(file.path))
+    private fun zipFiles(projectRoot: VirtualFile): ByteArray {
+        val outputStream = ByteArrayOutputStream()
+
+        ZipOutputStream(outputStream).use {
+            VfsUtil.collectChildrenRecursively(projectRoot).map { virtualFile -> File(virtualFile.path) }.forEach { file ->
+                if (file.isFile() && !ignoreFile(file)) {
+                    val relativePath = Path(file.path).relativeTo(projectRoot.toNioPath())
+                    it.putNextEntry(relativePath.toString(), Path(file.path))
+                }
             }
         }
-    }.toFile()
+
+        return outputStream.toByteArray()
+    }
 
     private fun parseGitIgnore(gitIgnoreFile: File): List<String> {
         if (!gitIgnoreFile.exists()) {

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationState.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationState.kt
@@ -6,7 +6,6 @@ package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAnswerPart
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.createUploadUrl
-import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.deleteUploadArtifact
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.uploadArtifactToS3
 import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
 import software.aws.toolkits.resources.message
@@ -59,7 +58,6 @@ class PrepareCodeGenerationState(
             repositorySize = zipFileLength.toDouble(),
             messenger = messenger
         )
-        deleteUploadArtifact(fileToUpload)
 
         return nextState.interact(action)
     }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareRefinementState.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareRefinementState.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session
 
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.createUploadUrl
-import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.deleteUploadArtifact
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.uploadArtifactToS3
 import software.aws.toolkits.telemetry.AmazonqTelemetry
 import software.aws.toolkits.telemetry.AmazonqUploadIntent
@@ -32,7 +31,6 @@ class PrepareRefinementState(override var approach: String, override var tabID: 
             amazonqRepositorySize = zipFileLength.toDouble(),
             amazonqUploadIntent = AmazonqUploadIntent.TASKASSISTPLANNING
         )
-        deleteUploadArtifact(fileToUpload)
 
         val nextState = RefinementState(approach, tabID, config, uploadUrlResponse.uploadId(), 0)
         return nextState.interact(action)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/UploadArtifact.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/UploadArtifact.kt
@@ -20,7 +20,7 @@ import java.io.File
 import java.net.HttpURLConnection
 
 private val logger = getLogger<FeatureDevClient>()
-fun uploadArtifactToS3(url: String, fileToUpload: File, checksumSha256: String, contentLength: Long, kmsArn: String?) {
+fun uploadArtifactToS3(url: String, payload: ByteArray, checksumSha256: String, contentLength: Long, kmsArn: String?) {
     try {
         HttpRequests.put(url, APPLICATION_ZIP).userAgent(AwsClientManager.userAgent).tuner {
             it.setRequestProperty("Content-Type", APPLICATION_ZIP)
@@ -33,8 +33,8 @@ fun uploadArtifactToS3(url: String, fileToUpload: File, checksumSha256: String, 
         }
             .connect {
                 val connection = it.connection as HttpURLConnection
-                connection.setFixedLengthStreamingMode(fileToUpload.length())
-                IoUtils.copy(fileToUpload.inputStream(), connection.outputStream)
+                connection.setFixedLengthStreamingMode(payload.size)
+                IoUtils.copy(payload.inputStream(), connection.outputStream)
             }
     } catch (err: Exception) {
         logger.warn(err) { "$FEATURE_NAME: Failed to upload code to S3" }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description

There is an AppSec concern on saving temporal files in a default temporal OS folder. This PR looks to remove the usage of this temporal folder and just buffer the customer's repo.

## Checklist
- [x] My code follows the code style of this project
- [n/a] I have added tests to cover my changes
   -  manual testing
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
