### PR TITLE
Disable PKCE for integration tests

### DIFF
--- a/plugins/toolkit/jetbrains-core/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-core/build.gradle.kts
@@ -48,6 +48,11 @@ tasks.jar {
     }
 }
 
+tasks.integrationTest {
+    // cant run tests under authorization_grant with PKCE yet
+    systemProperty("aws.dev.useDAG", true)
+}
+
 val gatewayPluginXml = tasks.create<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXmlForGateway") {
     pluginXmlFiles.set(tasks.patchPluginXml.map { it.pluginXmlFiles }.get())
     destinationDir.set(project.buildDir.resolve("patchedPluginXmlFilesGW"))


### PR DESCRIPTION
Auth invocation lambda needs to be updated to support the `authorization_grant` case
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
