### PR TITLE
Remove duplicated HIL ApiError metrics

### DIFF
--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/ArtifactHandler.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/ArtifactHandler.kt
@@ -33,7 +33,6 @@ import software.aws.toolkits.jetbrains.services.codemodernizer.utils.openTrouble
 import software.aws.toolkits.jetbrains.utils.notifyStickyInfo
 import software.aws.toolkits.jetbrains.utils.notifyStickyWarn
 import software.aws.toolkits.resources.message
-import software.aws.toolkits.telemetry.CodeTransformApiNames
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -90,14 +89,7 @@ class ArtifactHandler(private val project: Project, private val clientAdaptor: G
     }
 
     suspend fun downloadHilArtifact(jobId: JobId, artifactId: String, tmpDir: File): CodeTransformHilDownloadArtifact? {
-        val downloadResultsResponse = try {
-            clientAdaptor.downloadExportResultArchive(jobId, artifactId)
-        } catch (e: Exception) {
-            val errorMessage = "Unexpected error when downloading hil artifact: ${e.localizedMessage}"
-            LOG.error { errorMessage }
-            telemetry.apiError(errorMessage, CodeTransformApiNames.ExportResultArchive, jobId = jobId.id)
-            throw e
-        }
+        val downloadResultsResponse = clientAdaptor.downloadExportResultArchive(jobId, artifactId)
 
         return try {
             val tmpPath = tmpDir.toPath()

--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
@@ -270,27 +270,13 @@ class CodeModernizerSession(
 
     fun resumeTransformFromHil() {
         val clientAdaptor = GumbyClient.getInstance(sessionContext.project)
-        try {
-            clientAdaptor.resumeCodeTransformation(state.currentJobId as JobId, TransformationUserActionStatus.COMPLETED)
-        } catch (e: Exception) {
-            val errorMessage = "Unexpected error when resuming transformation: ${e.localizedMessage}"
-            LOG.error { errorMessage }
-            telemetry.apiError(errorMessage, CodeTransformApiNames.ResumeTransformation, jobId = state.currentJobId?.id)
-            throw e
-        }
+        clientAdaptor.resumeCodeTransformation(state.currentJobId as JobId, TransformationUserActionStatus.COMPLETED)
     }
 
     fun rejectHilAndContinue(): ResumeTransformationResponse {
         val clientAdaptor = GumbyClient.getInstance(sessionContext.project)
-        return try {
-            val jobId = state.currentJobId ?: throw CodeModernizerException("No Job ID found")
-            clientAdaptor.resumeCodeTransformation(jobId, TransformationUserActionStatus.REJECTED)
-        } catch (e: Exception) {
-            val errorMessage = "Unexpected error when resuming transformation: ${e.localizedMessage}"
-            LOG.error { errorMessage }
-            telemetry.apiError(errorMessage, CodeTransformApiNames.ResumeTransformation, jobId = state.currentJobId?.id)
-            throw e
-        }
+        val jobId = state.currentJobId ?: throw CodeModernizerException("No Job ID found")
+        return clientAdaptor.resumeCodeTransformation(jobId, TransformationUserActionStatus.REJECTED)
     }
 
     fun uploadHilPayload(payload: File): String {
@@ -300,14 +286,7 @@ class CodeModernizerSession(
         }
         val jobId = state.currentJobId ?: throw CodeModernizerException("No Job ID found")
         val clientAdaptor = GumbyClient.getInstance(sessionContext.project)
-        val createUploadUrlResponse = try {
-            clientAdaptor.createHilUploadUrl(sha256checksum, jobId = jobId)
-        } catch (e: Exception) {
-            val errorMessage = "Unexpected error when creating upload url for HIL: ${e.localizedMessage}"
-            LOG.error { errorMessage }
-            telemetry.apiError(errorMessage, CodeTransformApiNames.CreateUploadUrl, jobId = state.currentJobId?.id)
-            throw e
-        }
+        val createUploadUrlResponse = clientAdaptor.createHilUploadUrl(sha256checksum, jobId = jobId)
 
         LOG.info {
             "Uploading zip with checksum $sha256checksum using uploadId: ${


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
ApiError telemetry for HIL paths are being emitted twice. This PR removes the redundant logging and metric emission.
ApiError metrics are emitted uniformly for all transform API calls (except UploadZip, which does not go through CodeWhisperer client) inside GumbyClient.callApi().

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
