### PR TITLE
fix(amazonq): Autofocus to prompt field when Q panel is open

### DIFF
--- a/.changes/next-release/bugfix-20d3ae15-c11a-4746-bdfc-222e7821db6c.json
+++ b/.changes/next-release/bugfix-20d3ae15-c11a-4746-bdfc-222e7821db6c.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Prompt input field in Q Chat tabs doesn't stop after it reaches to the given maxLength"
+}

--- a/.changes/next-release/bugfix-78d6a195-205c-4cc3-b5d9-a97366014aca.json
+++ b/.changes/next-release/bugfix-78d6a195-205c-4cc3-b5d9-a97366014aca.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: When window gets focus, even though the autoFocus property is set to true, input field doesn't get focus"
+}

--- a/.changes/next-release/bugfix-cf7feded-bf79-4e3d-aee8-3d09c79181fe.json
+++ b/.changes/next-release/bugfix-cf7feded-bf79-4e3d-aee8-3d09c79181fe.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Inside chat body, if there is a code block inside a list item it shows <br/> tags"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.8.0",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.9.0",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.8.0.tgz",
-            "integrity": "sha512-UHzY7xRsVxO4p9R+tf+3RTk6hBWW8sD3gIW5Q0G9oWVcEKEIBx067hwkkmtffzppIaQDdU0ckSKcPH5Mtk5qqQ==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.0.tgz",
+            "integrity": "sha512-XlvtQ89km6NI9EwJ0DRTbFv6hvs+0vW/gdsmwoD6fBJLSl8kfiRUCteUjTDsnfVMMqtfx+7FnmHo5p6+xbG0gg==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.8.0",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.9.0",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem(s)
- When Q panel opens, it doesn't autofocus to prompt input field
- Inside chat body, if there is a code block inside a list item it shows `<br/>` tags
- Prompt input field in Q Chat tabs doesn't stop after it reaches to the given maxLength
- Links are not behaving as expected for middle mouse clicks inside a chat item.

### Solution(s)
- Added autofocus to prompt field when the panel opens or there is a new tab.
- Removed break generation for list items (which is the supposed way from markedjs and github's own markdown styling)
- Prompt input `maxLength` value was used incorrectly, it was using the function declaration instead of the return value of the function. It is corrected.
- As we do for the clicks, we also mapped the middle clicks (`auxclick`) to the same handler functions.

Related `mynah-ui` changes:
[Autofocus](https://github.com/aws/mynah-ui/pull/48)
[Rest of the fixes](https://github.com/aws/mynah-ui/pull/49)

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
