### PR TITLE
Fix Gateway plugin validation failure

### DIFF
--- a/plugins/toolkit/jetbrains-core/resources/META-INF/plugin-intellij.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/plugin-intellij.xml
@@ -1,11 +1,14 @@
 <!-- Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-<idea-plugin>
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
 
     <incompatible-with>com.intellij.cwm.guest</incompatible-with>
     <incompatible-with>com.intellij.jetbrains.client</incompatible-with>
     <incompatible-with>com.intellij.gateway</incompatible-with>
+
+    <!-- delete when fully split -->
+    <xi:include href="/META-INF/module-amazonq.xml"/>
 </idea-plugin>

--- a/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
@@ -132,7 +132,6 @@
     </xi:include>
 
     <!-- delete when fully split -->
-    <xi:include href="/META-INF/module-amazonq.xml"/>
     <xi:include href="/META-INF/module-core.xml" />
 
     <!-- global optional dependencies here, otherwise in their respective optional includes -->


### PR DESCRIPTION
Gateway does not need any references to Q
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
