### PR TITLE
Removed install Q notification if Q is already installed

### DIFF
--- a/.changes/next-release/bugfix-d9e51383-075c-4253-b9c5-3e7c588c2605.json
+++ b/.changes/next-release/bugfix-d9e51383-075c-4253-b9c5-3e7c588c2605.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Removed install Q notification if Q is already installed"
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/startup/QMigrationActivity.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/startup/QMigrationActivity.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.core.startup
 
 import com.intellij.ide.BrowserUtil
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.ide.plugins.PluginManagerConfigurable
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.ide.plugins.PluginManagerMain
@@ -55,7 +56,7 @@ class QMigrationActivity : StartupActivity.DumbAware {
         if (hasUsedCodeWhisperer || hasUsedQ) {
             // do auto-install
             installQPlugin(project, autoInstall = true)
-        } else {
+        } else if (!PluginManager.isPluginInstalled(PluginId.getId(AwsToolkit.Q_PLUGIN_ID))) {
             // show opt-in/install notification
             notifyInfo(
                 title = message("aws.q.migration.new_users.notify.title"),


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
This notification will not show up if Q is already installed
<img width="371" alt="Screenshot 2024-05-08 at 10 55 37 AM" src="https://github.com/aws/aws-toolkit-jetbrains/assets/166647264/1d039176-e88b-45fc-94f5-b5f630d3abb0">

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
