### PR TITLE
webview-ui: fix aws toolkit logo text not shown

### DIFF
--- a/plugins/core/webview/src/q-ui/components/logo.vue
+++ b/plugins/core/webview/src/q-ui/components/logo.vue
@@ -91,7 +91,7 @@ export default defineComponent({
     </div>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
 .logoIcon {
     display: flex;
     flex-direction: row;
@@ -99,5 +99,13 @@ export default defineComponent({
     align-items: flex-start;
     padding-top: 75px;
     height: auto;
+}
+
+body.jb-dark #logo-text {
+    fill: white;
+}
+
+body.jb-light #logo-text {
+    fill: #232f3e; /* squid ink */
 }
 </style>


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Before

<img width="604" alt="befofre" src="https://github.com/aws/aws-toolkit-jetbrains/assets/96078566/b0aad2b3-1f72-4b67-a33b-5377fc425277">


## After

<img width="604" alt="after" src="https://github.com/aws/aws-toolkit-jetbrains/assets/96078566/5f7bad6c-710a-471a-84a0-825a60946492">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
