### PR TITLE
feat(amazonqFeatureDev): add code generation unit tests

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
@@ -1,0 +1,109 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.controller
+
+import com.intellij.notification.NotificationAction
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FeatureDevMessageType
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUp
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUpStatusType
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUpTypes
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAnswer
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAsyncEventProgress
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendChatInputEnabledMessage
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendCodeResult
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendSystemPrompt
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendUpdatePlaceholder
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.DeletedFileInfo
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.NewFileZipInfo
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.PrepareCodeGenerationState
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.Session
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.getFollowUpOptions
+import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
+import software.aws.toolkits.jetbrains.utils.notifyInfo
+import software.aws.toolkits.resources.message
+
+suspend fun FeatureDevController.onCodeGeneration(session: Session, message: String, tabId: String) {
+    messenger.sendAsyncEventProgress(
+        tabId = tabId,
+        inProgress = true,
+        message = message("amazonqFeatureDev.chat_message.start_code_generation"),
+    )
+
+    try {
+        this.messenger.sendAnswer(
+            tabId = tabId,
+            message = message("amazonqFeatureDev.chat_message.requesting_changes"),
+            messageType = FeatureDevMessageType.AnswerStream,
+        )
+
+        messenger.sendUpdatePlaceholder(tabId = tabId, newPlaceholder = message("amazonqFeatureDev.placeholder.generating_code"))
+
+        session.send(message) // Trigger code generation
+
+        val state = session.sessionState
+
+        var filePaths: List<NewFileZipInfo> = emptyList()
+        var deletedFiles: List<DeletedFileInfo> = emptyList()
+        var references: List<CodeReference> = emptyList()
+        var uploadId = ""
+
+        when (state) {
+            is PrepareCodeGenerationState -> {
+                filePaths = state.filePaths
+                deletedFiles = state.deletedFiles
+                references = state.references
+                uploadId = state.uploadId
+            }
+        }
+
+        // Atm this is the only possible path as codegen is mocked to return empty.
+        if (filePaths.size or deletedFiles.size == 0) {
+            messenger.sendAnswer(
+                tabId = tabId,
+                messageType = FeatureDevMessageType.Answer,
+                message = message("amazonqFeatureDev.code_generation.no_file_changes")
+            )
+            messenger.sendSystemPrompt(
+                tabId = tabId,
+                followUp = if (retriesRemaining(session) > 0) {
+                    listOf(
+                        FollowUp(
+                            pillText = message("amazonqFeatureDev.follow_up.retry"),
+                            type = FollowUpTypes.RETRY,
+                            status = FollowUpStatusType.Warning
+                        )
+                    )
+                } else {
+                    emptyList()
+                }
+            )
+            messenger.sendChatInputEnabledMessage(tabId = tabId, enabled = false) // Lock chat input until retry is clicked.
+            return
+        }
+
+        messenger.sendCodeResult(tabId = tabId, uploadId = uploadId, filePaths = filePaths, deletedFiles = deletedFiles, references = references)
+
+        messenger.sendSystemPrompt(tabId = tabId, followUp = getFollowUpOptions(session.sessionState.phase, interactionSucceeded = true))
+
+        messenger.sendUpdatePlaceholder(tabId = tabId, newPlaceholder = message("amazonqFeatureDev.placeholder.after_code_generation"))
+    } finally {
+        messenger.sendAsyncEventProgress(tabId = tabId, inProgress = false) // Finish processing the event
+        messenger.sendChatInputEnabledMessage(tabId = tabId, enabled = false) // Lock chat input until a follow-up is clicked.
+
+        if (toolWindow != null && !toolWindow.isVisible) {
+            notifyInfo(
+                title = message("amazonqFeatureDev.code_generation.notification_title"),
+                content = message("amazonqFeatureDev.code_generation.notification_message"),
+                project = getProject(),
+                notificationActions = listOf(openChatNotificationAction())
+            )
+        }
+    }
+}
+
+private fun FeatureDevController.openChatNotificationAction() = NotificationAction.createSimple(
+    message("amazonqFeatureDev.code_generation.notification_open_link")
+) {
+    toolWindow?.show()
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
@@ -64,8 +64,8 @@ class CodeGenerationState(
             messenger = messenger,
         )
 
-        // It is not needed to interact right away with the code generation state.
-        // returns a SessionStateInteraction object to be handled by the controller.
+        // It is not needed to interact right away with the PrepareCodeGeneration.
+        // returns therefore a SessionStateInteraction object to be handled by the controller.
         return SessionStateInteraction(
             nextState = nextState,
             interaction = Interaction(content = "", interactionSucceeded = true)

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FeatureDevControllerUtil.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FeatureDevControllerUtil.kt
@@ -1,0 +1,46 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util
+
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUp
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUpIcons
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUpStatusType
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUpTypes
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.SessionStatePhase
+import software.aws.toolkits.resources.message
+
+fun getFollowUpOptions(phase: SessionStatePhase?, interactionSucceeded: Boolean): List<FollowUp> {
+    when (phase) {
+        SessionStatePhase.APPROACH -> {
+            return when (interactionSucceeded) {
+                true -> listOf(
+                    FollowUp(
+                        pillText = message("amazonqFeatureDev.follow_up.generate_code"),
+                        type = FollowUpTypes.GENERATE_CODE,
+                        status = FollowUpStatusType.Info,
+                    )
+                )
+
+                false -> emptyList()
+            }
+        }
+        SessionStatePhase.CODEGEN -> {
+            return listOf(
+                FollowUp(
+                    pillText = message("amazonqFeatureDev.follow_up.insert_code"),
+                    type = FollowUpTypes.INSERT_CODE,
+                    icon = FollowUpIcons.Ok,
+                    status = FollowUpStatusType.Success
+                ),
+                FollowUp(
+                    pillText = message("amazonqFeatureDev.follow_up.provide_feedback_and_regenerate"),
+                    type = FollowUpTypes.PROVIDE_FEEDBACK_AND_REGENERATE_CODE,
+                    icon = FollowUpIcons.Refresh,
+                    status = FollowUpStatusType.Info
+                )
+            )
+        }
+        else -> return emptyList()
+    }
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FileUtils.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FileUtils.kt
@@ -1,0 +1,26 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util
+
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.writeBytes
+
+/**
+ * FileUtils.kt
+ *
+ * These are utility functions to abstact file IO calls for testing purposes.
+ */
+
+fun resolveAndCreateOrUpdateFile(projectRootPath: Path, relativeFilePath: String, fileContent: String) {
+    val filePath = projectRootPath.resolve(relativeFilePath)
+    filePath.parent.createDirectories() // Create directories if needed
+    filePath.writeBytes(fileContent.toByteArray(Charsets.UTF_8))
+}
+
+fun resolveAndDeleteFile(projectRootPath: Path, relativePath: String) {
+    val filePath = projectRootPath.resolve(relativePath)
+    filePath.deleteIfExists()
+}

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -5,21 +5,28 @@ package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.controller
 
 import com.intellij.testFramework.RuleChain
 import com.intellij.testFramework.replaceService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.just
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import software.aws.toolkits.jetbrains.services.amazonq.apps.AmazonQAppInitContext
 import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthController
@@ -27,11 +34,32 @@ import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededStates
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTestBase
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FeatureDevMessageType
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUp
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUpStatusType
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUpTypes
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.IncomingFeatureDevMessage
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAnswer
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAsyncEventProgress
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendChatInputEnabledMessage
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendCodeResult
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendSystemPrompt
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendUpdatePlaceholder
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.updateFileComponent
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.DeletedFileInfo
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.Interaction
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.NewFileZipInfo
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.PrepareCodeGenerationState
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.RefinementState
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.Session
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.SessionStatePhase
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.storage.ChatSessionStorage
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.getFollowUpOptions
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.uploadArtifactToS3
+import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
+import software.aws.toolkits.resources.message
+import software.aws.toolkits.telemetry.AmazonqTelemetry
+import org.mockito.kotlin.verify as mockitoVerify
 
 class FeatureDevControllerTest : FeatureDevTestBase() {
     @Rule
@@ -46,7 +74,15 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
     private lateinit var spySession: Session
     private lateinit var featureDevClient: FeatureDevClient
 
-    private val tabId = "tabId"
+    private val newFileContents = listOf(
+        NewFileZipInfo("test.ts", "This is a comment", false),
+        NewFileZipInfo("test2.ts", "This is a rejected file", true)
+    )
+    private val deletedFiles = listOf(
+        DeletedFileInfo("delete.ts", false),
+        DeletedFileInfo("delete2.ts", true)
+    )
+    private val references = listOf(CodeReference(information = "test"))
 
     @Before
     override fun setup() {
@@ -54,35 +90,56 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
         featureDevClient = mock()
         messenger = mock()
         chatSessionStorage = mock()
+        projectRule.project.replaceService(FeatureDevClient::class.java, featureDevClient, disposableRule.disposable)
         appContext = mock<AmazonQAppInitContext> {
-            on { project }.thenReturn(project)
+            on { project }.thenReturn(projectRule.project)
             on { messagesFromAppToUi }.thenReturn(messenger)
         }
-        authController = spy(AuthController())
+        authController = mock()
+        whenever(authController.getAuthNeededStates(any())).thenReturn(AuthNeededStates(amazonQ = null))
+        spySession = spy(Session(testTabId, projectRule.project))
+
+        mockkStatic(
+            MessagePublisher::sendAnswer,
+            MessagePublisher::sendSystemPrompt,
+            MessagePublisher::sendUpdatePlaceholder,
+            MessagePublisher::sendChatInputEnabledMessage,
+            MessagePublisher::sendCodeResult,
+            MessagePublisher::updateFileComponent
+        )
+
         mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.UploadArtifactKt")
         every { uploadArtifactToS3(any(), any(), any(), any(), any()) } just runs
 
         controller = FeatureDevController(appContext, chatSessionStorage, authController)
     }
 
+    @After
+    fun clear() {
+        unmockkAll()
+    }
+
     @Test
     fun `test new tab opened`() {
-        val message = IncomingFeatureDevMessage.NewTabCreated("new-tab-created", tabId)
+        authController = spy(AuthController())
+        controller = FeatureDevController(appContext, chatSessionStorage, authController)
+
+        val message = IncomingFeatureDevMessage.NewTabCreated("new-tab-created", testTabId)
         spySession = spy(Session("tabId", project))
         whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
 
         runTest {
             controller.processNewTabCreatedMessage(message)
         }
-        verify(authController, times(1)).getAuthNeededStates(project)
-        verify(chatSessionStorage, times(1)).getSession(tabId, project)
+        mockitoVerify(authController, times(1)).getAuthNeededStates(project)
+        mockitoVerify(chatSessionStorage, times(1)).getSession(testTabId, project)
         assertThat(spySession.isAuthenticating).isTrue()
     }
 
     @Test
     fun `test handle chat for planning phase`() {
         val testAuth = AuthNeededStates(amazonQ = null)
-        val message: IncomingFeatureDevMessage.ChatPrompt = IncomingFeatureDevMessage.ChatPrompt(userMessage, "chat-prompt", tabId)
+        val message: IncomingFeatureDevMessage.ChatPrompt = IncomingFeatureDevMessage.ChatPrompt(userMessage, "chat-prompt", testTabId)
         projectRule.project.replaceService(FeatureDevClient::class.java, featureDevClient, disposableRule.disposable)
         spySession = spy(Session("tabId", project))
 
@@ -96,12 +153,248 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
 
             controller.processPromptChatMessage(message)
 
-            verify(spySession, times(1)).preloader(any(), any())
-            verify(spySession, times(1)).send(any())
+            mockitoVerify(spySession, times(1)).preloader(any(), any())
+            mockitoVerify(spySession, times(1)).send(any())
             assertThat(spySession.send(userMessage).content?.trim()).isEqualTo(exampleGenerateTaskAssistPlanResult.approach)
             assertThat(spySession.send(userMessage).interactionSucceeded).isTrue()
         }
-        verify(authController, times(1)).getAuthNeededStates(any())
+        mockitoVerify(authController, times(1)).getAuthNeededStates(any())
         assertThat(spySession.sessionState).isInstanceOf(RefinementState::class.java)
+    }
+
+    @Test
+    fun `test newTask and closeSession followUp`() {
+        /*
+            Testing both followups together as they share logic, atm they could be verified together.
+         */
+        val followUp = FollowUp(FollowUpTypes.NEW_TASK, pillText = "Work on new task")
+        val message = IncomingFeatureDevMessage.FollowupClicked(followUp, testTabId, "", "test-command")
+
+        whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
+        whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
+        doNothing().`when`(chatSessionStorage).deleteSession(any())
+
+        mockkObject(AmazonqTelemetry)
+        every { AmazonqTelemetry.endChat(amazonqConversationId = any(), amazonqEndOfTheConversationLatency = any()) } just runs
+
+        runTest {
+            spySession.preloader(userMessage, messenger)
+            controller.processFollowupClickedMessage(message)
+        }
+
+        mockitoVerify(chatSessionStorage, times(1)).deleteSession(testTabId)
+
+        coVerifyOrder {
+            messenger.sendAnswer(testTabId, message("amazonqFeatureDev.chat_message.closed_session"), FeatureDevMessageType.Answer)
+            messenger.sendUpdatePlaceholder(testTabId, message("amazonqFeatureDev.placeholder.closed_session"))
+            messenger.sendChatInputEnabledMessage(testTabId, false)
+            messenger.sendAnswer(testTabId, message("amazonqFeatureDev.chat_message.ask_for_new_task"), FeatureDevMessageType.Answer)
+            messenger.sendUpdatePlaceholder(testTabId, message("amazonqFeatureDev.placeholder.new_plan"))
+        }
+
+        verify(
+            exactly = 1
+        ) { AmazonqTelemetry.endChat(amazonqConversationId = testConversationId, amazonqEndOfTheConversationLatency = any(), createTime = any()) }
+    }
+
+    @Test
+    fun `test generateCodeClicked starts code generation`() = runTest {
+        doNothing().`when`(spySession).initCodegen(any())
+        whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
+        mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.controller.FeatureDevControllerExtensionsKt")
+        coEvery { controller.onCodeGeneration(any(), any(), any()) } just runs
+
+        val followUp = FollowUp(FollowUpTypes.GENERATE_CODE, pillText = "Generate code")
+        val message = IncomingFeatureDevMessage.FollowupClicked(followUp, testTabId, "", "test-command")
+
+        controller.processFollowupClickedMessage(message)
+
+        mockitoVerify(spySession, times(1)).initCodegen(messenger)
+        coVerify(exactly = 1) { controller.onCodeGeneration(spySession, "", testTabId) }
+    }
+
+    @Test
+    fun `test provideFeedbackAndRegenerateCode`() = runTest {
+        val followUp = FollowUp(FollowUpTypes.PROVIDE_FEEDBACK_AND_REGENERATE_CODE, pillText = "Regenerate code")
+        val message = IncomingFeatureDevMessage.FollowupClicked(followUp, testTabId, "", "test-command")
+
+        whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
+        whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
+
+        mockkObject(AmazonqTelemetry)
+        every { AmazonqTelemetry.isProvideFeedbackForCodeGen(amazonqConversationId = any(), enabled = any()) } just runs
+
+        spySession.preloader(userMessage, messenger)
+        controller.processFollowupClickedMessage(message)
+
+        coVerifyOrder {
+            AmazonqTelemetry.isProvideFeedbackForCodeGen(amazonqConversationId = testConversationId, enabled = true, createTime = any())
+            messenger.sendAsyncEventProgress(testTabId, inProgress = false)
+            messenger.sendAnswer(testTabId, message("amazonqFeatureDev.code_generation.provide_code_feedback"), FeatureDevMessageType.Answer)
+            messenger.sendUpdatePlaceholder(testTabId, message("amazonqFeatureDev.placeholder.provide_code_feedback"))
+        }
+    }
+
+    @Test
+    fun `test insertCode`() = runTest {
+        val followUp = FollowUp(FollowUpTypes.INSERT_CODE, pillText = "Insert code")
+        val message = IncomingFeatureDevMessage.FollowupClicked(followUp, testTabId, "", "test-command")
+
+        mockkObject(AmazonqTelemetry)
+        every {
+            AmazonqTelemetry.isAcceptedCodeChanges(amazonqNumberOfFilesAccepted = any(), amazonqConversationId = any(), enabled = any())
+        } just runs
+
+        whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
+        whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
+        whenever(spySession.sessionState).thenReturn(
+            PrepareCodeGenerationState(
+                testTabId, "", mock(), newFileContents, deletedFiles, testReferences, testUploadId, 0, messenger
+            )
+        )
+        doNothing().`when`(spySession).insertChanges(any(), any(), any())
+
+        spySession.preloader(userMessage, messenger)
+        controller.processFollowupClickedMessage(message)
+
+        mockitoVerify(
+            spySession,
+            times(1)
+        ).insertChanges(listOf(newFileContents[0]), listOf(deletedFiles[0]), testReferences) // insert changes for only non rejected files
+        coVerifyOrder {
+            AmazonqTelemetry.isAcceptedCodeChanges(
+                amazonqNumberOfFilesAccepted = 2.0, // it should be 2 files per test setup
+                amazonqConversationId = spySession.conversationId,
+                enabled = true,
+                createTime = any()
+            )
+            messenger.sendAnswer(testTabId, message("amazonqFeatureDev.code_generation.updated_code"), FeatureDevMessageType.Answer)
+            messenger.sendSystemPrompt(
+                testTabId,
+                listOf(
+                    FollowUp(FollowUpTypes.NEW_TASK, message("amazonqFeatureDev.follow_up.new_task"), status = FollowUpStatusType.Info),
+                    FollowUp(FollowUpTypes.CLOSE_SESSION, message("amazonqFeatureDev.follow_up.close_session"), status = FollowUpStatusType.Info)
+                )
+            )
+            messenger.sendChatInputEnabledMessage(testTabId, true)
+            messenger.sendUpdatePlaceholder(testTabId, message("amazonqFeatureDev.placeholder.additional_improvements"))
+        }
+    }
+
+    @Test
+    fun `test handleChat onCodeGeneration succeeds to create files`() = runTest {
+        val mockInteraction = mock<Interaction>()
+
+        val mockSession = mock<Session>()
+        whenever(mockSession.send(userMessage)).thenReturn(mockInteraction)
+        whenever(mockSession.sessionState).thenReturn(
+            PrepareCodeGenerationState(
+                testTabId, "", mock(), newFileContents, deletedFiles, references, testUploadId, 0, messenger
+            )
+        )
+
+        controller.onCodeGeneration(mockSession, userMessage, testTabId)
+
+        coVerifyOrder {
+            messenger.sendAsyncEventProgress(testTabId, true, message("amazonqFeatureDev.chat_message.start_code_generation"))
+            messenger.sendAnswer(testTabId, message("amazonqFeatureDev.chat_message.requesting_changes"), FeatureDevMessageType.AnswerStream)
+            messenger.sendUpdatePlaceholder(testTabId, message("amazonqFeatureDev.placeholder.generating_code"))
+            messenger.sendCodeResult(testTabId, testUploadId, newFileContents, deletedFiles, references)
+            messenger.sendSystemPrompt(testTabId, getFollowUpOptions(SessionStatePhase.CODEGEN, true))
+            messenger.sendUpdatePlaceholder(testTabId, message("amazonqFeatureDev.placeholder.after_code_generation"))
+            messenger.sendAsyncEventProgress(testTabId, false)
+            messenger.sendChatInputEnabledMessage(testTabId, false)
+        }
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `test handleChat onCodeGeneration throws error when sending message to state`() = runTest {
+        val mockSession = mock<Session>()
+
+        whenever(mockSession.send(userMessage)).thenThrow(RuntimeException())
+
+        controller.onCodeGeneration(mockSession, userMessage, testTabId)
+
+        coVerifyOrder {
+            messenger.sendAsyncEventProgress(testTabId, true, message("amazonqFeatureDev.chat_message.start_code_generation"))
+            messenger.sendAnswer(testTabId, message("amazonqFeatureDev.chat_message.requesting_changes"), FeatureDevMessageType.AnswerStream)
+            messenger.sendUpdatePlaceholder(testTabId, message("amazonqFeatureDev.placeholder.generating_code"))
+            messenger.sendAsyncEventProgress(testTabId, false)
+            messenger.sendChatInputEnabledMessage(testTabId, false)
+        }
+    }
+
+    @Test
+    fun `test handleChat onCodeGeneration doesn't return any files with retries`() = runTest {
+        val filePaths = emptyList<NewFileZipInfo>()
+        val deletedFiles = emptyList<DeletedFileInfo>()
+        val references = listOf(CodeReference(information = "test"))
+
+        val mockInteraction = mock<Interaction>()
+
+        val mockSession = mock<Session>()
+        whenever(mockSession.send(userMessage)).thenReturn(mockInteraction)
+        whenever(mockSession.sessionState).thenReturn(
+            PrepareCodeGenerationState(
+                testTabId, "", mock(), filePaths, deletedFiles, references, testUploadId, 0, messenger
+            )
+        )
+        whenever(mockSession.retries).thenReturn(3)
+
+        controller.onCodeGeneration(mockSession, userMessage, testTabId)
+
+        coVerifyOrder {
+            messenger.sendAnswer(testTabId, message("amazonqFeatureDev.code_generation.no_file_changes"), FeatureDevMessageType.Answer)
+            messenger.sendSystemPrompt(
+                testTabId,
+                listOf(FollowUp(FollowUpTypes.RETRY, message("amazonqFeatureDev.follow_up.retry"), status = FollowUpStatusType.Warning))
+            )
+            messenger.sendChatInputEnabledMessage(testTabId, false)
+        }
+    }
+
+    @Test
+    fun `test handleChat onCodeGeneration doesn't return any files no retries`() = runTest {
+        val filePaths = emptyList<NewFileZipInfo>()
+        val deletedFiles = emptyList<DeletedFileInfo>()
+        val references = listOf(CodeReference(information = "test"))
+
+        val mockInteraction = mock<Interaction>()
+
+        val mockSession = mock<Session>()
+        whenever(mockSession.send(userMessage)).thenReturn(mockInteraction)
+        whenever(mockSession.sessionState).thenReturn(
+            PrepareCodeGenerationState(
+                testTabId, "", mock(), filePaths, deletedFiles, references, testUploadId, 0, messenger
+            )
+        )
+        whenever(mockSession.retries).thenReturn(0)
+
+        controller.onCodeGeneration(mockSession, userMessage, testTabId)
+
+        coVerifyOrder {
+            messenger.sendAnswer(testTabId, message("amazonqFeatureDev.code_generation.no_file_changes"), FeatureDevMessageType.Answer)
+            messenger.sendSystemPrompt(testTabId, emptyList())
+            messenger.sendChatInputEnabledMessage(testTabId, false)
+        }
+    }
+
+    @Test
+    fun `test processFileClicked changes the state of the clicked file`() = runTest {
+        val message = IncomingFeatureDevMessage.FileClicked(testTabId, newFileContents[0].zipFilePath, "", "")
+
+        whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
+        whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
+        whenever(spySession.sessionState).thenReturn(
+            PrepareCodeGenerationState(
+                testTabId, "", mock(), newFileContents, deletedFiles, references, testUploadId, 0, messenger
+            )
+        )
+
+        controller.processFileClicked(message)
+
+        val newFileContentsCopy = newFileContents.toList()
+        newFileContentsCopy[0].rejected = !newFileContentsCopy[0].rejected
+        coVerify { messenger.updateFileComponent(testTabId, newFileContentsCopy, deletedFiles) }
     }
 }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationStateTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationStateTest.kt
@@ -1,0 +1,167 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session
+
+import com.intellij.testFramework.RuleChain
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTestBase
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAnswerPart
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.exportTaskAssistArchiveResult
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.getTaskAssistCodeGeneration
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.startTaskAssistCodeGeneration
+import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
+import software.aws.toolkits.resources.message
+
+class CodeGenerationStateTest : FeatureDevTestBase() {
+    @Rule
+    @JvmField
+    val ruleChain = RuleChain(projectRule, disposableRule)
+
+    private lateinit var codeGenerationState: CodeGenerationState
+    private lateinit var featureDevClient: FeatureDevClient
+    private lateinit var messenger: MessagePublisher
+    private val action = SessionStateAction("test-task", userMessage)
+
+    @Before
+    override fun setup() {
+        featureDevClient = mock()
+        messenger = mock()
+        val repoContext = mock<FeatureDevSessionContext>()
+        val sessionStateConfig = SessionStateConfig(testConversationId, featureDevClient, repoContext)
+
+        codeGenerationState = CodeGenerationState(
+            testTabId,
+            "",
+            sessionStateConfig,
+            testUploadId,
+            0,
+            testRepositorySize,
+            messenger
+        )
+
+        mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.FeatureDevClientUtilKt")
+
+        mockkStatic(MessagePublisher::sendAnswerPart)
+        coEvery { messenger.sendAnswerPart(any(), any()) } just runs
+    }
+
+    @After
+    fun clear() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `test code generated is complete`() {
+        val action = SessionStateAction("test-task", userMessage)
+        every { getTaskAssistCodeGeneration(any(), any(), any()) } returns exampleCompleteGetTaskAssistCodeGenerationResponse
+        every { startTaskAssistCodeGeneration(any(), any(), any(), any()) } returns exampleStartTaskAssistConversationResponse
+        coEvery { exportTaskAssistArchiveResult(any(), any()) } returns CodeGenerationStreamResult(testFilePaths, testDeletedFiles, testReferences)
+
+        runTest {
+            val actual = codeGenerationState.interact(action)
+            assertThat(actual.nextState).isInstanceOf(PrepareCodeGenerationState::class.java)
+            val nextState = actual.nextState as PrepareCodeGenerationState
+            assertThat(nextState.uploadId).isEqualTo(testUploadId)
+            assertThat(nextState.phase).isEqualTo(SessionStatePhase.CODEGEN)
+            assertThat(nextState.filePaths).isEqualTo(
+                listOf(NewFileZipInfo("test.ts", "This is a comment", false))
+            )
+            assertThat(nextState.deletedFiles).isEqualTo(
+                listOf(DeletedFileInfo("deleted.ts", false))
+            )
+            assertThat(nextState.references).isEqualTo(testReferences)
+            assertThat(actual.interaction.interactionSucceeded).isEqualTo(true)
+            assertThat(actual.interaction.content).isEqualTo("")
+        }
+        assertThat(codeGenerationState.phase).isEqualTo(SessionStatePhase.CODEGEN)
+        coVerify(exactly = 1) { messenger.sendAnswerPart(testTabId, message("amazonqFeatureDev.code_generation.generating_code")) }
+        verify(exactly = 1) { startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage) }
+        verify(exactly = 1) { getTaskAssistCodeGeneration(featureDevClient, testConversationId, testCodeGenerationId) }
+        coVerify(exactly = 1) { exportTaskAssistArchiveResult(featureDevClient, testConversationId) }
+    }
+
+    @Test(expected = FeatureDevException::class)
+    fun `test code generation failed`() = runTest {
+        every { startTaskAssistCodeGeneration(any(), any(), any(), any()) } returns exampleStartTaskAssistConversationResponse
+        every { getTaskAssistCodeGeneration(any(), any(), any()) } returns exampleFailedGetTaskAssistCodeGenerationResponse
+
+        codeGenerationState.interact(action)
+
+        verify(exactly = 1) { startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage) }
+        verify(exactly = 1) { getTaskAssistCodeGeneration(featureDevClient, testConversationId, testCodeGenerationId) }
+        coVerify(exactly = 0) { exportTaskAssistArchiveResult(any(), any()) }
+    }
+
+    @Test
+    fun `test code generation returns any other handled status`() {
+        every { startTaskAssistCodeGeneration(any(), any(), any(), any()) } returns exampleStartTaskAssistConversationResponse
+        every { getTaskAssistCodeGeneration(any(), any(), any()) } returns exampleOtherGetTaskAssistCodeGenerationResponse
+
+        assertThatThrownBy {
+            runTest {
+                codeGenerationState.interact(action)
+            }
+        }.isExactlyInstanceOf(IllegalStateException::class.java).withFailMessage("Unknown status: $otherStatus")
+
+        verify(exactly = 1) { startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage) }
+        verify(exactly = 1) { getTaskAssistCodeGeneration(featureDevClient, testConversationId, testCodeGenerationId) }
+        coVerify(exactly = 0) { exportTaskAssistArchiveResult(any(), any()) }
+    }
+
+    @Test
+    fun `test code generation returns in progress at least once`() {
+        every { startTaskAssistCodeGeneration(any(), any(), any(), any()) } returns exampleStartTaskAssistConversationResponse
+        every {
+            getTaskAssistCodeGeneration(any(), any(), any())
+        } returnsMany listOf(exampleGetTaskAssistConversationResponse, exampleCompleteGetTaskAssistCodeGenerationResponse)
+        coEvery { exportTaskAssistArchiveResult(any(), any()) } returns CodeGenerationStreamResult(emptyMap(), emptyList(), emptyList())
+
+        runTest {
+            codeGenerationState.interact(action)
+        }
+
+        verify(exactly = 1) { startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage) }
+        verify(exactly = 2) { getTaskAssistCodeGeneration(featureDevClient, testConversationId, testCodeGenerationId) }
+        coVerify(exactly = 1) { exportTaskAssistArchiveResult(featureDevClient, testConversationId) }
+    }
+
+    @Test
+    fun `test using all polling count`() {
+        every { startTaskAssistCodeGeneration(any(), any(), any(), any()) } returns exampleStartTaskAssistConversationResponse
+        every { getTaskAssistCodeGeneration(any(), any(), any()) } returns exampleGetTaskAssistConversationResponse
+
+        runTest {
+            val actual = codeGenerationState.interact(action)
+            assertThat(actual.nextState).isInstanceOf(PrepareCodeGenerationState::class.java)
+            val nextState = actual.nextState as PrepareCodeGenerationState
+            assertThat(nextState.filePaths).isEqualTo(emptyList<NewFileZipInfo>())
+            assertThat(nextState.deletedFiles).isEqualTo(emptyList<String>())
+            assertThat(nextState.references).isEqualTo(emptyList<CodeReference>())
+            assertThat(actual.interaction.interactionSucceeded).isEqualTo(true)
+            assertThat(actual.interaction.content).isEqualTo("")
+        }
+
+        verify(exactly = 1) { startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage) }
+        verify(exactly = 180) { getTaskAssistCodeGeneration(featureDevClient, testConversationId, testCodeGenerationId) }
+        coVerify(exactly = 0) { exportTaskAssistArchiveResult(featureDevClient, testConversationId) }
+    }
+}

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationStateTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationStateTest.kt
@@ -1,0 +1,101 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session
+
+import com.intellij.testFramework.RuleChain
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTestBase
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAnswerPart
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.model.ZipCreationResult
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.deleteUploadArtifact
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.exportTaskAssistArchiveResult
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.getTaskAssistCodeGeneration
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.startTaskAssistCodeGeneration
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.uploadArtifactToS3
+import java.io.File
+
+class PrepareCodeGenerationStateTest : FeatureDevTestBase() {
+    @Rule
+    @JvmField
+    val ruleChain = RuleChain(projectRule, disposableRule)
+
+    private lateinit var prepareCodeGenerationState: PrepareCodeGenerationState
+    private lateinit var repoContext: FeatureDevSessionContext
+    private lateinit var sessionStateConfig: SessionStateConfig
+    private lateinit var featureDevClient: FeatureDevClient
+    private lateinit var messenger: MessagePublisher
+
+    @Before
+    override fun setup() {
+        repoContext = mock()
+        featureDevClient = mock()
+        messenger = mock()
+        sessionStateConfig = SessionStateConfig(testConversationId, featureDevClient, repoContext)
+        prepareCodeGenerationState = PrepareCodeGenerationState(
+            "",
+            "tabId",
+            sessionStateConfig,
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            testUploadId,
+            0,
+            messenger
+        )
+
+        mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.UploadArtifactKt")
+        every { uploadArtifactToS3(any(), any(), any(), any(), any()) } just runs
+        every { deleteUploadArtifact(any()) } just runs
+
+        mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.FeatureDevClientUtilKt")
+        every { getTaskAssistCodeGeneration(any(), any(), any()) } returns exampleCompleteGetTaskAssistCodeGenerationResponse
+        every { startTaskAssistCodeGeneration(any(), any(), any(), any()) } returns exampleStartTaskAssistConversationResponse
+        coEvery { exportTaskAssistArchiveResult(any(), any()) } returns exampleExportTaskAssistResultArchiveResponse
+
+        mockkStatic(MessagePublisher::sendAnswerPart)
+        coEvery { messenger.sendAnswerPart(any(), any()) } just runs
+    }
+
+    @After
+    fun clear() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `test interact`() {
+        val mockFile: File = mock()
+        val repoZipResult = ZipCreationResult(mockFile, testChecksumSha, testContentLength)
+        val action = SessionStateAction("test-task", userMessage)
+
+        whenever(repoContext.getProjectZip()).thenReturn(repoZipResult)
+        whenever(featureDevClient.createTaskAssistUploadUrl(testConversationId, testChecksumSha, testContentLength)).thenReturn(exampleCreateUploadUrlResponse)
+
+        runTest {
+            val actual = prepareCodeGenerationState.interact(action)
+            assertThat(actual.nextState).isInstanceOf(PrepareCodeGenerationState::class.java)
+            assertThat((actual.nextState as PrepareCodeGenerationState).uploadId).isEqualTo(testUploadId)
+        }
+        assertThat(prepareCodeGenerationState.phase).isEqualTo(SessionStatePhase.CODEGEN)
+        verify(repoContext, times(1)).getProjectZip()
+        verify(featureDevClient, times(1)).createTaskAssistUploadUrl(any(), any(), any())
+    }
+}

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FeatureDevClientUtilTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FeatureDevClientUtilTest.kt
@@ -13,16 +13,22 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails
+import software.amazon.awssdk.services.codewhispererruntime.model.CodeWhispererRuntimeException
 import software.amazon.awssdk.services.codewhispererruntime.model.CreateUploadUrlResponse
+import software.amazon.awssdk.services.codewhispererruntime.model.ServiceQuotaExceededException
+import software.amazon.awssdk.services.codewhispererruntime.model.ThrottlingException
 import software.amazon.awssdk.services.codewhispererruntime.model.ValidationException
-import software.amazon.awssdk.services.codewhispererstreaming.model.ThrottlingException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CodeIterationLimitError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ContentLengthError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTestBase
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.PlanIterationLimitError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.GenerateTaskAssistPlanResult
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.CodeGenerationStreamResult
+import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
 import software.aws.toolkits.resources.message
+import software.amazon.awssdk.services.codewhispererstreaming.model.ThrottlingException as StreamingThrottlingException
 
 class FeatureDevClientUtilTest : FeatureDevTestBase() {
     @Rule
@@ -31,7 +37,8 @@ class FeatureDevClientUtilTest : FeatureDevTestBase() {
 
     private lateinit var featureDevClient: FeatureDevClient
 
-    private val uploadId = "test-upload-id"
+    private val cwExceptionMsg = "CWException"
+    private val otherExceptionMsg = "otherException"
 
     @Before
     override fun setup() {
@@ -88,24 +95,24 @@ class FeatureDevClientUtilTest : FeatureDevTestBase() {
 
     @Test
     fun `test generatePlan`() = runTest {
-        whenever(featureDevClient.generateTaskAssistPlan(testConversationId, uploadId, userMessage)).thenReturn(exampleGenerateTaskAssistPlanResult)
+        whenever(featureDevClient.generateTaskAssistPlan(testConversationId, testUploadId, userMessage)).thenReturn(exampleGenerateTaskAssistPlanResult)
 
-        val actual = generatePlan(featureDevClient, testConversationId, uploadId, userMessage, 0)
+        val actual = generatePlan(featureDevClient, testConversationId, testUploadId, userMessage, 0)
         assertThat(actual).isInstanceOf(GenerateTaskAssistPlanResult::class.java)
         assertThat(actual.approach).isEqualTo("Generated approach for plan")
     }
 
     @Test(expected = FeatureDevException::class)
     fun `test generatePlan with error`() = runTest {
-        whenever(featureDevClient.generateTaskAssistPlan(testConversationId, uploadId, userMessage)).thenThrow(RuntimeException())
+        whenever(featureDevClient.generateTaskAssistPlan(testConversationId, testUploadId, userMessage)).thenThrow(RuntimeException())
 
-        generatePlan(featureDevClient, testConversationId, uploadId, userMessage, 0)
+        generatePlan(featureDevClient, testConversationId, testUploadId, userMessage, 0)
     }
 
     @Test
     fun `test generatePlan with throttling error`() = runTest {
-        whenever(featureDevClient.generateTaskAssistPlan(testConversationId, uploadId, userMessage)).thenThrow(
-            ThrottlingException.builder()
+        whenever(featureDevClient.generateTaskAssistPlan(testConversationId, testUploadId, userMessage)).thenThrow(
+            StreamingThrottlingException.builder()
                 .requestId(testRequestId)
                 .message("limit for number of iterations on an implementation plan")
                 .awsErrorDetails(AwsErrorDetails.builder().errorMessage("Plan Iteration limit").build())
@@ -113,11 +120,152 @@ class FeatureDevClientUtilTest : FeatureDevTestBase() {
         )
         var caughtException: Throwable? = null
         try {
-            generatePlan(featureDevClient, testConversationId, uploadId, userMessage, 0)
+            generatePlan(featureDevClient, testConversationId, testUploadId, userMessage, 0)
         } catch (e: Throwable) {
             caughtException = e
         }
         assertThat(caughtException is PlanIterationLimitError).isTrue()
         assertThat(caughtException).hasMessage(message("amazonqFeatureDev.approach_gen.iteration_limit.error_text"))
     }
+
+    @Test
+    fun `test getTaskAssistCodeGeneration success`() {
+        whenever(featureDevClient.getTaskAssistCodeGeneration(testConversationId, testCodeGenerationId)).thenReturn(exampleGetTaskAssistConversationResponse)
+
+        val actual = getTaskAssistCodeGeneration(featureDevClient, testConversationId, testCodeGenerationId)
+
+        assertThat(actual).isEqualTo(exampleGetTaskAssistConversationResponse)
+    }
+
+    @Test
+    fun `test getTaskAssistCodeGeneration throws a CodeWhispererRuntimeException`() {
+        val exampleCWException = CodeWhispererRuntimeException.builder().awsErrorDetails(
+            AwsErrorDetails.builder().errorMessage(cwExceptionMsg).build()
+        ).build()
+        whenever(featureDevClient.getTaskAssistCodeGeneration(testConversationId, testCodeGenerationId)).thenThrow(exampleCWException)
+
+        assertThatThrownBy {
+            getTaskAssistCodeGeneration(featureDevClient, testConversationId, testCodeGenerationId)
+        }.isExactlyInstanceOf(FeatureDevException::class.java).withFailMessage(cwExceptionMsg)
+    }
+
+    @Test
+    fun `test getTaskAssistCodeGeneration throws another Exception`() {
+        val exampleOtherException = RuntimeException(otherExceptionMsg)
+        whenever(featureDevClient.getTaskAssistCodeGeneration(testConversationId, testCodeGenerationId)).thenThrow(exampleOtherException)
+
+        assertThatThrownBy {
+            getTaskAssistCodeGeneration(featureDevClient, testConversationId, testCodeGenerationId)
+        }.isExactlyInstanceOf(FeatureDevException::class.java).withFailMessage(otherExceptionMsg)
+    }
+
+    @Test
+    fun `test startTaskAssistConversation success`() {
+        whenever(
+            featureDevClient.startTaskAssistCodeGeneration(testConversationId, testUploadId, userMessage)
+        ).thenReturn(exampleStartTaskAssistConversationResponse)
+
+        val actual = startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage)
+
+        assertThat(actual).isEqualTo(exampleStartTaskAssistConversationResponse)
+    }
+
+    @Test
+    fun `test startTaskAssistConversation throws ThrottlingException`() {
+        val exampleCWException = ThrottlingException.builder().awsErrorDetails(
+            AwsErrorDetails.builder().errorMessage("limit for number of iterations on a code generation").build()
+        ).build()
+        whenever(featureDevClient.startTaskAssistCodeGeneration(testConversationId, testUploadId, userMessage)).thenThrow(exampleCWException)
+
+        assertThatThrownBy {
+            startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage)
+        }.isExactlyInstanceOf(CodeIterationLimitError::class.java).withFailMessage(
+            message("amazonqFeatureDev.code_generation.iteration_limit.error_text")
+        )
+    }
+
+    @Test
+    fun `test startTaskAssistConversation throws ServiceQuotaExceededException`() {
+        val exampleCWException = ServiceQuotaExceededException.builder().awsErrorDetails(
+            AwsErrorDetails.builder().errorMessage("service quota exceeded").build()
+        ).build()
+        whenever(featureDevClient.startTaskAssistCodeGeneration(testConversationId, testUploadId, userMessage)).thenThrow(exampleCWException)
+
+        assertThatThrownBy {
+            startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage)
+        }.isExactlyInstanceOf(CodeIterationLimitError::class.java).withFailMessage(
+            message("amazonqFeatureDev.code_generation.iteration_limit.error_text")
+        )
+    }
+
+    @Test
+    fun `test startTaskAssistConversation throws another CodeWhispererRuntimeException`() {
+        val exampleCWException = CodeWhispererRuntimeException.builder().awsErrorDetails(
+            AwsErrorDetails.builder().errorMessage(cwExceptionMsg).build()
+        ).build()
+        whenever(featureDevClient.startTaskAssistCodeGeneration(testConversationId, testUploadId, userMessage)).thenThrow(exampleCWException)
+
+        assertThatThrownBy {
+            startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage)
+        }.isExactlyInstanceOf(FeatureDevException::class.java).withFailMessage(cwExceptionMsg)
+    }
+
+    @Test
+    fun `test startTaskAssistConversation throws any other exception`() {
+        val exampleOtherException = RuntimeException(otherExceptionMsg)
+        whenever(featureDevClient.startTaskAssistCodeGeneration(testConversationId, testUploadId, userMessage)).thenThrow(exampleOtherException)
+
+        assertThatThrownBy {
+            startTaskAssistCodeGeneration(featureDevClient, testConversationId, testUploadId, userMessage)
+        }.isExactlyInstanceOf(FeatureDevException::class.java).withFailMessage(otherExceptionMsg)
+    }
+
+    @Test
+    fun `test exportTaskAssistArchiveResult throws CodeWhispererStreamingException`() {
+        val exampleCWException = CodeWhispererRuntimeException.builder().awsErrorDetails(
+            AwsErrorDetails.builder().errorMessage(cwExceptionMsg).build()
+        ).build()
+
+        assertThatThrownBy {
+            runTest {
+                whenever(featureDevClient.exportTaskAssistResultArchive(testConversationId)).thenThrow(exampleCWException)
+                exportTaskAssistArchiveResult(featureDevClient, testConversationId)
+            }
+        }.isExactlyInstanceOf(FeatureDevException::class.java).withFailMessage(cwExceptionMsg)
+    }
+
+    @Test
+    fun `test exportTaskAssistArchiveResult throws other exception`() {
+        val exampleOtherException = RuntimeException(otherExceptionMsg)
+
+        assertThatThrownBy {
+            runTest {
+                whenever(featureDevClient.exportTaskAssistResultArchive(testConversationId)).thenThrow(exampleOtherException)
+                exportTaskAssistArchiveResult(featureDevClient, testConversationId)
+            }
+        }.isExactlyInstanceOf(FeatureDevException::class.java).withFailMessage(otherExceptionMsg)
+    }
+
+    @Test
+    fun `test exportTaskAssistArchiveResult throws an exportParseError`() {
+        assertThatThrownBy {
+            runTest {
+                whenever(featureDevClient.exportTaskAssistResultArchive(testConversationId)).thenReturn(mutableListOf(byteArrayOf(0, 1, 2)))
+                exportTaskAssistArchiveResult(featureDevClient, testConversationId)
+            }
+        }.isExactlyInstanceOf(FeatureDevException::class.java)
+    }
+
+    @Test
+    fun `test exportTaskAssistArchiveResult returns correct parsed result`() =
+        runTest {
+            val codeGenerationJson = "{\"code_generation_result\":{\"new_file_contents\":{\"test.ts\":\"contents\"},\"deleted_files\":[],\"references\":[]}}"
+            whenever(featureDevClient.exportTaskAssistResultArchive(testConversationId)).thenReturn(mutableListOf(codeGenerationJson.toByteArray()))
+
+            val actual = exportTaskAssistArchiveResult(featureDevClient, testConversationId)
+            assertThat(actual).isInstanceOf(CodeGenerationStreamResult::class.java)
+            assertThat(actual.new_file_contents).isEqualTo(mapOf(Pair("test.ts", "contents")))
+            assertThat(actual.deleted_files).isEqualTo(emptyList<String>())
+            assertThat(actual.references).isEqualTo(emptyList<CodeReference>())
+        }
 }


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description

amazonqFeatureDev codebase is lacking unit tests. This PR is extending the coverage for the critical logic that needs to be verified. It includes testing for the codegen chat states, session functions, api utility functions and minor refactors to allow simpler testing.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [n/a] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [n/a] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
