### PR TITLE
fix(amazonq): fix issue underline peristing after apply fix

### DIFF
--- a/.changes/next-release/bugfix-ab6b33d4-cd91-4add-a0fb-d3aaa27cbca0.json
+++ b/.changes/next-release/bugfix-ab6b33d4-cd91-4add-a0fb-d3aaa27cbca0.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Security Scan: Fixes inconsistent behavior with how security issues are underlined in the editor."
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
@@ -412,29 +412,8 @@ class CodeWhispererCodeScanManager(val project: Project) {
     fun getOverlappingScanNodes(file: VirtualFile, range: TextRange): List<DefaultMutableTreeNode> = synchronized(scanNodesLookup) {
         scanNodesLookup[file]?.mapNotNull { node ->
             val issue = node.userObject as CodeWhispererCodeScanIssue
-            if (issue.textRange?.overlaps(range) == true) node else null
+            if (issue.textRange?.overlaps(range) == true && !issue.isInvalid) node else null
         } ?: listOf()
-    }
-
-    fun updateScanNodesForIssuesOutOfTextRange(fixedIssue: CodeWhispererCodeScanIssue) {
-        val nodes = fixedIssue.textRange?.let { getOverlappingScanNodes(fixedIssue.file, it) }
-        val treeModel = getScanTree().model
-        var fixedNodes = 0
-        val overlappingNodes = nodes?.size
-        nodes?.forEach {
-            val issue = it.userObject as CodeWhispererCodeScanIssue
-            if (issue == fixedIssue) {
-                synchronized(it) {
-                    treeModel.valueForPathChanged(TreePath(it.path), issue.copy(isInvalid = true))
-                }
-                fixedNodes++
-            }
-            if (fixedNodes == overlappingNodes) {
-                issue.rangeHighlighter?.dispose()
-                issue.rangeHighlighter?.textAttributes = null
-            }
-        }
-        updateScanNodes(fixedIssue.file)
     }
 
     fun getScanTree(): Tree = codeScanResultsPanel.getCodeScanTree()
@@ -599,6 +578,12 @@ class CodeWhispererCodeScanManager(val project: Project) {
                 node
             }
         }
+        // Remove the underline for old issues
+        scanNodesLookup[file]?.forEach { node ->
+            val issue = node.userObject as CodeWhispererCodeScanIssue
+            issue.rangeHighlighter?.textAttributes = null
+            issue.rangeHighlighter?.dispose()
+        }
         // Remove the old scan nodes from the file node.
         synchronized(fileNode) {
             fileNode.removeAllChildren()
@@ -625,6 +610,32 @@ class CodeWhispererCodeScanManager(val project: Project) {
         }
 
         return codeScanTreeNodeRoot
+    }
+
+    fun removeIssueByFindingId(file: VirtualFile, findingId: String) {
+        scanNodesLookup[file]?.forEach { node ->
+            val issue = node.userObject as CodeWhispererCodeScanIssue
+            if (issue.findingId == findingId) {
+                issue.rangeHighlighter?.textAttributes = null
+                issue.rangeHighlighter?.dispose()
+                node.removeFromParent()
+            }
+        }
+        fileNodeLookup[file]?.let {
+            if (it.childCount == 0) {
+                it.removeFromParent()
+                fileNodeLookup.remove(file)
+            }
+        }
+        val codeScanTreeModel = CodeWhispererCodeScanTreeModel(codeScanTreeNodeRoot)
+        val totalIssuesCount = codeScanTreeModel.getTotalIssuesCount()
+        if (totalIssuesCount > 0) {
+            codeScanIssuesContent.displayName =
+                message("codewhisperer.codescan.scan_display_with_issues", totalIssuesCount, INACTIVE_TEXT_COLOR)
+        } else {
+            codeScanIssuesContent.displayName = message("codewhisperer.codescan.scan_display")
+        }
+        codeScanResultsPanel.refreshUIWithUpdatedModel(codeScanTreeModel)
     }
 
     suspend fun renderResponseOnUIThread(

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanResultsView.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanResultsView.kt
@@ -145,6 +145,13 @@ internal class CodeWhispererCodeScanResultsView(private val project: Project) : 
         }
     }
 
+    fun refreshUIWithUpdatedModel(scanTreeModel: CodeWhispererCodeScanTreeModel) {
+        codeScanTree.apply {
+            model = scanTreeModel
+            repaint()
+        }
+    }
+
     fun setStoppingCodeScan() {
         completeInfoLabel.isVisible = false
         stopCodeScanButton.isVisible = false

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanDocumentListener.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanDocumentListener.kt
@@ -29,8 +29,8 @@ internal class CodeWhispererCodeScanDocumentListener(val project: Project) : Doc
             synchronized(it) {
                 treeModel.valueForPathChanged(TreePath(it.path), issue.copy(isInvalid = true))
             }
-            issue.rangeHighlighter?.dispose()
             issue.rangeHighlighter?.textAttributes = null
+            issue.rangeHighlighter?.dispose()
         }
         scanManager.updateScanNodes(file)
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
@@ -35,6 +35,7 @@ import software.aws.toolkits.jetbrains.ToolkitPlaces
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.CodeWhispererCodeScanIssue
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.CodeWhispererCodeScanManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererClientAdaptor
+import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhispererProgrammingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.programmingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
@@ -403,7 +404,9 @@ class CodeWhispererCodeScanEditorMouseMotionListener(private val project: Projec
                 PsiDocumentManager.getInstance(issue.project).commitDocument(document)
                 CodeWhispererTelemetryService.getInstance().sendCodeScanIssueApplyFixEvent(issue, Result.Succeeded)
                 hidePopup()
-                CodeWhispererCodeScanManager.getInstance(issue.project).updateScanNodesForIssuesOutOfTextRange(issue)
+                if (CodeWhispererExplorerActionManager.getInstance().isAutoEnabledForCodeScan()) {
+                    CodeWhispererCodeScanManager.getInstance(issue.project).removeIssueByFindingId(issue.file, issue.findingId)
+                }
             }
             sendCodeRemediationTelemetryToServiceApi(
                 issue.file.programmingLanguage(),


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
### Problem
1. After auto-scan rescans, the yellow underline is not removed even if the issue node is removed.
2. Sometimes yellow underline is not removed when modifying the text range that overlaps with the issue.
3. After the apply fix action, the issue that was fixed should be immediately removed (if auto-scanning is enabled).

### Solution
1. For each auto-scan render, always remove all underlines by clearing the rangeHighlighter
2. Switch the order so that text attributes are unset before disposing the rangeHighlighter.
3. Add a method to remove an issue node by findingId and refresh the UI

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
