### PR TITLE
Remove unused `Q_SCOPES_UNAVAILABLE_BUILDER_ID`

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sono/SonoConstants.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sono/SonoConstants.kt
@@ -22,11 +22,6 @@ val Q_SCOPES = listOf(
     "codewhisperer:taskassist"
 )
 
-val Q_SCOPES_UNAVAILABLE_BUILDER_ID = listOf(
-    "codewhisperer:transformations",
-    "codewhisperer:taskassist"
-)
-
 val CODECATALYST_SCOPES = listOf(
     "codecatalyst:read_write"
 )


### PR DESCRIPTION
With 4/18, should no longer be a scenario

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
