### PR TITLE
fix(amazonq): Markdown parsing inside list items

### DIFF
--- a/.changes/next-release/bugfix-283aad71-efa1-4cbd-a118-bc02efbd8c73.json
+++ b/.changes/next-release/bugfix-283aad71-efa1-4cbd-a118-bc02efbd8c73.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Fixed markdown is not getting parsed inside list items."
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.6.4",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.7.0",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.6.4",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.6.4.tgz",
-            "integrity": "sha512-gHwCAWZmP5ssL0TN+7Qo7suC3BbTqeKSEver/mHPimI9yTEI0EIBTuA8sirZcdCEe4BZWfGuOYlBcrQWpLgtYg==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.7.0.tgz",
+            "integrity": "sha512-Tr30CRijaJEfcLj5e8v+BymaqZrY9/4COaTgWZhx9H6OslEgs5oumH7jfDTz+ZStMz1NyWL7Te2Z0NozFAYZDQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.6.4",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.7.0",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem
Incoming markdown is strings are not getting parsed properly for the list items. 
<img width="498" alt="Screenshot 2024-04-30 at 08 02 09" src="https://github.com/aws/aws-toolkit-vscode/assets/116281103/ed28f252-b570-4586-b004-bbaa2fe2967a">

### Solution
Implemented a solution through [mynah-ui version 4..7.0](https://github.com/aws/mynah-ui/releases/tag/v4.7.0) which parses the list items again with `marked.parse`.
<img width="604" alt="Screenshot 2024-04-30 at 08 14 32" src="https://github.com/aws/aws-toolkit-vscode/assets/116281103/af42c05a-88ef-46f8-8700-78519e44704c">

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
