### PR TITLE
Fix issue with competing SDK proxy configuration

### DIFF
--- a/.changes/next-release/bugfix-c8090208-8e8a-4a41-bcdd-02579f74d40e.json
+++ b/.changes/next-release/bugfix-c8090208-8e8a-4a41-bcdd-02579f74d40e.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Fix issue with competing SDK proxy configuration"
+  "description" : "Fix issue with competing SDK proxy configuration (#4279)"
 }

--- a/.changes/next-release/bugfix-c8090208-8e8a-4a41-bcdd-02579f74d40e.json
+++ b/.changes/next-release/bugfix-c8090208-8e8a-4a41-bcdd-02579f74d40e.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue with competing SDK proxy configuration"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ apache-commons-collections = "4.4"
 apache-commons-io = "2.16.0"
 assertJ = "3.20.2" # Upgrading leads to SAM errors: https://youtrack.jetbrains.com/issue/KT-17765
 # match with <root>/settings.gradle.kts
-awsSdk = "2.21.33"
+awsSdk = "2.25.32"
 commonmark = "0.17.1"
 detekt = "1.23.6"
 intellijGradle = "1.17.3"

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/AwsSdkClient.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/AwsSdkClient.kt
@@ -24,7 +24,12 @@ class AwsSdkClient : SdkClientProvider, Disposable {
     private val sdkHttpClient: SdkHttpClient by lazy {
         LOG.info { "Create new Apache client" }
         val httpClientBuilder = ApacheHttpClient.builder()
-            .proxyConfiguration(ProxyConfiguration.builder().useSystemPropertyValues(false).build())
+            .proxyConfiguration(
+                ProxyConfiguration.builder()
+                    .useSystemPropertyValues(false)
+                    .useEnvironmentVariableValues(false)
+                    .build()
+            )
             .httpRoutePlanner(SystemDefaultRoutePlanner(CommonProxy.getInstance()))
             .credentialsProvider(SystemDefaultCredentialsProvider())
             .tlsTrustManagersProvider { arrayOf(CertificateManager.getInstance().trustManager) }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitCredentialProcessProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitCredentialProcessProvider.kt
@@ -69,7 +69,7 @@ class ToolkitCredentialProcessProvider @TestOnly constructor(
         } catch (e: Exception) {
             handleException(message("credentials.profile.credential_process.parse_exception_prefix"), output)
         }
-        val credentials = when (val token = result.sessionToken) {
+        val credentials: AwsCredentials = when (val token = result.sessionToken) {
             null -> AwsBasicCredentials.create(result.accessKeyId, result.secretAccessKey)
             else -> AwsSessionCredentials.create(result.accessKeyId, result.secretAccessKey, token)
         }

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -177,9 +177,9 @@ class AwsClientManagerTest {
     @Test
     fun clientWithoutBuilderFailsDescriptively() {
         val sut = getClientManager()
+
         assertThatThrownBy { sut.getClient<InvalidServiceClient>(credentialManager.createCredentialProvider(), regionProvider.createAwsRegion()) }
             .isInstanceOf(IllegalArgumentException::class.java)
-
             .hasMessageContaining("builder()")
     }
 

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/AwsClientManagerTest.kt
@@ -177,9 +177,9 @@ class AwsClientManagerTest {
     @Test
     fun clientWithoutBuilderFailsDescriptively() {
         val sut = getClientManager()
-
         assertThatThrownBy { sut.getClient<InvalidServiceClient>(credentialManager.createCredentialProvider(), regionProvider.createAwsRegion()) }
             .isInstanceOf(IllegalArgumentException::class.java)
+
             .hasMessageContaining("builder()")
     }
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
A recent [change](https://github.com/aws/aws-sdk-java-v2/commit/3748964d2793d732eae6dfead9691327fdd14569) in the AWS SDK introduced the ability to provide proxy configuration via environment variables. Since the Toolkit primarily relies on proxy configuration provided by the host IDE configuration this introduces a potential conflict when configuration exists in both places, leading to an SDK exception (see #4279).

This change disables the SDK from picking up proxy configuration from environment variables meaning that configuration will only be inherited from IDE settings. Additionally the SDK version is bumped to the latest. 

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
