### PR TITLE
Support for additional metadata with loginSso calls

### DIFF
--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
@@ -74,7 +74,6 @@ class DefaultToolkitAuthManagerTest {
         telemetryService = spy(TestTelemetryService(batcher = batcher))
         ApplicationManager.getApplication().replaceService(TelemetryService::class.java, telemetryService, disposable)
         isTelemetryEnabledDefault = AwsSettings.getInstance().isTelemetryEnabled
-
     }
 
     @AfterEach

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
@@ -3,66 +3,81 @@
 
 package software.aws.toolkits.jetbrains.core.credentials
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.testFramework.ApplicationRule
-import com.intellij.testFramework.DisposableRule
+import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.ProjectExtension
 import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.junit5.TestDisposable
 import com.intellij.testFramework.replaceService
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito.mockConstruction
+import org.mockito.internal.verification.Times
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ssooidc.SsoOidcClient
+import software.aws.toolkits.core.telemetry.MetricEvent
+import software.aws.toolkits.core.telemetry.TelemetryBatcher
+import software.aws.toolkits.core.telemetry.TelemetryPublisher
 import software.aws.toolkits.core.utils.test.aString
-import software.aws.toolkits.jetbrains.core.MockClientManagerRule
+import software.aws.toolkits.jetbrains.core.MockClientManagerExtension
 import software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileSsoSessionIdentifier
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenAuthState
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderExtension
 import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
+import software.aws.toolkits.jetbrains.services.telemetry.NoOpPublisher
+import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.aws.toolkits.jetbrains.utils.isInstanceOf
 import software.aws.toolkits.jetbrains.utils.isInstanceOfSatisfying
 import software.aws.toolkits.jetbrains.utils.satisfiesKt
 
+@ExtendWith(ApplicationExtension::class)
 class DefaultToolkitAuthManagerTest {
-    @JvmField
-    @Rule
-    val applicationRule = ApplicationRule()
+    private class TestTelemetryService(
+        publisher: TelemetryPublisher = NoOpPublisher(),
+        batcher: TelemetryBatcher
+    ) : TelemetryService(publisher, batcher)
 
-    @JvmField
-    @Rule
+    @ExtendWith(ProjectExtension::class)
     val projectRule = ProjectRule()
 
-    @JvmField
-    @Rule
+    @ExtendWith(MockRegionProviderExtension::class)
     val regionProvider = MockRegionProviderRule()
 
-    @JvmField
-    @Rule
-    val disposableRule = DisposableRule()
+    @TestDisposable
+    private lateinit var disposable: Disposable
 
     @JvmField
-    @Rule
-    val mockClientManager = MockClientManagerRule()
+    @RegisterExtension
+    val mockClientManager = MockClientManagerExtension()
 
     private lateinit var sut: DefaultToolkitAuthManager
-
     private lateinit var connectionManager: ToolkitConnectionManager
+    private lateinit var batcher: TelemetryBatcher
+    private lateinit var telemetryService: TelemetryService
 
-    @Before
+    @BeforeEach
     fun setUp() {
         mockClientManager.create<SsoOidcClient>()
         sut = DefaultToolkitAuthManager()
         connectionManager = DefaultToolkitConnectionManager()
+        batcher = mock()
+        telemetryService = spy(TestTelemetryService(batcher = batcher))
+        ApplicationManager.getApplication().replaceService(TelemetryService::class.java, telemetryService, disposable)
     }
 
     @Test
@@ -208,8 +223,8 @@ class DefaultToolkitAuthManagerTest {
     fun `loginSso with an working existing connection`() {
         val connectionManager: ToolkitConnectionManager = mock()
         regionProvider.addRegion(Region.US_EAST_1)
-        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposableRule.disposable)
-        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposableRule.disposable)
+        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposable)
+        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposable)
 
         mockConstruction(InteractiveBearerTokenProvider::class.java) { context, _ ->
             whenever(context.state()).thenReturn(BearerTokenAuthState.AUTHORIZED)
@@ -234,8 +249,8 @@ class DefaultToolkitAuthManagerTest {
     fun `loginSso with an existing connection but expired and refresh token is valid, should refreshToken`() {
         val connectionManager = ToolkitConnectionManager.getInstance(projectRule.project)
         regionProvider.addRegion(Region.US_EAST_1)
-        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposableRule.disposable)
-        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposableRule.disposable)
+        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposable)
+        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposable)
 
         mockConstruction(InteractiveBearerTokenProvider::class.java) { context, _ ->
             whenever(context.id).thenReturn("id")
@@ -262,7 +277,7 @@ class DefaultToolkitAuthManagerTest {
     fun `loginSso with an existing connection that token is invalid and there's no refresh token, should re-authenticate`() {
         val connectionManager = ToolkitConnectionManager.getInstance(projectRule.project)
         regionProvider.addRegion(Region.US_EAST_1)
-        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposableRule.disposable)
+        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposable)
 
         mockConstruction(InteractiveBearerTokenProvider::class.java) { context, _ ->
             whenever(context.state()).thenReturn(BearerTokenAuthState.NOT_AUTHENTICATED)
@@ -288,7 +303,7 @@ class DefaultToolkitAuthManagerTest {
     fun `loginSso reuses connection if requested scopes are subset of existing`() {
         val connectionManager = ToolkitConnectionManager.getInstance(projectRule.project)
         regionProvider.addRegion(Region.US_EAST_1)
-        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposableRule.disposable)
+        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposable)
 
         mockConstruction(InteractiveBearerTokenProvider::class.java) { context, _ ->
             whenever(context.state()).thenReturn(BearerTokenAuthState.AUTHORIZED)
@@ -316,8 +331,8 @@ class DefaultToolkitAuthManagerTest {
     fun `loginSso forces reauth if requested scopes are not complete subset`() {
         regionProvider.addRegion(Region.US_EAST_1)
 
-        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposableRule.disposable)
-        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposableRule.disposable)
+        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposable)
+        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposable)
 
         mockConstruction(InteractiveBearerTokenProvider::class.java) { context, _ ->
             whenever(context.state()).thenReturn(BearerTokenAuthState.AUTHORIZED)
@@ -346,8 +361,8 @@ class DefaultToolkitAuthManagerTest {
     @Test
     fun `loginSso with a new connection`() {
         val connectionManager: ToolkitConnectionManager = mock()
-        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposableRule.disposable)
-        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposableRule.disposable)
+        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposable)
+        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposable)
 
         mockConstruction(InteractiveBearerTokenProvider::class.java) { context, _ ->
             doNothing().whenever(context).reauthenticate()
@@ -381,7 +396,7 @@ class DefaultToolkitAuthManagerTest {
     @Test
     fun `logoutFromConnection should invalidate the token provider and the connection and invoke callback`() {
         regionProvider.addRegion(Region.US_EAST_1)
-        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposableRule.disposable)
+        projectRule.project.replaceService(ToolkitConnectionManager::class.java, connectionManager, disposable)
 
         val profile = ManagedSsoProfile("us-east-1", "startUrl000", listOf("scopes"))
         val connection = ToolkitAuthManager.getInstance().createConnection(profile) as ManagedBearerSsoConnection
@@ -413,5 +428,38 @@ class DefaultToolkitAuthManagerTest {
         assertThat(providerInvalidatedMessageReceived).isEqualTo(1)
         assertThat(connectionSwitchedMessageReceived).isEqualTo(1)
         assertThat(callbackInvoked).isEqualTo(1)
+    }
+
+    @Test
+    fun `loginSso telemetry contains default source ID`() {
+        loginSso(
+            project = projectRule.project,
+            startUrl = "foo",
+            region = "us-east-1",
+            requestedScopes = listOf("scopes")
+        )
+        val metricCaptor = argumentCaptor<MetricEvent>()
+        verify(batcher, Times(2)).enqueue(metricCaptor.capture())
+        assertMetricEventsContains(metricCaptor.allValues, "awsId")
+    }
+
+    @Test
+    fun `loginSso telemetry contains provided source ID`() {
+        loginSso(
+            project = projectRule.project,
+            startUrl = "foo",
+            region = "us-east-1",
+            requestedScopes = listOf("scopes"),
+            metadata = ConnectionMetadata("fooSourceId")
+        )
+        val metricCaptor = argumentCaptor<MetricEvent>()
+        verify(batcher, Times(2)).enqueue(metricCaptor.capture())
+        assertMetricEventsContains(metricCaptor.allValues, "fooSourceId")
+    }
+
+    private fun assertMetricEventsContains(events: Collection<MetricEvent>, credentialSourceId: String) {
+        assertThat(events).allSatisfy { event ->
+            assertThat(event.data.all { it.metadata["credentialSourceId"] == credentialSourceId }).isTrue()
+        }
     }
 }

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/telemetry/PluginResolverTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/telemetry/PluginResolverTest.kt
@@ -11,19 +11,19 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
-import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import junit.framework.TestCase.assertEquals
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import software.amazon.awssdk.services.toolkittelemetry.model.AWSProduct
 
 class PluginResolverTest {
-    @Before
+    @BeforeEach
     fun setup() {
         mockkStatic(PluginManagerCore::class)
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         clearAllMocks()
     }

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/settings/AwsSettingsTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/settings/AwsSettingsTest.kt
@@ -9,6 +9,7 @@ import com.intellij.testFramework.ApplicationExtension
 import com.intellij.testFramework.junit5.TestDisposable
 import com.intellij.testFramework.replaceService
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -41,7 +42,11 @@ class AwsSettingsTest {
         awsConfiguration = spy(AwsConfiguration())
         awsSettings.loadState(awsConfiguration)
         ApplicationManager.getApplication().replaceService(TelemetryService::class.java, telemetryService, disposable)
-        ApplicationManager.getApplication().replaceService(AwsSettings::class.java, awsSettings, disposable)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        telemetryService.dispose()
     }
 
     @Test
@@ -59,7 +64,7 @@ class AwsSettingsTest {
         val changeCaptor = argumentCaptor<Boolean>()
         val onChangeEventCaptor = argumentCaptor<(Boolean) -> Unit>()
 
-        AwsSettings.getInstance().isTelemetryEnabled = value
+        awsSettings.isTelemetryEnabled = value
 
         inOrder.verify(telemetryService).setTelemetryEnabled(changeCaptor.capture(), onChangeEventCaptor.capture())
         assertThat(changeCaptor.firstValue).isEqualTo(value)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Adds the ability to provide additional metadata with `loginSso` and `reauthConnectionIfNeeded` calls - currently limited to an ability to pass an overridden `credentialSourceId`. This value will be subsequently used in telemetry metrics emitted in this call path.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
