### PR TITLE
Read current repository from env instead of hardcoding in workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -179,5 +179,5 @@ jobs:
           gh release upload "$TAG_NAME" plugin-amazonq-*/*.zip
       - name: Publish XML manifest
         run: |
-          gh release view "$TAG_NAME" --repo aws/aws-toolkit-jetbrains --json assets | python3 "$GITHUB_WORKSPACE/.github/workflows/generateUpdatesXml.py" - > updatePlugins.xml
+          gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json assets | python3 "$GITHUB_WORKSPACE/.github/workflows/generateUpdatesXml.py" - > updatePlugins.xml
           gh release upload "$TAG_NAME" updatePlugins.xml


### PR DESCRIPTION
Fork workflows fail with "release not found"
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
