### PR TITLE
Fix to trigger scans for only active editor text change.

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
@@ -387,7 +387,6 @@ class CodeWhispererCodeScanManager(val project: Project) {
      */
     fun addCodeScanUI(setSelected: Boolean = false) = runInEdt {
         reset()
-        EditorFactory.getInstance().eventMulticaster.addDocumentListener(documentListener, project)
         val problemsWindow = getProblemsWindow()
         if (!problemsWindow.contentManager.contents.contains(codeScanIssuesContent)) {
             problemsWindow.contentManager.addContent(codeScanIssuesContent)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanFileListener.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanFileListener.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.services.codewhisperer.codescan.listener
 import com.intellij.openapi.editor.event.EditorFactoryEvent
 import com.intellij.openapi.editor.event.EditorFactoryListener
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.isFile
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.CodeWhispererCodeScanManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isUserBuilderId
@@ -13,7 +14,10 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 
 internal class CodeWhispererCodeScanFileListener(val project: Project) : EditorFactoryListener {
     override fun editorCreated(event: EditorFactoryEvent) {
-        if (!CodeWhispererExplorerActionManager.getInstance().isMonthlyQuotaForCodeScansExceeded() && !isUserBuilderId(project)) {
+        val actionManager = CodeWhispererExplorerActionManager.getInstance()
+        if (event.editor.virtualFile.isFile && actionManager.isAutoEnabledForCodeScan() &&
+            !actionManager.isMonthlyQuotaForCodeScansExceeded() && !isUserBuilderId(project)
+        ) {
             CodeWhispererCodeScanManager.getInstance(project).createDebouncedRunCodeScan(CodeWhispererConstants.CodeAnalysisScope.FILE)
         }
     }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/actions/ResumeCodeScans.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/actions/ResumeCodeScans.kt
@@ -22,7 +22,7 @@ class ResumeCodeScans : DumbAwareAction(
         val actionManager = CodeWhispererExplorerActionManager.getInstance()
         actionManager.setAutoCodeScan(project, true)
         //  Run Proactive Code File Scan once toggle is enabled
-        if (!actionManager.isMonthlyQuotaForCodeScansExceeded() && !isUserBuilderId(project)) {
+        if (actionManager.isAutoEnabledForCodeScan() && !actionManager.isMonthlyQuotaForCodeScansExceeded() && !isUserBuilderId(project)) {
             CodeWhispererCodeScanManager.getInstance(project).createDebouncedRunCodeScan(CodeWhispererConstants.CodeAnalysisScope.FILE)
         }
     }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/nodes/ResumeCodeScanNode.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/codewhisperer/explorer/nodes/ResumeCodeScanNode.kt
@@ -24,7 +24,7 @@ class ResumeCodeScanNode(nodeProject: Project) : CodeWhispererActionNode(
         actionManager.setAutoCodeScan(project, true)
 
         //  Run Proactive Code File Scan once toggle is enabled
-        if (!actionManager.isMonthlyQuotaForCodeScansExceeded() && !isUserBuilderId(project)) {
+        if (actionManager.isAutoEnabledForCodeScan() && !actionManager.isMonthlyQuotaForCodeScansExceeded() && !isUserBuilderId(project)) {
             CodeWhispererCodeScanManager.getInstance(project).createDebouncedRunCodeScan(CodeWhispererConstants.CodeAnalysisScope.FILE)
         }
     }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Problem: we are seeing consistent throttling for file scans on service side on JetBrains plugin. This is due to sensitivity of text change and also scans being triggered for all editors instead of active editor.

Solution: Adding check for active editor and triggering scans only after user stops typing for a second.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
