### PR TITLE
fix(amazonq): Listitems inside markdown shows shows typewriter wrapper spans as text

### DIFF
--- a/.changes/next-release/bugfix-d992faf3-4f19-453c-8fde-ede6fc7f3156.json
+++ b/.changes/next-release/bugfix-d992faf3-4f19-453c-8fde-ede6fc7f3156.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Typewriter animator parts showing up in code fields inside listitems"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.7.1",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.8.0",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,13 +57,13 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.7.1.tgz",
-            "integrity": "sha512-IfsXvq1VOdINCyNHgcyf9MdoikIIONCGAOwoysIk++7NbNHFcpMIWPtSEVdvv6Z/vZRF2Op2ZjhTNVWa/PiMuA==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.8.0.tgz",
+            "integrity": "sha512-UHzY7xRsVxO4p9R+tf+3RTk6hBWW8sD3gIW5Q0G9oWVcEKEIBx067hwkkmtffzppIaQDdU0ckSKcPH5Mtk5qqQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",
-                "marked": "^7.0.3",
+                "marked": "^12.0.2",
                 "prismjs": "1.29.0",
                 "sanitize-html": "^2.12.1",
                 "unescape-html": "^1.1.0"
@@ -2292,14 +2292,14 @@
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
         },
         "node_modules/marked": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-7.0.5.tgz",
-            "integrity": "sha512-lwNAFTfXgqpt/XvK17a/8wY9/q6fcSPZT1aP6QW0u74VwaJF/Z9KbRcX23sWE4tODM+AolJNcUtErTkgOeFP/Q==",
+            "version": "12.0.2",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+            "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
             "bin": {
                 "marked": "bin/marked.js"
             },
             "engines": {
-                "node": ">= 16"
+                "node": ">= 18"
             }
         },
         "node_modules/merge-stream": {

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.7.1",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.8.0",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem
Code fields inside listitems for the markdowns are showing parts of the typewriter animator wrapper spans.
<img width="486" alt="image" src="https://github.com/aws/mynah-ui/assets/116281103/196efe48-e0be-46c8-8bea-320a3e714294">

### Solution
Updated markdown parser structure and added a skip also to the code fields inside the list items through [`mynah-ui v4.8.0`](https://github.com/aws/mynah-ui/releases/tag/v4.8.0)

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
