### PR TITLE
Speed up CI builds by disabling Java incremental compilation

### DIFF
--- a/plugins/toolkit/jetbrains-core/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-core/build.gradle.kts
@@ -27,6 +27,12 @@ val changelog = tasks.register<GeneratePluginChangeLog>("pluginChangeLog") {
     changeLogFile.set(project.file("$buildDir/changelog/change-notes.xml"))
 }
 
+tasks.compileJava {
+    // https://github.com/gradle/gradle/issues/26006
+    // consistently saves 6+ minutes in CI. we do not need incremental compilation for 2 java files
+    options.isIncremental = false
+}
+
 tasks.jar {
     dependsOn(changelog)
     from(changelog) {


### PR DESCRIPTION
Counterintuitively, incremental compilation of Java takes up nearly half our build time, spent on creating 'classpath snapshot for incremental compilation'.

This is completely unnecessary for 2 Java sources files that take less than 30 seconds to compile
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
