### PR TITLE
Fix failure to due invalid core plugin reference

### DIFF
--- a/plugins/amazonq/src/main/resources/META-INF/plugin.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
 
     <resource-bundle>software.aws.toolkits.resources.MessagesBundle</resource-bundle>
 
-    <depends>core</depends>
+    <depends>aws.toolkit.core</depends>
     <xi:include href="/META-INF/module-amazonq.xml" />
 
     <extensions defaultExtensionNs="com.intellij">

--- a/plugins/toolkit/intellij-standalone/src/main/resources/META-INF/plugin-shim.xml
+++ b/plugins/toolkit/intellij-standalone/src/main/resources/META-INF/plugin-shim.xml
@@ -2,5 +2,5 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
-    <depends>core</depends>
+    <depends>aws.toolkit.core</depends>
 </idea-plugin>


### PR DESCRIPTION
core -> aws.toolkit.core
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
