### PR TITLE
Declare platform dep for core/amazonq plugins

### DIFF
--- a/plugins/amazonq/src/main/resources/META-INF/plugin.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
-    <id>plugin-amazonq</id>
+    <id>amazon.q</id>
     <version>1.0</version>
     <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://github.com/aws/aws-toolkit-jetbrains">AWS</vendor>
     <idea-version since-build="231" />

--- a/plugins/amazonq/src/main/resources/META-INF/plugin.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,9 @@
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
     <id>plugin-amazonq</id>
     <version>1.0</version>
-    <idea-version since-build="231" until-build="999"/>
+    <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://github.com/aws/aws-toolkit-jetbrains">AWS</vendor>
+    <idea-version since-build="231" />
+    <depends>com.intellij.modules.platform</depends>
 
     <resource-bundle>software.aws.toolkits.resources.MessagesBundle</resource-bundle>
 

--- a/plugins/core/src/main/resources/META-INF/plugin.xml
+++ b/plugins/core/src/main/resources/META-INF/plugin.xml
@@ -5,9 +5,10 @@
     <id>core</id>
     <name>core</name>
     <description>corecorecorecorecorecorecorecorecorecore</description>
-    <vendor email="a@example.com">vendor</vendor>
+    <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://github.com/aws/aws-toolkit-jetbrains">AWS</vendor>
     <version>1.0</version>
-    <idea-version since-build="231" until-build="999"/>
+    <idea-version since-build="231" />
+    <depends>com.intellij.modules.platform</depends>
 
     <xi:include href="/META-INF/module-core.xml" />
 

--- a/plugins/core/src/main/resources/META-INF/plugin.xml
+++ b/plugins/core/src/main/resources/META-INF/plugin.xml
@@ -2,9 +2,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
-    <id>core</id>
-    <name>core</name>
-    <description>corecorecorecorecorecorecorecorecorecore</description>
+    <id>aws.toolkit.core</id>
     <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://github.com/aws/aws-toolkit-jetbrains">AWS</vendor>
     <version>1.0</version>
     <idea-version since-build="231" />


### PR DESCRIPTION
Required for non-IJ IDEs
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
