### PR TITLE
fix(amazonq): dependency vulnerability, workspace context query timeout and context length

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ sshd = "2.12.1"
 wiremock = "3.3.1"
 undercouch-download = "5.2.1"
 zjsonpatch = "0.4.16"
-nimbus-jose-jwt = "9.24.4"
+nimbus-jose-jwt = "9.40"
 
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertJ" }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
@@ -236,7 +236,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
 
     private fun setConnectionTimeout(connection: HttpURLConnection) {
         connection.connectTimeout = 5000 // 5 seconds
-        connection.readTimeout = 10000 // 10 second
+        connection.readTimeout = 5000 // 5 second
     }
 
     private fun setConnectionProperties(connection: HttpURLConnection) {
@@ -310,7 +310,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
         chunksMap.forEach { (filePath, chunkList) ->
             var text = ""
             chunkList.forEach { chunk -> text += (chunk.context ?: chunk.content) }
-            val document = RelevantDocument(filePath, text)
+            val document = RelevantDocument(filePath, text.take(10200))
             documents.add(document)
             logger.info { "project context: query retrieved document $filePath with content: ${text.take(200)}" }
         }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
@@ -293,26 +293,15 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
     }
 
     private fun queryResultToRelevantDocuments(queryResult: List<Chunk>): List<RelevantDocument> {
-        val chunksMap: MutableMap<String, MutableList<Chunk>> = mutableMapOf()
+        val documents: MutableList<RelevantDocument> = mutableListOf()
         queryResult.forEach { chunk ->
             run {
-                if (chunk.relativePath == null) return@forEach
-                val list: MutableList<Chunk> = if (chunksMap.containsKey(chunk.relativePath)) {
-                    chunksMap[chunk.relativePath] ?: mutableListOf()
-                } else {
-                    mutableListOf()
-                }
-                list.add(chunk)
-                chunksMap[chunk.relativePath] = list
+                val path = chunk.relativePath.orEmpty()
+                val text = chunk.context ?: chunk.content.orEmpty()
+                val document = RelevantDocument(path, text.take(10240))
+                documents.add(document)
+                logger.info { "project context: query retrieved document $path with content: ${text.take(200)}" }
             }
-        }
-        val documents: MutableList<RelevantDocument> = mutableListOf()
-        chunksMap.forEach { (filePath, chunkList) ->
-            var text = ""
-            chunkList.forEach { chunk -> text += (chunk.context ?: chunk.content) }
-            val document = RelevantDocument(filePath, text.take(10200))
-            documents.add(document)
-            logger.info { "project context: query retrieved document $filePath with content: ${text.take(200)}" }
         }
         return documents
     }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

1.  Adjust query read timeout to be 5s
2. Remove consolidating chunks at file level which has a chance to cause the text length exceeds the 10240 chars limit

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
