### PR TITLE
feat(amazonq): Add accepted lines of code of Q chat telemetry

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/telemetry/TelemetryHelper.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/telemetry/TelemetryHelper.kt
@@ -207,6 +207,7 @@ class TelemetryHelper(private val context: AmazonQAppInitContext, private val se
                     cwsprChatMessageId = message.messageId,
                     cwsprChatInteractionType = CwsprChatInteractionType.InsertAtCursor,
                     cwsprChatAcceptedCharactersLength = message.code.length,
+                    cwsprChatAcceptedNumberOfLines = message.code.split('\n').length,
                     cwsprChatInteractionTarget = message.insertionTargetType,
                     cwsprChatHasReference = null,
                     credentialStartUrl = getStartUrl(context.project)
@@ -217,6 +218,7 @@ class TelemetryHelper(private val context: AmazonQAppInitContext, private val se
                     interactionType(ChatMessageInteractionType.INSERT_AT_CURSOR)
                     interactionTarget(message.insertionTargetType)
                     acceptedCharacterCount(message.code.length)
+                    acceptedLineCount(message.code.split('\n').length)
                 }.build()
             }
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/telemetry/TelemetryHelper.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/telemetry/TelemetryHelper.kt
@@ -207,7 +207,7 @@ class TelemetryHelper(private val context: AmazonQAppInitContext, private val se
                     cwsprChatMessageId = message.messageId,
                     cwsprChatInteractionType = CwsprChatInteractionType.InsertAtCursor,
                     cwsprChatAcceptedCharactersLength = message.code.length,
-                    cwsprChatAcceptedNumberOfLines = message.code.split('\n').length,
+                    cwsprChatAcceptedNumberOfLines = message.code.lines().size,
                     cwsprChatInteractionTarget = message.insertionTargetType,
                     cwsprChatHasReference = null,
                     credentialStartUrl = getStartUrl(context.project)
@@ -218,7 +218,7 @@ class TelemetryHelper(private val context: AmazonQAppInitContext, private val se
                     interactionType(ChatMessageInteractionType.INSERT_AT_CURSOR)
                     interactionTarget(message.insertionTargetType)
                     acceptedCharacterCount(message.code.length)
-                    acceptedLineCount(message.code.split('\n').length)
+                    acceptedLineCount(message.code.lines().size)
                 }.build()
             }
 

--- a/plugins/core/jetbrains-community/resources/telemetryOverride.json
+++ b/plugins/core/jetbrains-community/resources/telemetryOverride.json
@@ -171,6 +171,11 @@
             "description": "Count of code characters copied to the editor"
         },
         {
+            "name": "cwsprChatAcceptedNumberOfLines",
+            "type": "int",
+            "description": "Count of lines of code copied to the editor"
+        },
+        {
             "name": "cwsprChatHasReference",
             "type": "boolean",
             "description": "True if the code snippet that user interacts with has a reference."
@@ -466,6 +471,10 @@
                 },
                 {
                     "type": "cwsprChatAcceptedCharactersLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatAcceptedNumberOfLines",
                     "required": false
                 },
                 {

--- a/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
+++ b/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
@@ -388,6 +388,7 @@
                 "interactionType": { "shape": "ChatMessageInteractionType" },
                 "interactionTarget": { "shape": "String" },
                 "acceptedCharacterCount": { "shape": "Integer" },
+                "acceptedLineCount": { "shape": "Integer" },
                 "acceptedSnippetHasReference": { "shape": "Boolean" }
             }
         },


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
In q chat telemetry, lines of inserted code is not included.

Add lines of inserted code of Q chat in the telemetry event.

This is not customer facing and this does not introduce a new telemetry event, so I am not adding a change log.

Relevant VSC PR:
https://github.com/aws/aws-toolkit-vscode/pull/4775

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
