### PR TITLE
fix(amazonq): use generic patch applier

### DIFF
--- a/.changes/next-release/bugfix-04f91235-8b99-45c3-a4bd-096c530739af.json
+++ b/.changes/next-release/bugfix-04f91235-8b99-45c3-a4bd-096c530739af.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Security Scan: Improved method of applying security fixes"
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/TextUtils.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/TextUtils.kt
@@ -7,7 +7,7 @@ import com.intellij.lang.Language
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.diff.impl.patch.PatchReader
 import com.intellij.openapi.diff.impl.patch.TextFilePatch
-import com.intellij.openapi.diff.impl.patch.apply.PlainSimplePatchApplier
+import com.intellij.openapi.diff.impl.patch.apply.GenericPatchApplier
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiFileFactory
@@ -38,7 +38,7 @@ fun generateUnifiedPatch(patch: String, filePath: String): TextFilePatch {
     return patches[0]
 }
 
-fun applyPatch(patch: String, fileContent: String, filePath: String): String? {
+fun applyPatch(patch: String, fileContent: String, filePath: String): String {
     val unifiedPatch = generateUnifiedPatch(patch, filePath)
-    return PlainSimplePatchApplier.apply(fileContent, unifiedPatch.hunks)
+    return GenericPatchApplier.applySomehow(fileContent, unifiedPatch.hunks).patchedText
 }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/TextUtilsTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/TextUtilsTest.kt
@@ -106,12 +106,12 @@ class TextUtilsTest {
     }
 
     @Test
-    fun canReturnNullWhenApplyPatchFails() {
+    fun shouldTryToApplyPatchEvenIfPatchIsIncorrect() {
         val inputPatch = "@@ -1,3 +1,3 @@\n first line\n-second line\n+third line\n forth line"
         val inputFilePath = "dummy.py"
         val fileContent = "first line\nThree line\nforth line"
         val actual = applyPatch(inputPatch, fileContent, inputFilePath)
-        val expected = null
+        val expected = "first line\nthird line\nThree line\nforth line"
         assertThat(actual).isEqualTo(expected)
     }
 

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/TextUtilsTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/TextUtilsTest.kt
@@ -137,4 +137,22 @@ class TextUtilsTest {
         val inputPatchLines = inputPatch.split("\n")
         hunk.lines.forEachIndexed { index, patchLine -> assertThat(inputPatchLines[index + 1].substring(1)).isEqualTo(patchLine.text) }
     }
+
+    @Test
+    fun shouldApplyPatchEvenIfNeighboringLinesDiffer() {
+        val inputPatch = "@@ -1,3 +1,3 @@\n first line\n-second line\n+third line\n forth line"
+        val inputFilePath = "dummy.py"
+        val fileContent = "foo\nsecond line\nbar"
+        val actual = applyPatch(inputPatch, fileContent, inputFilePath)
+        assertThat(actual).isEqualTo("foo\nthird line\nbar")
+    }
+
+    @Test
+    fun shouldApplyPatchEvenIfLineNumbersDiffer() {
+        val inputPatch = "@@ -1,3 +1,3 @@\n first line\n-second line\n+third line\n forth line"
+        val inputFilePath = "dummy.py"
+        val fileContent = "dummy\ndummy\ndummy\ndummy\nfirst line\nsecond line\nforth line"
+        val actual = applyPatch(inputPatch, fileContent, inputFilePath)
+        assertThat(actual).isEqualTo("dummy\ndummy\ndummy\ndummy\nfirst line\nthird line\nforth line")
+    }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

### Problem
`PlainSimplePatchApplier` is too strict and does not allow any differences in the diff patch and actual code. This is a problem because the document would likely change after a security scan, either by manual edits or by previous fixes being applied.

### Solution
Use `GenericPatchApplier.applySomehow` which 1) tries to use `PlainSimplePatchApplier` first anyways so we are not risking anything with this change and 2) is much more lenient in incorrect line numbers or differing neighboring lines from the location of the change.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
