### PR TITLE
Fix HelpIds returning null in split plugin mode

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/help/HelpIdTranslator.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/help/HelpIdTranslator.kt
@@ -8,6 +8,8 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 
 class HelpIdTranslator : WebHelpProvider() {
+    override fun getHelpTopicPrefix() = HELP_ID_PREFIX
+
     override fun getHelpPageUrl(helpTopicId: String) = HELP_REGISTRY.getOrElse(helpTopicId) {
         LOGGER.warn { "Missing id $helpTopicId" }
         DEFAULT_LOCATION

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/help/HelpIds.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/help/HelpIds.kt
@@ -127,5 +127,7 @@ enum class HelpIds(shortId: String, val url: String) {
     )
     ;
 
-    val id = "aws.toolkit.$shortId"
+    val id = "$HELP_ID_PREFIX.$shortId"
 }
+
+const val HELP_ID_PREFIX = "aws.toolkit"


### PR DESCRIPTION
Help topic prefix defaults to the plugin identifier
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
