### PR TITLE
fix authManager.deleteConnection predicate not being read

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManager.kt
@@ -137,13 +137,17 @@ class DefaultToolkitAuthManager : ToolkitAuthManager, PersistentStateComponent<T
         val deleted = mutableListOf<ToolkitConnection>()
         connections.removeAll { connection ->
             predicate(connection).also {
-                deleted.add(connection)
+                if (it) {
+                    deleted.add(connection)
+                }
             }
         }
 
         transientConnections.removeAll { connection ->
             predicate(connection).also {
-                deleted.add(connection)
+                if (it) {
+                    deleted.add(connection)
+                }
             }
         }
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
