### PR TITLE
Make 'Plugin DevKit' required for project

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="DevKit" />
+  </component>
+</project>


### PR DESCRIPTION
At some point, JetBrains moved download responsibility of platform source code from the Gradle plugin to the IDE

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
