### PR TITLE
Add `@JvmOverloads` annotation to `loginSso`

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
@@ -102,6 +102,7 @@ interface ToolkitConnectionManager : Disposable {
  * Individual service should subscribe [ToolkitConnectionManagerListener.TOPIC] to fire their service activation / UX update
  */
 @Deprecated("Connections created through this function are not written to the user's ~/.aws/config file")
+@JvmOverloads
 fun loginSso(
     project: Project?,
     startUrl: String,


### PR DESCRIPTION
A dependency is getting `java.lang.NoSuchMethodError` since they make the call without the new parameters. Apply `@JvmOverloads` so the compiler generates the relevant method signature.


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
