### PR TITLE
fix(/dev): source folder modification now allows any sub-folder

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevConstants.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevConstants.kt
@@ -17,7 +17,7 @@ const val DEFAULT_RETRY_LIMIT = 0
 // Max allowed size for a repository in bytes
 const val MAX_PROJECT_SIZE_BYTES: Long = 200 * 1024 * 1024
 
-enum class ModifySourceFolderReason(
+enum class ModifySourceFolderErrorReason(
     private val reasonText: String
 ) {
     ClosedBeforeSelection("ClosedBeforeSelection"),

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevConstants.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevConstants.kt
@@ -16,3 +16,13 @@ const val DEFAULT_RETRY_LIMIT = 0
 
 // Max allowed size for a repository in bytes
 const val MAX_PROJECT_SIZE_BYTES: Long = 200 * 1024 * 1024
+
+enum class ModifySourceFolderReason(
+    private val reasonText: String
+) {
+    ClosedBeforeSelection("ClosedBeforeSelection"),
+    NotInWorkspaceFolder("NotInWorkspaceFolder"),
+    ;
+
+    override fun toString(): String = reasonText
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -31,7 +31,7 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CodeIterationL
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.DEFAULT_RETRY_LIMIT
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FEATURE_NAME
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.InboundAppMessagesHandler
-import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ModifySourceFolderReason
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ModifySourceFolderErrorReason
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MonthlyConversationLimitError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.PlanIterationLimitError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.createUserFacingErrorMessage
@@ -612,7 +612,7 @@ class FeatureDevController(
         )
 
         var result: Result = Result.Failed
-        var reason: ModifySourceFolderReason? = null
+        var reason: ModifySourceFolderErrorReason? = null
 
         withContext(EDT) {
             val selectedFolder = selectFolder(context.project, currentSourceFolder)
@@ -625,7 +625,7 @@ class FeatureDevController(
                     followUp = listOf(modifyFolderFollowUp),
                 )
 
-                reason = ModifySourceFolderReason.ClosedBeforeSelection
+                reason = ModifySourceFolderErrorReason.ClosedBeforeSelection
                 return@withContext
             }
 
@@ -644,7 +644,7 @@ class FeatureDevController(
                     followUp = listOf(modifyFolderFollowUp),
                 )
 
-                reason = ModifySourceFolderReason.NotInWorkspaceFolder
+                reason = ModifySourceFolderErrorReason.NotInWorkspaceFolder
                 return@withContext
             }
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -13,8 +13,6 @@ import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileChooser.FileChooser
-import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.wm.ToolWindowManager
@@ -33,6 +31,7 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CodeIterationL
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.DEFAULT_RETRY_LIMIT
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FEATURE_NAME
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.InboundAppMessagesHandler
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ModifySourceFolderReason
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MonthlyConversationLimitError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.PlanIterationLimitError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.createUserFacingErrorMessage
@@ -61,6 +60,7 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.Sessio
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.SessionStatePhase
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.storage.ChatSessionStorage
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.getFollowUpOptions
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.selectFolder
 import software.aws.toolkits.jetbrains.services.cwc.controller.chat.telemetry.getStartUrl
 import software.aws.toolkits.jetbrains.ui.feedback.FeatureDevFeedbackDialog
 import software.aws.toolkits.resources.message
@@ -192,7 +192,7 @@ class FeatureDevController(
         when (sessionState) {
             is PrepareCodeGenerationState -> {
                 runInEdt {
-                    val existingFile = VfsUtil.findRelativeFile(message.filePath, session.context.projectRoot)
+                    val existingFile = VfsUtil.findRelativeFile(message.filePath, session.context.selectedSourceFolder)
 
                     val leftDiffContent = if (existingFile == null) {
                         EmptyContent()
@@ -602,8 +602,8 @@ class FeatureDevController(
 
     private suspend fun modifyDefaultSourceFolder(tabId: String) {
         val session = getSessionInfo(tabId)
-        val uri = session.context.projectRoot
-        val fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
+        val currentSourceFolder = session.context.selectedSourceFolder
+        val projectRoot = session.context.projectRoot
 
         val modifyFolderFollowUp = FollowUp(
             pillText = message("amazonqFeatureDev.follow_up.modify_source_folder"),
@@ -612,11 +612,10 @@ class FeatureDevController(
         )
 
         var result: Result = Result.Failed
-        var reason: String? = null
+        var reason: ModifySourceFolderReason? = null
 
         withContext(EDT) {
-            val selectedFolder = FileChooser.chooseFile(fileChooserDescriptor, context.project, uri)
-
+            val selectedFolder = selectFolder(context.project, currentSourceFolder)
             // No folder was selected
             if (selectedFolder == null) {
                 logger.info { "Cancelled dialog and not selected any folder" }
@@ -626,12 +625,12 @@ class FeatureDevController(
                     followUp = listOf(modifyFolderFollowUp),
                 )
 
-                reason = "ClosedBeforeSelection"
+                reason = ModifySourceFolderReason.ClosedBeforeSelection
                 return@withContext
             }
 
             // The folder is not in the workspace
-            if (selectedFolder.parent.path != uri.path) {
+            if (!selectedFolder.path.startsWith(projectRoot.path)) {
                 logger.info { "Selected folder not in workspace: ${selectedFolder.path}" }
 
                 messenger.sendAnswer(
@@ -645,13 +644,13 @@ class FeatureDevController(
                     followUp = listOf(modifyFolderFollowUp),
                 )
 
-                reason = "NotInWorkspaceFolder"
+                reason = ModifySourceFolderReason.NotInWorkspaceFolder
                 return@withContext
             }
 
             logger.info { "Selected correct folder inside workspace: ${selectedFolder.path}" }
 
-            session.context.projectRoot = selectedFolder
+            session.context.selectedSourceFolder = selectedFolder
             result = Result.Succeeded
 
             messenger.sendAnswer(
@@ -665,7 +664,7 @@ class FeatureDevController(
             amazonqConversationId = session.conversationId,
             credentialStartUrl = getStartUrl(project = context.project),
             result = result,
-            reason = reason
+            reason = reason?.toString()
         )
     }
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -97,16 +97,16 @@ class Session(val tabID: String, val project: Project) {
      * Triggered by the Insert code follow-up button to apply code changes.
      */
     fun insertChanges(filePaths: List<NewFileZipInfo>, deletedFiles: List<DeletedFileInfo>, references: List<CodeReferenceGenerated>) {
-        val projectRootPath = context.projectRoot.toNioPath()
+        val selectedSourceFolder = context.selectedSourceFolder.toNioPath()
 
-        filePaths.forEach { resolveAndCreateOrUpdateFile(projectRootPath, it.zipFilePath, it.fileContent) }
+        filePaths.forEach { resolveAndCreateOrUpdateFile(selectedSourceFolder, it.zipFilePath, it.fileContent) }
 
-        deletedFiles.forEach { resolveAndDeleteFile(projectRootPath, it.zipFilePath) }
+        deletedFiles.forEach { resolveAndDeleteFile(selectedSourceFolder, it.zipFilePath) }
 
         ReferenceLogController.addReferenceLog(references, project)
 
         // Taken from https://intellij-support.jetbrains.com/hc/en-us/community/posts/206118439-Refresh-after-external-changes-to-project-structure-and-sources
-        VfsUtil.markDirtyAndRefresh(true, true, true, context.projectRoot)
+        VfsUtil.markDirtyAndRefresh(true, true, true, context.selectedSourceFolder)
     }
 
     suspend fun send(msg: String): Interaction {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FileUtils.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FileUtils.kt
@@ -3,6 +3,10 @@
 
 package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util
 
+import com.intellij.openapi.fileChooser.FileChooser
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.deleteIfExists
@@ -23,4 +27,9 @@ fun resolveAndCreateOrUpdateFile(projectRootPath: Path, relativeFilePath: String
 fun resolveAndDeleteFile(projectRootPath: Path, relativePath: String) {
     val filePath = projectRootPath.resolve(relativePath)
     filePath.deleteIfExists()
+}
+
+fun selectFolder(project: Project, openOn: VirtualFile): VirtualFile? {
+    val fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
+    return FileChooser.chooseFile(fileChooserDescriptor, project, openOn)
 }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -35,7 +35,6 @@ import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthController
 import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededStates
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTestBase
-import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ModifySourceFolderReason
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FeatureDevMessageType
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUp
@@ -62,7 +61,6 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.selectFol
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.uploadArtifactToS3
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AmazonqTelemetry
-import software.aws.toolkits.telemetry.Result
 import org.mockito.kotlin.verify as mockitoVerify
 
 class FeatureDevControllerTest : FeatureDevTestBase() {
@@ -407,9 +405,6 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
         whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
         whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
 
-        mockkObject(AmazonqTelemetry)
-        every { AmazonqTelemetry.modifySourceFolder(amazonqConversationId = any()) } just runs
-
         mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.FileUtilsKt")
         every { selectFolder(any(), any()) } returns null
 
@@ -427,13 +422,6 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                     )
                 )
             )
-            AmazonqTelemetry.modifySourceFolder(
-                amazonqConversationId = spySession.conversationId,
-                credentialStartUrl = any(),
-                result = Result.Failed,
-                reason = ModifySourceFolderReason.ClosedBeforeSelection.toString(),
-                createTime = any()
-            )
         }
     }
 
@@ -444,9 +432,6 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
 
         whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
         whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
-
-        mockkObject(AmazonqTelemetry)
-        every { AmazonqTelemetry.modifySourceFolder(amazonqConversationId = any()) } just runs
 
         mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.FileUtilsKt")
         every { selectFolder(any(), any()) } returns LightVirtualFile("/path")
@@ -470,13 +455,6 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                     )
                 )
             )
-            AmazonqTelemetry.modifySourceFolder(
-                amazonqConversationId = spySession.conversationId,
-                credentialStartUrl = any(),
-                result = Result.Failed,
-                reason = ModifySourceFolderReason.NotInWorkspaceFolder.toString(),
-                createTime = any()
-            )
         }
     }
 
@@ -487,9 +465,6 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
 
         whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
         whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
-
-        mockkObject(AmazonqTelemetry)
-        every { AmazonqTelemetry.modifySourceFolder(amazonqConversationId = any()) } just runs
 
         val folder = LightVirtualFile("${spySession.context.projectRoot.name}/path/to/sub/folder")
         mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.FileUtilsKt")
@@ -503,13 +478,6 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                 tabId = testTabId,
                 messageType = FeatureDevMessageType.Answer,
                 message = message("amazonqFeatureDev.follow_up.modified_source_folder", folder.path)
-            )
-            AmazonqTelemetry.modifySourceFolder(
-                amazonqConversationId = spySession.conversationId,
-                credentialStartUrl = any(),
-                result = Result.Succeeded,
-                reason = isNull(),
-                createTime = any()
             )
         }
     }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.controller
 
+import com.intellij.testFramework.LightVirtualFile
 import com.intellij.testFramework.RuleChain
 import com.intellij.testFramework.replaceService
 import io.mockk.coEvery
@@ -34,6 +35,7 @@ import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthController
 import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededStates
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTestBase
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ModifySourceFolderReason
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FeatureDevMessageType
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUp
@@ -56,9 +58,11 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.Sessio
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.SessionStatePhase
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.storage.ChatSessionStorage
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.getFollowUpOptions
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.selectFolder
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.uploadArtifactToS3
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AmazonqTelemetry
+import software.aws.toolkits.telemetry.Result
 import org.mockito.kotlin.verify as mockitoVerify
 
 class FeatureDevControllerTest : FeatureDevTestBase() {
@@ -393,5 +397,120 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
         val newFileContentsCopy = newFileContents.toList()
         newFileContentsCopy[0].rejected = !newFileContentsCopy[0].rejected
         coVerify { messenger.updateFileComponent(testTabId, newFileContentsCopy, deletedFiles, "") }
+    }
+
+    @Test
+    fun `test modifyDefaultSourceFolder customer does not select a folder`() = runTest {
+        val followUp = FollowUp(FollowUpTypes.MODIFY_DEFAULT_SOURCE_FOLDER, pillText = "Modify default source folder")
+        val message = IncomingFeatureDevMessage.FollowupClicked(followUp, testTabId, "", "test-command")
+
+        whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
+        whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
+
+        mockkObject(AmazonqTelemetry)
+        every { AmazonqTelemetry.modifySourceFolder(amazonqConversationId = any()) } just runs
+
+        mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.FileUtilsKt")
+        every { selectFolder(any(), any()) } returns null
+
+        spySession.preloader(userMessage, messenger)
+        controller.processFollowupClickedMessage(message)
+
+        coVerifyOrder {
+            messenger.sendSystemPrompt(
+                tabId = testTabId,
+                followUp = listOf(
+                    FollowUp(
+                        pillText = message("amazonqFeatureDev.follow_up.modify_source_folder"),
+                        type = FollowUpTypes.MODIFY_DEFAULT_SOURCE_FOLDER,
+                        status = FollowUpStatusType.Info,
+                    )
+                )
+            )
+            AmazonqTelemetry.modifySourceFolder(
+                amazonqConversationId = spySession.conversationId,
+                credentialStartUrl = any(),
+                result = Result.Failed,
+                reason = ModifySourceFolderReason.ClosedBeforeSelection.toString(),
+                createTime = any()
+            )
+        }
+    }
+
+    @Test
+    fun `test modifyDefaultSourceFolder customer selects a folder outside the workspace`() = runTest {
+        val followUp = FollowUp(FollowUpTypes.MODIFY_DEFAULT_SOURCE_FOLDER, pillText = "Modify default source folder")
+        val message = IncomingFeatureDevMessage.FollowupClicked(followUp, testTabId, "", "test-command")
+
+        whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
+        whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
+
+        mockkObject(AmazonqTelemetry)
+        every { AmazonqTelemetry.modifySourceFolder(amazonqConversationId = any()) } just runs
+
+        mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.FileUtilsKt")
+        every { selectFolder(any(), any()) } returns LightVirtualFile("/path")
+
+        spySession.preloader(userMessage, messenger)
+        controller.processFollowupClickedMessage(message)
+
+        coVerifyOrder {
+            messenger.sendAnswer(
+                tabId = testTabId,
+                messageType = FeatureDevMessageType.Answer,
+                message = message("amazonqFeatureDev.follow_up.incorrect_source_folder")
+            )
+            messenger.sendSystemPrompt(
+                tabId = testTabId,
+                followUp = listOf(
+                    FollowUp(
+                        pillText = message("amazonqFeatureDev.follow_up.modify_source_folder"),
+                        type = FollowUpTypes.MODIFY_DEFAULT_SOURCE_FOLDER,
+                        status = FollowUpStatusType.Info,
+                    )
+                )
+            )
+            AmazonqTelemetry.modifySourceFolder(
+                amazonqConversationId = spySession.conversationId,
+                credentialStartUrl = any(),
+                result = Result.Failed,
+                reason = ModifySourceFolderReason.NotInWorkspaceFolder.toString(),
+                createTime = any()
+            )
+        }
+    }
+
+    @Test
+    fun `test modifyDefaultSourceFolder customer selects a correct sub folder`() = runTest {
+        val followUp = FollowUp(FollowUpTypes.MODIFY_DEFAULT_SOURCE_FOLDER, pillText = "Modify default source folder")
+        val message = IncomingFeatureDevMessage.FollowupClicked(followUp, testTabId, "", "test-command")
+
+        whenever(featureDevClient.createTaskAssistConversation()).thenReturn(exampleCreateTaskAssistConversationResponse)
+        whenever(chatSessionStorage.getSession(any(), any())).thenReturn(spySession)
+
+        mockkObject(AmazonqTelemetry)
+        every { AmazonqTelemetry.modifySourceFolder(amazonqConversationId = any()) } just runs
+
+        val folder = LightVirtualFile("${spySession.context.projectRoot.name}/path/to/sub/folder")
+        mockkStatic("software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.FileUtilsKt")
+        every { selectFolder(any(), any()) } returns folder
+
+        spySession.preloader(userMessage, messenger)
+        controller.processFollowupClickedMessage(message)
+
+        coVerify {
+            messenger.sendAnswer(
+                tabId = testTabId,
+                messageType = FeatureDevMessageType.Answer,
+                message = message("amazonqFeatureDev.follow_up.modified_source_folder", folder.path)
+            )
+            AmazonqTelemetry.modifySourceFolder(
+                amazonqConversationId = spySession.conversationId,
+                credentialStartUrl = any(),
+                result = Result.Succeeded,
+                reason = isNull(),
+                createTime = any()
+            )
+        }
     }
 }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionTest.kt
@@ -91,8 +91,8 @@ class SessionTest : FeatureDevTestBase() {
         val mockNewFile = listOf(NewFileZipInfo("test.ts", "testContent", false))
         val mockDeletedFile = listOf(DeletedFileInfo("deletedTest.ts", false))
 
-        session.context.projectRoot = mock()
-        whenever(session.context.projectRoot.toNioPath()).thenReturn(Path(""))
+        session.context.selectedSourceFolder = mock()
+        whenever(session.context.selectedSourceFolder.toNioPath()).thenReturn(Path(""))
 
         session.insertChanges(mockNewFile, mockDeletedFile, emptyList())
 


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

The source folder modification happens when the customers repository is too big for uploading and /dev allows the customer to select a new source folder from within their working project. Until now, this check was faulty as it would only check for one level of sub-folder from the root, now it is any level. And of course, folders outside the workspace are not allowed. Workspace being for VSCode the project's root.

Before: 

```
yes (root): root 
yes (root's subfolder): root/sub-folder
no (any sub-folder level): root/sub-folder/sub-sub-folder/... 
no (folder outside the root): other-root/folder
```

Now:

```
yes (root): root 
yes (root's subfolder): root/sub-folder
yes (any sub-folder level): root/sub-folder/sub-sub-folder/... 
no (folder outside the root): other-root/folder
```
## Checklist
- [x] My code follows the code style of this project
- [n/a] I have added tests to cover my changes
- [n/a] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [n/a] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
