### PR TITLE
fix(amazonq): add timeout to workspace context updateIndex operation

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
@@ -227,6 +227,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
         val encrypted = encoderServer.encrypt(payloadJson)
         with(url.openConnection() as HttpURLConnection) {
             setConnectionProperties(this)
+            setConnectionTimeout(this)
             setConnectionRequest(this, encrypted)
             val responseCode = responseCode
             logger.debug { "project context update index response code: $responseCode for $filePath" }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
add timeout to updateIndex in case for any reason server is not responding

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
