### PR TITLE
Don't assume repo tree is in a valid Git respository

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/BuildScriptUtils.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/BuildScriptUtils.kt
@@ -8,7 +8,6 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import software.aws.toolkits.gradle.intellij.IdeVersions
-import java.io.IOException
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion as KotlinVersionEnum
 
 /**
@@ -55,7 +54,7 @@ fun Project.buildMetadata() =
                 append(".modified")
             }
         }
-    } catch(e: IOException) {
+    } catch(e: Exception) {
         logger.warn("Could not determine current commit", e)
 
         "unknownCommit"


### PR DESCRIPTION
```
org.eclipse.jgit.errors.RepositoryNotFoundException: repository not found: [...]
	at org.eclipse.jgit.lib.BaseRepositoryBuilder.build(BaseRepositoryBuilder.java:627)
	at org.eclipse.jgit.api.Git.open(Git.java:93)
	at org.eclipse.jgit.api.Git.open(Git.java:73)
	at software.aws.toolkits.gradle.BuildScriptUtilsKt.buildMetadata(BuildScriptUtils.kt:47)
	at Toolkit_patch_plugin_xml_conventions_gradle.<init>(toolkit-patch-plugin-xml-conventions.gradle.kts:29)
	at java.base@17.0.5/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base@17.0.5/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
```

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
