### PR TITLE
fix: q conn not pinned if it's builder id conn

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/pinning/QConnection.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/pinning/QConnection.kt
@@ -6,6 +6,8 @@ package software.aws.toolkits.jetbrains.core.credentials.pinning
 import software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
 import software.aws.toolkits.jetbrains.core.credentials.sono.Q_SCOPES
+import software.aws.toolkits.jetbrains.core.credentials.sono.Q_SCOPES_UNAVAILABLE_BUILDER_ID
+import software.aws.toolkits.jetbrains.core.credentials.sono.isSono
 
 class QConnection : FeatureWithPinnedConnection {
     override val featureId = "aws.q"
@@ -13,6 +15,10 @@ class QConnection : FeatureWithPinnedConnection {
 
     override fun supportsConnectionType(connection: ToolkitConnection): Boolean {
         if (connection is AwsBearerTokenConnection) {
+            if (connection.isSono()) {
+                (Q_SCOPES - Q_SCOPES_UNAVAILABLE_BUILDER_ID.toSet()).all { it in connection.scopes }
+            }
+
             return Q_SCOPES.all { it in connection.scopes }
         }
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->


LOG
```
2024-04-17 14:13:33,164 [   8219]   FINE - software.aws.toolkits.jetbrains.core.credentials.DefaultToolkitConnectionManager - isFeatureEnabled: Feature software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection@4211ddeb is not connected
ActiveConnectionForFeature=null
2024-04-17 14:13:33,165 [   8220]   FINE - software.aws.toolkits.jetbrains.services.amazonq.toolwindow.AmazonQToolWindow - isQConnected return false; isFeatureEnabled(Q)=false; isFeatureEnabled(CW)=true
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
