### PR TITLE
close popup afterEach test case

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
@@ -89,6 +89,8 @@ class CodeWhispererPopupManager {
     var sessionContext = SessionContext()
         private set
 
+    private var myPopup: JBPopup? = null
+
     init {
         // Listen for global scheme changes
         ApplicationManager.getApplication().messageBus.connect().subscribe(
@@ -268,6 +270,10 @@ class CodeWhispererPopupManager {
         popup.closeOk(null)
     }
 
+    fun closePopup() {
+        myPopup?.closeOk(null)
+    }
+
     fun showPopup(
         states: InvocationContext,
         sessionContext: SessionContext,
@@ -384,7 +390,9 @@ class CodeWhispererPopupManager {
         .setCancelOnOtherWindowOpen(true)
         .setCancelKeyEnabled(true)
         .setCancelOnWindowDeactivation(true)
-        .createPopup()
+        .createPopup().also {
+            myPopup = it
+        }
 
     fun getReformattedRecommendation(detailContext: DetailContext, userInput: String) =
         detailContext.reformatted.content().substring(userInput.length)

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestBase.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTestBase.kt
@@ -156,6 +156,9 @@ open class CodeWhispererTestBase {
         stateManager.loadState(originalExplorerActionState)
         settingsManager.loadState(originalSettings)
         popupManagerSpy.reset()
+        runInEdtAndWait {
+            popupManagerSpy.closePopup()
+        }
     }
 
     fun withCodeWhispererServiceInvokedAndWait(runnable: (InvocationContext) -> Unit) {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
notice this issue from PR https://github.com/aws/aws-toolkit-jetbrains/pull/4497#issuecomment-2125460983
This issue happens in a undeterministic way and will cause CI fails

sometimes there was a cw popup not cleaned up correctly after one test case and the following test cases will get exception `conflicting popup` while creating another cw popup in a different test case. 

## Root cause
lack of closing popup in `afterEach` hook

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
