### PR TITLE
Always use system trust store when creating Q client

### DIFF
--- a/.changes/next-release/bugfix-9a8eaf22-9631-404f-a67c-fc792142a8b4.json
+++ b/.changes/next-release/bugfix-9a8eaf22-9631-404f-a67c-fc792142a8b4.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix Q Chat not respecting system trust store unless a proxy is configured"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererEndpointCustomizer.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererEndpointCustomizer.kt
@@ -95,10 +95,12 @@ class CodeWhispererEndpointCustomizer : ToolkitClientCustomizer {
                         .useSystemPropertyValues(false)
 
                     clientBuilder.proxyConfiguration(proxyConfiguration.build())
-                        .tlsTrustManagersProvider { arrayOf<TrustManager>(CertificateManager.getInstance().trustManager) }
                 }
 
-                builder.httpClientBuilder(clientBuilder)
+                builder.httpClientBuilder(
+                    clientBuilder
+                        .tlsTrustManagersProvider { arrayOf<TrustManager>(CertificateManager.getInstance().trustManager) }
+                )
             }
         } else if (builder is CodeWhispererClientBuilder) {
             clientOverrideConfiguration.addExecutionInterceptor(


### PR DESCRIPTION
Some users may have a networking setup where they implicitly traverse SSL-introspecting appliances without explicit configuration. 

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
