### PR TITLE
Removing getProjectSize function for efficiency.

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
@@ -9,11 +9,7 @@ import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.project.modules
 import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VFileProperty
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.time.withTimeout
 import software.aws.toolkits.core.utils.createTemporaryZipFile
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
@@ -37,7 +33,6 @@ import software.aws.toolkits.telemetry.CodewhispererLanguage
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
-import java.time.Duration
 import java.time.Instant
 import java.util.Stack
 import kotlin.io.path.relativeTo
@@ -141,30 +136,6 @@ class CodeScanSessionConfig(
         return bufferedReader.useLines { lines -> lines.count() }
     }
 
-    suspend fun getTotalProjectSizeInBytes(): Long {
-        var totalSize = 0L
-        try {
-            withTimeout(Duration.ofSeconds(TELEMETRY_TIMEOUT_IN_SECONDS)) {
-                if (scope == CodeAnalysisScope.FILE) {
-                    totalSize = selectedFile?.length ?: 0L
-                } else {
-                    val changeListManager = ChangeListManager.getInstance(project)
-                    VfsUtil.collectChildrenRecursively(projectRoot).filter {
-                        !it.isDirectory && !it.`is`((VFileProperty.SYMLINK)) && (
-                            !changeListManager.isIgnoredFile(it)
-                            )
-                    }.fold(0L) { acc, next ->
-                        totalSize = acc + next.length
-                        totalSize
-                    }
-                }
-            }
-        } catch (e: TimeoutCancellationException) {
-            // Do nothing
-        }
-        return totalSize
-    }
-
     private fun zipFiles(files: List<Path>): File = createTemporaryZipFile {
         files.forEach { file ->
             val relativePath = file.relativeTo(projectRoot.toNioPath())
@@ -242,7 +213,6 @@ class CodeScanSessionConfig(
 
     companion object {
         private val LOG = getLogger<CodeScanSessionConfig>()
-        private const val TELEMETRY_TIMEOUT_IN_SECONDS: Long = 10
         fun create(file: VirtualFile?, project: Project, scope: CodeAnalysisScope): CodeScanSessionConfig = CodeScanSessionConfig(file, project, scope)
     }
 }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanTestBase.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanTestBase.kt
@@ -226,10 +226,6 @@ open class CodeWhispererCodeScanTestBase(projectRule: CodeInsightTestFixtureRule
         ]                
     """
 
-    internal fun getTotalProjectSizeInBytes(sessionConfigSpy: CodeScanSessionConfig, totalSize: Long) = runBlocking {
-        assertThat(sessionConfigSpy.getTotalProjectSizeInBytes()).isEqualTo(totalSize)
-    }
-
     internal fun selectedFileLargerThanPayloadSizeThrowsException(sessionConfigSpy: CodeScanSessionConfig) {
         sessionConfigSpy.stub {
             onGeneric { getPayloadLimitInBytes() }.thenReturn(100)

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererProjectCodeScanTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererProjectCodeScanTest.kt
@@ -87,11 +87,6 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
     }
 
     @Test
-    fun `test getTotalProjectSizeInBytes()`() {
-        getTotalProjectSizeInBytes(sessionConfigSpy, this.totalSize)
-    }
-
-    @Test
     fun `selected file larger than payload limit throws exception`() {
         selectedFileLargerThanPayloadSizeThrowsException(sessionConfigSpy)
     }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
- Removing redundant `getProjectSize` for efficiency. Previously, this function was used to calculate entire project size including all files when we only parsed specific type of code files for scanning(only Java, only Python etc.,) but now we collect all files in project, so this function we use to send data for telemetry is redundant and instead we use codeScanResponseContext's `payloadSize` to the telemetry.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
