### PR TITLE
fix(q): handle ServiceQuotaExceededException that is returned from backend when iteration limits reached for plan and code generation of feature dev

### DIFF
--- a/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
+++ b/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
@@ -39,6 +39,7 @@
             "output":{"shape":"CreateUploadUrlResponse"},
             "errors":[
                 {"shape":"ThrottlingException"},
+                {"shape":"ServiceQuotaExceededException"},
                 {"shape":"ConflictException"},
                 {"shape":"ResourceNotFoundException"},
                 {"shape":"InternalServerException"},
@@ -62,6 +63,9 @@
             "errors": [
                 {
                     "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ServiceQuotaExceededException"
                 },
                 {
                     "shape": "InternalServerException"
@@ -258,6 +262,7 @@
             "output":{"shape":"StartTaskAssistCodeGenerationResponse"},
             "errors":[
                 {"shape":"ThrottlingException"},
+                {"shape":"ServiceQuotaExceededException"},
                 {"shape":"ConflictException"},
                 {"shape":"ResourceNotFoundException"},
                 {"shape":"InternalServerException"},
@@ -1552,6 +1557,15 @@
             "sensitive":true
         },
         "ThrottlingException":{
+            "type":"structure",
+            "required":["message"],
+            "members":{
+                "message":{"shape":"String"}
+            },
+            "exception":true,
+            "retryable":{"throttling":true}
+        },
+        "ServiceQuotaExceededException":{
             "type":"structure",
             "required":["message"],
             "members":{

--- a/plugins/core/sdk-codegen/codegen-resources/codewhispererstreaming/service-2.json
+++ b/plugins/core/sdk-codegen/codegen-resources/codewhispererstreaming/service-2.json
@@ -55,6 +55,7 @@
             "output":{"shape":"GenerateTaskAssistPlanResponse"},
             "errors":[
                 {"shape":"ThrottlingException"},
+                {"shape":"ServiceQuotaExceededException"},
                 {"shape":"ConflictException"},
                 {"shape":"ResourceNotFoundException"},
                 {"shape":"InternalServerException"},
@@ -624,6 +625,15 @@
             "sensitive":true
         },
         "ThrottlingException":{
+            "type":"structure",
+            "required":["message"],
+            "members":{
+                "message":{"shape":"String"}
+            },
+            "exception":true,
+            "retryable":{"throttling":true}
+        },
+        "ServiceQuotaExceededException":{
             "type":"structure",
             "required":["message"],
             "members":{


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

We're going to change the backend to return with ServiceQuotaExceededException when the users hit the limit for plan and code iteration in Amazon Q Feature development. Therefore, we're adjusting the toolkit to handle the new error from backend. 

## Checklist
- [Yes] My code follows the code style of this project
- [N/a] I have added tests to cover my changes
- [N/A] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [N/A] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
