### PR TITLE
Fix issue where Amazon Q Chat does not appear in IDEs other than IntelliJ IDEA

### DIFF
--- a/.changes/next-release/bugfix-bc0e59e4-17ff-45d9-a890-143b1f43512c.json
+++ b/.changes/next-release/bugfix-bc0e59e4-17ff-45d9-a890-143b1f43512c.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue where Amazon Q Chat does not appear in IDEs other than IntelliJ IDEA (#4218)"
+}

--- a/plugins/amazonq/chat/jetbrains-community/resources/META-INF/plugin-chat.xml
+++ b/plugins/amazonq/chat/jetbrains-community/resources/META-INF/plugin-chat.xml
@@ -25,7 +25,6 @@
     <extensions defaultExtensionNs="aws.toolkit.amazonq">
         <appFactory implementation="software.aws.toolkits.jetbrains.services.cwc.AppFactory" />
         <appFactory implementation="software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevAppFactory" />
-        <appFactory implementation="software.aws.toolkits.jetbrains.services.codemodernizer.CodeTransformChatAppFactory" />
     </extensions>
 
     <actions>

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AppSource.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AppSource.kt
@@ -9,5 +9,9 @@ import software.aws.toolkits.jetbrains.services.amazonq.apps.AmazonQAppFactory
 
 class AppSource {
     private val extensionPointName = ExtensionPointName.create<AmazonQAppFactory>("aws.toolkit.amazonq.appFactory")
-    fun getApps(project: Project) = extensionPointName.extensionList.map { it.createApp(project) }
+    fun getApps(project: Project) = buildList {
+        extensionPointName.forEachExtensionSafe {
+            add(it.createApp(project))
+        }
+    }
 }

--- a/plugins/amazonq/codetransform/jetbrains-community/resources/META-INF/ext-codetransform-java.xml
+++ b/plugins/amazonq/codetransform/jetbrains-community/resources/META-INF/ext-codetransform-java.xml
@@ -23,6 +23,10 @@
         <fileEditorProvider implementation="software.aws.toolkits.jetbrains.services.codemodernizer.summary.CodeModernizerSummaryEditorProvider"/>
     </extensions>
 
+    <extensions defaultExtensionNs="aws.toolkit.amazonq">
+        <appFactory implementation="software.aws.toolkits.jetbrains.services.codemodernizer.CodeTransformChatAppFactory" />
+    </extensions>
+
     <actions>
         <group id="aws.toolkit.codemodernizer.toolbar">
             <action


### PR DESCRIPTION
CodeTransform services are only availble in Java-IDEs, so chat initialization was failing to load the relevant services.

Temporarily fix by skipping the /transform command when the Java module is not available and being more defensive during panel initialization

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
#4218

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
