### PR TITLE
Mirror changelog to Q plugin

### DIFF
--- a/plugins/amazonq/build.gradle.kts
+++ b/plugins/amazonq/build.gradle.kts
@@ -1,12 +1,25 @@
 // Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import software.aws.toolkits.gradle.changelog.tasks.GeneratePluginChangeLog
 import software.aws.toolkits.gradle.intellij.IdeFlavor
 import software.aws.toolkits.gradle.intellij.IdeVersions
 
 plugins {
     id("toolkit-publishing-conventions")
     id("toolkit-patch-plugin-xml-conventions")
+}
+
+val changelog = tasks.register<GeneratePluginChangeLog>("pluginChangeLog") {
+    includeUnreleased.set(true)
+    changeLogFile.set(project.file("$buildDir/changelog/change-notes.xml"))
+}
+
+tasks.jar {
+    dependsOn(changelog)
+    from(changelog) {
+        into("META-INF")
+    }
 }
 
 intellij {

--- a/plugins/amazonq/src/main/resources/META-INF/plugin.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/plugin.xml
@@ -48,4 +48,8 @@
 
     <depends>aws.toolkit.core</depends>
     <xi:include href="/META-INF/module-amazonq.xml" />
+
+    <xi:include href="/META-INF/change-notes.xml" xpointer="xpointer(/idea-plugin/*)">
+        <xi:fallback/>
+    </xi:include>
 </idea-plugin>


### PR DESCRIPTION
Needs to be separate per-plugin, but implementing is too high-lift at the moment
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
