### PR TITLE
fix(amazonq): fix index cache not loaded when IDE restarts

### DIFF
--- a/.changes/next-release/bugfix-21fb7c63-7c53-462b-a8c6-2f4e6e8e669a.json
+++ b/.changes/next-release/bugfix-21fb7c63-7c53-462b-a8c6-2f4e6e8e669a.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix bug when workspace index cache is not loaded"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
@@ -145,7 +145,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
         val url = URL("http://localhost:${encoderServer.port}/indexFiles")
         val filesResult = collectFiles()
         val projectRoot = project.guessProjectDir()?.path ?: return false
-        val payload = IndexRequestPayload(filesResult.files, projectRoot, true)
+        val payload = IndexRequestPayload(filesResult.files, projectRoot, false)
         val payloadJson = mapper.writeValueAsString(payload)
         val encrypted = encoderServer.encrypt(payloadJson)
 


### PR DESCRIPTION
Fix index cache not loaded when IDE restarts.

The boolean field `refresh` of Index request tells LSP whether to rebuild the index completely (force refresh). When it is set to false, the LSP always loads cached index (if it is not more than 2 days old). Refresh should be set to true only if the IDE has absolute reason to force the LSP re-calculate the index.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
