### PR TITLE
Q Developer: Remove logging on non-existent files.

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanDocumentListener.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanDocumentListener.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.editor.event.DocumentListener
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
-import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.CodeWhispererCodeScanIssue
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.CodeWhispererCodeScanManager
@@ -20,13 +19,10 @@ import javax.swing.tree.TreePath
 internal class CodeWhispererCodeScanDocumentListener(val project: Project) : DocumentListener {
 
     override fun documentChanged(event: DocumentEvent) {
+        val file = FileDocumentManager.getInstance().getFile(event.document) ?: return
         val scanManager = CodeWhispererCodeScanManager.getInstance(project)
         val treeModel = scanManager.getScanTree().model
-        val file = FileDocumentManager.getInstance().getFile(event.document)
-        if (file == null) {
-            LOG.error { "Cannot find file for document ${event.document}" }
-            return
-        }
+
         val editedTextRange = TextRange.create(event.offset, event.offset + event.oldLength)
         val nodes = scanManager.getOverlappingScanNodes(file, editedTextRange)
         nodes.forEach {

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanDocumentListener.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanDocumentListener.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.editor.event.DocumentListener
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
-import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.CodeWhispererCodeScanIssue
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.CodeWhispererCodeScanManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
@@ -38,9 +37,5 @@ internal class CodeWhispererCodeScanDocumentListener(val project: Project) : Doc
         if (editedTextRange.length > 0 && !CodeWhispererExplorerActionManager.getInstance().isMonthlyQuotaForCodeScansExceeded() && !isUserBuilderId(project)) {
             scanManager.createDebouncedRunCodeScan(CodeWhispererConstants.CodeAnalysisScope.FILE)
         }
-    }
-
-    companion object {
-        private val LOG = getLogger<CodeWhispererCodeScanDocumentListener>()
     }
 }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
@@ -361,11 +361,7 @@ class CodeWhispererCodeScanEditorMouseMotionListener(private val project: Projec
             return
         }
         val offset = e.offset
-        val file = FileDocumentManager.getInstance().getFile(e.editor.document)
-        if (file == null) {
-            LOG.error { "Cannot find file for the document ${e.editor.document}" }
-            return
-        }
+        val file = FileDocumentManager.getInstance().getFile(e.editor.document) ?: return
         val issuesInRange = scanManager.getScanNodesInRange(file, offset).map {
             it.userObject as CodeWhispererCodeScanIssue
         }


### PR DESCRIPTION
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Seeing intellij logs being flooded by:
```
2024-05-23 15:46:47,074 [2189034] SEVERE - software.aws.toolkits.jetbrains.services.codewhisperer.codescan.listeners.CodeWhispererCodeScanDocumentListener - Cannot find file for document DocumentImpl[null,inEventHandling,nonWriteThreadOnly]
```
And
```
2024-05-23 15:55:28,364 [2710324] SEVERE - software.aws.toolkits.jetbrains.services.codewhisperer.codescan.listeners.CodeWhispererCodeScanEditorMouseMotionListener - Cannot find file for the document DocumentImpl[null,nonWriteThreadOnly]
```

~10000 lines in a day of this rendering the logs unreadable.
I'm on latest release 3.4.

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
