### PR TITLE
fix(amazonq): Code blocks with typewriter text inside list items

### DIFF
--- a/.changes/next-release/.changes/next-release/bugfix-21701bb3-5189-474e-868b-9ec46ecde6ee.json
+++ b/.changes/next-release/.changes/next-release/bugfix-21701bb3-5189-474e-868b-9ec46ecde6ee.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Feature Development: Fix file rejections for files outside of src/"
+}

--- a/.changes/next-release/bugfix-48791e50-4f9c-4345-8b31-a62f4c4488d3.json
+++ b/.changes/next-release/bugfix-48791e50-4f9c-4345-8b31-a62f4c4488d3.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Fixed broken code blocks with typewriter text in list items."
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.9.2",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.13.0",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,11 +57,20 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.9.2.tgz",
-            "integrity": "sha512-w8xAyFhi5nTy+aMBo/AEGSx+FtPhzaVrjjtfQz5g8gJDFoWmVdGI1vIJCZcz6cHHyV/7acb7ULcOYY5Do4uWoQ==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.13.0.tgz",
+            "integrity": "sha512-ZOl4hggf1M7HuHipnNxf4lnh8Dt38hFD/SZPpmL1fw2pJbT+hnIAkz6nru7wUtfUSh990PshuzLRNmVrZDPpag==",
             "hasInstallScript": true,
             "dependencies": {
+                "escape-html": "^1.0.3",
+                "just-clone": "^6.2.0",
+                "marked": "^12.0.2",
+                "prismjs": "1.29.0",
+                "sanitize-html": "^2.12.1",
+                "unescape-html": "^1.1.0"
+            },
+            "peerDependencies": {
+                "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
                 "marked": "^12.0.2",
                 "prismjs": "1.29.0",
@@ -1407,6 +1416,11 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.9.2",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.13.0",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem
- `<span class='typewriter-part>...</span>` shows up in contents within list items.
- Chat card component reordering and update structure is broken sometimes depending on update type.

### Solution
- Streaming content component wrapped out from the chat-item-card and builded as a separate component
- Typewriter animation injection removed from the markdown parsing process
- Typewriter animation injection added to node process state with a check if the node type is TEXT, then we're adding the animation wrapper.

[MynahUI 4.13.0](https://github.com/aws/mynah-ui/releases/tag/v4.13.0)

### Before
<img width="666" alt="broken" src="https://github.com/aws/aws-toolkit-vscode/assets/116281103/42064797-4fdb-4a42-affa-525c7dabd4d2">

### After
<img width="670" alt="fixed" src="https://github.com/aws/aws-toolkit-vscode/assets/116281103/a83b4076-d2d7-436d-9cae-e299403abc83">


## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
