### PR TITLE
fix: set netty http stream client timeout to 3 minutes

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererEndpointCustomizer.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererEndpointCustomizer.kt
@@ -30,6 +30,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.settings.CodeWhisp
 import software.aws.toolkits.jetbrains.services.telemetry.AwsCognitoCredentialsProvider
 import java.net.Proxy
 import java.net.URI
+import java.time.Duration
 import javax.net.ssl.TrustManager
 
 // TODO: move this file to package /client
@@ -67,7 +68,7 @@ class CodeWhispererEndpointCustomizer : ToolkitClientCustomizer {
             if (builder is CodeWhispererStreamingAsyncClientBuilder) {
                 val proxy = CommonProxy.getInstance().select(endpoint).first()
                 val address = proxy.address()
-                val clientBuilder = NettyNioAsyncHttpClient.builder()
+                val clientBuilder = NettyNioAsyncHttpClient.builder().readTimeout(Duration.ofMinutes(3))
 
                 // proxy.type is one of {DIRECT, HTTP, SOCKS}, and is definitely a InetSocketAddress in the HTTP/SOCKS case
                 // and is null in DIRECT case


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

Found out during bug bash that amazonqFeatureDev streaming client was timeouting after 30s. Netty's HttPClient default read timeout is 30s.

Example of the readTimeout: 
```
2024-04-19 16:47:11,325 [ 525478]  FINE - software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient - Executing generateTaskAssistPlan with conversationId 59d1511c-6582-4ba5-a16c-c2eb33da89f9
2024-04-19 16:47:42,046 [ 556199]  WARN - software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient - Amazon Q feature development: Failed to execute planning : Unable to execute HTTP request: Read timed out
```
## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
    - tested manually the plan was taking more than 30s and passed.
- [n/a] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [n/a] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
