### PR TITLE
feat: proactively show code generation iterations

### DIFF
--- a/.changes/next-release/feature-dbb83daa-1648-4af8-be1b-8ba0af36e073.json
+++ b/.changes/next-release/feature-dbb83daa-1648-4af8-be1b-8ba0af36e073.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Amazon Q/dev: proactively show code generation iterations"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
@@ -51,6 +51,8 @@ suspend fun FeatureDevController.onCodeGeneration(session: Session, message: Str
         var deletedFiles: List<DeletedFileInfo> = emptyList()
         var references: List<CodeReferenceGenerated> = emptyList()
         var uploadId = ""
+        var remainingIterations: Int? = null
+        var totalIterations: Int? = null
 
         when (state) {
             is PrepareCodeGenerationState -> {
@@ -58,6 +60,8 @@ suspend fun FeatureDevController.onCodeGeneration(session: Session, message: Str
                 deletedFiles = state.deletedFiles
                 references = state.references
                 uploadId = state.uploadId
+                remainingIterations = state.codeGenerationRemainingIterationCount
+                totalIterations = state.codeGenerationTotalIterationCount
             }
         }
 
@@ -87,6 +91,14 @@ suspend fun FeatureDevController.onCodeGeneration(session: Session, message: Str
         }
 
         messenger.sendCodeResult(tabId = tabId, uploadId = uploadId, filePaths = filePaths, deletedFiles = deletedFiles, references = references)
+
+        if (remainingIterations != null && totalIterations != null) {
+            messenger.sendAnswer(
+                tabId = tabId,
+                messageType = FeatureDevMessageType.Answer,
+                message = message("amazonqFeatureDev.code_generation.iteration_counts", remainingIterations, totalIterations)
+            )
+        }
 
         messenger.sendSystemPrompt(tabId = tabId, followUp = getFollowUpOptions(session.sessionState.phase, interactionSucceeded = true))
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationState.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/PrepareCodeGenerationState.kt
@@ -27,7 +27,9 @@ class PrepareCodeGenerationState(
     val references: List<CodeReferenceGenerated>,
     var uploadId: String,
     private val currentIteration: Int,
-    private var messenger: MessagePublisher
+    private var messenger: MessagePublisher,
+    var codeGenerationRemainingIterationCount: Int? = null,
+    var codeGenerationTotalIterationCount: Int? = null
 ) : SessionState {
     override val phase = SessionStatePhase.CODEGEN
     override suspend fun interact(action: SessionStateAction): SessionStateInteraction {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionStateTypes.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionStateTypes.kt
@@ -52,6 +52,8 @@ data class CodeGenerationResult(
     var newFiles: List<NewFileZipInfo>,
     var deletedFiles: List<DeletedFileInfo>,
     var references: List<CodeReferenceGenerated>,
+    var codeGenerationRemainingIterationCount: Int? = null,
+    var codeGenerationTotalIterationCount: Int? = null
 )
 
 data class CodeReferenceGenerated(

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevTestBase.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevTestBase.kt
@@ -104,6 +104,8 @@ open class FeatureDevTestBase(
     internal val exampleCompleteGetTaskAssistCodeGenerationResponse = GetTaskAssistCodeGenerationResponse.builder()
         .conversationId(testConversationId)
         .codeGenerationStatus(CodeGenerationStatus.builder().status(CodeGenerationWorkflowStatus.COMPLETE).currentStage("Complete").build())
+        .codeGenerationRemainingIterationCount(2)
+        .codeGenerationTotalIterationCount(3)
         .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(AwsHeader.AWS_REQUEST_ID to testRequestId)))
         .build() as GetTaskAssistCodeGenerationResponse
 

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationStateTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationStateTest.kt
@@ -88,6 +88,8 @@ class CodeGenerationStateTest : FeatureDevTestBase() {
                 listOf(DeletedFileInfo("deleted.ts", false))
             )
             assertThat(nextState.references).isEqualTo(testReferences)
+            assertThat(nextState.codeGenerationRemainingIterationCount).isEqualTo(2)
+            assertThat(nextState.codeGenerationTotalIterationCount).isEqualTo(3)
             assertThat(actual.interaction.interactionSucceeded).isEqualTo(true)
             assertThat(actual.interaction.content).isEqualTo("")
         }
@@ -155,6 +157,8 @@ class CodeGenerationStateTest : FeatureDevTestBase() {
             assertThat(nextState.filePaths).isEqualTo(emptyList<NewFileZipInfo>())
             assertThat(nextState.deletedFiles).isEqualTo(emptyList<String>())
             assertThat(nextState.references).isEqualTo(emptyList<CodeReference>())
+            assertThat(nextState.codeGenerationRemainingIterationCount).isEqualTo(null)
+            assertThat(nextState.codeGenerationTotalIterationCount).isEqualTo(null)
             assertThat(actual.interaction.interactionSucceeded).isEqualTo(true)
             assertThat(actual.interaction.content).isEqualTo("")
         }

--- a/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -46,6 +46,7 @@ amazonqFeatureDev.chat_message.start_code_generation=This may take a few minutes
 amazonqFeatureDev.chat_message.uploading_code=Uploading code ...
 amazonqFeatureDev.code_generation.failed_generation=Code generation failed
 amazonqFeatureDev.code_generation.generating_code=Generating code ...
+amazonqFeatureDev.code_generation.iteration_counts=You have {0} out of {1} code iterations remaining.
 amazonqFeatureDev.code_generation.iteration_limit.error_text=You have reached the free tier limit for number of iterations on a code generation. Please proceed to accept the code or start a new conversation.
 amazonqFeatureDev.code_generation.no_file_changes=Unable to generate any file changes
 amazonqFeatureDev.code_generation.notification_message=Your code suggestions from Amazon Q are ready to review

--- a/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
+++ b/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
@@ -1019,6 +1019,12 @@
                 },
                 "codeGenerationStatus": {
                     "shape": "CodeGenerationStatus"
+                },
+                "codeGenerationRemainingIterationCount": {
+                    "shape": "Integer"
+                },
+                "codeGenerationTotalIterationCount": {
+                    "shape": "Integer"
                 }
             }
         },


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Proactively show code generation iteration counts. 

See same change on vscode: https://github.com/aws/aws-toolkit-vscode/pull/5282
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Currently, there is no information shown to customers in the chat regarding the number of iterations they could run during code generation.
They only get to know this on hitting the iteration limits and seeing the error like you have reached the limit for number of iterations.

related issue: D138685414

## Checklist
- [x ] My code follows the code style of this project
- [x] I have added tests to cover my changes - related unit tests updated
- [x ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [n/a ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
