### PR TITLE
feat(amazonqFeatureDev): add partial code acceptance

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevApp.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevApp.kt
@@ -39,7 +39,8 @@ class FeatureDevApp : AmazonQApp {
             "chat-item-voted" to IncomingFeatureDevMessage.ChatItemVotedMessage::class,
             "response-body-link-click" to IncomingFeatureDevMessage.ClickedLink::class,
             "insert_code_at_cursor_position" to IncomingFeatureDevMessage.InsertCodeAtCursorPosition::class,
-            "open-diff" to IncomingFeatureDevMessage.OpenDiff::class
+            "open-diff" to IncomingFeatureDevMessage.OpenDiff::class,
+            "file-click" to IncomingFeatureDevMessage.FileClicked::class
         )
 
         scope.launch {
@@ -78,6 +79,7 @@ class FeatureDevApp : AmazonQApp {
             is IncomingFeatureDevMessage.ClickedLink -> inboundAppMessagesHandler.processLinkClick(message)
             is IncomingFeatureDevMessage.InsertCodeAtCursorPosition -> inboundAppMessagesHandler.processInsertCodeAtCursorPosition(message)
             is IncomingFeatureDevMessage.OpenDiff -> inboundAppMessagesHandler.processOpenDiff(message)
+            is IncomingFeatureDevMessage.FileClicked -> inboundAppMessagesHandler.processFileClicked(message)
         }
     }
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/InboundAppMessagesHandler.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/InboundAppMessagesHandler.kt
@@ -15,4 +15,5 @@ interface InboundAppMessagesHandler {
     suspend fun processLinkClick(message: IncomingFeatureDevMessage.ClickedLink)
     suspend fun processInsertCodeAtCursorPosition(message: IncomingFeatureDevMessage.InsertCodeAtCursorPosition)
     suspend fun processOpenDiff(message: IncomingFeatureDevMessage.OpenDiff)
+    suspend fun fileClicked(message: IncomingFeatureDevMessage.FileClicked)
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/InboundAppMessagesHandler.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/InboundAppMessagesHandler.kt
@@ -16,5 +16,4 @@ interface InboundAppMessagesHandler {
     suspend fun processInsertCodeAtCursorPosition(message: IncomingFeatureDevMessage.InsertCodeAtCursorPosition)
     suspend fun processOpenDiff(message: IncomingFeatureDevMessage.OpenDiff)
     suspend fun processFileClicked(message: IncomingFeatureDevMessage.FileClicked)
-
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/InboundAppMessagesHandler.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/InboundAppMessagesHandler.kt
@@ -15,5 +15,6 @@ interface InboundAppMessagesHandler {
     suspend fun processLinkClick(message: IncomingFeatureDevMessage.ClickedLink)
     suspend fun processInsertCodeAtCursorPosition(message: IncomingFeatureDevMessage.InsertCodeAtCursorPosition)
     suspend fun processOpenDiff(message: IncomingFeatureDevMessage.OpenDiff)
-    suspend fun fileClicked(message: IncomingFeatureDevMessage.FileClicked)
+    suspend fun processFileClicked(message: IncomingFeatureDevMessage.FileClicked)
+
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -207,8 +207,8 @@ class FeatureDevController(
             }
         }
     }
-    
-    override suspend fun fileClicked(message: IncomingFeatureDevMessage.FileClicked) {
+
+    override suspend fun processFileClicked(message: IncomingFeatureDevMessage.FileClicked) {
         // TODO: telemetery?
         val fileToUpdate = message.filePath
         var session: Session? = null
@@ -233,7 +233,7 @@ class FeatureDevController(
                 deletedFiles = deletedFiles
             )
         } catch (err: Exception) {
-            val errorMessage = createUserFacingErrorMessage("Failed to insert code changes: ${err.message}")
+            val errorMessage = createUserFacingErrorMessage("Failed to process diff tree file clicked: ${err.message}")
             messenger.sendError(
                 tabId = message.tabId,
                 errMessage = errorMessage ?: message("amazonqFeatureDev.exception.insert_code_failed"),

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -209,8 +209,8 @@ class FeatureDevController(
     }
 
     override suspend fun processFileClicked(message: IncomingFeatureDevMessage.FileClicked) {
-        // TODO: telemetery?
         val fileToUpdate = message.filePath
+
         var session: Session? = null
         try {
             session = getSessionInfo(message.tabId)
@@ -223,8 +223,8 @@ class FeatureDevController(
                     deletedFiles = state.deletedFiles
                 }
             }
-            filePaths.find { it.zipFilePath == fileToUpdate }?.let{ it.rejected = !it.rejected}
-            deletedFiles.find { it.zipFilePath == fileToUpdate }?.let{ it.rejected = !it.rejected}
+            filePaths.find { it.zipFilePath == fileToUpdate }?.let { it.rejected = !it.rejected }
+            deletedFiles.find { it.zipFilePath == fileToUpdate }?.let { it.rejected = !it.rejected }
 
             session.updateFilesPaths(
                 messenger = messenger,
@@ -304,7 +304,7 @@ class FeatureDevController(
             }
             AmazonqTelemetry.isAcceptedCodeChanges(
                 project = null,
-                amazonqNumberOfFilesAccepted = (filePaths.size + deletedFiles.size) * 1.0,
+                amazonqNumberOfFilesAccepted = (filePaths.filterNot { it.rejected }.size + deletedFiles.filterNot { it.rejected }.size) * 1.0,
                 amazonqConversationId = session.conversationId,
                 enabled = true
             )

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessage.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessage.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthFollowUpType
 import software.aws.toolkits.jetbrains.services.amazonq.messages.AmazonQMessage
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.DeletedFileInfo
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.NewFileZipInfo
 import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
 import java.time.Instant
 import java.util.UUID
@@ -69,6 +71,13 @@ sealed interface IncomingFeatureDevMessage : FeatureDevBaseMessage {
         val filePath: String,
         val deleted: Boolean
     ) : IncomingFeatureDevMessage
+
+    data class FileClicked(
+        @JsonProperty("tabID") val tabId: String,
+        val filePath: String,
+        val messageId: String,
+        val actionName: String
+    ) : IncomingFeatureDevMessage
 }
 
 // === UI -> App Messages ===
@@ -119,6 +128,15 @@ data class UpdatePlaceholderMessage(
 ) : UiMessage(
     tabId = tabId,
     type = "updatePlaceholderMessage"
+)
+
+data class FileComponent (
+    @JsonProperty("tabID") override val tabId: String,
+    val filePaths: List<NewFileZipInfo>,
+    val deletedFiles: List<DeletedFileInfo>
+) : UiMessage(
+    tabId = tabId,
+    type = "updateFileComponent"
 )
 
 data class ChatInputEnabledMessage(

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessage.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessage.kt
@@ -180,8 +180,8 @@ data class AuthNeededException(
 data class CodeResultMessage(
     @JsonProperty("tabID") override val tabId: String,
     val conversationId: String,
-    val filePaths: List<String>,
-    val deletedFiles: List<String>,
+    val filePaths: List<NewFileZipInfo>,
+    val deletedFiles: List<DeletedFileInfo>,
     val references: List<ReducedCodeReference>
 ) : UiMessage(
     tabId = tabId,

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessage.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessage.kt
@@ -130,7 +130,7 @@ data class UpdatePlaceholderMessage(
     type = "updatePlaceholderMessage"
 )
 
-data class FileComponent (
+data class FileComponent(
     @JsonProperty("tabID") override val tabId: String,
     val filePaths: List<NewFileZipInfo>,
     val deletedFiles: List<DeletedFileInfo>

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessagePublisherExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessagePublisherExtensions.kt
@@ -5,6 +5,7 @@ package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages
 
 import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededState
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.DeletedFileInfo
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.NewFileZipInfo
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.SessionStatePhase
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.licenseText
@@ -54,6 +55,15 @@ suspend fun MessagePublisher.sendSystemPrompt(
         messageType = FeatureDevMessageType.SystemPrompt,
         followUp = followUp
     )
+}
+
+suspend fun MessagePublisher.updateFileComponent(tabId: String, filePaths: List<NewFileZipInfo>, deletedFiles: List<DeletedFileInfo>) {
+    val fileComponentMessage = FileComponent(
+        tabId = tabId,
+        filePaths = filePaths,
+        deletedFiles = deletedFiles,
+    )
+    this.publish(fileComponentMessage)
 }
 
 suspend fun MessagePublisher.sendAsyncEventProgress(tabId: String, inProgress: Boolean, message: String? = null) {
@@ -171,7 +181,7 @@ suspend fun MessagePublisher.sendCodeResult(
     tabId: String,
     uploadId: String,
     filePaths: List<NewFileZipInfo>,
-    deletedFiles: List<String>,
+    deletedFiles: List<DeletedFileInfo>,
     references: List<CodeReference>
 ) {
     // It is being done this mapping as featureDev currently doesn't support fully references.
@@ -184,7 +194,7 @@ suspend fun MessagePublisher.sendCodeResult(
             tabId = tabId,
             conversationId = uploadId,
             filePaths = filePaths.map { it.zipFilePath },
-            deletedFiles = deletedFiles,
+            deletedFiles = deletedFiles.map { it.zipFilePath },
             references = refs
         )
     )

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessagePublisherExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessagePublisherExtensions.kt
@@ -193,8 +193,8 @@ suspend fun MessagePublisher.sendCodeResult(
         CodeResultMessage(
             tabId = tabId,
             conversationId = uploadId,
-            filePaths = filePaths.map { it.zipFilePath },
-            deletedFiles = deletedFiles.map { it.zipFilePath },
+            filePaths = filePaths,
+            deletedFiles = deletedFiles,
             references = refs
         )
     )

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
@@ -92,10 +92,11 @@ private suspend fun CodeGenerationState.generateCode(codeGenerationId: String): 
                 )
 
                 val newFileInfo = registerNewFiles(newFileContents = codeGenerationStreamResult.new_file_contents)
+                val deletedFileInfo = registerDeletedFiles(deletedFiles = codeGenerationStreamResult.deleted_files)
 
                 return CodeGenerationResult(
                     newFiles = newFileInfo,
-                    deletedFiles = codeGenerationStreamResult.deleted_files,
+                    deletedFiles = deletedFileInfo,
                     references = codeGenerationStreamResult.references
                 )
             }
@@ -109,5 +110,16 @@ private suspend fun CodeGenerationState.generateCode(codeGenerationId: String): 
 }
 
 fun registerNewFiles(newFileContents: Map<String, String>): List<NewFileZipInfo> = newFileContents.map {
-    NewFileZipInfo(zipFilePath = it.key, fileContent = it.value)
+    NewFileZipInfo(
+        zipFilePath = it.key,
+        fileContent = it.value,
+        rejected = false
+    )
+}
+
+fun registerDeletedFiles(deletedFiles: List<String>): List<DeletedFileInfo> = deletedFiles.map {
+    DeletedFileInfo(
+        zipFilePath = it,
+        rejected = false
+    )
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationState.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationState.kt
@@ -18,7 +18,7 @@ class PrepareCodeGenerationState(
     override var approach: String,
     private var config: SessionStateConfig,
     val filePaths: List<NewFileZipInfo>,
-    val deletedFiles: List<String>,
+    val deletedFiles: List<DeletedFileInfo>,
     val references: List<CodeReference>,
     var uploadId: String,
     private val currentIteration: Int,

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -11,6 +11,7 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CODE_GENERATIO
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.conversationIdNotFound
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAsyncEventProgress
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.updateFileComponent
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.createConversation
 import software.aws.toolkits.jetbrains.services.cwc.controller.ReferenceLogController
 import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
@@ -90,10 +91,19 @@ class Session(val tabID: String, val project: Project) {
         AmazonqTelemetry.isApproachAccepted(amazonqConversationId = conversationId, enabled = true)
     }
 
+    suspend fun updateFilesPaths(
+        messenger: MessagePublisher,
+        tabId: String,
+        filePaths: List<NewFileZipInfo>,
+        deletedFiles: List<DeletedFileInfo>
+    ) {
+        messenger.updateFileComponent(tabId, filePaths, deletedFiles)
+    }
+
     /**
      * Triggered by the Insert code follow-up button to apply code changes.
      */
-    fun insertChanges(filePaths: List<NewFileZipInfo>, deletedFiles: List<String>, references: List<CodeReference>) {
+    fun insertChanges(filePaths: List<NewFileZipInfo>, deletedFiles: List<DeletedFileInfo>, references: List<CodeReference>) {
         val projectRootPath = context.projectRoot.toNioPath()
 
         filePaths.forEach {
@@ -102,8 +112,10 @@ class Session(val tabID: String, val project: Project) {
             filePath.writeBytes(it.fileContent.toByteArray(Charsets.UTF_8))
         }
 
-        deletedFiles.forEach {
-            val deleteFilePath = projectRootPath.resolve(it)
+        deletedFiles.filter {
+            !it.rejected
+        }.forEach {
+            val deleteFilePath = projectRootPath.resolve(it.zipFilePath)
             deleteFilePath.deleteIfExists()
         }
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -106,18 +106,20 @@ class Session(val tabID: String, val project: Project) {
     fun insertChanges(filePaths: List<NewFileZipInfo>, deletedFiles: List<DeletedFileInfo>, references: List<CodeReference>) {
         val projectRootPath = context.projectRoot.toNioPath()
 
-        filePaths.forEach {
-            val filePath = projectRootPath.resolve(it.zipFilePath)
-            filePath.parent.createDirectories() // Create directories if needed
-            filePath.writeBytes(it.fileContent.toByteArray(Charsets.UTF_8))
-        }
+        filePaths
+            .filterNot { it.rejected }
+            .forEach {
+                val filePath = projectRootPath.resolve(it.zipFilePath)
+                filePath.parent.createDirectories() // Create directories if needed
+                filePath.writeBytes(it.fileContent.toByteArray(Charsets.UTF_8))
+            }
 
-        deletedFiles.filter {
-            !it.rejected
-        }.forEach {
-            val deleteFilePath = projectRootPath.resolve(it.zipFilePath)
-            deleteFilePath.deleteIfExists()
-        }
+        deletedFiles
+            .filterNot { it.rejected }
+            .forEach {
+                val deleteFilePath = projectRootPath.resolve(it.zipFilePath)
+                deleteFilePath.deleteIfExists()
+            }
 
         ReferenceLogController.addReferenceLog(references, project)
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionStateTypes.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionStateTypes.kt
@@ -39,11 +39,17 @@ data class SessionStateConfig(
 data class NewFileZipInfo(
     val zipFilePath: String,
     val fileContent: String,
+    var rejected: Boolean
+)
+
+data class DeletedFileInfo(
+    val zipFilePath: String, // The string is the path of the file to be deleted
+    var rejected: Boolean
 )
 
 data class CodeGenerationResult(
     var newFiles: List<NewFileZipInfo>,
-    var deletedFiles: List<String>, // The string is the path of the file to be deleted
+    var deletedFiles: List<DeletedFileInfo>,
     var references: List<CodeReference>,
 )
 

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/featureDevChatConnector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/featureDevChatConnector.ts
@@ -8,6 +8,8 @@ import { ExtensionMessage } from '../commands'
 import { TabType, TabsStorage } from '../storages/tabsStorage'
 import { CodeReference } from './amazonqCommonsConnector'
 import { FollowUpGenerator } from '../followUps/generator'
+import { getActions } from '../diffTree/actions'
+import { DiffTreeFileInfo } from '../diffTree/types'
 
 interface ChatPayload {
     chatMessage: string
@@ -26,6 +28,7 @@ export interface ConnectorProps {
     onUpdateAuthentication: (featureDevEnabled: boolean, codeTransformEnabled: boolean, authenticatingTabIDs: string[]) => void
     onNewTab: (tabType: TabType) => void
     tabsStorage: TabsStorage
+    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => void
 }
 
 export class Connector {
@@ -39,6 +42,7 @@ export class Connector {
     private readonly onUpdateAuthentication
     private readonly followUpGenerator: FollowUpGenerator
     private readonly onNewTab
+    private readonly onFileComponentUpdate
 
     constructor(props: ConnectorProps) {
         this.sendMessageToExtension = props.sendMessageToExtension
@@ -51,6 +55,7 @@ export class Connector {
         this.onUpdateAuthentication = props.onUpdateAuthentication
         this.followUpGenerator = new FollowUpGenerator()
         this.onNewTab = props.onNewTab
+        this.onFileComponentUpdate = props.onFileComponentUpdate
     }
 
     onCodeInsertToCursorPosition = (
@@ -112,6 +117,17 @@ export class Connector {
             })
         })
 
+    onFileActionClick = (tabID: string, messageId: string, filePath: string, actionName: string): void => {
+        this.sendMessageToExtension({
+            command: 'file-click',
+            tabID,
+            messageId,
+            filePath,
+            actionName,
+            tabType: 'featuredev',
+        })
+    }
+
     private processChatMessage = async (messageData: any): Promise<void> => {
         if (this.onChatAnswerReceived !== undefined) {
             const answer: ChatItem = {
@@ -137,6 +153,10 @@ export class Connector {
 
     private processCodeResultMessage = async (messageData: any): Promise<void> => {
         if (this.onChatAnswerReceived !== undefined) {
+            const actions = getActions([
+                ...messageData.filePaths,
+                ...messageData.deletedFiles,
+            ])
             const answer: ChatItem = {
                 type: ChatItemType.CODE_RESULT,
                 relatedContent: undefined,
@@ -148,6 +168,7 @@ export class Connector {
                 fileList: {
                     filePaths: messageData.filePaths,
                     deletedFiles: messageData.deletedFiles,
+                    actions,
                 },
                 body: '',
             }
@@ -178,6 +199,10 @@ export class Connector {
     }
 
     handleMessageReceive = async (messageData: any): Promise<void> => {
+        if (messageData.type === 'updateFileComponent') {
+            this.onFileComponentUpdate(messageData.tabID, messageData.filePaths, messageData.deletedFiles)
+            return
+        }
         if (messageData.type === 'errorMessage') {
             this.onError(messageData.tabID, messageData.message, messageData.title)
             return

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/featureDevChatConnector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/featureDevChatConnector.ts
@@ -166,8 +166,8 @@ export class Connector {
                 // TODO get the backend to store a message id in addition to conversationID
                 messageId: messageData.messageID ?? messageData.triggerID ?? messageData.conversationID,
                 fileList: {
-                    filePaths: messageData.filePaths,
-                    deletedFiles: messageData.deletedFiles,
+                    filePaths: (messageData.filePaths as DiffTreeFileInfo[]).map(path => path.zipFilePath),
+                    deletedFiles: (messageData.deletedFiles as DiffTreeFileInfo[]).map(path => path.zipFilePath),
                     actions,
                 },
                 body: '',

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/commands.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/commands.ts
@@ -37,5 +37,6 @@ type MessageCommand =
     | 'codetransform-open-mvn-build'
     | 'codetransform-view-diff'
     | 'codetransform-view-summary'
+    | 'file-click'
 
 export type ExtensionMessage = Record<string, any> & { command: MessageCommand }

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
@@ -13,6 +13,7 @@ import { WelcomeFollowupType } from './apps/amazonqCommonsConnector'
 import { AuthFollowUpType } from './followUps/generator'
 import { CodeTransformChatConnector } from "./apps/codeTransformChatConnector";
 import { isFormButtonCodeTransform } from './forms/constants'
+import {DiffTreeFileInfo} from "./diffTree/types";
 
 export interface CodeReference {
     licenseName?: string
@@ -41,6 +42,7 @@ export interface ConnectorProps {
     onCWCOnboardingPageInteractionMessage: (message: ChatItem) => string | undefined
     onError: (tabID: string, message: string, title: string) => void
     onWarning: (tabID: string, message: string, title: string) => void
+    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => void
     onUpdatePlaceholder: (tabID: string, newPlaceholder: string) => void
     onChatInputEnabled: (tabID: string, enabled: boolean) => void
     onUpdateAuthentication: (featureDevEnabled: boolean, codeTransformEnabled: boolean, authenticatingTabIDs: string[]) => void
@@ -48,6 +50,7 @@ export interface ConnectorProps {
     onStartNewTransform: (tabID: string) => void
     onCodeTransformCommandMessageReceived: (message: ChatItem, command?: string) => void
     onNotification: (props: {content: string; title?: string; type: NotificationType}) => void
+    onFileActionClick: (tabID: string, messageId: string, filePath: string, actionName: string) => void
     tabsStorage: TabsStorage
 }
 
@@ -321,6 +324,14 @@ export class Connector {
                 break
             default:
                 this.cwChatConnector.followUpClicked(tabID, messageId, followUp)
+                break
+        }
+    }
+
+    onFileActionClick = (tabID: string, messageId: string, filePath: string, actionName: string): void => {
+        switch (this.tabsStorage.getTab(tabID)?.type) {
+            case 'featuredev':
+                this.featureDevChatConnector.onFileActionClick(tabID, messageId, filePath, actionName)
                 break
         }
     }

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/diffTree/actions.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/diffTree/actions.ts
@@ -1,0 +1,48 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { MynahIcons } from '@aws/mynah-ui-chat'
+import { FileNodeAction, TreeNodeDetails } from '@aws/mynah-ui-chat/dist/static'
+import { DiffTreeFileInfo } from './types'
+
+export function getDetails(filePaths: DiffTreeFileInfo[]): Record<string, TreeNodeDetails> {
+    const details: Record<string, TreeNodeDetails> = {}
+    for (const filePath of filePaths) {
+        if (filePath.rejected) {
+            details[filePath.relativePath] = {
+                status: 'error',
+                label: 'File rejected',
+                icon: MynahIcons.CANCEL_CIRCLE,
+            }
+        }
+    }
+    return details
+}
+
+export function getActions(filePaths: DiffTreeFileInfo[]): Record<string, FileNodeAction[]> {
+    const actions: Record<string, FileNodeAction[]> = {}
+    for (const filePath of filePaths) {
+        switch (filePath.rejected) {
+            case true:
+                actions[filePath.relativePath] = [
+                    {
+                        icon: MynahIcons.REVERT,
+                        name: 'revert-rejection',
+                        description: 'Revert rejection',
+                    },
+                ]
+                break
+            case false:
+                actions[filePath.relativePath] = [
+                    {
+                        icon: MynahIcons.CANCEL_CIRCLE,
+                        status: 'error',
+                        name: 'reject-change',
+                        description: 'Reject change',
+                    },
+                ]
+                break
+        }
+    }
+    return actions
+}

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/diffTree/actions.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/diffTree/actions.ts
@@ -6,43 +6,30 @@ import { FileNodeAction, TreeNodeDetails } from '@aws/mynah-ui-chat/dist/static'
 import { DiffTreeFileInfo } from './types'
 
 export function getDetails(filePaths: DiffTreeFileInfo[]): Record<string, TreeNodeDetails> {
-    const details: Record<string, TreeNodeDetails> = {}
-    for (const filePath of filePaths) {
+    return filePaths.reduce((details, filePath) => {
         if (filePath.rejected) {
-            details[filePath.relativePath] = {
+            details[filePath.zipFilePath] = {
                 status: 'error',
                 label: 'File rejected',
                 icon: MynahIcons.CANCEL_CIRCLE,
             }
         }
-    }
-    return details
+        return details
+    }, {} as Record<string, TreeNodeDetails>)
 }
 
 export function getActions(filePaths: DiffTreeFileInfo[]): Record<string, FileNodeAction[]> {
-    const actions: Record<string, FileNodeAction[]> = {}
-    for (const filePath of filePaths) {
-        switch (filePath.rejected) {
-            case true:
-                actions[filePath.relativePath] = [
-                    {
-                        icon: MynahIcons.REVERT,
-                        name: 'revert-rejection',
-                        description: 'Revert rejection',
-                    },
-                ]
-                break
-            case false:
-                actions[filePath.relativePath] = [
-                    {
-                        icon: MynahIcons.CANCEL_CIRCLE,
-                        status: 'error',
-                        name: 'reject-change',
-                        description: 'Reject change',
-                    },
-                ]
-                break
-        }
-    }
-    return actions
+    return filePaths.reduce((actions, filePath) => {
+        actions[filePath.zipFilePath] = [filePath.rejected ? {
+            icon: MynahIcons.REVERT,
+            name: 'revert-rejection',
+            description: 'Revert rejection',
+        } : {
+            icon: MynahIcons.CANCEL_CIRCLE,
+            status: 'error',
+            name: 'reject-change',
+            description: 'Reject change',
+        }]
+        return actions
+    }, {} as Record<string, FileNodeAction[]>)
 }

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/diffTree/types.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/diffTree/types.ts
@@ -1,0 +1,8 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type DiffTreeFileInfo = {
+    zipFilePath: string
+    relativePath: string
+    rejected: boolean
+}

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/diffTree/types.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/diffTree/types.ts
@@ -3,6 +3,5 @@
 
 export type DiffTreeFileInfo = {
     zipFilePath: string
-    relativePath: string
     rejected: boolean
 }

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
@@ -15,6 +15,8 @@ import { FollowUpInteractionHandler } from './followUps/handler'
 import { QuickActionHandler } from './quickActions/handler'
 import { TextMessageHandler } from './messages/handler'
 import { MessageController } from './messages/controller'
+import {getActions, getDetails} from "./diffTree/actions";
+import {DiffTreeFileInfo} from "./diffTree/types";
 
 export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeTransformInitEnabled: boolean) => {
     // eslint-disable-next-line prefer-const
@@ -97,6 +99,7 @@ export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeT
                 }
             }
         },
+        onFileActionClick: (tabID: string, messageId: string, filePath: string, actionName: string): void => {},
         onCWCOnboardingPageInteractionMessage: (message: ChatItem): string | undefined => {
             return messageController.sendMessageToTab(message, 'cwc')
         },
@@ -262,6 +265,18 @@ export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeT
         onMessageReceived: (tabID: string, messageData: MynahUIDataModel) => {
             mynahUI.updateStore(tabID, messageData)
         },
+        onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => {
+            const updateWith: Partial<ChatItem> = {
+                type: ChatItemType.CODE_RESULT,
+                fileList: {
+                    filePaths: filePaths.map(i => i.relativePath),
+                    deletedFiles: deletedFiles.map(i => i.relativePath),
+                    details: getDetails(filePaths),
+                    actions: getActions([...filePaths, ...deletedFiles]),
+                },
+            }
+            mynahUI.updateLastChatAnswer(tabID, updateWith)
+        },
         onWarning: (tabID: string, message: string, title: string) => {
             mynahUI.notify({
                 title: title,
@@ -407,6 +422,9 @@ export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeT
         onResetStore: () => {},
         onFollowUpClicked: (tabID, messageId, followUp) => {
             followUpsInteractionHandler.onFollowUpClicked(tabID, messageId, followUp)
+        },
+        onFileActionClick: async (tabID: string, messageId: string, filePath: string, actionName: string) => {
+            connector.onFileActionClick(tabID, messageId, filePath, actionName)
         },
         onOpenDiff: connector.onOpenDiff,
         tabs: {

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
@@ -269,8 +269,8 @@ export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeT
             const updateWith: Partial<ChatItem> = {
                 type: ChatItemType.CODE_RESULT,
                 fileList: {
-                    filePaths: filePaths.map(i => i.relativePath),
-                    deletedFiles: deletedFiles.map(i => i.relativePath),
+                    filePaths: filePaths.map(i => i.zipFilePath),
+                    deletedFiles: deletedFiles.map(i => i.zipFilePath),
                     details: getDetails(filePaths),
                     actions: getActions([...filePaths, ...deletedFiles]),
                 },


### PR DESCRIPTION

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description

Mynah UI already supports an option to handle file clicking. This is being leveraged to add a partial code acceptance feautre to the /dev chat. That is, the user will be able to click through the file changes generated from code generation step to reject them or not. 

## Checklist
- [x] My code follows the code style of this project
- [n/a] I have added tests to cover my changes
   -  will be added in a follow up
- [n/a] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [n/a] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
