### PR TITLE
Fix memory leak due to browser not being disposed

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQPanel.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQPanel.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.amazonq.toolwindow
 
 import com.intellij.idea.AppMode
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.panels.Wrapper
@@ -16,7 +17,7 @@ import software.aws.toolkits.jetbrains.services.amazonq.webview.Browser
 import java.awt.event.ActionListener
 import javax.swing.JButton
 
-class AmazonQPanel {
+class AmazonQPanel(private val parent: Disposable) {
     private val webviewContainer = Wrapper()
     var browser: Browser? = null
         private set
@@ -72,7 +73,7 @@ class AmazonQPanel {
             }
             browser = null
         } else {
-            browser = Browser().also {
+            browser = Browser(parent).also {
                 webviewContainer.add(it.component())
             }
         }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindow.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindow.kt
@@ -40,7 +40,7 @@ class AmazonQToolWindow private constructor(
     private val browserConnector = BrowserConnector()
     private val editorThemeAdapter = EditorThemeAdapter()
 
-    private val chatPanel = AmazonQPanel()
+    private val chatPanel = AmazonQPanel(parent = this)
 
     val component: JComponent = chatPanel.component
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
@@ -15,9 +15,9 @@ typealias MessageReceiver = Function<String, JBCefJSQuery.Response>
 /*
 Displays the web view for the Amazon Q tool window
  */
-class Browser : Disposable {
+class Browser(parent: Disposable) : Disposable {
 
-    val jcefBrowser = createBrowser(this)
+    val jcefBrowser = createBrowser(parent)
 
     val receiveMessageQuery = JBCefJSQuery.create(jcefBrowser)
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

Fix memory leak by attaching the browser to its parent disposable: in this case the amazon q tool window


 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
