### PR TITLE
Amazon Q[ACR]: fixing the line number on document change

### DIFF
--- a/.changes/next-release/bugfix-6862d9d5-751a-40c6-a907-53478af6991c.json
+++ b/.changes/next-release/bugfix-6862d9d5-751a-40c6-a907-53478af6991c.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Security Scan: Improved accuracy when applying security fixes"
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
@@ -74,6 +74,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIdcConne
 import software.aws.toolkits.jetbrains.utils.isQConnected
 import software.aws.toolkits.jetbrains.utils.isQExpired
 import software.aws.toolkits.jetbrains.utils.isRunningOnRemoteBackend
+import software.aws.toolkits.jetbrains.utils.offsetSuggestedFix
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.Result
 import java.time.Duration
@@ -455,21 +456,6 @@ class CodeWhispererCodeScanManager(val project: Project) {
                 }
             }
         }
-    }
-
-    private fun offsetSuggestedFix(suggestedFix: SuggestedFix, lines: Int): SuggestedFix {
-        val updatedCode = suggestedFix.code.replace(
-            Regex("""(@@ -)(\d+)(,\d+ \+)(\d+)(,\d+ @@)""")
-        ) { result ->
-            val prefix = result.groupValues[1]
-            val startLine = result.groupValues[2].toInt() + lines
-            val middle = result.groupValues[3]
-            val endLine = result.groupValues[4].toInt() + lines
-            val suffix = result.groupValues[5]
-            "$prefix$startLine$middle$endLine$suffix"
-        }
-
-        return suggestedFix.copy(code = updatedCode)
     }
 
     fun updateScanNodesForOffSet(file: VirtualFile, lineOffset: Int, editedTextRange: TextRange) {

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
@@ -460,23 +460,23 @@ class CodeWhispererCodeScanManager(val project: Project) {
     private fun offsetSuggestedFix(suggestedFix: SuggestedFix, lines: Int): SuggestedFix {
         val updatedCode = suggestedFix.code.replace(
             Regex("""(@@ -)(\d+)(,\d+ \+)(\d+)(,\d+ @@)""")
-        ) { matchResult ->
-            val prefix = matchResult.groupValues[1]
-            val startLine = matchResult.groupValues[2].toInt() + lines
-            val middle = matchResult.groupValues[3]
-            val endLine = matchResult.groupValues[4].toInt() + lines
-            val suffix = matchResult.groupValues[5]
+        ) { result ->
+            val prefix = result.groupValues[1]
+            val startLine = result.groupValues[2].toInt() + lines
+            val middle = result.groupValues[3]
+            val endLine = result.groupValues[4].toInt() + lines
+            val suffix = result.groupValues[5]
             "$prefix$startLine$middle$endLine$suffix"
         }
 
         return suggestedFix.copy(code = updatedCode)
     }
 
-    fun updateScanNodesForOffSet(file: VirtualFile, lineOffset: Int, eventOffset: TextRange) {
+    fun updateScanNodesForOffSet(file: VirtualFile, lineOffset: Int, editedTextRange: TextRange) {
         val document = FileDocumentManager.getInstance().getDocument(file) ?: return
         scanNodesLookup[file]?.forEach { node ->
             val issue = node.userObject as CodeWhispererCodeScanIssue
-            if (document.getLineNumber(eventOffset.startOffset) <= issue.startLine) {
+            if (document.getLineNumber(editedTextRange.startOffset) <= issue.startLine) {
                 issue.startLine = issue.startLine + lineOffset
                 issue.endLine = issue.endLine + lineOffset
                 issue.suggestedFixes = issue.suggestedFixes.map { fix -> offsetSuggestedFix(fix, lineOffset) }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanDocumentListener.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanDocumentListener.kt
@@ -22,12 +22,12 @@ internal class CodeWhispererCodeScanDocumentListener(val project: Project) : Doc
         val scanManager = CodeWhispererCodeScanManager.getInstance(project)
         val treeModel = scanManager.getScanTree().model
 
-        val oldLineDeletedCount = event.oldFragment.toString().count { it == '\n' }
-        val newLineInsertedCount = event.newFragment.toString().count { it == '\n' }
+        val deletedLineCount = event.oldFragment.toString().count { it == '\n' }
+        val insertedLineCount = event.newFragment.toString().count { it == '\n' }
 
         val lineOffset = when {
-            oldLineDeletedCount == 0 && newLineInsertedCount != 0 -> newLineInsertedCount
-            oldLineDeletedCount != 0 && newLineInsertedCount == 0 -> -oldLineDeletedCount
+            deletedLineCount == 0 && insertedLineCount != 0 -> insertedLineCount
+            deletedLineCount != 0 && insertedLineCount == 0 -> -deletedLineCount
             else -> 0
         }
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/TextUtils.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/TextUtils.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.codeStyle.CodeStyleManager
+import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.SuggestedFix
 
 fun formatText(project: Project, language: Language, content: String): String {
     var result = content
@@ -41,4 +42,19 @@ fun generateUnifiedPatch(patch: String, filePath: String): TextFilePatch {
 fun applyPatch(patch: String, fileContent: String, filePath: String): String? {
     val unifiedPatch = generateUnifiedPatch(patch, filePath)
     return PlainSimplePatchApplier.apply(fileContent, unifiedPatch.hunks)
+}
+
+fun offsetSuggestedFix(suggestedFix: SuggestedFix, lines: Int): SuggestedFix {
+    val updatedCode = suggestedFix.code.replace(
+        Regex("""(@@ -)(\d+)(,\d+ \+)(\d+)(,\d+ @@)""")
+    ) { result ->
+        val prefix = result.groupValues[1]
+        val startLine = result.groupValues[2].toInt() + lines
+        val middle = result.groupValues[3]
+        val endLine = result.groupValues[4].toInt() + lines
+        val suffix = result.groupValues[5]
+        "$prefix$startLine$middle$endLine$suffix"
+    }
+
+    return suggestedFix.copy(code = updatedCode)
 }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/TextUtilsTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/TextUtilsTest.kt
@@ -8,9 +8,9 @@ import com.intellij.testFramework.ProjectRule
 import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Assert.assertEquals
 import software.aws.toolkits.core.utils.convertMarkdownToHTML
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.SuggestedFix
 
@@ -142,12 +142,6 @@ class TextUtilsTest {
 
     @Test
     fun offsetSuggestedFixUpdateLineNumbersWithInsertion() {
-        val originalCode = """
-        fun main() {
-            println("Hello, Suggested Fix is Here!")
-        }
-    """.trimIndent()
-
         val suggestedFix = SuggestedFix(
             code = """
             @@ -1,3 +1,4 @@
@@ -155,7 +149,7 @@ class TextUtilsTest {
             +    val greeting = "Hello, Suggested Fix is Here!"
                  println("Hello, Suggested Fix is Here!")
              }
-        """.trimIndent(),
+            """.trimIndent(),
             description = "Add a variable for the greeting"
         )
 
@@ -173,12 +167,6 @@ class TextUtilsTest {
 
     @Test
     fun offsetSuggestedFixUpdateMultipleLineNumbersWithInsertion() {
-        val originalCode = """
-        fun main() {
-            println("Hello, Suggested Fix is Here!")
-        }
-    """.trimIndent()
-
         val suggestedFix = SuggestedFix(
             code = """
             @@ -1,3 +1,5 @@
@@ -187,7 +175,7 @@ class TextUtilsTest {
                  println("Hello, Suggested Fix is Here!"))
             +    println("Hello, Welcome to Amazon Q")
              }
-        """.trimIndent(),
+            """.trimIndent(),
             description = "Add a variable for the greeting with multiple lines"
         )
 
@@ -206,12 +194,6 @@ class TextUtilsTest {
 
     @Test
     fun offsetSuggestedFixUpdateLineNumbersWithDeletion() {
-        val originalCode = """
-        fun main() {
-            println("Hello, Suggested Fix is Here!")
-        }
-    """.trimIndent()
-
         val suggestedFix = SuggestedFix(
             code = """
             @@ -24,3 +24,4 @@
@@ -219,7 +201,7 @@ class TextUtilsTest {
             +    val greeting = "Hello, Suggested Fix is Here!"
                  println("Hello, Suggested Fix is Here!")
              }
-        """.trimIndent(),
+            """.trimIndent(),
             description = "Add a variable for the greeting"
         )
 
@@ -237,12 +219,6 @@ class TextUtilsTest {
 
     @Test
     fun offsetSuggestedFixUpdateMultipleLineNumbersWithDeletion() {
-        val originalCode = """
-        fun main() {
-            println("Hello, Suggested Fix is Here!")
-        }
-    """.trimIndent()
-
         val suggestedFix = SuggestedFix(
             code = """
             @@ -10,3 +10,5 @@
@@ -251,7 +227,7 @@ class TextUtilsTest {
                  println("Hello, Suggested Fix is Here!"))
             +    println("Hello, Welcome to Amazon Q")
              }
-        """.trimIndent(),
+            """.trimIndent(),
             description = "Add a variable for the greeting with multiple lines"
         )
 
@@ -267,5 +243,4 @@ class TextUtilsTest {
         val result = offsetSuggestedFix(suggestedFix, -2)
         assertEquals(expectedCode, result.code)
     }
-
 }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/TextUtilsTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/TextUtilsTest.kt
@@ -144,7 +144,7 @@ class TextUtilsTest {
     fun offsetSuggestedFixUpdateLineNumbersWithInsertion() {
         val originalCode = """
         fun main() {
-            println("Hello, World!")
+            println("Hello, Suggested Fix is Here!")
         }
     """.trimIndent()
 
@@ -152,8 +152,8 @@ class TextUtilsTest {
             code = """
             @@ -1,3 +1,4 @@
              fun main() {
-            +    val greeting = "Hello, World!"
-                 println("Hello, World!")
+            +    val greeting = "Hello, Suggested Fix is Here!"
+                 println("Hello, Suggested Fix is Here!")
              }
         """.trimIndent(),
             description = "Add a variable for the greeting"
@@ -162,8 +162,8 @@ class TextUtilsTest {
         val expectedCode = """
             @@ -2,3 +2,4 @@
              fun main() {
-            +    val greeting = "Hello, World!"
-                 println("Hello, World!")
+            +    val greeting = "Hello, Suggested Fix is Here!"
+                 println("Hello, Suggested Fix is Here!")
              }
         """.trimIndent()
 
@@ -175,7 +175,7 @@ class TextUtilsTest {
     fun offsetSuggestedFixUpdateMultipleLineNumbersWithInsertion() {
         val originalCode = """
         fun main() {
-            println("Hello, World!")
+            println("Hello, Suggested Fix is Here!")
         }
     """.trimIndent()
 
@@ -183,20 +183,20 @@ class TextUtilsTest {
             code = """
             @@ -1,3 +1,5 @@
              fun main() {
-            +    val greeting = "Hello, World!"
-                 println("Hello, World!")
-            +    println("Goodbye, World!")
+            +    val greeting = "Hello, Suggested Fix is Here!"
+                 println("Hello, Suggested Fix is Here!"))
+            +    println("Hello, Welcome to Amazon Q")
              }
         """.trimIndent(),
-            description = "Add a variable for the greeting and a goodbye message"
+            description = "Add a variable for the greeting with multiple lines"
         )
 
         val expectedCode = """
             @@ -4,3 +4,5 @@
              fun main() {
-            +    val greeting = "Hello, World!"
-                 println("Hello, World!")
-            +    println("Goodbye, World!")
+            +    val greeting = "Hello, Suggested Fix is Here!"
+                 println("Hello, Suggested Fix is Here!"))
+            +    println("Hello, Welcome to Amazon Q")
              }
         """.trimIndent()
 
@@ -208,7 +208,7 @@ class TextUtilsTest {
     fun offsetSuggestedFixUpdateLineNumbersWithDeletion() {
         val originalCode = """
         fun main() {
-            println("Hello, World!")
+            println("Hello, Suggested Fix is Here!")
         }
     """.trimIndent()
 
@@ -216,8 +216,8 @@ class TextUtilsTest {
             code = """
             @@ -24,3 +24,4 @@
              fun main() {
-            +    val greeting = "Hello, World!"
-                 println("Hello, World!")
+            +    val greeting = "Hello, Suggested Fix is Here!"
+                 println("Hello, Suggested Fix is Here!")
              }
         """.trimIndent(),
             description = "Add a variable for the greeting"
@@ -226,8 +226,8 @@ class TextUtilsTest {
         val expectedCode = """
             @@ -19,3 +19,4 @@
              fun main() {
-            +    val greeting = "Hello, World!"
-                 println("Hello, World!")
+            +    val greeting = "Hello, Suggested Fix is Here!"
+                 println("Hello, Suggested Fix is Here!")
              }
         """.trimIndent()
 
@@ -239,7 +239,7 @@ class TextUtilsTest {
     fun offsetSuggestedFixUpdateMultipleLineNumbersWithDeletion() {
         val originalCode = """
         fun main() {
-            println("Hello, World!")
+            println("Hello, Suggested Fix is Here!")
         }
     """.trimIndent()
 
@@ -247,20 +247,20 @@ class TextUtilsTest {
             code = """
             @@ -10,3 +10,5 @@
              fun main() {
-            +    val greeting = "Hello, World!"
-                 println("Hello, World!")
-            +    println("Goodbye, World!")
+            +    val greeting = "Hello, Suggested Fix is Here!"
+                 println("Hello, Suggested Fix is Here!"))
+            +    println("Hello, Welcome to Amazon Q")
              }
         """.trimIndent(),
-            description = "Add a variable for the greeting and a goodbye message"
+            description = "Add a variable for the greeting with multiple lines"
         )
 
         val expectedCode = """
             @@ -8,3 +8,5 @@
              fun main() {
-            +    val greeting = "Hello, World!"
-                 println("Hello, World!")
-            +    println("Goodbye, World!")
+            +    val greeting = "Hello, Suggested Fix is Here!"
+                 println("Hello, Suggested Fix is Here!"))
+            +    println("Hello, Welcome to Amazon Q")
              }
         """.trimIndent()
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Problem

1. Line numbers of suggested fixes can be out of sync if the document changes.
2. Line offset calculation is incorrect in some cases.
3. Document listener is triggered multiple times for a single character change.

## Solution

1. Add line offset to suggested fix code during document changes using regex replace
2. Removing redundant document listener as this is triggering the documentChange multiple times.


## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
