### PR TITLE
Fix buildspec not collecting all build artifacts for Windows

### DIFF
--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -50,19 +50,17 @@ phases:
         Get-ChildItem -Recurse -Directory
         $script:TEST_ARTIFACTS=Join-Path $env:TEMP testArtifacts
         $script:TEST_REPORTS=Join-Path $script:TEST_ARTIFACTS test-reports
-        New-Item -ItemType dir -Path $script:TEST_ARTIFACTS
-        New-Item -ItemType dir -Path $script:TEST_REPORTS
 
         function copyArtifacts($filter, $destdir) {
           Get-ChildItem -Recurse -Directory -ErrorAction SilentlyContinue | Where-Object { $_.FullName -Like "$filter" } | ForEach-Object {
-              Copy-Item -Path $_.FullName -Destination "$destdir/$(Resolve-Path -Relative $_.FullName)" -Recurse -Container -Verbose
+              Copy-Item -Path $_.FullName -Destination "$destdir/$(Resolve-Path -Relative $_.FullName)" -Recurse -Container
           }
         }
 
-        copyArtifacts "*/build/idea-sandbox/system*/log" $script:TEST_ARTIFACTS
-        copyArtifacts "*/build/reports" $script:TEST_ARTIFACTS
+        copyArtifacts "*\build\idea-sandbox\system*\log" $script:TEST_ARTIFACTS
+        copyArtifacts "*\build\reports" $script:TEST_ARTIFACTS
 
-        copyArtifacts "*/test-results" $script:TEST_ARTIFACTS
+        copyArtifacts "*\test-results" $script:TEST_REPORTS
 
         if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
           $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;
@@ -74,12 +72,12 @@ phases:
             -c $Env:CODEBUILD_RESOLVED_SOURCE_VERSION
         }
 
-#reports:
-#  unit-test:
-#    files:
-#      - "**/*"
-#    base-directory: "$env:TEMP/testArtifacts/test-reports"
-#    discard-paths: yes
+reports:
+  unit-test:
+    files:
+      - "**/*"
+    base-directory: "$env:TEMP/testArtifacts/test-reports"
+    discard-paths: yes
 
 artifacts:
     base-directory: "$env:TEMP/testArtifacts"

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -47,6 +47,7 @@ phases:
   post_build:
     commands:
       - |
+        Get-ChildItem -Recurse -Directory
         $script:TEST_ARTIFACTS=Join-Path $env:TEMP testArtifacts
         $script:TEST_REPORTS=Join-Path $script:TEST_ARTIFACTS test-reports
         New-Item -ItemType dir -Path $script:TEST_ARTIFACTS

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -50,22 +50,16 @@ phases:
         $script:TEST_ARTIFACTS=Join-Path $env:TEMP testArtifacts
         $script:TEST_REPORTS=Join-Path $script:TEST_ARTIFACTS test-reports
 
-        function copyFolder($basedir, $subdir, $destdir) {
-          $src = Join-Path "." -ChildPath $basedir | Join-Path -ChildPath $subdir
-          $dest = Join-Path $destdir -ChildPath $basedir | Join-Path -ChildPath $subDir
-          if( (Get-ChildItem $src -ErrorAction SilentlyContinue | Measure-Object).Count -ne 0) {
-            Copy-Item $src $dest -Recurse -Force -ErrorAction SilentlyContinue
+        function copyArtifacts($filter, $destdir) {
+          Get-ChildItem -Recurse -Directory -ErrorAction SilentlyContinue | Where-Object { $_.FullName -Like "$filter" } | ForEach-Object {
+              Copy-Item -Path $_.FullName -Destination "$destdir/$(Resolve-Path -relative $_.FullName)" -Recurse -Container
           }
         }
 
-        function copyArtifacts($root) {
-            copyFolder $root "build/reports/" $script:TEST_ARTIFACTS
-            copyFolder $root "build/idea-sandbox/system-test/log/" $script:TEST_ARTIFACTS
-            copyFolder $root "build/test-results/test/" $script:TEST_REPORTS
-        }
+        copyArtifacts "*/build/idea-sandbox/system*/log" $script:TEST_ARTIFACTS
+        copyArtifacts "*/build/reports" $script:TEST_ARTIFACTS
 
-        copyArtifacts "."
-        Get-ChildItem -Directory | ForEach-Object { copyArtifacts $_.Name }
+        copyArtifacts "*/test-results" $script:TEST_REPORTS
 
         if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
           $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -54,14 +54,14 @@ phases:
 
         function copyArtifacts($filter, $destdir) {
           Get-ChildItem -Recurse -Directory -ErrorAction SilentlyContinue | Where-Object { $_.FullName -Like "$filter" } | ForEach-Object {
-              Copy-Item -Path $_.FullName -Destination "$destdir/$(Resolve-Path -Relative $_.FullName)" -Recurse -Container
+              Copy-Item -Path $_.FullName -Destination "$destdir/$(Resolve-Path -Relative $_.FullName)" -Recurse -Container -Verbose
           }
         }
 
         copyArtifacts "*/build/idea-sandbox/system*/log" $script:TEST_ARTIFACTS
         copyArtifacts "*/build/reports" $script:TEST_ARTIFACTS
 
-        copyArtifacts "*/test-results" $script:TEST_REPORTS
+        copyArtifacts "*/test-results" $script:TEST_ARTIFACTS
 
         if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
           $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;
@@ -73,12 +73,12 @@ phases:
             -c $Env:CODEBUILD_RESOLVED_SOURCE_VERSION
         }
 
-reports:
-  unit-test:
-    files:
-      - "**/*"
-    base-directory: "$env:TEMP/testArtifacts/test-reports"
-    discard-paths: yes
+#reports:
+#  unit-test:
+#    files:
+#      - "**/*"
+#    base-directory: "$env:TEMP/testArtifacts/test-reports"
+#    discard-paths: yes
 
 artifacts:
     base-directory: "$env:TEMP/testArtifacts"

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -47,7 +47,6 @@ phases:
   post_build:
     commands:
       - |
-        Get-ChildItem -Recurse -Directory
         $script:TEST_ARTIFACTS=Join-Path $env:TEMP testArtifacts
         $script:TEST_REPORTS=Join-Path $script:TEST_ARTIFACTS test-reports
 

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -49,10 +49,12 @@ phases:
       - |
         $script:TEST_ARTIFACTS=Join-Path $env:TEMP testArtifacts
         $script:TEST_REPORTS=Join-Path $script:TEST_ARTIFACTS test-reports
+        New-Item -ItemType dir -Path $script:TEST_ARTIFACTS
+        New-Item -ItemType dir -Path $script:TEST_REPORTS
 
         function copyArtifacts($filter, $destdir) {
           Get-ChildItem -Recurse -Directory -ErrorAction SilentlyContinue | Where-Object { $_.FullName -Like "$filter" } | ForEach-Object {
-              Copy-Item -Path $_.FullName -Destination "$destdir/$(Resolve-Path -relative $_.FullName)" -Recurse -Container
+              Copy-Item -Path $_.FullName -Destination "$destdir/$(Resolve-Path -Relative $_.FullName)" -Recurse -Container
           }
         }
 


### PR DESCRIPTION
File locations changed with extension split
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
