### PR TITLE
Mark Q/Core as incompatible with thin clients

### DIFF
--- a/.changes/next-release/bugfix-8634301a-bffb-4daf-976a-6473d7e9a40a.json
+++ b/.changes/next-release/bugfix-8634301a-bffb-4daf-976a-6473d7e9a40a.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Don't allow Q/Core to be installed in the unsupported thin client context (#4658)"
+}

--- a/plugins/amazonq/src/main/resources/META-INF/plugin.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/plugin.xml
@@ -56,6 +56,10 @@
     <depends optional="true" config-file="ext-rust.xml">com.jetbrains.rust</depends>
     <depends optional="true" config-file="ext-rust-deprecated.xml">org.rust.lang</depends>
 
+    <incompatible-with>com.intellij.cwm.guest</incompatible-with>
+    <incompatible-with>com.intellij.jetbrains.client</incompatible-with>
+    <incompatible-with>com.intellij.gateway</incompatible-with>
+
     <xi:include href="/META-INF/module-amazonq.xml" />
 
     <xi:include href="/META-INF/change-notes.xml" xpointer="xpointer(/idea-plugin/*)">

--- a/plugins/core/src/main/resources/META-INF/plugin.xml
+++ b/plugins/core/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,10 @@
     <idea-version since-build="232" />
     <depends>com.intellij.modules.platform</depends>
 
+    <incompatible-with>com.intellij.cwm.guest</incompatible-with>
+    <incompatible-with>com.intellij.jetbrains.client</incompatible-with>
+    <incompatible-with>com.intellij.gateway</incompatible-with>
+
     <xi:include href="/META-INF/module-core.xml" />
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Q and Core do not work when installed on a thin client

#4658
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
