### PR TITLE
fix(amazonq): Quick Action commands are inconsistent between Q tabs and prompt input not getting focus after code sent to Q

### DIFF
--- a/.changes/next-release/bugfix-0bcc1352-2203-4a45-b205-4b71cf93941a.json
+++ b/.changes/next-release/bugfix-0bcc1352-2203-4a45-b205-4b71cf93941a.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q: Fixed quick action command list inconsistency between Q tabs"
+}

--- a/.changes/next-release/bugfix-a1fe7822-625c-4447-9bd8-108d0ab088bb.json
+++ b/.changes/next-release/bugfix-a1fe7822-625c-4447-9bd8-108d0ab088bb.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q: Fixed cursor not focuses to prompt input when code is sent to Q Chat"
+}

--- a/.changes/next-release/feature-cb653e4f-ff0b-4aa9-82a1-8d9128709ea3.json
+++ b/.changes/next-release/feature-cb653e4f-ff0b-4aa9-82a1-8d9128709ea3.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Amazon Q: Added description and a new tab button when there is no tab open"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.4.2",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.5.4",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.4.2.tgz",
-            "integrity": "sha512-ctpSGdG2BLPZktzAzvpcGYsm/53eMS7ig9oUxkFrqGcZhYoPoK3Obc/zBGMhxduhYeOcXYhd70laiPO8rTVyCA==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.5.4.tgz",
+            "integrity": "sha512-ZFJLLxybwzfBKhO5NKDzt++ntHbtf7bUqyAX//9pcvYVLHBHegGgqJcDECA1inYMUb2rybeVRIv7jpmjX7ks2g==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.5.4",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.5.5",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.5.4.tgz",
-            "integrity": "sha512-ZFJLLxybwzfBKhO5NKDzt++ntHbtf7bUqyAX//9pcvYVLHBHegGgqJcDECA1inYMUb2rybeVRIv7jpmjX7ks2g==",
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.5.5.tgz",
+            "integrity": "sha512-xvqr46XFfCWxcHsQURnDuHHs0GLJaCBanJpV22t9TBf/BNjzJN8aBM7AGYwXvZbykRKIGNpHnvQnKlMfVvr/aQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.5.4",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.5.5",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.4.2",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.5.4",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/quickActions/generator.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/quickActions/generator.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { QuickActionCommandGroup } from '@aws/mynah-ui-chat/dist/static'
+import { QuickActionCommand, QuickActionCommandGroup } from '@aws/mynah-ui-chat/dist/static'
 import { TabType } from '../storages/tabsStorage'
 
 export interface QuickActionGeneratorProps {
@@ -21,51 +21,89 @@ export class QuickActionGenerator {
     }
 
     public generateForTab(tabType: TabType): QuickActionCommandGroup[] {
-        switch (tabType) {
-            case 'featuredev':
-                return []
-            default:
-                return [
-                    ...(this.isFeatureDevEnabled
-                        ? [
-                              {
-                                  groupName: 'Application Development',
-                                  commands: [
-                                      {
-                                          command: '/dev',
-                                          placeholder: 'Briefly describe a task or issue',
-                                          description:
-                                              'Use all project files as context for code suggestions (increases latency).',
-                                      },
-                                  ],
-                              },
-                          ]
-                        : []),
-                    ...(this.isCodeTransformEnabled
-                        ? [
-                              {
-                                  commands: [
-                                      {
-                                          command: '/transform',
-                                          description: 'Transform your Java 8 or 11 Maven project to Java 17',
-                                      },
-                                  ],
-                              },
-                          ]
-                        : []),
+        const quickActionCommands = [
+            ...(this.isFeatureDevEnabled
+                ? [
                     {
+                        groupName: 'Application Development',
                         commands: [
                             {
-                                command: '/help',
-                                description: 'Learn more about Amazon Q',
-                            },
-                            {
-                                command: '/clear',
-                                description: 'Clear this session',
+                                command: '/dev',
+                                placeholder: 'Briefly describe a task or issue',
+                                description:
+                                    'Use all project files as context for code suggestions (increases latency).',
                             },
                         ],
                     },
                 ]
+                : []),
+            ...(this.isCodeTransformEnabled
+                ? [
+                    {
+                        commands: [
+                            {
+                                command: '/transform',
+                                description: 'Transform your Java 8 or 11 Maven project to Java 17',
+                            },
+                        ],
+                    },
+                ]
+                : []),
+            {
+                commands: [
+                    {
+                        command: '/help',
+                        description: 'Learn more about Amazon Q',
+                    },
+                    {
+                        command: '/clear',
+                        description: 'Clear this session',
+                    },
+                ],
+            },
+        ]
+
+        const commandUnavailability: Record<
+            TabType,
+            {
+                description: string
+                unavailableItems: string[]
+            }
+        > = {
+            cwc: {
+                description: '',
+                unavailableItems: [],
+            },
+            featuredev: {
+                description: "This command isn't available in /dev",
+                unavailableItems: ['/dev', '/transform', '/help', '/clear'],
+            },
+            codetransform: {
+                description: "This command isn't available in /transform",
+                unavailableItems: ['/dev', '/transform'],
+            },
+            unknown: {
+                description: "This command isn't available",
+                unavailableItems: ['/dev', '/transform', '/help', '/clear'],
+            },
         }
+
+        return quickActionCommands.map(commandGroup => {
+            return {
+                groupName: commandGroup.groupName,
+                commands: commandGroup.commands.map((commandItem: QuickActionCommand) => {
+                    const commandNotAvailable = commandUnavailability[tabType].unavailableItems.includes(
+                        commandItem.command
+                    )
+                    return {
+                        ...commandItem,
+                        disabled: commandNotAvailable,
+                        description: commandNotAvailable
+                            ? commandUnavailability[tabType].description
+                            : commandItem.description,
+                    }
+                }) as QuickActionCommand[],
+            }
+        }) as QuickActionCommandGroup[]
     }
 }

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/quickActions/generator.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/quickActions/generator.ts
@@ -83,12 +83,12 @@ export class QuickActionGenerator {
                 unavailableItems: ['/dev', '/transform'],
             },
             unknown: {
-                description: "This command isn't available",
-                unavailableItems: ['/dev', '/transform', '/help', '/clear'],
+                description: "",
+                unavailableItems: [],
             },
         }
 
-        return quickActionCommands.map(commandGroup => {
+        return structuredClone(quickActionCommands).map(commandGroup => {
             return {
                 groupName: commandGroup.groupName,
                 commands: commandGroup.commands.map((commandItem: QuickActionCommand) => {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Description
Fixed quick action commands inconsistency between Q tabs and prompt input not getting autofocus when code is sent. 
Added no tabs description with open new tab button when no tab is open

## Problem
- Quick action commands are inconsistent between Q tabs (`/dev`, `/transform` and q chat)
- Prompt input doesn't get focus when user sends code to Q chat
- No indication when all tabs closed.

## Solution
- All quick action commands are now visible in all Q tab types. But depending on the tab type, some of them are disabled with description messages.
- Prompt input now gets auto focus after code is sent to Q chat. It is solved with [mynah-ui update](https://github.com/aws/mynah-ui/commit/402425c075908e5702b48be1bc2fd3498ce81b6b) which is available from version [4.5.4](https://github.com/aws/mynah-ui/releases/tag/v4.5.4)
- Added indication and open new tab button when all tabs are closed with a [mynah-ui update](https://github.com/aws/mynah-ui/commit/02785da612630c82a8c8f4b868437de9dd457cb5) which is available from [4.5.3](https://github.com/aws/mynah-ui/releases/tag/v4.5.3)

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
