### PR TITLE
Stop using `--stacktrace` on linux tests

### DIFF
--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -32,7 +32,7 @@ phases:
         fi
 
       - chmod +x gradlew
-      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME check coverageReport --info --stacktrace --console plain --continue"
+      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME check coverageReport --info --console plain --continue"
       - ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME :plugin-toolkit:intellij-standalone:buildPlugin :plugin-core:buildPlugin :plugin-amazonq:buildPlugin
       - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
       - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site


### PR DESCRIPTION
Adds unnecessary noise to build output
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
