### PR TITLE
Add aws_installAmazonQ UiTelemetry event for Toolkit

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/InstallAmazonQAction.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/InstallAmazonQAction.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.ShowSettingsUtil
 import software.aws.toolkits.resources.AwsToolkitBundle.message
+import software.aws.toolkits.telemetry.UiTelemetry
 
 class InstallAmazonQAction : AnAction(message("codewhisperer.explorer.node.install_q"), null, AllIcons.Actions.Install) {
     override fun actionPerformed(e: AnActionEvent) {
@@ -18,5 +19,6 @@ class InstallAmazonQAction : AnAction(message("codewhisperer.explorer.node.insta
         ) { configurable: PluginManagerConfigurable ->
             configurable.openMarketplaceTab("Amazon Q")
         }
+        UiTelemetry.click(e.project, "aws_installAmazonQ")
     }
 }


### PR DESCRIPTION
Telemetry event for the Install Q explorer node.
<img width="350" alt="image" src="https://github.com/aws/aws-toolkit-jetbrains/assets/14608226/1d2daa2a-3d4f-45af-8421-bec7baafff4d">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
