### PR TITLE
feat(amazonq): Update quick action styles and grouping

### DIFF
--- a/.changes/next-release/bugfix-cfca5f64-baae-4ecc-95ab-8cbbfcf08398.json
+++ b/.changes/next-release/bugfix-cfca5f64-baae-4ecc-95ab-8cbbfcf08398.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Q panel doesn't fit to its parent"
+}

--- a/.changes/next-release/feature-95b0b124-c58c-44d3-96c6-fd8beb52df00.json
+++ b/.changes/next-release/feature-95b0b124-c58c-44d3-96c6-fd8beb52df00.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Amazon Q Chat: Updates quick action commands style and groupings"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.5.6",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.6.4",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.5.6.tgz",
-            "integrity": "sha512-aw0hAAS+gs8Vap3uqiLBs6sZ1JT5zXxQxc+WfMGIzd8YUfK+gcDcFyq0QHGFO8jTTAoefdvQPfSxabjJMIuiUw==",
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.6.4.tgz",
+            "integrity": "sha512-gHwCAWZmP5ssL0TN+7Qo7suC3BbTqeKSEver/mHPimI9yTEI0EIBTuA8sirZcdCEe4BZWfGuOYlBcrQWpLgtYg==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.5.6",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.6.4",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
@@ -5,7 +5,6 @@
 import { Connector } from './connector'
 import { ChatItem, ChatItemType, MynahUI, MynahUIDataModel, NotificationType } from '@aws/mynah-ui-chat'
 import './styles/dark.scss'
-import { ChatPrompt } from '@aws/mynah-ui-chat/dist/static'
 import { TabsStorage, TabType } from './storages/tabsStorage'
 import { WelcomeFollowupType } from './apps/amazonqCommonsConnector'
 import { TabDataGenerator } from './tabs/generator'
@@ -17,6 +16,7 @@ import { TextMessageHandler } from './messages/handler'
 import { MessageController } from './messages/controller'
 import {getActions, getDetails} from "./diffTree/actions";
 import {DiffTreeFileInfo} from "./diffTree/types";
+import './styles.css';
 
 export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeTransformInitEnabled: boolean) => {
     // eslint-disable-next-line prefer-const
@@ -99,7 +99,7 @@ export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeT
                 }
             }
         },
-        onFileActionClick: (tabID: string, messageId: string, filePath: string, actionName: string): void => {},
+        onFileActionClick: (): void => {},
         onCWCOnboardingPageInteractionMessage: (message: ChatItem): string | undefined => {
             return messageController.sendMessageToTab(message, 'cwc')
         },

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/quickActions/generator.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/quickActions/generator.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { QuickActionCommandGroup } from '@aws/mynah-ui-chat/dist/static'
+import {QuickActionCommand, QuickActionCommandGroup} from '@aws/mynah-ui-chat/dist/static'
 import { TabType } from '../storages/tabsStorage'
 
 export interface QuickActionGeneratorProps {
@@ -21,51 +21,83 @@ export class QuickActionGenerator {
     }
 
     public generateForTab(tabType: TabType): QuickActionCommandGroup[] {
-        switch (tabType) {
-            case 'featuredev':
-                return []
-            default:
-                return [
+        const quickActionCommands = [
+            {
+                commands: [
                     ...(this.isFeatureDevEnabled
                         ? [
-                              {
-                                  groupName: 'Application Development',
-                                  commands: [
-                                      {
-                                          command: '/dev',
-                                          placeholder: 'Briefly describe a task or issue',
-                                          description:
-                                              'Use all project files as context for code suggestions (increases latency).',
-                                      },
-                                  ],
-                              },
-                          ]
+                            {
+                                command: '/dev',
+                                placeholder: 'Briefly describe a task or issue',
+                                description:
+                                    'Use all project files as context for code suggestions (increases latency).',
+                            },
+                        ]
                         : []),
                     ...(this.isCodeTransformEnabled
                         ? [
-                              {
-                                  commands: [
-                                      {
-                                          command: '/transform',
-                                          description: 'Transform your Java 8 or 11 Maven project to Java 17',
-                                      },
-                                  ],
-                              },
-                          ]
+                            {
+                                command: '/transform',
+                                description: 'Transform your Java 8 or 11 Maven project to Java 17',
+                            },
+                        ]
                         : []),
+                ],
+            },
+            {
+                commands: [
                     {
-                        commands: [
-                            {
-                                command: '/help',
-                                description: 'Learn more about Amazon Q',
-                            },
-                            {
-                                command: '/clear',
-                                description: 'Clear this session',
-                            },
-                        ],
+                        command: '/help',
+                        description: 'Learn more about Amazon Q',
                     },
-                ]
+                    {
+                        command: '/clear',
+                        description: 'Clear this session',
+                    },
+                ],
+            },
+        ]
+
+        const commandUnavailability: Record<
+            TabType,
+            {
+                description: string
+                unavailableItems: string[]
+            }
+        > = {
+            cwc: {
+                description: '',
+                unavailableItems: [],
+            },
+            featuredev: {
+                description: "This command isn't available in /dev",
+                unavailableItems: ['/dev', '/transform', '/help', '/clear'],
+            },
+            codetransform: {
+                description: "This command isn't available in /transform",
+                unavailableItems: ['/dev', '/transform'],
+            },
+            unknown: {
+                description: '',
+                unavailableItems: [],
+            },
         }
+
+        return quickActionCommands.map((commandGroup: QuickActionCommandGroup) => {
+            return {
+                commands: commandGroup.commands.map((commandItem: QuickActionCommand) => {
+                    const commandNotAvailable = commandUnavailability[tabType].unavailableItems.includes(
+                        commandItem.command
+                    )
+                    return {
+                        ...commandItem,
+                        disabled: commandNotAvailable,
+                        description: commandNotAvailable
+                            ? commandUnavailability[tabType].description
+                            : commandItem.description,
+                    }
+                }) as QuickActionCommand[],
+            }
+        }) as QuickActionCommandGroup[]
     }
 }

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/styles.css
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/styles.css
@@ -1,0 +1,13 @@
+/* Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+body,
+html {
+    background-color: var(--mynah-color-bg);
+    color: var(--mynah-color-text-default);
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+    margin: 0;
+    padding: 0;
+}

--- a/plugins/amazonq/mynah-ui/webpack.media.config.js
+++ b/plugins/amazonq/mynah-ui/webpack.media.config.js
@@ -35,7 +35,7 @@ const config = {
     experiments: { asyncWebAssembly: true },
     module: {
         rules: [
-            {test: /\.scss$/, use: ['style-loader', 'css-loader', 'sass-loader']},
+            {test: /\.(sa|sc|c)ss$/, use: ['style-loader', 'css-loader', 'sass-loader']},
             {
                 test: /\.ts$/,
                 exclude: /node_modules/,


### PR DESCRIPTION
## Problem
- As requested from UX team quick actions list should not have a title anymore and needs a separator between `/transform, /dev` commands and the `/help, /clear` commands.
- Webview content is not fitting to its parent panel
## Solution
- Updated quick action commands group look&feel from mynah-ui with version update to **[`v4.6.4`](https://github.com/aws/mynah-ui/releases/tag/v4.6.4)**
- Updated quick action commands list. Removed the `groupName` from /dev group. `/transform` and `/dev` combined in one group.
- Applied necessary body and html width and height styles to the webview's content which were not coming from mynah-ui. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Description
<img width="621" alt="image" src="https://github.com/aws/aws-toolkit-vscode/assets/116281103/3a339a1b-596a-4931-9148-2d92ccf61e3b">

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
