### PR TITLE
Updating SNAPSHOT version to 3.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Toolkit Version
-toolkitVersion=3.0
+toolkitVersion=3.1-SNAPSHOT
 
 # Publish Settings
 publishToken=


### PR DESCRIPTION

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
