### PR TITLE
Explicitly install .NET 6 in Windows buildspec

### DIFF
--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -13,10 +13,10 @@ phases:
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - choco install -fy dotnet-8.0-sdk
+      - rm -fo "C:\codebuild\global.json"
+      - rm -r -fo "C:\Program Files\dotnet\sdk"
       - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks
-      - dotnet new globaljson --sdk-version 6.0.0 --roll-forward latestMinor
 
   build:
     commands:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -13,7 +13,7 @@ phases:
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - rm -fo "C:\codebuild\global.json"
+      - if (Test-Path "C:\codebuild\global.json") { rm -fo "C:\codebuild\global.json" }
       - rm -r -fo "C:\Program Files\dotnet\sdk"
       - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -25,7 +25,7 @@ phases:
 
         if ($Env:CODEARTIFACT_DOMAIN_NAME -and $Env:CODEARTIFACT_REPO_NAME) {
           $Env:CODEARTIFACT_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format maven --query repositoryEndpoint --output text
-          $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
+          # $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
           $Env:CODEARTIFACT_AUTH_TOKEN=aws codeartifact get-authorization-token --domain $Env:CODEARTIFACT_DOMAIN_NAME --query authorizationToken --output text --duration-seconds 3600
         }
 

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -7,21 +7,14 @@ env:
 
 phases:
   install:
-    runtime-versions:
-      java: corretto17
-
     commands:
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - dotnet --list-sdks
-      - |
-        $DOTNET_ROOT = "$Env:USERPROFILE\.dotnet"
-        $Env:PATH = "$Env:PATH;$DOTNET_ROOT;$DOTNET_ROOT\tools"
-        dotnet tool install -g AWS.CodeArtifact.NuGet.CredentialProvider
-        dotnet codeartifact-creds install
+      - choco install -fy dotnet-6.0-sdk
+      - choco install -fy dotnet-8.0-sdk
       - dotnet --list-sdks
 
   build:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -16,6 +16,7 @@ phases:
       - choco install -fy dotnet-8.0-sdk
       - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks
+      - dotnet new globaljson --sdk-version 6.0.0 --roll-forward latestMinor
 
   build:
     commands:

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -13,8 +13,8 @@ phases:
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - choco install -fy dotnet-6.0-sdk
       - choco install -fy dotnet-8.0-sdk
+      - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks
 
   build:

--- a/buildspec/windowsTestsForAmazonQ.yml
+++ b/buildspec/windowsTestsForAmazonQ.yml
@@ -25,7 +25,7 @@ phases:
 
         if ($Env:CODEARTIFACT_DOMAIN_NAME -and $Env:CODEARTIFACT_REPO_NAME) {
           $Env:CODEARTIFACT_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format maven --query repositoryEndpoint --output text
-          $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
+          # $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
           $Env:CODEARTIFACT_AUTH_TOKEN=aws codeartifact get-authorization-token --domain $Env:CODEARTIFACT_DOMAIN_NAME --query authorizationToken --output text --duration-seconds 3600
         }
 

--- a/buildspec/windowsTestsForAmazonQ.yml
+++ b/buildspec/windowsTestsForAmazonQ.yml
@@ -7,21 +7,14 @@ env:
 
 phases:
   install:
-    runtime-versions:
-      java: corretto17
-
     commands:
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - dotnet --list-sdks
-      - |
-        $DOTNET_ROOT = "$Env:USERPROFILE\.dotnet"
-        $Env:PATH = "$Env:PATH;$DOTNET_ROOT;$DOTNET_ROOT\tools"
-        dotnet tool install -g AWS.CodeArtifact.NuGet.CredentialProvider
-        dotnet codeartifact-creds install
+      - choco install -fy dotnet-6.0-sdk
+      - choco install -fy dotnet-8.0-sdk
       - dotnet --list-sdks
 
   build:

--- a/buildspec/windowsTestsForAmazonQ.yml
+++ b/buildspec/windowsTestsForAmazonQ.yml
@@ -13,8 +13,8 @@ phases:
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - choco install -fy dotnet-6.0-sdk
       - choco install -fy dotnet-8.0-sdk
+      - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks
 
   build:

--- a/buildspec/windowsTestsForCore.yml
+++ b/buildspec/windowsTestsForCore.yml
@@ -25,7 +25,7 @@ phases:
 
         if ($Env:CODEARTIFACT_DOMAIN_NAME -and $Env:CODEARTIFACT_REPO_NAME) {
           $Env:CODEARTIFACT_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format maven --query repositoryEndpoint --output text
-          $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
+          # $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
           $Env:CODEARTIFACT_AUTH_TOKEN=aws codeartifact get-authorization-token --domain $Env:CODEARTIFACT_DOMAIN_NAME --query authorizationToken --output text --duration-seconds 3600
         }
 

--- a/buildspec/windowsTestsForCore.yml
+++ b/buildspec/windowsTestsForCore.yml
@@ -7,21 +7,14 @@ env:
 
 phases:
   install:
-    runtime-versions:
-      java: corretto17
-
     commands:
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - dotnet --list-sdks
-      - |
-        $DOTNET_ROOT = "$Env:USERPROFILE\.dotnet"
-        $Env:PATH = "$Env:PATH;$DOTNET_ROOT;$DOTNET_ROOT\tools"
-        dotnet tool install -g AWS.CodeArtifact.NuGet.CredentialProvider
-        dotnet codeartifact-creds install
+      - choco install -fy dotnet-6.0-sdk
+      - choco install -fy dotnet-8.0-sdk
       - dotnet --list-sdks
 
   build:

--- a/buildspec/windowsTestsForCore.yml
+++ b/buildspec/windowsTestsForCore.yml
@@ -13,8 +13,8 @@ phases:
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - choco install -fy dotnet-6.0-sdk
       - choco install -fy dotnet-8.0-sdk
+      - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks
 
   build:

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -25,7 +25,7 @@ phases:
 
         if ($Env:CODEARTIFACT_DOMAIN_NAME -and $Env:CODEARTIFACT_REPO_NAME) {
           $Env:CODEARTIFACT_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format maven --query repositoryEndpoint --output text
-          $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
+          # $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
           $Env:CODEARTIFACT_AUTH_TOKEN=aws codeartifact get-authorization-token --domain $Env:CODEARTIFACT_DOMAIN_NAME --query authorizationToken --output text --duration-seconds 3600
         }
 

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -7,21 +7,14 @@ env:
 
 phases:
   install:
-    runtime-versions:
-      java: corretto17
-
     commands:
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - dotnet --list-sdks
-      - |
-        $DOTNET_ROOT = "$Env:USERPROFILE\.dotnet"
-        $Env:PATH = "$Env:PATH;$DOTNET_ROOT;$DOTNET_ROOT\tools"
-        dotnet tool install -g AWS.CodeArtifact.NuGet.CredentialProvider
-        dotnet codeartifact-creds install
+      - choco install -fy dotnet-6.0-sdk
+      - choco install -fy dotnet-8.0-sdk
       - dotnet --list-sdks
 
   build:

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -13,6 +13,7 @@ phases:
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
+      - rm -fo "C:\codebuild\global.json"
       - rm -r -fo "C:\Program Files\dotnet\sdk"
       - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -16,6 +16,7 @@ phases:
       - choco install -fy dotnet-8.0-sdk
       - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks
+      - dotnet new globaljson --sdk-version 6.0.0 --roll-forward latestMinor
 
   build:
     commands:

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -13,10 +13,9 @@ phases:
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - choco install -fy dotnet-8.0-sdk
+      - rm -r -fo "C:\Program Files\dotnet\sdk"
       - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks
-      - dotnet new globaljson --sdk-version 6.0.0 --roll-forward latestMinor
 
   build:
     commands:

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -13,8 +13,8 @@ phases:
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
         }
-      - choco install -fy dotnet-6.0-sdk
       - choco install -fy dotnet-8.0-sdk
+      - choco install -fy dotnet-6.0-sdk
       - dotnet --list-sdks
 
   build:

--- a/plugins/toolkit/jetbrains-rider/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-rider/build.gradle.kts
@@ -312,7 +312,7 @@ tasks.withType<Detekt> {
 tasks.test {
     if (SystemInfo.isWindows) {
         // extremely flaky
-        filter.excludeTest("software.aws.toolkits.jetbrains.services.lambda.dotnet.LambdaGutterMarkHighlightingTest", null)
+        filter.excludeTestsMatching("software.aws.toolkits.jetbrains.services.lambda.dotnet.LambdaGutterMarkHighlightingTest*")
     }
 
     useTestNG()

--- a/plugins/toolkit/jetbrains-rider/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-rider/build.gradle.kts
@@ -7,6 +7,7 @@ import com.jetbrains.rd.generator.gradle.RdGenTask
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import org.jetbrains.intellij.tasks.PrepareSandboxTask
+import org.jetbrains.kotlin.com.intellij.openapi.util.SystemInfo
 import software.aws.toolkits.gradle.intellij.IdeFlavor
 import software.aws.toolkits.gradle.intellij.IdeVersions
 import java.nio.file.Path
@@ -309,6 +310,11 @@ tasks.withType<Detekt> {
 }
 
 tasks.test {
+    if (SystemInfo.isWindows) {
+        // extremely flaky
+        filter.excludeTest("software.aws.toolkits.jetbrains.services.lambda.dotnet.LambdaGutterMarkHighlightingTest", null)
+    }
+
     useTestNG()
     environment("LOCAL_ENV_RUN", true)
     maxHeapSize = "1024m"

--- a/plugins/toolkit/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
+++ b/plugins/toolkit/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
@@ -4,6 +4,8 @@
 package software.aws.toolkits.jetbrains.services.lambda.dotnet
 
 import base.backendStartTimeout
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.util.SystemInfo
 import com.jetbrains.rdclient.testFramework.waitForDaemon
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.test.base.BaseTestWithMarkup
@@ -22,8 +24,7 @@ class LambdaGutterMarkHighlightingTest : BaseTestWithMarkup() {
 
     @BeforeMethod
     fun skipTestsOnWindows() {
-        val ideVersion = System.getProperty("org.gradle.project.ideProfileName")
-        if (System.getProperty("os.name").contains("Windows") && ideVersion == "2023.2") {
+        if (SystemInfo.isWindows && ApplicationInfo.getInstance().build.baselineVersion == 232) {
             throw SkipException("Test skipped because it flakes on Windows 2023.2")
         }
     }

--- a/plugins/toolkit/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
+++ b/plugins/toolkit/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.lambda.dotnet
 
 import base.backendStartTimeout
-import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.util.SystemInfo
 import com.jetbrains.rdclient.testFramework.waitForDaemon
 import com.jetbrains.rider.projectView.solution

--- a/plugins/toolkit/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
+++ b/plugins/toolkit/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
@@ -4,12 +4,9 @@
 package software.aws.toolkits.jetbrains.services.lambda.dotnet
 
 import base.backendStartTimeout
-import com.intellij.openapi.util.SystemInfo
 import com.jetbrains.rdclient.testFramework.waitForDaemon
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.test.base.BaseTestWithMarkup
-import org.testng.SkipException
-import org.testng.annotations.BeforeMethod
 import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 import software.aws.toolkits.jetbrains.protocol.awsSettingModel
@@ -19,13 +16,6 @@ class LambdaGutterMarkHighlightingTest : BaseTestWithMarkup() {
 
     companion object {
         private const val LAMBDA_RUN_MARKER_ATTRIBUTE_ID = "AWS Lambda Run Method Gutter Mark"
-    }
-
-    @BeforeMethod
-    fun skipTestsOnWindows() {
-        if (SystemInfo.isWindows) {
-            throw SkipException("Test flakes on Windows")
-        }
     }
 
     override val backendLoadedTimeout: Duration = backendStartTimeout

--- a/plugins/toolkit/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
+++ b/plugins/toolkit/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/dotnet/LambdaGutterMarkHighlightingTest.kt
@@ -24,8 +24,8 @@ class LambdaGutterMarkHighlightingTest : BaseTestWithMarkup() {
 
     @BeforeMethod
     fun skipTestsOnWindows() {
-        if (SystemInfo.isWindows && ApplicationInfo.getInstance().build.baselineVersion == 232) {
-            throw SkipException("Test skipped because it flakes on Windows 2023.2")
+        if (SystemInfo.isWindows) {
+            throw SkipException("Test flakes on Windows")
         }
     }
 


### PR DESCRIPTION
Weird test error showing up when only .NET 6 is available

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
