### PR TITLE
fix(amazonq): only use relative path inside project

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
@@ -380,6 +380,9 @@ class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
             val file = try {
                 LocalFileSystem.getInstance().findFileByIoFile(
                     Path.of(sessionContext.sessionConfig.projectRoot.path, it.filePath).toFile()
+                ) ?: LocalFileSystem.getInstance().findFileByIoFile(
+                    // Files outside project use absolute path
+                    Path.of("/", it.filePath).toFile()
                 )
             } catch (e: Exception) {
                 LOG.debug { "Cannot find file at location ${it.filePath}" }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
@@ -91,7 +91,7 @@ class CodeScanSessionConfig(
         }
 
         // Copy all the included source files to the source zip
-        val srcZip = zipFiles(payloadMetadata.sourceFiles.map { Path.of(it) }, scope)
+        val srcZip = zipFiles(payloadMetadata.sourceFiles.map { Path.of(it) })
         val payloadContext = PayloadContext(
             payloadMetadata.language,
             payloadMetadata.linesScanned,
@@ -124,10 +124,11 @@ class CodeScanSessionConfig(
         return bufferedReader.useLines { lines -> lines.count() }
     }
 
-    private fun zipFiles(files: List<Path>, scope: CodeAnalysisScope): File = createTemporaryZipFile {
+    private fun zipFiles(files: List<Path>): File = createTemporaryZipFile {
         files.forEach { file ->
-            val relativePath = when (scope) {
-                CodeAnalysisScope.PROJECT -> file.relativeTo(projectRoot.toNioPath())
+            val relativePath = when {
+                file.startsWith(projectRoot.toNioPath()) -> file.relativeTo(projectRoot.toNioPath())
+                // If the file is outside the project, use absolute path
                 else -> file
             }
             LOG.debug { "Selected file for truncation: $file" }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Fixes an issue for auto-scans where issues are not appearing due to the wrong filePath mapping.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
