### PR TITLE
Make Amazon Q inline inlay compatiable with JB remote 2024.1+

### DIFF
--- a/.changes/next-release/bugfix-6f6aaf13-6392-4bf2-ae8c-ac63b920ca53.json
+++ b/.changes/next-release/bugfix-6f6aaf13-6392-4bf2-ae8c-ac63b920ca53.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q: Fix an issue where inline suggestion will not properly show in JetBrains remote env 2024.1+"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ toolkitVersion=3.15-SNAPSHOT
 publishToken=
 publishChannel=
 
-ideProfileName=2024.1
+ideProfileName=2023.3
 
 remoteRobotPort=8080
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ toolkitVersion=3.15-SNAPSHOT
 publishToken=
 publishChannel=
 
-ideProfileName=2023.3
+ideProfileName=2024.1
 
 remoteRobotPort=8080
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src-232-241/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/InlineCompletionRemoteRendererFactory.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src-232-241/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/InlineCompletionRemoteRendererFactory.kt
@@ -1,0 +1,63 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.aws.toolkits.jetbrains.services.codewhisperer.inlay
+
+import com.intellij.codeInsight.inline.completion.render.InlineBlockElementRenderer
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorCustomElementRenderer
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.xdebugger.ui.DebuggerColors
+
+// from 232-241.1, we have `InlineSuffixRenderer`, but with 241.2+ it becomes `InlineCompletionLineRenderer`,
+// for both line and block inlays
+// Also InlineBlockElementRenderer is deprecated
+// TODO: Remove this ugly piece once we drop 233(241?)
+object InlineCompletionRemoteRendererFactory {
+    private var hasOldLineConstructor = true
+    private val lineConstructor = run {
+        val clazz =
+            try {
+                Class.forName("com.intellij.codeInsight.inline.completion.render.InlineSuffixRenderer")
+            } catch (e: ClassNotFoundException) {
+                hasOldLineConstructor = false
+                Class.forName("com.intellij.codeInsight.inline.completion.render.InlineCompletionLineRenderer")
+            }
+        if (hasOldLineConstructor) clazz.getConstructor(Editor::class.java, String::class.java)
+        else clazz.getConstructor(Editor::class.java, String::class.java, TextAttributes::class.java)
+    }
+    private var hasNewBlockConstructor = true
+    private val blockConstructor = run {
+        val clazz =
+            try {
+                Class.forName("com.intellij.codeInsight.inline.completion.render.InlineCompletionLineRenderer")
+            } catch (e: ClassNotFoundException) {
+                hasNewBlockConstructor = false
+                Class.forName("com.intellij.codeInsight.inline.completion.render.InlineBlockElementRenderer")
+            }
+        clazz.getConstructor(Editor::class.java, List::class.java)
+    }
+
+    fun createLineInlay(editor: Editor, text: String): EditorCustomElementRenderer {
+        return (if (hasOldLineConstructor)
+            lineConstructor.newInstance(editor, text)
+        else
+            lineConstructor.newInstance(editor, text, editor.colorsScheme.getAttributes(DebuggerColors.INLINED_VALUES_EXECUTION_LINE)))
+            as EditorCustomElementRenderer
+    }
+
+    fun createBlockInlays(editor: Editor, block: List<String>): List<EditorCustomElementRenderer> {
+        return if (hasNewBlockConstructor) {
+            // 241.2+
+            val textBlockClazz = Class.forName("com.intellij.codeInsight.inline.completion.render.InlineCompletionRenderTextBlock")
+            val textBlockConstructor = textBlockClazz.getConstructor(String::class.java, TextAttributes::class.java)
+            block.map {
+                blockConstructor.newInstance(
+                    editor,
+                    listOf(textBlockConstructor.newInstance(it, editor.colorsScheme.getAttributes(DebuggerColors.INLINED_VALUES_EXECUTION_LINE)))
+                ) as EditorCustomElementRenderer
+            }
+        } else {
+            listOf(InlineBlockElementRenderer(editor, block))
+        }
+    }
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src-232-241/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/InlineCompletionRemoteRendererFactory.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src-232-241/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/InlineCompletionRemoteRendererFactory.kt
@@ -22,8 +22,11 @@ object InlineCompletionRemoteRendererFactory {
                 hasOldLineConstructor = false
                 Class.forName("com.intellij.codeInsight.inline.completion.render.InlineCompletionLineRenderer")
             }
-        if (hasOldLineConstructor) clazz.getConstructor(Editor::class.java, String::class.java)
-        else clazz.getConstructor(Editor::class.java, String::class.java, TextAttributes::class.java)
+        if (hasOldLineConstructor) {
+            clazz.getConstructor(Editor::class.java, String::class.java)
+        } else {
+            clazz.getConstructor(Editor::class.java, String::class.java, TextAttributes::class.java)
+        }
     }
     private var hasNewBlockConstructor = true
     private val blockConstructor = run {
@@ -37,16 +40,17 @@ object InlineCompletionRemoteRendererFactory {
         clazz.getConstructor(Editor::class.java, List::class.java)
     }
 
-    fun createLineInlay(editor: Editor, text: String): EditorCustomElementRenderer {
-        return (if (hasOldLineConstructor)
-            lineConstructor.newInstance(editor, text)
-        else
-            lineConstructor.newInstance(editor, text, editor.colorsScheme.getAttributes(DebuggerColors.INLINED_VALUES_EXECUTION_LINE)))
-            as EditorCustomElementRenderer
-    }
+    fun createLineInlay(editor: Editor, text: String): EditorCustomElementRenderer =
+        (
+            if (hasOldLineConstructor) {
+                lineConstructor.newInstance(editor, text)
+            } else {
+                lineConstructor.newInstance(editor, text, editor.colorsScheme.getAttributes(DebuggerColors.INLINED_VALUES_EXECUTION_LINE))
+            }
+            ) as EditorCustomElementRenderer
 
-    fun createBlockInlays(editor: Editor, block: List<String>): List<EditorCustomElementRenderer> {
-        return if (hasNewBlockConstructor) {
+    fun createBlockInlays(editor: Editor, block: List<String>): List<EditorCustomElementRenderer> =
+        if (hasNewBlockConstructor) {
             // 241.2+
             val textBlockClazz = Class.forName("com.intellij.codeInsight.inline.completion.render.InlineCompletionRenderTextBlock")
             val textBlockConstructor = textBlockClazz.getConstructor(String::class.java, TextAttributes::class.java)
@@ -59,5 +63,4 @@ object InlineCompletionRemoteRendererFactory {
         } else {
             listOf(InlineBlockElementRenderer(editor, block))
         }
-    }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src-232-241/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/InlineCompletionRemoteRendererFactory.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src-232-241/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/InlineCompletionRemoteRendererFactory.kt
@@ -8,10 +8,9 @@ import com.intellij.openapi.editor.EditorCustomElementRenderer
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.xdebugger.ui.DebuggerColors
 
-// from 232-241.1, we have `InlineSuffixRenderer`, but with 241.2+ it becomes `InlineCompletionLineRenderer`,
-// for both line and block inlays
-// Also InlineBlockElementRenderer is deprecated
-// TODO: Remove this ugly piece once we drop 233(241?)
+// from 232-241.1, we have `InlineSuffixRenderer`, but with 241.2+ it becomes `InlineCompletionLineRenderer`
+// for both line and block inlays. Also InlineBlockElementRenderer is deprecated
+// 242 is not yet handled by this
 object InlineCompletionRemoteRendererFactory {
     private var hasOldLineConstructor = true
     private val lineConstructor = run {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/CodeWhispererInlayManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/CodeWhispererInlayManager.kt
@@ -63,7 +63,7 @@ class CodeWhispererInlayManager {
                 InlineCompletionRemoteRendererFactory.createBlockInlays(editor, otherLines.split("\n"))
             }
 
-        otherLinesRenderers.forEachIndexed { index, otherLinesRenderer ->
+        otherLinesRenderers.forEach { otherLinesRenderer ->
             val blockInlay = editor.inlayModel.addBlockElement(
                 startOffset,
                 true,

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/CodeWhispererInlayManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/CodeWhispererInlayManager.kt
@@ -3,8 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer.inlay
 
-import com.intellij.codeInsight.inline.completion.render.InlineBlockElementRenderer
-import com.intellij.codeInsight.inline.completion.render.InlineSuffixRenderer
 import com.intellij.idea.AppMode
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -46,7 +44,7 @@ class CodeWhispererInlayManager {
                 if (!AppMode.isRemoteDevHost()) {
                     CodeWhispererInlayInlineRenderer(firstLine)
                 } else {
-                    InlineSuffixRenderer(editor, firstLine)
+                    InlineCompletionRemoteRendererFactory.createLineInlay(editor, firstLine)
                 }
             val inlineInlay = editor.inlayModel.addInlineElement(startOffset, true, firstLineRenderer)
             inlineInlay?.let {
@@ -58,22 +56,25 @@ class CodeWhispererInlayManager {
         if (otherLines.isEmpty()) {
             return
         }
-        val otherLinesRenderer =
+        val otherLinesRenderers =
             if (!AppMode.isRemoteDevHost()) {
-                CodeWhispererInlayBlockRenderer(otherLines)
+                listOf(CodeWhispererInlayBlockRenderer(otherLines))
             } else {
-                InlineBlockElementRenderer(editor, otherLines.split("\n"))
+                InlineCompletionRemoteRendererFactory.createBlockInlays(editor, otherLines.split("\n"))
             }
-        val blockInlay = editor.inlayModel.addBlockElement(
-            startOffset,
-            true,
-            false,
-            0,
-            otherLinesRenderer
-        )
-        blockInlay?.let {
-            existingInlays.add(it)
-            Disposer.register(popup, it)
+
+        otherLinesRenderers.forEachIndexed { index, otherLinesRenderer ->
+            val blockInlay = editor.inlayModel.addBlockElement(
+                startOffset,
+                true,
+                false,
+                0,
+                otherLinesRenderer
+            )
+            blockInlay?.let {
+                existingInlays.add(it)
+                Disposer.register(popup, it)
+            }
         }
     }
 


### PR DESCRIPTION
Adapt the change of APIs for the following:
1. line inlays: InlineSuffixRenderer -> InlineCompletionLineRenderer
2. block inlays: InlineBlockElementRenderer -> InlineCompletionLineRenderer

JB will use InlineCompletionLineRenderer to render inlays in remote regardless of whether it's single or multi-line inlays.

<img width="631" alt="Screenshot 2024-07-08 at 1 48 56 AM" src="https://github.com/aws/aws-toolkit-jetbrains/assets/89420755/e8075fd8-7556-4311-ae97-0e471c843eff">

As shown above the inlay height issues are discussed separately with JetBrains team, most likely waiting JetBrains team to fix it.
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
