### PR TITLE
Take AWS error message only if details exists in refreshToken failure

### DIFF
--- a/.changes/next-release/bugfix-0a41e319-c7eb-413f-b43f-367b3d6379c1.json
+++ b/.changes/next-release/bugfix-0a41e319-c7eb-413f-b43f-367b3d6379c1.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Fix refresh token telemetry failure due to null aws error details"
+  "description" : "Fix refresh token failure due to null aws error details"
 }

--- a/.changes/next-release/bugfix-0a41e319-c7eb-413f-b43f-367b3d6379c1.json
+++ b/.changes/next-release/bugfix-0a41e319-c7eb-413f-b43f-367b3d6379c1.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix refresh token telemetry failure due to null aws error details"
+}

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProvider.kt
@@ -406,7 +406,7 @@ class SsoAccessTokenProvider(
                 else -> null
             }
             val message = when (e) {
-                is AwsServiceException -> e.awsErrorDetails().errorMessage()
+                is AwsServiceException -> e.awsErrorDetails()?.errorMessage() ?: "Unknown error"
                 else -> e.message ?: "Unknown error"
             }
             sendFailedRefreshCredentialsMetricIfNeeded(

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProviderTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProviderTest.kt
@@ -320,11 +320,7 @@ class SsoAccessTokenProviderTest {
             on(
                 ssoOidcClient.createToken(refreshTokenRequest())
             )
-                .thenThrow(
-                    AwsServiceException.builder()
-                        .awsErrorDetails(AwsErrorDetails.builder().errorMessage("Test Err Msg").build())
-                        .build()
-                )
+                .thenThrow(AwsServiceException.builder().build())
         }
 
         assertThatThrownBy { runBlocking { sut.refreshToken(sut.accessToken()) } }

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProviderTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProviderTest.kt
@@ -24,6 +24,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails
+import software.amazon.awssdk.awscore.exception.AwsServiceException
 import software.amazon.awssdk.services.ssooidc.SsoOidcClient
 import software.amazon.awssdk.services.ssooidc.model.AuthorizationPendingException
 import software.amazon.awssdk.services.ssooidc.model.CreateTokenRequest
@@ -298,6 +300,35 @@ class SsoAccessTokenProviderTest {
         verify(ssoCache).loadClientRegistration(argThat { region == ssoRegion })
         verify(ssoOidcClient).createToken(any<CreateTokenRequest>())
         verify(ssoCache).saveAccessToken(argThat<DeviceGrantAccessTokenCacheKey> { startUrl == ssoUrl }, eq(refreshedToken))
+    }
+
+    @Test
+    fun `refresh access token error handling does not fail if AWS error details are missing`() {
+        val expirationClientRegistration = clock.instant().plusSeconds(120)
+        setupCacheStub(expirationClientRegistration)
+
+        val accessToken = DeviceAuthorizationGrantToken(ssoUrl, ssoRegion, "dummyToken", "refreshToken", clock.instant())
+        ssoCache.stub {
+            on(
+                ssoCache.loadAccessToken(argThat<DeviceGrantAccessTokenCacheKey> { startUrl == ssoUrl })
+            ).thenReturn(
+                accessToken
+            )
+        }
+
+        ssoOidcClient.stub {
+            on(
+                ssoOidcClient.createToken(refreshTokenRequest())
+            )
+                .thenThrow(
+                    AwsServiceException.builder()
+                        .awsErrorDetails(AwsErrorDetails.builder().errorMessage("Test Err Msg").build())
+                        .build()
+                )
+        }
+
+        assertThatThrownBy { runBlocking { sut.refreshToken(sut.accessToken()) } }
+            .isInstanceOf(AwsServiceException::class.java)
     }
 
     @Test

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProviderTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProviderTest.kt
@@ -24,7 +24,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import software.amazon.awssdk.awscore.exception.AwsErrorDetails
 import software.amazon.awssdk.awscore.exception.AwsServiceException
 import software.amazon.awssdk.services.ssooidc.SsoOidcClient
 import software.amazon.awssdk.services.ssooidc.model.AuthorizationPendingException


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
This line:
https://github.com/aws/aws-toolkit-jetbrains/blob/main/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProvider.kt#L409
could fail if `e.awsErrorDetails()` returns null. Kotlin can't catch the typing error because AwsServiceException is defined in java.

https://github.com/aws/aws-toolkit-jetbrains/issues/4609
https://github.com/aws/aws-toolkit-jetbrains/issues/4610


## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
