### PR TITLE
enabled workspace context once for amazon users

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/clients/chat/model/Requests.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/clients/chat/model/Requests.kt
@@ -23,7 +23,8 @@ data class ChatRequestData(
     val userIntent: UserIntent?,
     val triggerType: TriggerType,
     val customization: CodeWhispererCustomization?,
-    val relevantTextDocuments: List<RelevantDocument>
+    val relevantTextDocuments: List<RelevantDocument>,
+    val useRelevantDocuments: Boolean
 )
 
 interface CodeNames {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/clients/chat/v1/ChatSessionV1.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/clients/chat/v1/ChatSessionV1.kt
@@ -198,7 +198,7 @@ class ChatSessionV1(
      */
     private fun ChatRequestData.toChatRequest(): GenerateAssistantResponseRequest {
         val userInputMessageContextBuilder = UserInputMessageContext.builder()
-        userInputMessageContextBuilder.editorState(activeFileContext.toEditorState(relevantTextDocuments))
+        userInputMessageContextBuilder.editorState(activeFileContext.toEditorState(relevantTextDocuments, useRelevantDocuments))
         val userInputMessageContext = userInputMessageContextBuilder.build()
 
         val userInput = UserInputMessage.builder()
@@ -217,7 +217,7 @@ class ChatSessionV1(
             .build()
     }
 
-    private fun ActiveFileContext.toEditorState(relevantDocuments: List<RelevantDocument>): EditorState {
+    private fun ActiveFileContext.toEditorState(relevantDocuments: List<RelevantDocument>, useRelevantDocuments: Boolean): EditorState {
         val editorStateBuilder = EditorState.builder()
         if (fileContext != null) {
             val cursorStateBuilder = CursorState.builder()
@@ -284,6 +284,7 @@ class ChatSessionV1(
         }
 
         editorStateBuilder.relevantDocuments(documents)
+        editorStateBuilder.useRelevantDocuments(useRelevantDocuments)
         return editorStateBuilder.build()
     }
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/telemetry/TelemetryHelper.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/telemetry/TelemetryHelper.kt
@@ -59,7 +59,7 @@ class TelemetryHelper(private val context: AmazonQAppInitContext, private val se
         TriggerType.ContextMenu, TriggerType.Hotkeys -> CwsprChatTriggerInteraction.ContextMenu
     }
 
-    private fun getIsProjectContextEnabled() = CodeWhispererSettings.getInstance().isProjectContextEnabled()
+    private fun getIsProjectContextEnabled() = CodeWhispererSettings.getInstance().isProjectContextEnabled(context.project)
 
     // When chat panel is focused
     fun recordEnterFocusChat() {
@@ -82,7 +82,7 @@ class TelemetryHelper(private val context: AmazonQAppInitContext, private val se
             cwsprChatHasCodeSnippet = data.activeFileContext.focusAreaContext?.codeSelection?.isNotEmpty() ?: false,
             cwsprChatProgrammingLanguage = data.activeFileContext.fileContext?.fileLanguage,
             credentialStartUrl = getStartUrl(context.project),
-            cwsprChatHasProjectContext = getIsProjectContextEnabled()
+            cwsprChatHasProjectContext = getIsProjectContextEnabled() && data.useRelevantDocuments && data.relevantTextDocuments.isNotEmpty()
         )
     }
 
@@ -110,7 +110,7 @@ class TelemetryHelper(private val context: AmazonQAppInitContext, private val se
             cwsprChatConversationType = CwsprChatConversationType.Chat,
             credentialStartUrl = getStartUrl(context.project),
             codewhispererCustomizationArn = data.customization?.arn,
-            cwsprChatHasProjectContext = getIsProjectContextEnabled()
+            cwsprChatHasProjectContext = getIsProjectContextEnabled() && data.useRelevantDocuments && data.relevantTextDocuments.isNotEmpty()
         )
 
         val programmingLanguage = data.activeFileContext.fileContext?.fileLanguage
@@ -129,7 +129,7 @@ class TelemetryHelper(private val context: AmazonQAppInitContext, private val se
             data.message.length,
             responseLength,
             numberOfCodeBlocks,
-            getIsProjectContextEnabled()
+            getIsProjectContextEnabled() && data.useRelevantDocuments && data.relevantTextDocuments.isNotEmpty()
         )
     }
 
@@ -254,7 +254,7 @@ class TelemetryHelper(private val context: AmazonQAppInitContext, private val se
                     cwsprChatInteractionTarget = message.link,
                     cwsprChatHasReference = null,
                     credentialStartUrl = getStartUrl(context.project),
-                    cwsprChatHasProjectContext = getIsProjectContextEnabled(),
+                    cwsprChatHasProjectContext = getIsProjectContextEnabled()
                 )
                 ChatInteractWithMessageEvent.builder().apply {
                     conversationId(getConversationId(message.tabId).orEmpty())

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextController.kt
@@ -21,7 +21,7 @@ class ProjectContextController(private val project: Project) : Disposable {
     private val scope = disposableCoroutineScope(this)
     init {
         scope.launch {
-            if (CodeWhispererSettings.getInstance().isProjectContextEnabled()) {
+            if (CodeWhispererSettings.getInstance().isProjectContextEnabled(project)) {
                 encoderServer.downloadArtifactsAndStartServer()
             }
         }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextEditorListener.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextEditorListener.kt
@@ -9,7 +9,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.settings.CodeWhisp
 
 class ProjectContextEditorListener : FileEditorManagerListener {
     override fun fileClosed(source: FileEditorManager, file: VirtualFile) {
-        if (CodeWhispererSettings.getInstance().isProjectContextEnabled()) {
+        if (CodeWhispererSettings.getInstance().isProjectContextEnabled(source.project)) {
             ProjectContextController.getInstance(source.project).updateIndex(file.path)
         }
     }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
@@ -38,7 +38,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
     private val scope = disposableCoroutineScope(this)
     init {
         scope.launch {
-            if (CodeWhispererSettings.getInstance().isProjectContextEnabled()) {
+            if (CodeWhispererSettings.getInstance().isProjectContextEnabled(project)) {
                 while (true) {
                     if (encoderServer.isNodeProcessRunning()) {
                         // TODO: need better solution for this

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererConfigurable.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererConfigurable.kt
@@ -101,7 +101,7 @@ class CodeWhispererConfigurable(private val project: Project) :
                         }
                     )
                     enabled(invoke)
-                    bindSelected(codeWhispererSettings::isProjectContextEnabled, codeWhispererSettings::toggleProjectContextEnabled)
+                    bindSelected({ (codeWhispererSettings::isProjectContextEnabled)(project) }, codeWhispererSettings::toggleProjectContextEnabled)
                 }.comment(message("aws.settings.codewhisperer.project_context.tooltip"))
             }
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererSettings.kt
@@ -10,7 +10,9 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
 import com.intellij.util.xmlb.annotations.Property
+import software.aws.toolkits.jetbrains.services.cwc.controller.chat.telemetry.getIsAmazonStartUrl
 
 @Service
 @State(name = "codewhispererSettings", storages = [Storage("aws.xml", roamingType = RoamingType.DISABLED)])
@@ -48,7 +50,25 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
         state.value[CodeWhispererConfigurationType.IsProjectContextEnabled] = value
     }
 
-    fun isProjectContextEnabled() = state.value.getOrDefault(CodeWhispererConfigurationType.IsProjectContextEnabled, false)
+    fun isProjectContextEnabled(project: Project) = getIsProjectContextEnabled(project)
+
+    private fun getIsProjectContextEnabled(project: Project): Boolean {
+        val value = state.value.getOrDefault(CodeWhispererConfigurationType.IsProjectContextEnabled, false)
+        if (!value) {
+            if (getIsAmazonStartUrl(project) && !hasEnabledProjectContextOnce()) {
+                toggleProjectContextEnabled(true)
+                toggleEnabledProjectContextOnce(true)
+                return true
+            }
+        }
+        return value
+    }
+
+    private fun hasEnabledProjectContextOnce() = state.value.getOrDefault(CodeWhispererConfigurationType.HasEnabledProjectContextOnce, false)
+
+    private fun toggleEnabledProjectContextOnce(value: Boolean) {
+        state.value[CodeWhispererConfigurationType.HasEnabledProjectContextOnce] = value
+    }
 
     fun isProjectContextGpu() = state.value.getOrDefault(CodeWhispererConfigurationType.IsProjectContextGpu, false)
 
@@ -106,6 +126,7 @@ enum class CodeWhispererConfigurationType {
     IsAutoUpdateFeatureNotificationShownOnce,
     IsProjectContextEnabled,
     IsProjectContextGpu,
+    HasEnabledProjectContextOnce
 }
 
 enum class CodeWhispererIntConfigurationType {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererUserModificationTracker.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererUserModificationTracker.kt
@@ -211,7 +211,7 @@ class CodeWhispererUserModificationTracker(private val project: Project) : Dispo
             insertedCode.messageId,
             lang,
             percentage,
-            CodeWhispererSettings.getInstance().isProjectContextEnabled()
+            CodeWhispererSettings.getInstance().isProjectContextEnabled(project)
         )
     }
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/telemetry/QTelemetryUtils.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/telemetry/QTelemetryUtils.kt
@@ -12,3 +12,8 @@ fun getStartUrl(project: Project): String? {
     val connection = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance()) as? AwsBearerTokenConnection?
     return connection?.startUrl
 }
+
+fun getIsAmazonStartUrl(project: Project): Boolean {
+    val startUrl = getStartUrl(project)
+    return startUrl != null && startUrl == "https://amzn.awsapps.com/start"
+}

--- a/plugins/core/sdk-codegen/codegen-resources/codewhispererstreaming/service-2.json
+++ b/plugins/core/sdk-codegen/codegen-resources/codewhispererstreaming/service-2.json
@@ -134,6 +134,10 @@
             "event":true,
             "sensitive":true
         },
+        "Boolean":{
+            "type":"boolean",
+            "box":true
+        },
         "ChatHistory":{
             "type":"list",
             "member":{"shape":"ChatMessage"},
@@ -276,7 +280,8 @@
             "members":{
                 "document":{"shape":"TextDocument"},
                 "cursorState":{"shape":"CursorState"},
-                "relevantDocuments": {"shape": "RelevantDocumentList"}
+                "relevantDocuments": {"shape": "RelevantDocumentList"},
+                "useRelevantDocuments": {"shape": "Boolean"}
             }
         },
         "ExportContext":{


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description

1. enable workspace context feature one time for internal users
2. always query for internal chat requests even if the prompt is not using workspace

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
