### PR TITLE
telemetry: send loginWithBrowser telemetry onTokenRetrieved & onFailure

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
@@ -35,7 +35,6 @@ object SsoPrompt : SsoLoginCallback {
             ).showAndGet()
 
             if (result) {
-                AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.SsoProfile)
                 BrowserUtil.browse(authorization.verificationUriComplete)
             } else {
                 AwsTelemetry.loginWithBrowser(project = null, result = Result.Cancelled, credentialType = CredentialType.SsoProfile)
@@ -44,10 +43,13 @@ object SsoPrompt : SsoLoginCallback {
         }
     }
 
-    override fun tokenRetrieved() {}
+    override fun tokenRetrieved() {
+        AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.SsoProfile)
+    }
 
     override fun tokenRetrievalFailure(e: Exception) {
         e.notifyError(message("credentials.sso.login.failed"))
+        AwsTelemetry.loginWithBrowser(project = null, result = Result.Failed, credentialType = CredentialType.SsoProfile)
     }
 }
 
@@ -61,7 +63,6 @@ object BearerTokenPrompt : SsoLoginCallback {
             ).showAndGet()
 
             if (codeCopied) {
-                AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.BearerToken)
                 BrowserUtil.browse(authorization.verificationUriComplete)
             } else {
                 AwsTelemetry.loginWithBrowser(project = null, result = Result.Cancelled, credentialType = CredentialType.BearerToken)
@@ -69,7 +70,11 @@ object BearerTokenPrompt : SsoLoginCallback {
         }
     }
 
-    override fun tokenRetrieved() {}
+    override fun tokenRetrieved() {
+        AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.BearerToken)
+    }
 
-    override fun tokenRetrievalFailure(e: Exception) {}
+    override fun tokenRetrievalFailure(e: Exception) {
+        AwsTelemetry.loginWithBrowser(project = null, result = Result.Failed, credentialType = CredentialType.BearerToken)
+    }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

`loginWithBrwoser:Success` if SsoAccessTokenProvider.pollForToken() succeed
`loginWithBrowser:Canceled` if users press [Cancel] button on the confirmUserCodeDialog
`loginWithBrwoser:Failed` if SsoAccessTokenProvider.pollForToken() fail

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
