### PR TITLE
Telemetry(AmazonQ): Adding different algorithm to calculate the numberOfCodeBlocks

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/messenger/ChatPromptHandler.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/messenger/ChatPromptHandler.kt
@@ -21,6 +21,7 @@ import software.aws.toolkits.jetbrains.services.cwc.messages.FollowUp
 import software.aws.toolkits.jetbrains.services.cwc.messages.RecommendationContentSpan
 import software.aws.toolkits.jetbrains.services.cwc.messages.Suggestion
 import software.aws.toolkits.jetbrains.services.cwc.storage.ChatSessionInfo
+import software.aws.toolkits.jetbrains.utils.convertMarkdownToHTML
 
 class ChatPromptHandler(private val telemetryHelper: TelemetryHelper) {
 
@@ -32,17 +33,13 @@ class ChatPromptHandler(private val telemetryHelper: TelemetryHelper) {
     private var requestId: String = ""
     private var statusCode: Int = 0
 
-    companion object {
-        val CODE_BLOCK_REGEX: Regex = Regex("^```", RegexOption.MULTILINE)
-    }
-
     private fun countTotalNumberOfCodeBlocks(message: StringBuilder): Int {
         if (message.isEmpty()) {
             return 0
         }
-        val countOfCodeBlocks = CODE_BLOCK_REGEX.findAll(message)
-        val numberOfTripleBackTicksInMarkdown = countOfCodeBlocks.count()
-        return numberOfTripleBackTicksInMarkdown / 2
+        val htmlInString = convertMarkdownToHTML(message.toString())
+        val patternOfCodeBlock = Regex("<pre><code")
+        return patternOfCodeBlock.findAll(htmlInString).count()
     }
 
     fun handle(


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

- Existing we count number of code blocks by searching 3  \```  backticks in the generated response.
- More precise method is to convert Markdown string to HTML and count the existing `<pre><code>` tags in the html.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
