### PR TITLE
Properly resolve plugin in worker thread tasks

### DIFF
--- a/.changes/next-release/bugfix-157ef077-cf07-42c8-99f7-1412ee28ce2b.json
+++ b/.changes/next-release/bugfix-157ef077-cf07-42c8-99f7-1412ee28ce2b.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix an issue where worker threads are unable to properly resolve the calling plugin, resulting in invalid telemetry data"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -37,6 +36,7 @@ import software.aws.toolkits.jetbrains.core.webview.LoginBrowser
 import software.aws.toolkits.jetbrains.core.webview.WebviewResourceHandlerFactory
 import software.aws.toolkits.jetbrains.isDeveloperMode
 import software.aws.toolkits.jetbrains.services.amazonq.util.createBrowser
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.isQConnected
 import software.aws.toolkits.jetbrains.utils.isQExpired
 import software.aws.toolkits.telemetry.FeatureId
@@ -164,7 +164,7 @@ class QWebviewBrowser(val project: Project, private val parentDisposable: Dispos
             "reauth" -> {
                 ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())?.let { conn ->
                     if (conn is ManagedBearerSsoConnection) {
-                        ApplicationManager.getApplication().executeOnPooledThread {
+                        executeOnPooledThreadWithParentContext {
                             reauthConnectionIfNeeded(project, conn, onPendingToken)
                         }
                     }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
@@ -36,9 +36,9 @@ import software.aws.toolkits.jetbrains.core.webview.LoginBrowser
 import software.aws.toolkits.jetbrains.core.webview.WebviewResourceHandlerFactory
 import software.aws.toolkits.jetbrains.isDeveloperMode
 import software.aws.toolkits.jetbrains.services.amazonq.util.createBrowser
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.isQConnected
 import software.aws.toolkits.jetbrains.utils.isQExpired
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.telemetry.FeatureId
 import software.aws.toolkits.telemetry.WebviewTelemetry
 import java.awt.event.ActionListener
@@ -164,7 +164,7 @@ class QWebviewBrowser(val project: Project, private val parentDisposable: Dispos
             "reauth" -> {
                 ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())?.let { conn ->
                     if (conn is ManagedBearerSsoConnection) {
-                        executeOnPooledThreadWithParentContext {
+                        pluginAwareExecuteOnPooledThread {
                             reauthConnectionIfNeeded(project, conn, onPendingToken)
                         }
                     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
@@ -43,8 +43,8 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.CODE_SCAN_ISSUE_TITLE_MAX_LENGTH
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIdcConnectionOrTelemetryEnabled
 import software.aws.toolkits.jetbrains.utils.applyPatch
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyError
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.Result
 import java.awt.Dimension
@@ -330,7 +330,7 @@ class CodeWhispererCodeScanEditorMouseMotionListener(private val project: Projec
         includesFix: Boolean?
     ) {
         runIfIdcConnectionOrTelemetryEnabled(project) {
-            executeOnPooledThreadWithParentContext {
+            pluginAwareExecuteOnPooledThread {
                 try {
                     val response = CodeWhispererClientAdaptor.getInstance(project)
                         .sendCodeScanRemediationTelemetry(

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataKey
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.openapi.editor.event.EditorMouseEventArea
@@ -44,6 +43,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.CODE_SCAN_ISSUE_TITLE_MAX_LENGTH
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIdcConnectionOrTelemetryEnabled
 import software.aws.toolkits.jetbrains.utils.applyPatch
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.Result
@@ -330,7 +330,7 @@ class CodeWhispererCodeScanEditorMouseMotionListener(private val project: Projec
         includesFix: Boolean?
     ) {
         runIfIdcConnectionOrTelemetryEnabled(project) {
-            ApplicationManager.getApplication().executeOnPooledThread {
+            executeOnPooledThreadWithParentContext {
                 try {
                     val response = CodeWhispererClientAdaptor.getInstance(project)
                         .sendCodeScanRemediationTelemetry(

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.kt
@@ -24,6 +24,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWh
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererFeatureConfigService
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.calculateIfIamIdentityCenterConnection
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyInfo
 import software.aws.toolkits.jetbrains.utils.notifyWarn
 import software.aws.toolkits.resources.message
@@ -206,7 +207,7 @@ class DefaultCodeWhispererModelConfigurator : CodeWhispererModelConfigurator, Pe
                 true -> true
 
                 null -> run {
-                    ApplicationManager.getApplication().executeOnPooledThread {
+                    executeOnPooledThreadWithParentContext {
                         listCustomizations(project, passive = true)
                     }
 
@@ -215,7 +216,7 @@ class DefaultCodeWhispererModelConfigurator : CodeWhispererModelConfigurator, Pe
 
                 false -> run {
                     if (forceUpdate) {
-                        ApplicationManager.getApplication().executeOnPooledThread {
+                        executeOnPooledThreadWithParentContext {
                             listCustomizations(project, passive = true)
                         }
                     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.kt
@@ -24,9 +24,9 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWh
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererFeatureConfigService
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.calculateIfIamIdentityCenterConnection
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyInfo
 import software.aws.toolkits.jetbrains.utils.notifyWarn
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicBoolean
@@ -207,7 +207,7 @@ class DefaultCodeWhispererModelConfigurator : CodeWhispererModelConfigurator, Pe
                 true -> true
 
                 null -> run {
-                    executeOnPooledThreadWithParentContext {
+                    pluginAwareExecuteOnPooledThread {
                         listCustomizations(project, passive = true)
                     }
 
@@ -216,7 +216,7 @@ class DefaultCodeWhispererModelConfigurator : CodeWhispererModelConfigurator, Pe
 
                 false -> run {
                     if (forceUpdate) {
-                        executeOnPooledThreadWithParentContext {
+                        pluginAwareExecuteOnPooledThread {
                             listCustomizations(project, passive = true)
                         }
                     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.shouldSkipInvokingBasedOnRightContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutoTriggerService
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutomatedTriggerType
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 
 class CodeWhispererEnterHandler(private val originalHandler: EditorActionHandler) : EnterHandler(originalHandler) {
     override fun executeWriteAction(editor: Editor, caret: Caret?, dataContext: DataContext?) {
@@ -21,7 +21,7 @@ class CodeWhispererEnterHandler(private val originalHandler: EditorActionHandler
             return
         }
 
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             CodeWhispererAutoTriggerService.getInstance().tryInvokeAutoTrigger(editor, CodeWhispererAutomatedTriggerType.Enter())
         }
     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEnterHandler.kt
@@ -5,13 +5,13 @@ package software.aws.toolkits.jetbrains.services.codewhisperer.editor
 
 import com.intellij.codeInsight.editorActions.EnterHandler
 import com.intellij.openapi.actionSystem.DataContext
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.shouldSkipInvokingBasedOnRightContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutoTriggerService
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutomatedTriggerType
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 
 class CodeWhispererEnterHandler(private val originalHandler: EditorActionHandler) : EnterHandler(originalHandler) {
     override fun executeWriteAction(editor: Editor, caret: Caret?, dataContext: DataContext?) {
@@ -21,7 +21,7 @@ class CodeWhispererEnterHandler(private val originalHandler: EditorActionHandler
             return
         }
 
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             CodeWhispererAutoTriggerService.getInstance().tryInvokeAutoTrigger(editor, CodeWhispererAutomatedTriggerType.Enter())
         }
     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -78,11 +78,11 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CrossFileStrategy
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.FileContextProvider
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.UtgStrategy
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.isInjectedText
 import software.aws.toolkits.jetbrains.utils.isQExpired
 import software.aws.toolkits.jetbrains.utils.isRunningOnCWNotSupportedRemoteBackend
 import software.aws.toolkits.jetbrains.utils.notifyWarn
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CodewhispererCompletionType
 import software.aws.toolkits.telemetry.CodewhispererSuggestionState
@@ -111,7 +111,7 @@ class CodeWhispererService {
         if (isQExpired(project)) {
             // say the connection is un-refreshable if refresh fails for 3 times
             val shouldReauth = if (refreshFailure < MAX_REFRESH_ATTEMPT) {
-                executeOnPooledThreadWithParentContext {
+                pluginAwareExecuteOnPooledThread {
                     promptReAuth(project)
                 }.get().also { success ->
                     if (!success) {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -78,6 +78,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CrossFileStrategy
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.FileContextProvider
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.UtgStrategy
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.isInjectedText
 import software.aws.toolkits.jetbrains.utils.isQExpired
 import software.aws.toolkits.jetbrains.utils.isRunningOnCWNotSupportedRemoteBackend
@@ -110,7 +111,7 @@ class CodeWhispererService {
         if (isQExpired(project)) {
             // say the connection is un-refreshable if refresh fails for 3 times
             val shouldReauth = if (refreshFailure < MAX_REFRESH_ATTEMPT) {
-                ApplicationManager.getApplication().executeOnPooledThread<Boolean> {
+                executeOnPooledThreadWithParentContext {
                     promptReAuth(project)
                 }.get().also { success ->
                     if (!success) {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
@@ -21,11 +21,11 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.FEATURE_CONFIG_POLL_INTERVAL_IN_MS
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.promptReAuth
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.calculateIfIamIdentityCenterConnection
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.isQConnected
 import software.aws.toolkits.jetbrains.utils.isQExpired
 import software.aws.toolkits.jetbrains.utils.isRunningOnCWNotSupportedRemoteBackend
 import software.aws.toolkits.jetbrains.utils.notifyWarn
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 
 // TODO: add logics to check if we want to remove recommendation suspension date when user open the IDE
@@ -66,7 +66,7 @@ class CodeWhispererProjectStartupActivity : StartupActivity.DumbAware {
         initFeatureConfigPollingJob(project)
 
         calculateIfIamIdentityCenterConnection(project) {
-            executeOnPooledThreadWithParentContext {
+            pluginAwareExecuteOnPooledThread {
                 CodeWhispererModelConfigurator.getInstance().listCustomizations(project, passive = true)
             }
         }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.codewhisperer.startup
 
 import com.intellij.codeInsight.lookup.LookupManagerListener
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
 import kotlinx.coroutines.delay
@@ -22,6 +21,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.FEATURE_CONFIG_POLL_INTERVAL_IN_MS
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.promptReAuth
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.calculateIfIamIdentityCenterConnection
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.isQConnected
 import software.aws.toolkits.jetbrains.utils.isQExpired
 import software.aws.toolkits.jetbrains.utils.isRunningOnCWNotSupportedRemoteBackend
@@ -66,7 +66,7 @@ class CodeWhispererProjectStartupActivity : StartupActivity.DumbAware {
         initFeatureConfigPollingJob(project)
 
         calculateIfIamIdentityCenterConnection(project) {
-            ApplicationManager.getApplication().executeOnPooledThread {
+            executeOnPooledThreadWithParentContext {
                 CodeWhispererModelConfigurator.getInstance().listCustomizations(project, passive = true)
             }
         }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -33,6 +33,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.model.Chunk
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.isTelemetryEnabled
 import software.aws.toolkits.jetbrains.settings.AwsSettings
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.isQExpired
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.message
@@ -239,7 +240,7 @@ object CodeWhispererUtil {
     fun reconnectCodeWhisperer(project: Project) {
         val connection = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeWhispererConnection.getInstance())
         if (connection !is ManagedBearerSsoConnection) return
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             reauthConnectionIfNeeded(project, connection)
         }
     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -33,9 +33,9 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.model.Chunk
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.isTelemetryEnabled
 import software.aws.toolkits.jetbrains.settings.AwsSettings
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.isQExpired
 import software.aws.toolkits.jetbrains.utils.notifyError
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CodewhispererCompletionType
 import software.aws.toolkits.telemetry.CodewhispererGettingStartedTask
@@ -240,7 +240,7 @@ object CodeWhispererUtil {
     fun reconnectCodeWhisperer(project: Project) {
         val connection = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeWhispererConnection.getInstance())
         if (connection !is ManagedBearerSsoConnection) return
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             reauthConnectionIfNeeded(project, connection)
         }
     }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
@@ -30,6 +30,7 @@ import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.getConnectionSettingsOrThrow
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -212,7 +213,7 @@ class DefaultAwsResourceCache(
     }
 
     private fun <T> getCachedResource(context: Context<T>) {
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             var currentValue: Entry<T>? = null
             try {
                 @Suppress("UNCHECKED_CAST")

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/AwsResourceCache.kt
@@ -30,7 +30,7 @@ import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.getConnectionSettingsOrThrow
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -213,7 +213,7 @@ class DefaultAwsResourceCache(
     }
 
     private fun <T> getCachedResource(context: Context<T>) {
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             var currentValue: Entry<T>? = null
             try {
                 @Suppress("UNCHECKED_CAST")

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/DefaultRemoteResourceResolverProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/DefaultRemoteResourceResolverProvider.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.application.PathManager
 import com.intellij.util.io.createDirectories
 import software.aws.toolkits.core.utils.DefaultRemoteResourceResolver
 import software.aws.toolkits.core.utils.UrlFetcher
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CompletableFuture
@@ -23,7 +23,7 @@ class DefaultRemoteResourceResolverProvider : RemoteResourceResolverProvider {
 
             DefaultRemoteResourceResolver(HttpRequestUrlFetcher, cachePath) {
                 val future = CompletableFuture<Path>()
-                executeOnPooledThreadWithParentContext {
+                pluginAwareExecuteOnPooledThread {
                     try {
                         future.complete(it.call())
                     } catch (e: Exception) {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/DefaultRemoteResourceResolverProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/DefaultRemoteResourceResolverProvider.kt
@@ -3,11 +3,11 @@
 
 package software.aws.toolkits.jetbrains.core
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.util.io.createDirectories
 import software.aws.toolkits.core.utils.DefaultRemoteResourceResolver
 import software.aws.toolkits.core.utils.UrlFetcher
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CompletableFuture
@@ -23,7 +23,7 @@ class DefaultRemoteResourceResolverProvider : RemoteResourceResolverProvider {
 
             DefaultRemoteResourceResolver(HttpRequestUrlFetcher, cachePath) {
                 val future = CompletableFuture<Path>()
-                ApplicationManager.getApplication().executeOnPooledThread {
+                executeOnPooledThreadWithParentContext {
                     try {
                         future.complete(it.call())
                     } catch (e: Exception) {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
@@ -27,7 +27,7 @@ import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.services.sts.StsResources
 import software.aws.toolkits.jetbrains.utils.MRUList
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
 import java.util.concurrent.atomic.AtomicReference
@@ -169,15 +169,15 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
 
     private fun validateCredentials(credentialsIdentifier: CredentialIdentifier?, region: AwsRegion?, isInitial: Boolean): AsyncPromise<ConnectionState> {
         val promise = AsyncPromise<ConnectionState>()
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             if (credentialsIdentifier == null || region == null) {
                 promise.setResult(ConnectionState.IncompleteConfiguration(credentialsIdentifier, region))
-                return@executeOnPooledThreadWithParentContext
+                return@pluginAwareExecuteOnPooledThread
             }
 
             if (isInitial && credentialsIdentifier is InteractiveCredential && credentialsIdentifier.userActionRequired()) {
                 promise.setResult(ConnectionState.RequiresUserAction(credentialsIdentifier))
-                return@executeOnPooledThreadWithParentContext
+                return@pluginAwareExecuteOnPooledThread
             }
 
             var success = true

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/AwsConnectionManager.kt
@@ -27,6 +27,7 @@ import software.aws.toolkits.jetbrains.core.AwsResourceCache
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.services.sts.StsResources
 import software.aws.toolkits.jetbrains.utils.MRUList
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
 import java.util.concurrent.atomic.AtomicReference
@@ -168,15 +169,15 @@ abstract class AwsConnectionManager(private val project: Project) : SimpleModifi
 
     private fun validateCredentials(credentialsIdentifier: CredentialIdentifier?, region: AwsRegion?, isInitial: Boolean): AsyncPromise<ConnectionState> {
         val promise = AsyncPromise<ConnectionState>()
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             if (credentialsIdentifier == null || region == null) {
                 promise.setResult(ConnectionState.IncompleteConfiguration(credentialsIdentifier, region))
-                return@executeOnPooledThread
+                return@executeOnPooledThreadWithParentContext
             }
 
             if (isInitial && credentialsIdentifier is InteractiveCredential && credentialsIdentifier.userActionRequired()) {
                 promise.setResult(ConnectionState.RequiresUserAction(credentialsIdentifier))
-                return@executeOnPooledThread
+                return@executeOnPooledThreadWithParentContext
             }
 
             var success = true

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.core.credentials.profiles
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.AsyncFileListener
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -16,6 +15,7 @@ import software.amazon.awssdk.profiles.ProfileFileLocation
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import java.nio.file.Paths
 
 typealias ProfileWatcher = migration.software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileWatcher
@@ -62,7 +62,7 @@ class DefaultProfileWatcher : AsyncFileListener, Disposable, ProfileWatcher {
             object : AsyncFileListener.ChangeApplier {
                 override fun afterVfsChange() {
                     // Off load this, since this is called under a write lock
-                    ApplicationManager.getApplication().executeOnPooledThread {
+                    executeOnPooledThreadWithParentContext {
                         listeners.forEach { it() }
                     }
                 }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/profiles/ProfileWatcher.kt
@@ -15,7 +15,7 @@ import software.amazon.awssdk.profiles.ProfileFileLocation
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import java.nio.file.Paths
 
 typealias ProfileWatcher = migration.software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileWatcher
@@ -62,7 +62,7 @@ class DefaultProfileWatcher : AsyncFileListener, Disposable, ProfileWatcher {
             object : AsyncFileListener.ChangeApplier {
                 override fun afterVfsChange() {
                     // Off load this, since this is called under a write lock
-                    executeOnPooledThreadWithParentContext {
+                    pluginAwareExecuteOnPooledThread {
                         listeners.forEach { it() }
                     }
                 }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
@@ -22,7 +22,7 @@ import software.aws.toolkits.jetbrains.core.gettingstarted.editor.getEnabledConn
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.getSourceOfEntry
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.getStartupState
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AuthTelemetry
 import software.aws.toolkits.telemetry.FeatureId
@@ -224,7 +224,7 @@ fun requestCredentialsForQ(
 fun reauthenticateWithQ(project: Project) {
     val connection = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())
     if (connection !is ManagedBearerSsoConnection) return
-    executeOnPooledThreadWithParentContext {
+    pluginAwareExecuteOnPooledThread {
         reauthConnectionIfNeeded(project, connection)
     }
 }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.core.gettingstarted
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefApp
 import software.aws.toolkits.core.utils.tryOrNull
@@ -23,6 +22,7 @@ import software.aws.toolkits.jetbrains.core.gettingstarted.editor.getEnabledConn
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.getSourceOfEntry
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.getStartupState
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AuthTelemetry
 import software.aws.toolkits.telemetry.FeatureId
@@ -224,7 +224,7 @@ fun requestCredentialsForQ(
 fun reauthenticateWithQ(project: Project) {
     val connection = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())
     if (connection !is ManagedBearerSsoConnection) return
-    ApplicationManager.getApplication().executeOnPooledThread {
+    executeOnPooledThreadWithParentContext {
         reauthConnectionIfNeeded(project, connection)
     }
 }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -181,8 +181,8 @@ abstract class LoginBrowser(
         }
     }
 
-    protected fun <T> loginWithBackgroundContext(action: () -> T): Future<T> {
-        return executeOnPooledThreadWithParentContext {
+    protected fun <T> loginWithBackgroundContext(action: () -> T): Future<T> =
+        executeOnPooledThreadWithParentContext {
             runBlocking {
                 withBackgroundProgress(project, message("credentials.pending.title")) {
                     blockingContext {
@@ -191,7 +191,6 @@ abstract class LoginBrowser(
                 }
             }
         }
-    }
 
     abstract fun loadWebView(query: JBCefJSQuery)
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -27,7 +27,7 @@ import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
 import software.aws.toolkits.jetbrains.core.credentials.sso.PendingAuthorization
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider
 import software.aws.toolkits.jetbrains.core.credentials.ssoErrorMessageFromException
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.jetbrains.utils.pollFor
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AuthTelemetry
@@ -182,7 +182,7 @@ abstract class LoginBrowser(
     }
 
     protected fun <T> loginWithBackgroundContext(action: () -> T): Future<T> =
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             runBlocking {
                 withBackgroundProgress(project, message("credentials.pending.title")) {
                     blockingContext {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.core.webview
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.blockingContext
@@ -28,6 +27,7 @@ import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
 import software.aws.toolkits.jetbrains.core.credentials.sso.PendingAuthorization
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider
 import software.aws.toolkits.jetbrains.core.credentials.ssoErrorMessageFromException
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.pollFor
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AuthTelemetry
@@ -181,8 +181,8 @@ abstract class LoginBrowser(
         }
     }
 
-    protected fun <T> loginWithBackgroundContext(action: () -> T): Future<T> =
-        ApplicationManager.getApplication().executeOnPooledThread<T> {
+    protected fun <T> loginWithBackgroundContext(action: () -> T): Future<T> {
+        return executeOnPooledThreadWithParentContext {
             runBlocking {
                 withBackgroundProgress(project, message("credentials.pending.title")) {
                     blockingContext {
@@ -191,6 +191,7 @@ abstract class LoginBrowser(
                 }
             }
         }
+    }
 
     abstract fun loadWebView(query: JBCefJSQuery)
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/PluginResolver.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/PluginResolver.kt
@@ -18,25 +18,23 @@ class PluginResolver private constructor(callerStackTrace: Array<StackTraceEleme
             .firstNotNullOfOrNull { PluginManagerCore.getPluginDescriptorOrPlatformByClassName(it.className) }
     }
 
-    val product: AWSProduct =
-        when (pluginDescriptor?.pluginId?.idString) {
+    val product: AWSProduct
+        get() = when (pluginDescriptor?.pluginId?.idString) {
             "amazon.q" -> AWSProduct.AMAZON_Q_FOR_JET_BRAINS
             else -> AWSProduct.AWS_TOOLKIT_FOR_JET_BRAINS
         }
 
-    val version = pluginDescriptor?.version ?: "unknown"
+    val version: String
+        get() = pluginDescriptor?.version ?: "unknown"
 
     companion object {
         private val threadLocalResolver = ThreadLocal<PluginResolver>()
 
         /**
          * Creates a new PluginResolver instance off the current thread's stack trace, or retrieves
-         * the existing thread-local resolver if it is set. If a value did not previously exist,
-         * the new instance is stored in the thread-local.
+         * the thread-local resolver if one is set.
          */
-        fun fromCurrentThread() = threadLocalResolver.get() ?: PluginResolver(Thread.currentThread().stackTrace).also {
-            threadLocalResolver.set(it)
-        }
+        fun fromCurrentThread() = threadLocalResolver.get() ?: PluginResolver(Thread.currentThread().stackTrace)
 
         /**
          * Creates a new PluginResolver instance from a provided stack trace.
@@ -44,8 +42,8 @@ class PluginResolver private constructor(callerStackTrace: Array<StackTraceEleme
         fun fromStackTrace(stackTrace: Array<StackTraceElement>) = PluginResolver(stackTrace)
 
         /**
-         * Sets the PluginResolver instance in a thread-local for the current thread.
-         * This is useful
+         * Sets a PluginResolver instance to a thread-local for the current thread.
+         * This value will be retrieved by subsequent calls to fromCurrentThread.
          */
         fun setThreadLocal(value: PluginResolver) {
             threadLocalResolver.set(value)

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/ThreadingUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/ThreadingUtils.kt
@@ -75,7 +75,7 @@ fun sleepWithCancellation(sleepAmount: Duration, indicator: ProgressIndicator?) 
     }
 }
 
-fun <T> executeOnPooledThreadWithParentContext(action: () -> T): Future<T> {
+fun <T> pluginAwareExecuteOnPooledThread(action: () -> T): Future<T> {
     /**
      * Ensures plugin resolution references parent thread plugin resolver since
      * worker thread will not contain original call stack. Necessary for telemetry.

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/ThreadingUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/ThreadingUtils.kt
@@ -14,7 +14,9 @@ import com.intellij.openapi.util.ThrowableComputable
 import com.intellij.util.ExceptionUtil
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.concurrency.Semaphore
+import software.aws.toolkits.jetbrains.services.telemetry.PluginResolver
 import java.time.Duration
+import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 
 // There is a new/experimental API in IJ SDK, but replicate a simpler one here till we can use it
@@ -70,5 +72,17 @@ fun sleepWithCancellation(sleepAmount: Duration, indicator: ProgressIndicator?) 
         ProgressIndicatorUtils.awaitWithCheckCanceled(semaphore, indicator)
     } finally {
         future.cancel(true)
+    }
+}
+
+fun <T> executeOnPooledThreadWithParentContext(action: () -> T): Future<T> {
+    /**
+     * Ensures plugin resolution references original call stack since worker
+     * thread will not contain it. Necessary for telemetry.
+     */
+    val pluginResolver = PluginResolver.fromCurrentThread()
+    return ApplicationManager.getApplication().executeOnPooledThread<T> {
+        PluginResolver.setThreadLocal(pluginResolver)
+        action()
     }
 }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/ThreadingUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/ThreadingUtils.kt
@@ -77,8 +77,8 @@ fun sleepWithCancellation(sleepAmount: Duration, indicator: ProgressIndicator?) 
 
 fun <T> executeOnPooledThreadWithParentContext(action: () -> T): Future<T> {
     /**
-     * Ensures plugin resolution references original call stack since worker
-     * thread will not contain it. Necessary for telemetry.
+     * Ensures plugin resolution references parent thread plugin resolver since
+     * worker thread will not contain original call stack. Necessary for telemetry.
      */
     val pluginResolver = PluginResolver.fromCurrentThread()
     return ApplicationManager.getApplication().executeOnPooledThread<T> {

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/utils/ThreadingUtilsKtTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/utils/ThreadingUtilsKtTest.kt
@@ -9,9 +9,14 @@ import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.testFramework.ApplicationRule
 import com.intellij.util.concurrency.AppExecutorUtil
+import io.mockk.every
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import software.amazon.awssdk.services.toolkittelemetry.model.AWSProduct
+import software.aws.toolkits.jetbrains.services.telemetry.PluginResolver
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -69,5 +74,17 @@ class ThreadingUtilsKtTest {
         assertThatThrownBy {
             sleepWithCancellation(Duration.ofHours(3), indicator)
         }.isInstanceOf<ProcessCanceledException>()
+    }
+
+    @Test
+    fun `executeOnPooledThreadWithParentContext inherits plugin resolver`() {
+        val pluginResolver = mockk<PluginResolver> {
+            every { product } returns AWSProduct.AMAZON_Q_FOR_JET_BRAINS
+        }
+        PluginResolver.setThreadLocal(pluginResolver)
+
+        executeOnPooledThreadWithParentContext {
+            assertEquals(PluginResolver.fromCurrentThread().product, AWSProduct.AMAZON_Q_FOR_JET_BRAINS)
+        }.get()
     }
 }

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/utils/ThreadingUtilsKtTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/utils/ThreadingUtilsKtTest.kt
@@ -77,13 +77,13 @@ class ThreadingUtilsKtTest {
     }
 
     @Test
-    fun `executeOnPooledThreadWithParentContext inherits plugin resolver`() {
+    fun `pluginAwareExecuteOnPooledThread inherits plugin resolver`() {
         val pluginResolver = mockk<PluginResolver> {
             every { product } returns AWSProduct.AMAZON_Q_FOR_JET_BRAINS
         }
         PluginResolver.setThreadLocal(pluginResolver)
 
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             assertEquals(PluginResolver.fromCurrentThread().product, AWSProduct.AMAZON_Q_FOR_JET_BRAINS)
         }.get()
     }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.core.executables
 
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
@@ -19,6 +18,7 @@ import software.aws.toolkits.core.utils.lastModified
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance.ExecutableWithPath
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -115,11 +115,11 @@ class DefaultExecutableManager : PersistentStateComponent<ExecutableStateList>, 
 
     override fun getExecutable(type: ExecutableType<*>): CompletionStage<ExecutableInstance> {
         val future = CompletableFuture<ExecutableInstance>()
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             val loaded = internalState[type.id]
             if (loaded == null) {
                 future.complete(load(type, null))
-                return@executeOnPooledThread
+                return@executeOnPooledThreadWithParentContext
             }
 
             val (persisted, instance, lastValidated) = loaded
@@ -143,7 +143,7 @@ class DefaultExecutableManager : PersistentStateComponent<ExecutableStateList>, 
 
     override fun setExecutablePath(type: ExecutableType<*>, path: Path): CompletionStage<ExecutableInstance> {
         val future = CompletableFuture<ExecutableInstance>()
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             val executable = validateAndSave(type, path, false)
             future.complete(executable)
         }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/executables/ExecutableManager.kt
@@ -18,7 +18,7 @@ import software.aws.toolkits.core.utils.lastModified
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.executables.ExecutableInstance.ExecutableWithPath
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamExecutable
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -115,11 +115,11 @@ class DefaultExecutableManager : PersistentStateComponent<ExecutableStateList>, 
 
     override fun getExecutable(type: ExecutableType<*>): CompletionStage<ExecutableInstance> {
         val future = CompletableFuture<ExecutableInstance>()
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             val loaded = internalState[type.id]
             if (loaded == null) {
                 future.complete(load(type, null))
-                return@executeOnPooledThreadWithParentContext
+                return@pluginAwareExecuteOnPooledThread
             }
 
             val (persisted, instance, lastValidated) = loaded
@@ -143,7 +143,7 @@ class DefaultExecutableManager : PersistentStateComponent<ExecutableStateList>, 
 
     override fun setExecutablePath(type: ExecutableType<*>, path: Path): CompletionStage<ExecutableInstance> {
         val future = CompletableFuture<ExecutableInstance>()
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             val executable = validateAndSave(type, path, false)
             future.complete(executable)
         }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
@@ -8,9 +8,9 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
 import software.aws.toolkits.jetbrains.core.explorer.DeleteResourceDialog
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.jetbrains.utils.notifyInfo
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
 import software.aws.toolkits.telemetry.Result
@@ -29,7 +29,7 @@ abstract class DeleteResourceAction<in T : AwsExplorerResourceNode<*>> : SingleR
         if (!response) {
             AwsTelemetry.deleteResource(project = selected.project, serviceType = selected.serviceId, result = Result.Cancelled)
         } else {
-            executeOnPooledThreadWithParentContext {
+            pluginAwareExecuteOnPooledThread {
                 try {
                     performDelete(selected)
                     notifyInfo(project = selected.project, title = message("delete_resource.deleted", resourceType, resourceName))

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/actions/DeleteResourceAction.kt
@@ -5,10 +5,10 @@ package software.aws.toolkits.jetbrains.core.explorer.actions
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAware
 import software.aws.toolkits.jetbrains.core.explorer.DeleteResourceDialog
 import software.aws.toolkits.jetbrains.core.explorer.nodes.AwsExplorerResourceNode
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.jetbrains.utils.notifyInfo
 import software.aws.toolkits.resources.message
@@ -29,7 +29,7 @@ abstract class DeleteResourceAction<in T : AwsExplorerResourceNode<*>> : SingleR
         if (!response) {
             AwsTelemetry.deleteResource(project = selected.project, serviceType = selected.serviceId, result = Result.Cancelled)
         } else {
-            ApplicationManager.getApplication().executeOnPooledThread {
+            executeOnPooledThreadWithParentContext {
                 try {
                     performDelete(selected)
                     notifyInfo(project = selected.project, title = message("delete_resource.deleted", resourceType, resourceName))

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/SonoLogin.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/SonoLogin.kt
@@ -5,7 +5,6 @@ package software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes.actions
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.DumbAwareAction
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
@@ -13,6 +12,7 @@ import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeCatalystConn
 import software.aws.toolkits.jetbrains.core.credentials.reauthConnectionIfNeeded
 import software.aws.toolkits.jetbrains.core.explorer.refreshDevToolTree
 import software.aws.toolkits.jetbrains.core.gettingstarted.requestCredentialsForCodeCatalyst
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.telemetry.UiTelemetry
 
 class SonoLogin : DumbAwareAction(AllIcons.Actions.Execute) {
@@ -20,7 +20,7 @@ class SonoLogin : DumbAwareAction(AllIcons.Actions.Execute) {
         val project = e.project ?: return
         UiTelemetry.click(project, elementId = "auth_start_CodeCatalyst")
 
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             val connectionManager = ToolkitConnectionManager.getInstance(project)
             connectionManager.activeConnectionForFeature(CodeCatalystConnection.getInstance())?.let {
                 reauthConnectionIfNeeded(project, it)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/SonoLogin.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/actions/SonoLogin.kt
@@ -12,7 +12,7 @@ import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeCatalystConn
 import software.aws.toolkits.jetbrains.core.credentials.reauthConnectionIfNeeded
 import software.aws.toolkits.jetbrains.core.explorer.refreshDevToolTree
 import software.aws.toolkits.jetbrains.core.gettingstarted.requestCredentialsForCodeCatalyst
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.telemetry.UiTelemetry
 
 class SonoLogin : DumbAwareAction(AllIcons.Actions.Execute) {
@@ -20,7 +20,7 @@ class SonoLogin : DumbAwareAction(AllIcons.Actions.Execute) {
         val project = e.project ?: return
         UiTelemetry.click(project, elementId = "auth_start_CodeCatalyst")
 
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             val connectionManager = ToolkitConnectionManager.getInstance(project)
             connectionManager.activeConnectionForFeature(CodeCatalystConnection.getInstance())?.let {
                 reauthConnectionIfNeeded(project, it)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/terminal/OpenAwsLocalTerminal.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/terminal/OpenAwsLocalTerminal.kt
@@ -6,7 +6,6 @@ package software.aws.toolkits.jetbrains.core.terminal
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.util.ExceptionUtil
@@ -24,6 +23,7 @@ import software.aws.toolkits.jetbrains.core.credentials.ConnectionState
 import software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileCredentialsIdentifier
 import software.aws.toolkits.jetbrains.core.experiments.ToolkitExperiment
 import software.aws.toolkits.jetbrains.core.experiments.isEnabled
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
 import software.aws.toolkits.telemetry.Result
@@ -48,13 +48,13 @@ class OpenAwsLocalTerminal : DumbAwareAction(
         when (val state = AwsConnectionManager.getInstance(project).connectionState) {
             is ConnectionState.ValidConnection -> {
                 val connection = state.connection
-                ApplicationManager.getApplication().executeOnPooledThread {
+                executeOnPooledThreadWithParentContext {
                     val credentials = try {
                         connection.credentials.resolveCredentials()
                     } catch (e: Exception) {
                         LOG.error(e) { message("aws.terminal.exception.failed_to_resolve_credentials", ExceptionUtil.getThrowableText(e)) }
                         AwsTelemetry.openLocalTerminal(project, result = Result.Failed)
-                        return@executeOnPooledThread
+                        return@executeOnPooledThreadWithParentContext
                     }
                     runInEdt {
                         val runner = AwsLocalTerminalRunner(project, connection.shortName) { envs ->

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/terminal/OpenAwsLocalTerminal.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/terminal/OpenAwsLocalTerminal.kt
@@ -23,7 +23,7 @@ import software.aws.toolkits.jetbrains.core.credentials.ConnectionState
 import software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileCredentialsIdentifier
 import software.aws.toolkits.jetbrains.core.experiments.ToolkitExperiment
 import software.aws.toolkits.jetbrains.core.experiments.isEnabled
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
 import software.aws.toolkits.telemetry.Result
@@ -48,13 +48,13 @@ class OpenAwsLocalTerminal : DumbAwareAction(
         when (val state = AwsConnectionManager.getInstance(project).connectionState) {
             is ConnectionState.ValidConnection -> {
                 val connection = state.connection
-                executeOnPooledThreadWithParentContext {
+                pluginAwareExecuteOnPooledThread {
                     val credentials = try {
                         connection.credentials.resolveCredentials()
                     } catch (e: Exception) {
                         LOG.error(e) { message("aws.terminal.exception.failed_to_resolve_credentials", ExceptionUtil.getThrowableText(e)) }
                         AwsTelemetry.openLocalTerminal(project, result = Result.Failed)
-                        return@executeOnPooledThreadWithParentContext
+                        return@pluginAwareExecuteOnPooledThread
                     }
                     runInEdt {
                         val runner = AwsLocalTerminalRunner(project, connection.shortName) { envs ->

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/tools/DefaultToolManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/tools/DefaultToolManager.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.core.tools
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.PerformInBackgroundOption
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
@@ -23,6 +22,7 @@ import software.aws.toolkits.core.utils.readText
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.tools.ToolManager.Companion.MANAGED_TOOL_INSTALL_ROOT
 import software.aws.toolkits.jetbrains.utils.assertIsNonDispatchThread
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.runUnderProgressIfNeeded
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
@@ -57,7 +57,7 @@ class DefaultToolManager @NonInjectable internal constructor(private val clock: 
         if (type is ManagedToolType<V>) {
             val managedTool = checkForInstalledTool(type)
             if (managedTool != null) {
-                ApplicationManager.getApplication().executeOnPooledThread {
+                executeOnPooledThreadWithParentContext {
                     checkForUpdates(type)
                 }
                 return managedTool

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/tools/DefaultToolManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/tools/DefaultToolManager.kt
@@ -22,7 +22,7 @@ import software.aws.toolkits.core.utils.readText
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.tools.ToolManager.Companion.MANAGED_TOOL_INSTALL_ROOT
 import software.aws.toolkits.jetbrains.utils.assertIsNonDispatchThread
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.jetbrains.utils.runUnderProgressIfNeeded
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AwsTelemetry
@@ -57,7 +57,7 @@ class DefaultToolManager @NonInjectable internal constructor(private val clock: 
         if (type is ManagedToolType<V>) {
             val managedTool = checkForInstalledTool(type)
             if (managedTool != null) {
-                executeOnPooledThreadWithParentContext {
+                pluginAwareExecuteOnPooledThread {
                     checkForUpdates(type)
                 }
                 return managedTool

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/caws/CawsCloneDialogComponent.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/caws/CawsCloneDialogComponent.kt
@@ -8,7 +8,6 @@ import com.intellij.dvcs.repo.ClonePathProvider
 import com.intellij.dvcs.ui.CloneDvcsValidationUtils
 import com.intellij.dvcs.ui.SelectChildTextFieldWithBrowseButton
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
@@ -46,6 +45,7 @@ import software.aws.toolkits.jetbrains.core.credentials.sono.lazilyGetUserId
 import software.aws.toolkits.jetbrains.services.caws.pat.generateAndStorePat
 import software.aws.toolkits.jetbrains.services.caws.pat.patExists
 import software.aws.toolkits.jetbrains.ui.connection.CawsLoginOverlay
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CodecatalystTelemetry
 import java.net.URI
@@ -83,7 +83,7 @@ class CawsCloneDialogComponent(
 
     override fun doClone(checkoutListener: CheckoutProvider.Listener) {
         val repository = repoList.selectedValue ?: throw RuntimeException("Repository was not selected")
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             val userId = lazilyGetUserId()
             try {
                 // TODO: show progress bar here so it doesn't look like we're stuck

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/caws/CawsCloneDialogComponent.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/caws/CawsCloneDialogComponent.kt
@@ -45,7 +45,7 @@ import software.aws.toolkits.jetbrains.core.credentials.sono.lazilyGetUserId
 import software.aws.toolkits.jetbrains.services.caws.pat.generateAndStorePat
 import software.aws.toolkits.jetbrains.services.caws.pat.patExists
 import software.aws.toolkits.jetbrains.ui.connection.CawsLoginOverlay
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CodecatalystTelemetry
 import java.net.URI
@@ -83,7 +83,7 @@ class CawsCloneDialogComponent(
 
     override fun doClone(checkoutListener: CheckoutProvider.Listener) {
         val repository = repoList.selectedValue ?: throw RuntimeException("Repository was not selected")
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             val userId = lazilyGetUserId()
             try {
                 // TODO: show progress bar here so it doesn't look like we're stuck

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormation.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormation.kt
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.cloudformation.model.DescribeStacksReques
 import software.amazon.awssdk.services.cloudformation.model.Stack
 import software.amazon.awssdk.services.cloudformation.model.StackStatus
 import software.aws.toolkits.core.utils.wait
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import java.time.Duration
 
@@ -36,14 +36,14 @@ fun CloudFormationClient.executeChangeSetAndWait(stackName: String, changeSet: S
 }
 
 fun CloudFormationClient.describeStack(stackName: String, callback: (Stack?) -> Unit) {
-    executeOnPooledThreadWithParentContext {
+    pluginAwareExecuteOnPooledThread {
         val stack = this.describeStacks { it.stackName(stackName) }.stacks().firstOrNull()
         callback(stack)
     }
 }
 
 fun CloudFormationClient.describeStackForSync(stackName: String, enableParamsAndTags: (Boolean) -> Unit, callback: (Stack?) -> Unit) {
-    executeOnPooledThreadWithParentContext {
+    pluginAwareExecuteOnPooledThread {
         try {
             enableParamsAndTags(false)
             val stack = this.describeStacks { it.stackName(stackName) }.stacks().firstOrNull()

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormation.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/CloudFormation.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.cloudformation
 
-import com.intellij.openapi.application.ApplicationManager
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
 import software.amazon.awssdk.services.cloudformation.model.ChangeSetStatus
 import software.amazon.awssdk.services.cloudformation.model.CloudFormationException
@@ -11,6 +10,7 @@ import software.amazon.awssdk.services.cloudformation.model.DescribeStacksReques
 import software.amazon.awssdk.services.cloudformation.model.Stack
 import software.amazon.awssdk.services.cloudformation.model.StackStatus
 import software.aws.toolkits.core.utils.wait
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import java.time.Duration
 
@@ -36,14 +36,14 @@ fun CloudFormationClient.executeChangeSetAndWait(stackName: String, changeSet: S
 }
 
 fun CloudFormationClient.describeStack(stackName: String, callback: (Stack?) -> Unit) {
-    ApplicationManager.getApplication().executeOnPooledThread {
+    executeOnPooledThreadWithParentContext {
         val stack = this.describeStacks { it.stackName(stackName) }.stacks().firstOrNull()
         callback(stack)
     }
 }
 
 fun CloudFormationClient.describeStackForSync(stackName: String, enableParamsAndTags: (Boolean) -> Unit, callback: (Stack?) -> Unit) {
-    ApplicationManager.getApplication().executeOnPooledThread {
+    executeOnPooledThreadWithParentContext {
         try {
             enableParamsAndTags(false)
             val stack = this.describeStacks { it.stackName(stackName) }.stacks().firstOrNull()

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.actionSystem.ToggleAction
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.DumbAwareAction
@@ -31,6 +30,7 @@ import software.aws.toolkits.jetbrains.core.explorer.actions.SingleResourceNodeA
 import software.aws.toolkits.jetbrains.core.toolwindow.ToolkitToolWindow
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationStackNode
 import software.aws.toolkits.jetbrains.services.cloudformation.toolwindow.CloudFormationToolWindow
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CloudformationTelemetry
 import java.time.Duration
@@ -229,7 +229,7 @@ private class StackUI(
 
             override fun setSelected(e: AnActionEvent, newState: Boolean) {
                 if (state.getAndSet(newState) != newState) {
-                    ApplicationManager.getApplication().executeOnPooledThread {
+                    executeOnPooledThreadWithParentContext {
                         updater.applyFilter {
                             newState || it.resourceStatus().type != StatusType.COMPLETED
                         }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cloudformation/stack/Stack.kt
@@ -30,7 +30,7 @@ import software.aws.toolkits.jetbrains.core.explorer.actions.SingleResourceNodeA
 import software.aws.toolkits.jetbrains.core.toolwindow.ToolkitToolWindow
 import software.aws.toolkits.jetbrains.services.cloudformation.CloudFormationStackNode
 import software.aws.toolkits.jetbrains.services.cloudformation.toolwindow.CloudFormationToolWindow
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CloudformationTelemetry
 import java.time.Duration
@@ -229,7 +229,7 @@ private class StackUI(
 
             override fun setSelected(e: AnActionEvent, newState: Boolean) {
                 if (state.getAndSet(newState) != newState) {
-                    executeOnPooledThreadWithParentContext {
+                    pluginAwareExecuteOnPooledThread {
                         updater.applyFilter {
                             newState || it.resourceStatus().type != StatusType.COMPLETED
                         }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecr/CreateEcrRepoDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecr/CreateEcrRepoDialog.kt
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.TestOnly
 import software.amazon.awssdk.services.ecr.EcrClient
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.ecr.resources.EcrResources
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.EcrTelemetry
 import software.aws.toolkits.telemetry.Result
@@ -73,7 +74,7 @@ class CreateEcrRepoDialog(
             setOKButtonText(message("general.create_in_progress"))
             isOKActionEnabled = false
 
-            ApplicationManager.getApplication().executeOnPooledThread {
+            executeOnPooledThreadWithParentContext {
                 try {
                     createRepo()
                     ApplicationManager.getApplication().invokeLater(

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecr/CreateEcrRepoDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/ecr/CreateEcrRepoDialog.kt
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.TestOnly
 import software.amazon.awssdk.services.ecr.EcrClient
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.ecr.resources.EcrResources
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.EcrTelemetry
 import software.aws.toolkits.telemetry.Result
@@ -74,7 +74,7 @@ class CreateEcrRepoDialog(
             setOKButtonText(message("general.create_in_progress"))
             isOKActionEnabled = false
 
-            executeOnPooledThreadWithParentContext {
+            pluginAwareExecuteOnPooledThread {
                 try {
                     createRepo()
                     ApplicationManager.getApplication().invokeLater(

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/federation/AwsConsoleUrlFactory.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/federation/AwsConsoleUrlFactory.kt
@@ -21,9 +21,9 @@ import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.credentials.getConnectionSettings
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.jetbrains.utils.notifyNoActiveCredentialsError
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.DeeplinkTelemetry
 import software.aws.toolkits.telemetry.Result
@@ -151,7 +151,7 @@ object AwsConsoleUrlFactory {
             return
         }
 
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 val encodedArn = URLEncoder.encode(arn, Charsets.UTF_8)
                 val encodedUa = URLEncoder.encode(AwsClientManager.getUserAgent(), Charsets.UTF_8)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/federation/AwsConsoleUrlFactory.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/federation/AwsConsoleUrlFactory.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.intellij.ide.BrowserUtil
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import org.apache.http.client.entity.UrlEncodedFormEntity
 import org.apache.http.client.methods.HttpPost
@@ -22,6 +21,7 @@ import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.credentials.getConnectionSettings
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.jetbrains.utils.notifyNoActiveCredentialsError
 import software.aws.toolkits.resources.message
@@ -151,7 +151,7 @@ object AwsConsoleUrlFactory {
             return
         }
 
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 val encodedArn = URLEncoder.encode(arn, Charsets.UTF_8)
                 val encodedUa = URLEncoder.encode(AwsClientManager.getUserAgent(), Charsets.UTF_8)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/iam/CreateIamRoleDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/iam/CreateIamRoleDialog.kt
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.iam.model.Role
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.iam.Iam.createRoleWithPolicy
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.ui.formatAndSet
 import software.aws.toolkits.resources.message
 import java.awt.Component
@@ -60,7 +61,7 @@ class CreateIamRoleDialog(
             setOKButtonText(message("general.create_in_progress"))
             isOKActionEnabled = false
 
-            ApplicationManager.getApplication().executeOnPooledThread {
+            executeOnPooledThreadWithParentContext {
                 try {
                     createIamRole()
                     ApplicationManager.getApplication().invokeLater(

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/iam/CreateIamRoleDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/iam/CreateIamRoleDialog.kt
@@ -16,7 +16,7 @@ import software.amazon.awssdk.services.iam.model.Role
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.iam.Iam.createRoleWithPolicy
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.jetbrains.utils.ui.formatAndSet
 import software.aws.toolkits.resources.message
 import java.awt.Component
@@ -61,7 +61,7 @@ class CreateIamRoleDialog(
             setOKButtonText(message("general.create_in_progress"))
             isOKActionEnabled = false
 
-            executeOnPooledThreadWithParentContext {
+            pluginAwareExecuteOnPooledThread {
                 try {
                     createIamRole()
                     ApplicationManager.getApplication().invokeLater(

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
@@ -18,14 +18,14 @@ import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.toDataClass
 import software.aws.toolkits.jetbrains.services.lambda.upload.UpdateFunctionCodeDialog
 import software.aws.toolkits.jetbrains.services.lambda.upload.UpdateFunctionConfigDialog
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 
 abstract class UpdateFunctionAction(title: String) : SingleResourceNodeAction<LambdaFunctionNode>(title) {
     override fun actionPerformed(selected: LambdaFunctionNode, e: AnActionEvent) {
         val project = e.getRequiredData(PlatformDataKeys.PROJECT)
 
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             val client: LambdaClient = project.awsClient()
 
             // Fetch latest version just in case

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/actions/UpdateFunctionAction.kt
@@ -5,7 +5,6 @@ package software.aws.toolkits.jetbrains.services.lambda.actions
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.Project
 import software.amazon.awssdk.services.lambda.LambdaClient
@@ -19,13 +18,14 @@ import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.toDataClass
 import software.aws.toolkits.jetbrains.services.lambda.upload.UpdateFunctionCodeDialog
 import software.aws.toolkits.jetbrains.services.lambda.upload.UpdateFunctionConfigDialog
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 
 abstract class UpdateFunctionAction(title: String) : SingleResourceNodeAction<LambdaFunctionNode>(title) {
     override fun actionPerformed(selected: LambdaFunctionNode, e: AnActionEvent) {
         val project = e.getRequiredData(PlatformDataKeys.PROJECT)
 
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             val client: LambdaClient = project.awsClient()
 
             // Fetch latest version just in case

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunner.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunner.kt
@@ -15,7 +15,7 @@ import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.runInEdt
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 
 class RemoteLambdaRunner : AsyncProgramRunner<RunnerSettings>() {
     override fun getRunnerId(): String = "Remote AWS Lambda"
@@ -26,7 +26,7 @@ class RemoteLambdaRunner : AsyncProgramRunner<RunnerSettings>() {
     override fun execute(environment: ExecutionEnvironment, state: RunProfileState): Promise<RunContentDescriptor?> {
         val runPromise = AsyncPromise<RunContentDescriptor?>()
         val remoteState = state as RemoteLambdaState
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 val executionResult = remoteState.execute(environment.executor, this)
                 val builder = RunContentBuilder(executionResult, environment)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunner.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaRunner.kt
@@ -11,11 +11,11 @@ import com.intellij.execution.runners.AsyncProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.RunContentBuilder
 import com.intellij.execution.ui.RunContentDescriptor
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.runInEdt
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 
 class RemoteLambdaRunner : AsyncProgramRunner<RunnerSettings>() {
     override fun getRunnerId(): String = "Remote AWS Lambda"
@@ -26,7 +26,7 @@ class RemoteLambdaRunner : AsyncProgramRunner<RunnerSettings>() {
     override fun execute(environment: ExecutionEnvironment, state: RunProfileState): Promise<RunContentDescriptor?> {
         val runPromise = AsyncPromise<RunContentDescriptor?>()
         val remoteState = state as RemoteLambdaState
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 val executionResult = remoteState.execute(environment.executor, this)
                 val builder = RunContentBuilder(executionResult, environment)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaState.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaState.kt
@@ -20,8 +20,8 @@ import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.lambda.LambdaClient
 import software.amazon.awssdk.services.lambda.model.LogType
 import software.aws.toolkits.jetbrains.core.AwsClientManager
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.formatText
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.LambdaTelemetry
 import software.aws.toolkits.telemetry.Result
@@ -53,7 +53,7 @@ class RemoteLambdaState(
         override fun startNotify() {
             super.startNotify()
 
-            executeOnPooledThreadWithParentContext { invokeLambda(this) }
+            pluginAwareExecuteOnPooledThread { invokeLambda(this) }
         }
 
         override fun getProcessInput(): OutputStream? = null

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaState.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/remote/RemoteLambdaState.kt
@@ -14,13 +14,13 @@ import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
 import com.intellij.json.JsonLanguage
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.psi.search.GlobalSearchScopes
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.lambda.LambdaClient
 import software.amazon.awssdk.services.lambda.model.LogType
 import software.aws.toolkits.jetbrains.core.AwsClientManager
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.formatText
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.LambdaTelemetry
@@ -53,7 +53,7 @@ class RemoteLambdaState(
         override fun startNotify() {
             super.startNotify()
 
-            ApplicationManager.getApplication().executeOnPooledThread { invokeLambda(this) }
+            executeOnPooledThreadWithParentContext { invokeLambda(this) }
         }
 
         override fun getProcessInput(): OutputStream? = null

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/sync/SyncApplicationRunProfile.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/sync/SyncApplicationRunProfile.kt
@@ -25,7 +25,7 @@ import software.aws.toolkits.core.ConnectionSettings
 import software.aws.toolkits.core.toEnvironmentVariables
 import software.aws.toolkits.jetbrains.services.lambda.sam.getSamCli
 import software.aws.toolkits.jetbrains.services.lambda.sam.samSyncCommand
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import java.io.IOException
 import java.nio.charset.Charset
 import java.nio.file.Path
@@ -78,7 +78,7 @@ class SyncApplicationRunProfile(
                             if (event.text.contains("[Y/n]:") && isDevStack) {
                                 insertAssertionNow = true
                                 isDevStack = false
-                                executeOnPooledThreadWithParentContext {
+                                pluginAwareExecuteOnPooledThread {
                                     try {
                                         while (insertAssertionNow) {
                                             processHandler.processInput?.write("Y\n".toByteArray(Charset.defaultCharset()))

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/sync/SyncApplicationRunProfile.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/sync/SyncApplicationRunProfile.kt
@@ -17,7 +17,6 @@ import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
 import com.intellij.execution.ui.RunContentManager
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
@@ -26,6 +25,7 @@ import software.aws.toolkits.core.ConnectionSettings
 import software.aws.toolkits.core.toEnvironmentVariables
 import software.aws.toolkits.jetbrains.services.lambda.sam.getSamCli
 import software.aws.toolkits.jetbrains.services.lambda.sam.samSyncCommand
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import java.io.IOException
 import java.nio.charset.Charset
 import java.nio.file.Path
@@ -78,7 +78,7 @@ class SyncApplicationRunProfile(
                             if (event.text.contains("[Y/n]:") && isDevStack) {
                                 insertAssertionNow = true
                                 isDevStack = false
-                                ApplicationManager.getApplication().executeOnPooledThread {
+                                executeOnPooledThreadWithParentContext {
                                     try {
                                         while (insertAssertionNow) {
                                             processHandler.processInput?.write("Y\n".toByteArray(Charset.defaultCharset()))

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionConfigDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionConfigDialog.kt
@@ -16,8 +16,8 @@ import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.help.HelpIds
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunction
 import software.aws.toolkits.jetbrains.services.lambda.waitForUpdatableState
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyInfo
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.LambdaPackageType
 import software.aws.toolkits.telemetry.LambdaTelemetry
@@ -81,7 +81,7 @@ class UpdateFunctionConfigDialog(private val project: Project, private val initi
         val functionDetails = viewToFunctionDetails()
         val lambdaClient: LambdaClient = project.awsClient()
 
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 lambdaClient.waitForUpdatableState(functionDetails.name)
                 lambdaClient.updateFunctionConfiguration(functionDetails)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionConfigDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/upload/UpdateFunctionConfigDialog.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.upload
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.Project
@@ -17,6 +16,7 @@ import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.help.HelpIds
 import software.aws.toolkits.jetbrains.services.lambda.LambdaFunction
 import software.aws.toolkits.jetbrains.services.lambda.waitForUpdatableState
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.jetbrains.utils.notifyInfo
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.LambdaPackageType
@@ -81,7 +81,7 @@ class UpdateFunctionConfigDialog(private val project: Project, private val initi
         val functionDetails = viewToFunctionDetails()
         val lambdaClient: LambdaClient = project.awsClient()
 
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 lambdaClient.waitForUpdatableState(functionDetails.name)
                 lambdaClient.updateFunctionConfiguration(functionDetails)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/CreateS3BucketDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/CreateS3BucketDialog.kt
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.TestOnly
 import software.amazon.awssdk.services.s3.S3Client
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.Result
 import software.aws.toolkits.telemetry.S3Telemetry
@@ -50,7 +50,7 @@ class CreateS3BucketDialog(
             setOKButtonText(message("general.create_in_progress"))
             isOKActionEnabled = false
 
-            executeOnPooledThreadWithParentContext {
+            pluginAwareExecuteOnPooledThread {
                 try {
                     createBucket()
                     ApplicationManager.getApplication().invokeLater(

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/CreateS3BucketDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/s3/CreateS3BucketDialog.kt
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.TestOnly
 import software.amazon.awssdk.services.s3.S3Client
 import software.aws.toolkits.jetbrains.core.explorer.refreshAwsTree
 import software.aws.toolkits.jetbrains.services.s3.resources.S3Resources
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.Result
 import software.aws.toolkits.telemetry.S3Telemetry
@@ -49,7 +50,7 @@ class CreateS3BucketDialog(
             setOKButtonText(message("general.create_in_progress"))
             isOKActionEnabled = false
 
-            ApplicationManager.getApplication().executeOnPooledThread {
+            executeOnPooledThreadWithParentContext {
                 try {
                     createBucket()
                     ApplicationManager.getApplication().invokeLater(

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/SchemaCodeDownloader.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/SchemaCodeDownloader.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.schemas.code
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.util.io.Decompressor
@@ -17,6 +16,7 @@ import software.amazon.awssdk.services.schemas.model.PutCodeBindingRequest
 import software.aws.toolkits.core.ConnectionSettings
 import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import java.io.File
 import java.io.FileOutputStream
@@ -91,7 +91,7 @@ class SchemaCodeDownloader(
 class CodeGenerator(private val schemasClient: SchemasClient) {
     fun generate(schemaDownload: SchemaCodeDownloadRequestDetails): CompletionStage<CodeGenerationStatus> {
         val future = CompletableFuture<CodeGenerationStatus>()
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 val request = PutCodeBindingRequest.builder()
                     .language(schemaDownload.language.apiValue)
@@ -118,7 +118,7 @@ class CodeGenerationStatusPoller(private val schemasClient: SchemasClient) {
         initialCodeGenerationStatus: CodeGenerationStatus = CodeGenerationStatus.CREATE_IN_PROGRESS
     ): CompletionStage<String> {
         val future = CompletableFuture<String>()
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 if (initialCodeGenerationStatus != CodeGenerationStatus.CREATE_COMPLETE) {
                     schemasClient.waiter().waitUntilCodeBindingExists {
@@ -141,7 +141,7 @@ class CodeGenerationStatusPoller(private val schemasClient: SchemasClient) {
         schemaDownload: SchemaCodeDownloadRequestDetails
     ): CompletionStage<CodeGenerationStatus> {
         val future = CompletableFuture<CodeGenerationStatus>()
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 val request = DescribeCodeBindingRequest.builder()
                     .language(schemaDownload.language.apiValue)
@@ -168,7 +168,7 @@ class CodeDownloader(private val schemasClient: SchemasClient) {
         schemaDownload: SchemaCodeDownloadRequestDetails
     ): CompletionStage<DownloadedSchemaCode> {
         val future = CompletableFuture<DownloadedSchemaCode>()
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 val request = GetCodeBindingSourceRequest.builder()
                     .language(schemaDownload.language.apiValue)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/SchemaCodeDownloader.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/code/SchemaCodeDownloader.kt
@@ -16,7 +16,7 @@ import software.amazon.awssdk.services.schemas.model.PutCodeBindingRequest
 import software.aws.toolkits.core.ConnectionSettings
 import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import java.io.File
 import java.io.FileOutputStream
@@ -91,7 +91,7 @@ class SchemaCodeDownloader(
 class CodeGenerator(private val schemasClient: SchemasClient) {
     fun generate(schemaDownload: SchemaCodeDownloadRequestDetails): CompletionStage<CodeGenerationStatus> {
         val future = CompletableFuture<CodeGenerationStatus>()
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 val request = PutCodeBindingRequest.builder()
                     .language(schemaDownload.language.apiValue)
@@ -118,7 +118,7 @@ class CodeGenerationStatusPoller(private val schemasClient: SchemasClient) {
         initialCodeGenerationStatus: CodeGenerationStatus = CodeGenerationStatus.CREATE_IN_PROGRESS
     ): CompletionStage<String> {
         val future = CompletableFuture<String>()
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 if (initialCodeGenerationStatus != CodeGenerationStatus.CREATE_COMPLETE) {
                     schemasClient.waiter().waitUntilCodeBindingExists {
@@ -141,7 +141,7 @@ class CodeGenerationStatusPoller(private val schemasClient: SchemasClient) {
         schemaDownload: SchemaCodeDownloadRequestDetails
     ): CompletionStage<CodeGenerationStatus> {
         val future = CompletableFuture<CodeGenerationStatus>()
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 val request = DescribeCodeBindingRequest.builder()
                     .language(schemaDownload.language.apiValue)
@@ -168,7 +168,7 @@ class CodeDownloader(private val schemasClient: SchemasClient) {
         schemaDownload: SchemaCodeDownloadRequestDetails
     ): CompletionStage<DownloadedSchemaCode> {
         val future = CompletableFuture<DownloadedSchemaCode>()
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 val request = GetCodeBindingSourceRequest.builder()
                     .language(schemaDownload.language.apiValue)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/search/SchemaSearchExecutor.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/search/SchemaSearchExecutor.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.schemas.search
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.services.schemas.SchemasClient
@@ -13,6 +12,7 @@ import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.getResource
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 
 class SchemaSearchExecutor(
     private val project: Project,
@@ -24,7 +24,7 @@ class SchemaSearchExecutor(
         incrementalResultsCallback: OnSearchResultReturned,
         registrySearchErrorCallback: OnSearchResultError
     ) {
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 val results = doSingleSearch(registryName, searchText)
                 incrementalResultsCallback(results.map { SchemaSearchResultWithRegistry(it.name, it.versions, registryName) })

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/search/SchemaSearchExecutor.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/schemas/search/SchemaSearchExecutor.kt
@@ -12,7 +12,7 @@ import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.awsClient
 import software.aws.toolkits.jetbrains.core.getResource
 import software.aws.toolkits.jetbrains.services.schemas.resources.SchemasResources
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 
 class SchemaSearchExecutor(
     private val project: Project,
@@ -24,7 +24,7 @@ class SchemaSearchExecutor(
         incrementalResultsCallback: OnSearchResultReturned,
         registrySearchErrorCallback: OnSearchResultError
     ) {
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 val results = doSingleSearch(registryName, searchText)
                 incrementalResultsCallback(results.map { SchemaSearchResultWithRegistry(it.name, it.versions, registryName) })

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/connection/CawsLoginOverlay.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/connection/CawsLoginOverlay.kt
@@ -23,7 +23,7 @@ import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.sono.CodeCatalystCredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
 import software.aws.toolkits.jetbrains.services.caws.CawsEndpoints
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import javax.swing.JComponent
 
@@ -55,7 +55,7 @@ open class CawsLoginOverlay(
 
             row {
                 button(message("caws.login")) {
-                    executeOnPooledThreadWithParentContext {
+                    pluginAwareExecuteOnPooledThread {
                         CodeCatalystCredentialManager.getInstance(project).promptAuth()
                     }
                 }.applyToComponent {

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/connection/CawsLoginOverlay.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/ui/connection/CawsLoginOverlay.kt
@@ -23,6 +23,7 @@ import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.sono.CodeCatalystCredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
 import software.aws.toolkits.jetbrains.services.caws.CawsEndpoints
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import javax.swing.JComponent
 
@@ -54,7 +55,7 @@ open class CawsLoginOverlay(
 
             row {
                 button(message("caws.login")) {
-                    ApplicationManager.getApplication().executeOnPooledThread {
+                    executeOnPooledThreadWithParentContext {
                         CodeCatalystCredentialManager.getInstance(project).promptAuth()
                     }
                 }.applyToComponent {

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/CachingAsyncEvaluator.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/CachingAsyncEvaluator.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.jetbrains.utils
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProcessCanceledException
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.concurrency.AsyncPromise
@@ -55,7 +54,7 @@ abstract class CachingAsyncEvaluator<TEntry, TReturn> {
         }
 
         if (promise == asyncPromise) {
-            ApplicationManager.getApplication().executeOnPooledThread {
+            executeOnPooledThreadWithParentContext {
                 try {
                     val result = getValue(entry)
                     asyncPromise.setResult(result)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/CachingAsyncEvaluator.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/CachingAsyncEvaluator.kt
@@ -54,7 +54,7 @@ abstract class CachingAsyncEvaluator<TEntry, TReturn> {
         }
 
         if (promise == asyncPromise) {
-            executeOnPooledThreadWithParentContext {
+            pluginAwareExecuteOnPooledThread {
                 try {
                     val result = getValue(entry)
                     asyncPromise.setResult(result)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/ParallelStep.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/ParallelStep.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.utils.execution.steps
 
-import com.intellij.openapi.application.ApplicationManager
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 
@@ -31,7 +31,7 @@ abstract class ParallelStep : Step() {
             val stepFuture = CompletableFuture<Unit>()
             listOfChildTasks.add(ChildStep(stepFuture))
 
-            ApplicationManager.getApplication().executeOnPooledThread {
+            executeOnPooledThreadWithParentContext {
                 try {
                     it.run(context, messageEmitter, ignoreCancellation)
                     stepFuture.complete(null)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/ParallelStep.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/ParallelStep.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.utils.execution.steps
 
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 
@@ -31,7 +31,7 @@ abstract class ParallelStep : Step() {
             val stepFuture = CompletableFuture<Unit>()
             listOfChildTasks.add(ChildStep(stepFuture))
 
-            executeOnPooledThreadWithParentContext {
+            pluginAwareExecuteOnPooledThread {
                 try {
                     it.run(context, messageEmitter, ignoreCancellation)
                     stepFuture.complete(null)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/StepExecutor.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/StepExecutor.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import software.aws.toolkits.core.utils.AttributeBagKey
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.tryOrNull
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import java.io.OutputStream
 
 /**
@@ -52,7 +52,7 @@ class StepExecutor(
     fun<T : Any> addContext(key: AttributeBagKey<T>, value: T) = context.putAttribute(key, value)
 
     private fun startWorkflow() {
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             execute(context, WorkflowEmitterWrapper(messageEmitter), processHandler)
         }
     }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/StepExecutor.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/execution/steps/StepExecutor.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import software.aws.toolkits.core.utils.AttributeBagKey
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.tryOrNull
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import java.io.OutputStream
 
 /**
@@ -51,7 +52,7 @@ class StepExecutor(
     fun<T : Any> addContext(key: AttributeBagKey<T>, value: T) = context.putAttribute(key, value)
 
     private fun startWorkflow() {
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             execute(context, WorkflowEmitterWrapper(messageEmitter), processHandler)
         }
     }

--- a/plugins/toolkit/jetbrains-gateway/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-gateway/build.gradle.kts
@@ -47,10 +47,11 @@ dependencies {
     // link against :j-c: and rely on :intellij:buildPlugin to pull in :j-c:instrumentedJar, but gateway variant when runIde/buildPlugin from :jetbrains-gateway
     compileOnly(project(":plugin-toolkit:jetbrains-core"))
     gatewayOnlyRuntimeOnly(project(":plugin-toolkit:jetbrains-core", "gatewayArtifacts"))
-
     // delete when fully split
     gatewayOnlyRuntimeOnly(project(":plugin-core:core"))
     gatewayOnlyRuntimeOnly(project(":plugin-core:jetbrains-community"))
+    gatewayOnlyRuntimeOnly(project(":plugin-core:resources"))
+    gatewayOnlyRuntimeOnly(project(":plugin-core:sdk-codegen"))
 
     testImplementation(project(path = ":plugin-core:core", configuration = "testArtifacts"))
     testImplementation(project(":plugin-core:core"))

--- a/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceConfigurationDialog.kt
+++ b/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceConfigurationDialog.kt
@@ -27,7 +27,7 @@ import software.aws.toolkits.jetbrains.gateway.cawsEnvironmentTimeout
 import software.aws.toolkits.jetbrains.gateway.ideVersionComboBox
 import software.aws.toolkits.jetbrains.services.caws.InactivityTimeout
 import software.aws.toolkits.jetbrains.services.caws.loadParameterDescriptions
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CodecatalystTelemetry
 import software.aws.toolkits.telemetry.CodecatalystUpdateDevEnvironmentLocationType
@@ -94,11 +94,11 @@ class WorkspaceConfigurationDialog private constructor(cawsClient: CodeCatalystC
                 dialog.setPreferredFocusComponent(content)
                 dialog.setOkText(message("general.update_button"))
                 dialog.setOkOperation {
-                    executeOnPooledThreadWithParentContext {
+                    pluginAwareExecuteOnPooledThread {
                         val errors = content.panel.validateAll()
                         errors.firstOrNull()?.let {
                             dialog.setErrorText(it.message, it.component)
-                            return@executeOnPooledThreadWithParentContext
+                            return@pluginAwareExecuteOnPooledThread
                         }
                         content.panel.apply()
 

--- a/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceConfigurationDialog.kt
+++ b/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceConfigurationDialog.kt
@@ -27,6 +27,7 @@ import software.aws.toolkits.jetbrains.gateway.cawsEnvironmentTimeout
 import software.aws.toolkits.jetbrains.gateway.ideVersionComboBox
 import software.aws.toolkits.jetbrains.services.caws.InactivityTimeout
 import software.aws.toolkits.jetbrains.services.caws.loadParameterDescriptions
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CodecatalystTelemetry
 import software.aws.toolkits.telemetry.CodecatalystUpdateDevEnvironmentLocationType
@@ -93,11 +94,11 @@ class WorkspaceConfigurationDialog private constructor(cawsClient: CodeCatalystC
                 dialog.setPreferredFocusComponent(content)
                 dialog.setOkText(message("general.update_button"))
                 dialog.setOkOperation {
-                    ApplicationManager.getApplication().executeOnPooledThread {
+                    executeOnPooledThreadWithParentContext {
                         val errors = content.panel.validateAll()
                         errors.firstOrNull()?.let {
                             dialog.setErrorText(it.message, it.component)
-                            return@executeOnPooledThread
+                            return@executeOnPooledThreadWithParentContext
                         }
                         content.panel.apply()
 

--- a/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceConfigurationDialog.kt
+++ b/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceConfigurationDialog.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.gateway.welcomescreen
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.ui.DialogBuilder

--- a/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceDetails.kt
+++ b/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceDetails.kt
@@ -47,7 +47,7 @@ import software.aws.toolkits.jetbrains.gateway.connection.caws.CawsCommandExecut
 import software.aws.toolkits.jetbrains.gateway.inProgress
 import software.aws.toolkits.jetbrains.isDeveloperMode
 import software.aws.toolkits.jetbrains.services.caws.isSubscriptionFreeTier
-import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
 import java.awt.Color
 import java.awt.FlowLayout
@@ -171,7 +171,7 @@ class PauseAction(private val ws: Workspace, private val workspaceList: Workspac
     override fun actionPerformed(e: AnActionEvent) {
         val result = Messages.showYesNoCancelDialog(message("caws.pause_warning"), message("caws.pause_warning_title"), null)
         if (result != Messages.YES) return
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 ThinClientTrackerService.getInstance().terminateIfRunning(ws.identifier.id)
                 cawsClient.stopDevEnvironment {
@@ -200,7 +200,7 @@ class TerminateAction(private val ws: Workspace, private val workspaceList: Work
     override fun actionPerformed(e: AnActionEvent) {
         val result = Messages.showYesNoDialog(message("caws.delete_workspace_warning"), message("caws.delete_workspace_warning_title"), null)
         if (result != Messages.YES) return
-        executeOnPooledThreadWithParentContext {
+        pluginAwareExecuteOnPooledThread {
             try {
                 cawsClient.deleteDevEnvironment {
                     it.spaceName(ws.identifier.project.space)

--- a/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceDetails.kt
+++ b/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceDetails.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.impl.ActionButton
 import com.intellij.openapi.actionSystem.impl.IdeaActionButtonLook
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.DefaultProjectFactory
 import com.intellij.openapi.project.DumbAwareAction

--- a/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceDetails.kt
+++ b/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/welcomescreen/WorkspaceDetails.kt
@@ -47,6 +47,7 @@ import software.aws.toolkits.jetbrains.gateway.connection.caws.CawsCommandExecut
 import software.aws.toolkits.jetbrains.gateway.inProgress
 import software.aws.toolkits.jetbrains.isDeveloperMode
 import software.aws.toolkits.jetbrains.services.caws.isSubscriptionFreeTier
+import software.aws.toolkits.jetbrains.utils.executeOnPooledThreadWithParentContext
 import software.aws.toolkits.resources.message
 import java.awt.Color
 import java.awt.FlowLayout
@@ -170,7 +171,7 @@ class PauseAction(private val ws: Workspace, private val workspaceList: Workspac
     override fun actionPerformed(e: AnActionEvent) {
         val result = Messages.showYesNoCancelDialog(message("caws.pause_warning"), message("caws.pause_warning_title"), null)
         if (result != Messages.YES) return
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 ThinClientTrackerService.getInstance().terminateIfRunning(ws.identifier.id)
                 cawsClient.stopDevEnvironment {
@@ -199,7 +200,7 @@ class TerminateAction(private val ws: Workspace, private val workspaceList: Work
     override fun actionPerformed(e: AnActionEvent) {
         val result = Messages.showYesNoDialog(message("caws.delete_workspace_warning"), message("caws.delete_workspace_warning_title"), null)
         if (result != Messages.YES) return
-        ApplicationManager.getApplication().executeOnPooledThread {
+        executeOnPooledThreadWithParentContext {
             try {
                 cawsClient.deleteDevEnvironment {
                     it.spaceName(ws.identifier.project.space)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
This change addresses an issue where tasks run in worker threads would be unable to properly resolve the original plugin calling context since the original call stack is lost. This resulted in bad telemetry in these scenarios when running the Amazon Q plugin.

To address this, this change refactors the PluginResolver class to allow each thread to have its own `PluginResolver` instance, while also supporting the ability for child threads to use the instance created by the parent thread. By using ThreadLocal, each thread has its own context for storing and retrieving the PluginResolver instance. A new threading utility function, `pluginAwareExecuteOnPooledThread`, wraps the original pooled thread execution logic and injects a resolved `PluginResolver` instance from the parent thread on the worker thread. This results in the worker inheriting the parent's correctly resolved plugin identifier.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.