### PR TITLE
Revert "fix(featureDev): File Rejection stopped working  (#4511)"

### DIFF
--- a/.changes/next-release/bugfix-9148976b-7bab-446e-9039-6f92bce12de5.json
+++ b/.changes/next-release/bugfix-9148976b-7bab-446e-9039-6f92bce12de5.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "(featureDev): Revert fix for file rejection. Reason: The plan disappears after clicking generate Code"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -231,7 +231,6 @@ class FeatureDevController(
     override suspend fun processFileClicked(message: IncomingFeatureDevMessage.FileClicked) {
         val fileToUpdate = message.filePath
         val session = getSessionInfo(message.tabId)
-        val messageId = message.messageId
 
         var filePaths: List<NewFileZipInfo> = emptyList()
         var deletedFiles: List<DeletedFileInfo> = emptyList()
@@ -246,7 +245,7 @@ class FeatureDevController(
         filePaths.find { it.zipFilePath == fileToUpdate }?.let { it.rejected = !it.rejected }
         deletedFiles.find { it.zipFilePath == fileToUpdate }?.let { it.rejected = !it.rejected }
 
-        messenger.updateFileComponent(message.tabId, filePaths, deletedFiles, messageId)
+        messenger.updateFileComponent(message.tabId, filePaths, deletedFiles)
     }
 
     private suspend fun newTabOpened(tabId: String) {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessage.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessage.kt
@@ -133,8 +133,7 @@ data class UpdatePlaceholderMessage(
 data class FileComponent(
     @JsonProperty("tabID") override val tabId: String,
     val filePaths: List<NewFileZipInfo>,
-    val deletedFiles: List<DeletedFileInfo>,
-    val messageId: String
+    val deletedFiles: List<DeletedFileInfo>
 ) : UiMessage(
     tabId = tabId,
     type = "updateFileComponent"

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessagePublisherExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/messages/FeatureDevMessagePublisherExtensions.kt
@@ -58,12 +58,11 @@ suspend fun MessagePublisher.sendSystemPrompt(
     )
 }
 
-suspend fun MessagePublisher.updateFileComponent(tabId: String, filePaths: List<NewFileZipInfo>, deletedFiles: List<DeletedFileInfo>, messageId: String) {
+suspend fun MessagePublisher.updateFileComponent(tabId: String, filePaths: List<NewFileZipInfo>, deletedFiles: List<DeletedFileInfo>) {
     val fileComponentMessage = FileComponent(
         tabId = tabId,
         filePaths = filePaths,
         deletedFiles = deletedFiles,
-        messageId = messageId,
     )
     this.publish(fileComponentMessage)
 }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -388,6 +388,6 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
 
         val newFileContentsCopy = newFileContents.toList()
         newFileContentsCopy[0].rejected = !newFileContentsCopy[0].rejected
-        coVerify { messenger.updateFileComponent(testTabId, newFileContentsCopy, deletedFiles, "") }
+        coVerify { messenger.updateFileComponent(testTabId, newFileContentsCopy, deletedFiles) }
     }
 }

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.9.1",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.9.0",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.1.tgz",
-            "integrity": "sha512-mVatvO/08jndDaCdVQnJu9DrBoTPxjdmxXE1koQi/BGqm4Wqs1dm7FQfhUpfX3LlRzgmMjAwMafAvABjGkTQ8w==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.0.tgz",
+            "integrity": "sha512-XlvtQ89km6NI9EwJ0DRTbFv6hvs+0vW/gdsmwoD6fBJLSl8kfiRUCteUjTDsnfVMMqtfx+7FnmHo5p6+xbG0gg==",
             "hasInstallScript": true,
             "dependencies": {
                 "just-clone": "^6.2.0",

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.9.1",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.9.0",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/featureDevChatConnector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/featureDevChatConnector.ts
@@ -28,7 +28,7 @@ export interface ConnectorProps {
     onUpdateAuthentication: (featureDevEnabled: boolean, codeTransformEnabled: boolean, authenticatingTabIDs: string[]) => void
     onNewTab: (tabType: TabType) => void
     tabsStorage: TabsStorage
-    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[], messageId: string) => void
+    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => void
 }
 
 export class Connector {
@@ -201,7 +201,7 @@ export class Connector {
 
     handleMessageReceive = async (messageData: any): Promise<void> => {
         if (messageData.type === 'updateFileComponent') {
-            this.onFileComponentUpdate(messageData.tabID, messageData.filePaths, messageData.deletedFiles, messageData.messageId)
+            this.onFileComponentUpdate(messageData.tabID, messageData.filePaths, messageData.deletedFiles)
             return
         }
         if (messageData.type === 'errorMessage') {

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
@@ -43,7 +43,7 @@ export interface ConnectorProps {
     onCWCOnboardingPageInteractionMessage: (message: ChatItem) => string | undefined
     onError: (tabID: string, message: string, title: string) => void
     onWarning: (tabID: string, message: string, title: string) => void
-    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[], messageId: string) => void
+    onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => void
     onUpdatePlaceholder: (tabID: string, newPlaceholder: string) => void
     onChatInputEnabled: (tabID: string, enabled: boolean) => void
     onUpdateAuthentication: (featureDevEnabled: boolean, codeTransformEnabled: boolean, authenticatingTabIDs: string[]) => void

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
@@ -274,7 +274,7 @@ export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeT
         onMessageReceived: (tabID: string, messageData: MynahUIDataModel) => {
             mynahUI.updateStore(tabID, messageData)
         },
-        onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[], messageId: string) => {
+        onFileComponentUpdate: (tabID: string, filePaths: DiffTreeFileInfo[], deletedFiles: DiffTreeFileInfo[]) => {
             const updateWith: Partial<ChatItem> = {
                 type: ChatItemType.ANSWER,
                 fileList: {
@@ -285,7 +285,7 @@ export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeT
                     actions: getActions([...filePaths, ...deletedFiles]),
                 },
             }
-            mynahUI.updateChatAnswerWithMessageId(tabID, messageId, updateWith)
+            mynahUI.updateLastChatAnswer(tabID, updateWith)
         },
         onWarning: (tabID: string, message: string, title: string) => {
             mynahUI.notify({


### PR DESCRIPTION
This reverts commit 5497ddcf2f29e5ed8c8221becbe6420d09a26297.
Reason for revert: This commit introduced a core functionality issue. When a Plan was generated and the customer clicked "Generate Code", the plan chat item disappeared from the chat. Having the plan visible at all times is a core functionality for featureDev, as it allows the customer to compare the generated code with the plan, etc.

Important note: This revert reintroduces the bug where the customer cannot reject generated files. The team is aware of this issue and will work towards a solution as soon as possible. This is a trade-off, as it has a smaller customer impact.

## Tested
Yes, after reverting this change plan stays, but it re-introduces bug when reverting file changes.
<img width="498" alt="Screenshot 2024-05-29 at 19 40 33" src="https://github.com/aws/aws-toolkit-jetbrains/assets/144136687/d90a2363-79ea-4a00-9b85-eb41fb0d3108">

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
