### PR TITLE
Fix duplicated IdC failure metrics

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
@@ -26,7 +26,6 @@ import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenPr
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider
 import software.aws.toolkits.jetbrains.utils.runUnderProgressIfNeeded
 import software.aws.toolkits.resources.message
-import software.aws.toolkits.telemetry.CredentialSourceId
 import software.aws.toolkits.telemetry.CredentialType
 import software.aws.toolkits.telemetry.Result
 import java.time.Instant
@@ -255,21 +254,6 @@ fun reauthConnectionIfNeeded(
     return tokenProvider
 }
 
-private fun reauthProviderIfNeeded(
-    project: Project?,
-    tokenProvider: BearerTokenProvider,
-    connection: ToolkitConnection,
-    metadata: ConnectionMetadata
-): BearerTokenProvider {
-    maybeReauthProviderIfNeeded(project, tokenProvider) {
-        runUnderProgressIfNeeded(project, message("credentials.pending.title"), true) {
-            tokenProvider.reauthenticate()
-        }
-    }
-
-    return tokenProvider
-}
-
 // Return true if need to re-auth, false otherwise
 fun maybeReauthProviderIfNeeded(
     project: Project?,
@@ -317,7 +301,6 @@ private fun getSsoSessionProfileNameFromCredentials(connection: CredentialIdenti
     return connection.ssoSessionName
 }
 
-
 private fun recordLoginWithBrowser(
     credentialStartUrl: String? = null,
     credentialSourceId: String? = null,
@@ -364,4 +347,3 @@ private fun recordAddConnection(
 data class ConnectionMetadata(
     val sourceId: String? = null
 )
-

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialog.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialog.kt
@@ -277,7 +277,7 @@ class SetupAuthenticationDialog(
                     scopes = scopes
                 )
 
-                val connection = authAndUpdateConfig(project, profile, configFilesFacade, {}) { e, _ ->
+                val connection = authAndUpdateConfig(project, profile, configFilesFacade, {}, {}) { e, _ ->
                     Messages.showErrorDialog(project, e.message, title)
                     AuthTelemetry.addConnection(
                         project,

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -115,17 +115,19 @@ abstract class LoginBrowser(
         else -> ""
     }
 
-    private fun isReAuth(scopes: List<String>): Boolean = if (scopes.toSet().intersect(Q_SCOPES.toSet()).isNotEmpty()) {
-        ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance()) != null
-    } else if (scopes.toSet().intersect(CODECATALYST_SCOPES.toSet()).isNotEmpty()) {
-        ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeCatalystConnection.getInstance()) != null
-    } else {
-        ToolkitConnectionManager.getInstance(project).activeConnection().let {
-            val ccCon = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeCatalystConnection.getInstance())
-            val qCon = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())
-            it != null && it != ccCon && it != qCon
+    private fun isReAuth(scopes: List<String>): Boolean = ToolkitConnectionManager.getInstance(project)
+        .let {
+            if (scopes.toSet().intersect(Q_SCOPES.toSet()).isNotEmpty()) {
+                it.activeConnectionForFeature(QConnection.getInstance()) != null
+            } else if (scopes.toSet().intersect(CODECATALYST_SCOPES.toSet()).isNotEmpty()) {
+                it.activeConnectionForFeature(CodeCatalystConnection.getInstance()) != null
+            } else {
+                val activeCon = it.activeConnection()
+                val ccCon = it.activeConnectionForFeature(CodeCatalystConnection.getInstance())
+                val qCon = it.activeConnectionForFeature(QConnection.getInstance())
+                activeCon != null && activeCon != ccCon && activeCon != qCon
+            }
         }
-    }
 
     open fun loginBuilderId(scopes: List<String>) {
         val onError: (Exception) -> Unit = { e ->

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -28,8 +28,10 @@ import software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection
 import software.aws.toolkits.jetbrains.core.credentials.Login
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
+import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeCatalystConnection
 import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
 import software.aws.toolkits.jetbrains.core.credentials.reauthConnectionIfNeeded
+import software.aws.toolkits.jetbrains.core.credentials.sono.CODECATALYST_SCOPES
 import software.aws.toolkits.jetbrains.core.credentials.sono.Q_SCOPES
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
 import software.aws.toolkits.jetbrains.core.credentials.sso.PendingAuthorization
@@ -151,9 +153,13 @@ abstract class LoginBrowser(
         // assumes scopes contains either Q or non-Q permissions but not both
         val isReAuth = if (scopes.toSet().intersect(Q_SCOPES.toSet()).isNotEmpty()) {
             ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance()) != null
+        } else if (scopes.toSet().intersect(CODECATALYST_SCOPES.toSet()).isNotEmpty()) {
+            ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeCatalystConnection.getInstance()) != null
         } else {
             ToolkitConnectionManager.getInstance(project).activeConnection().let {
-                it != null && it != ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())
+                val ccCon = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeCatalystConnection.getInstance())
+                val qCon = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())
+                it != null && it != ccCon && it != qCon
             }
         }
 

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito.mockConstruction
-import org.mockito.internal.verification.Times
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doNothing

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
@@ -444,7 +444,6 @@ class DefaultToolkitAuthManagerTest {
             requestedScopes = listOf("scopes")
         )
         val metricCaptor = argumentCaptor<MetricEvent>()
-        verify(batcher, Times(2)).enqueue(metricCaptor.capture())
         assertMetricEventsContains(metricCaptor.allValues, "awsId")
     }
 
@@ -459,7 +458,6 @@ class DefaultToolkitAuthManagerTest {
             metadata = ConnectionMetadata("fooSourceId")
         )
         val metricCaptor = argumentCaptor<MetricEvent>()
-        verify(batcher, Times(2)).enqueue(metricCaptor.capture())
         assertMetricEventsContains(metricCaptor.allValues, "fooSourceId")
     }
 

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialogTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialogTest.kt
@@ -105,6 +105,7 @@ class SetupAuthenticationDialogTest {
                 UserConfigSsoSessionProfile("", region.id, startUrl, scopes),
                 configFacade,
                 any(),
+                any(),
                 any()
             )
         }
@@ -158,6 +159,7 @@ class SetupAuthenticationDialogTest {
                 projectExtension.project,
                 UserConfigSsoSessionProfile("", region.id, startUrl, scopes + "sso:account:access"),
                 configFacade,
+                any(),
                 any(),
                 any()
             )

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/webview/ToolkitLoginWebview.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/webview/ToolkitLoginWebview.kt
@@ -309,8 +309,11 @@ class ToolkitWebviewBrowser(val project: Project, private val parentDisposable: 
         val onIdCError: (Exception, AuthProfile) -> Unit = { e, profile ->
             // TODO: telemetry
         }
+        val onIdCSuccess: () -> Unit = {
+            // TODO: telemetry
+        }
 
-        val login = Login.IdC(url, region, scopes, onPendingToken, onIdCError)
+        val login = Login.IdC(url, region, scopes, onPendingToken, onIdCSuccess, onIdCError)
 
         loginWithBackgroundContext {
             val connection = login.loginIdc(project)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/ToolkitAuthUtils.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/ToolkitAuthUtils.kt
@@ -38,7 +38,7 @@ fun rolePopupFromConnection(
                     scopes = scopes
                 )
 
-                authAndUpdateConfig(project, profile, configFilesFacade, {}) { e, _ ->
+                authAndUpdateConfig(project, profile, configFilesFacade, {}, {}) { e, _ ->
                     Messages.showErrorDialog(project, e.message, message("gettingstarted.explorer.iam.add"))
                 } ?: return@runInEdt
             } else {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Currently, attempting to sign in through the Q by clicking "Use with Pro License" then cancelling results in duplicate browser login and addConnection metrics. This is because we are submitting metrics in the IdC-specific login function and in the general login function (the IdC-specific login function calls the general one).

This change will move all metrics decisions to the IdC-specific login function. The general login function does the actual submission through a hook.

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [X] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
