### PR TITLE
Add test for binary compatibility of methods consumed by internal plugin

### DIFF
--- a/plugins/amazonq/build.gradle.kts
+++ b/plugins/amazonq/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id("toolkit-publishing-conventions")
     id("toolkit-publish-root-conventions")
     id("toolkit-jvm-conventions")
+    id("toolkit-testing")
 }
 
 val changelog = tasks.register<GeneratePluginChangeLog>("pluginChangeLog") {
@@ -35,6 +36,8 @@ dependencies {
     implementation(project(":plugin-amazonq:codewhisperer"))
     implementation(project(":plugin-amazonq:mynah-ui"))
     implementation(project(":plugin-amazonq:shared"))
+
+    testImplementation(project(":plugin-core"))
 }
 
 tasks.check {

--- a/plugins/amazonq/src/test/kotlin/PluginAmazonQJvmBinaryCompatabilityTest.kt
+++ b/plugins/amazonq/src/test/kotlin/PluginAmazonQJvmBinaryCompatabilityTest.kt
@@ -10,22 +10,21 @@ class PluginAmazonQJvmBinaryCompatabilityTest {
         // $ javap -c -classpath aws-toolkit-amazonq-2024.1.jar <...>.amazonq.AmazonQConnectionService
         //   public final boolean isAuthenticated();
         //       0: new           #27                 // class software/aws/toolkits/jetbrains/services/amazonq/auth/AuthController
-        //       3: dup
         //       4: invokespecial #28                 // Method software/aws/toolkits/jetbrains/services/amazonq/auth/AuthController."<init>":()V
-        //       7: aload_0
-        //       8: getfield      #21                 // Field project:Lcom/intellij/openapi/project/Project;
         //      11: invokevirtual #32                 // Method software/aws/toolkits/jetbrains/services/amazonq/auth/AuthController.getAuthNeededStates:(Lcom/intellij/openapi/project/Project;)Lsoftware/aws/toolkits/jetbrains/services/amazonq/auth/AuthNeededStates;
-        //      14: astore_1
-        //      15: aload_1
         //      16: invokevirtual #38                 // Method software/aws/toolkits/jetbrains/services/amazonq/auth/AuthNeededStates.getAmazonQ:()Lsoftware/aws/toolkits/jetbrains/services/amazonq/auth/AuthNeededState;
 
         // not really sure if they should be using AuthController to check this...
         val authControllerClazz = Class.forName("software.aws.toolkits.jetbrains.services.amazonq.auth.AuthController")
         val authNeededStatesClazz = Class.forName("software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededStates")
 
+        // AuthController()
         assertThat(authControllerClazz.getConstructor().canAccess(null)).isTrue()
+
+        // AuthController#getAuthNeededStates
         // type erasure :/
         assertThat(authControllerClazz.getMethod("getAuthNeededStates", Class.forName("com.intellij.openapi.project.Project")).returnType).isEqualTo(authNeededStatesClazz)
+        // AuthNeededStates#getAmazonQ
         assertThat(authNeededStatesClazz.getMethod("getAmazonQ").returnType).isEqualTo(Class.forName("software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededState"))
     }
 
@@ -35,22 +34,20 @@ class PluginAmazonQJvmBinaryCompatabilityTest {
         // $ javap -c -classpath aws-toolkit-amazonq-2024.1.jar <...>.amazonq.AmazonQConfigurationServiceKt
         //   public static final software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomization findCustomizationToUse(java.util.List<software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomization>);
         //      45: getfield      #40                 // Field software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization.arn:Ljava/lang/String;
-        //      50: invokestatic  #46                 // Method kotlin/jvm/internal/Intrinsics.areEqual:(Ljava/lang/Object;Ljava/lang/Object;)Z
         //      58: getfield      #49                 // Field software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization.name:Ljava/lang/String;
-        //      61: ldc           #51                 // String Amazon-Internal
 
         //   public static final void setCustomization(com.intellij.openapi.project.Project);
-        //       3: invokestatic  #18                 // Method kotlin/jvm/internal/Intrinsics.checkNotNullParameter:(Ljava/lang/Object;Ljava/lang/String;)V
         //       6: getstatic     #72                 // Field migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.Companion:Lmigration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator$Companion;
         //       9: invokevirtual #78                 // Method migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator$Companion.getInstance:()Lmigration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator;
         //      19: invokestatic  #82                 // InterfaceMethod migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.listCustomizations$default:(Lmigration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator;Lcom/intellij/openapi/project/Project;ZILjava/lang/Object;)Ljava/util/List;
         //      140: invokeinterface #118,  3          // InterfaceMethod migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.switchCustomization:(Lcom/intellij/openapi/project/Project;Lsoftware/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization;)V
 
+        // CodeWhispererModelConfigurator.getInstance()
         assertThat(Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator\$Companion").getMethod("getInstance").returnType)
             .isEqualTo(Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator"))
 
         val modelConfigurator = Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator")
-
+        // CodeWhispererModelConfigurator.listCustomizations(...)
         // type erasure :/
         assertThat(
             modelConfigurator.getMethod(
@@ -64,8 +61,12 @@ class PluginAmazonQJvmBinaryCompatabilityTest {
             ).returnType
         ).isEqualTo(Class.forName("java.util.List"))
 
+        // CodeWhispererCustomization fields
         val customization = Class.forName("software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomization")
         assertThat(customization.getField("arn").type).isEqualTo(Class.forName("java.lang.String"))
         assertThat(customization.getField("name").type).isEqualTo(Class.forName("java.lang.String"))
+
+        // CodeWhispererModelConfigurator.switchCustomization(...)
+        assertThat(modelConfigurator.getMethod("switchCustomization", Class.forName("com.intellij.openapi.project.Project"), customization).returnType).isEqualTo(Void.TYPE)
     }
 }

--- a/plugins/amazonq/src/test/kotlin/PluginAmazonQJvmBinaryCompatabilityTest.kt
+++ b/plugins/amazonq/src/test/kotlin/PluginAmazonQJvmBinaryCompatabilityTest.kt
@@ -1,0 +1,71 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PluginAmazonQJvmBinaryCompatabilityTest {
+    @Test
+    fun `AuthController is available`() {
+        // v1.0.133.0 of internal plugin
+        // $ javap -c -classpath aws-toolkit-amazonq-2024.1.jar <...>.amazonq.AmazonQConnectionService
+        //   public final boolean isAuthenticated();
+        //       0: new           #27                 // class software/aws/toolkits/jetbrains/services/amazonq/auth/AuthController
+        //       3: dup
+        //       4: invokespecial #28                 // Method software/aws/toolkits/jetbrains/services/amazonq/auth/AuthController."<init>":()V
+        //       7: aload_0
+        //       8: getfield      #21                 // Field project:Lcom/intellij/openapi/project/Project;
+        //      11: invokevirtual #32                 // Method software/aws/toolkits/jetbrains/services/amazonq/auth/AuthController.getAuthNeededStates:(Lcom/intellij/openapi/project/Project;)Lsoftware/aws/toolkits/jetbrains/services/amazonq/auth/AuthNeededStates;
+        //      14: astore_1
+        //      15: aload_1
+        //      16: invokevirtual #38                 // Method software/aws/toolkits/jetbrains/services/amazonq/auth/AuthNeededStates.getAmazonQ:()Lsoftware/aws/toolkits/jetbrains/services/amazonq/auth/AuthNeededState;
+
+        // not really sure if they should be using AuthController to check this...
+        val authControllerClazz = Class.forName("software.aws.toolkits.jetbrains.services.amazonq.auth.AuthController")
+        val authNeededStatesClazz = Class.forName("software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededStates")
+
+        assertThat(authControllerClazz.getConstructor().canAccess(null)).isTrue()
+        // type erasure :/
+        assertThat(authControllerClazz.getMethod("getAuthNeededStates", Class.forName("com.intellij.openapi.project.Project")).returnType).isEqualTo(authNeededStatesClazz)
+        assertThat(authNeededStatesClazz.getMethod("getAmazonQ").returnType).isEqualTo(Class.forName("software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededState"))
+    }
+
+    @Test
+    fun `CodeWhisperer customization classes are available`() {
+        // v1.0.133.0 of internal plugin
+        // $ javap -c -classpath aws-toolkit-amazonq-2024.1.jar <...>.amazonq.AmazonQConfigurationServiceKt
+        //   public static final software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomization findCustomizationToUse(java.util.List<software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomization>);
+        //      45: getfield      #40                 // Field software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization.arn:Ljava/lang/String;
+        //      50: invokestatic  #46                 // Method kotlin/jvm/internal/Intrinsics.areEqual:(Ljava/lang/Object;Ljava/lang/Object;)Z
+        //      58: getfield      #49                 // Field software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization.name:Ljava/lang/String;
+        //      61: ldc           #51                 // String Amazon-Internal
+
+        //   public static final void setCustomization(com.intellij.openapi.project.Project);
+        //       3: invokestatic  #18                 // Method kotlin/jvm/internal/Intrinsics.checkNotNullParameter:(Ljava/lang/Object;Ljava/lang/String;)V
+        //       6: getstatic     #72                 // Field migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.Companion:Lmigration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator$Companion;
+        //       9: invokevirtual #78                 // Method migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator$Companion.getInstance:()Lmigration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator;
+        //      19: invokestatic  #82                 // InterfaceMethod migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.listCustomizations$default:(Lmigration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator;Lcom/intellij/openapi/project/Project;ZILjava/lang/Object;)Ljava/util/List;
+        //      140: invokeinterface #118,  3          // InterfaceMethod migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.switchCustomization:(Lcom/intellij/openapi/project/Project;Lsoftware/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization;)V
+
+        assertThat(Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator\$Companion").getMethod("getInstance").returnType)
+            .isEqualTo(Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator"))
+
+        val modelConfigurator = Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator")
+
+        // type erasure :/
+        assertThat(
+            modelConfigurator.getMethod(
+                "listCustomizations\$default",
+                modelConfigurator,
+                Class.forName("com.intellij.openapi.project.Project"),
+                // can't request primitive type using reflection
+                java.lang.Boolean.TYPE,
+                Integer.TYPE,
+                Class.forName("java.lang.Object")
+            ).returnType
+        ).isEqualTo(Class.forName("java.util.List"))
+
+        val customization = Class.forName("software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomization")
+        assertThat(customization.getField("arn").type).isEqualTo(Class.forName("java.lang.String"))
+        assertThat(customization.getField("name").type).isEqualTo(Class.forName("java.lang.String"))
+    }
+}

--- a/plugins/amazonq/src/test/kotlin/PluginAmazonQJvmBinaryCompatabilityTest.kt
+++ b/plugins/amazonq/src/test/kotlin/PluginAmazonQJvmBinaryCompatabilityTest.kt
@@ -40,19 +40,20 @@ class PluginAmazonQJvmBinaryCompatabilityTest {
         //       6: getstatic     #72                 // Field migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.Companion:Lmigration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator$Companion;
         //       9: invokevirtual #78                 // Method migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator$Companion.getInstance:()Lmigration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator;
         //      19: invokestatic  #82                 // InterfaceMethod migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.listCustomizations$default:(Lmigration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator;Lcom/intellij/openapi/project/Project;ZILjava/lang/Object;)Ljava/util/List;
+        //      106: invokevirtual #106                // Method software/aws/toolkits/jetbrains/services/codewhisperer/customization/CustomizationUiItem.getCustomization:()Lsoftware/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization;
         //      140: invokeinterface #118,  3          // InterfaceMethod migration/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.switchCustomization:(Lcom/intellij/openapi/project/Project;Lsoftware/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization;)V
 
         // CodeWhispererModelConfigurator.getInstance()
         assertThat(Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator\$Companion").getMethod("getInstance").returnType)
             .isEqualTo(Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator"))
 
-        val modelConfigurator = Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator")
+        val modelConfiguratorClazz = Class.forName("migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator")
         // CodeWhispererModelConfigurator.listCustomizations(...)
         // type erasure :/
         assertThat(
-            modelConfigurator.getMethod(
+            modelConfiguratorClazz.getMethod(
                 "listCustomizations\$default",
-                modelConfigurator,
+                modelConfiguratorClazz,
                 Class.forName("com.intellij.openapi.project.Project"),
                 // can't request primitive type using reflection
                 java.lang.Boolean.TYPE,
@@ -62,11 +63,15 @@ class PluginAmazonQJvmBinaryCompatabilityTest {
         ).isEqualTo(Class.forName("java.util.List"))
 
         // CodeWhispererCustomization fields
-        val customization = Class.forName("software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomization")
-        assertThat(customization.getField("arn").type).isEqualTo(Class.forName("java.lang.String"))
-        assertThat(customization.getField("name").type).isEqualTo(Class.forName("java.lang.String"))
+        val customizationClazz = Class.forName("software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomization")
+        assertThat(customizationClazz.getField("arn").type).isEqualTo(Class.forName("java.lang.String"))
+        assertThat(customizationClazz.getField("name").type).isEqualTo(Class.forName("java.lang.String"))
+
+        // field CustomizationUiItem.customization
+        val customizationUiItem = Class.forName("software.aws.toolkits.jetbrains.services.codewhisperer.customization.CustomizationUiItem")
+        assertThat(customizationUiItem.getMethod("getCustomization").returnType).isEqualTo(customizationClazz)
 
         // CodeWhispererModelConfigurator.switchCustomization(...)
-        assertThat(modelConfigurator.getMethod("switchCustomization", Class.forName("com.intellij.openapi.project.Project"), customization).returnType).isEqualTo(Void.TYPE)
+        assertThat(modelConfiguratorClazz.getMethod("switchCustomization", Class.forName("com.intellij.openapi.project.Project"), customizationClazz).returnType).isEqualTo(Void.TYPE)
     }
 }

--- a/plugins/amazonq/src/test/kotlin/PluginAmazonQJvmBinaryCompatabilityTest.kt
+++ b/plugins/amazonq/src/test/kotlin/PluginAmazonQJvmBinaryCompatabilityTest.kt
@@ -22,7 +22,6 @@ class PluginAmazonQJvmBinaryCompatabilityTest {
         assertThat(authControllerClazz.getConstructor().canAccess(null)).isTrue()
 
         // AuthController#getAuthNeededStates
-        // type erasure :/
         assertThat(authControllerClazz.getMethod("getAuthNeededStates", Class.forName("com.intellij.openapi.project.Project")).returnType).isEqualTo(authNeededStatesClazz)
         // AuthNeededStates#getAmazonQ
         assertThat(authNeededStatesClazz.getMethod("getAmazonQ").returnType).isEqualTo(Class.forName("software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededState"))

--- a/plugins/core/build.gradle.kts
+++ b/plugins/core/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("toolkit-publishing-conventions")
     id("toolkit-publish-root-conventions")
     id("toolkit-jvm-conventions")
+    id("toolkit-testing")
 }
 
 dependencies {

--- a/plugins/core/src/test/kotlin/software/aws/toolkits/jetbrains/core/PluginCoreJvmBinaryCompatabilityTest.kt
+++ b/plugins/core/src/test/kotlin/software/aws/toolkits/jetbrains/core/PluginCoreJvmBinaryCompatabilityTest.kt
@@ -1,0 +1,62 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PluginCoreJvmBinaryCompatabilityTest {
+    @Test
+    fun `loginSso JVM signature is stable`() {
+        // v1.0.133.0 of internal plugin
+        // $ javap -c -classpath aws-toolkit-amazonq-2024.1.jar <...>.amazonq.AmazonQConnectionService
+        //   public final void authenticateInternal$aws_toolkit_amazonq(kotlin.jvm.functions.Function1<? super java.lang.Boolean, kotlin.Unit>);
+        //       38: invokestatic  #110                // Method software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManagerKt.loginSso$default:(
+        //           Lcom/intellij/openapi/project/Project;
+        //           Ljava/lang/String;Ljava/lang/String;
+        //           Ljava/util/List;
+        //           Lkotlin/jvm/functions/Function1;
+        //           Lkotlin/jvm/functions/Function1;
+        //           Lkotlin/jvm/functions/Function0;
+        //           Lsoftware/aws/toolkits/jetbrains/core/credentials/ConnectionMetadata;
+        //           I
+        //           Ljava/lang/Object;
+        //       )Lsoftware/aws/toolkits/jetbrains/core/credentials/AwsBearerTokenConnection;
+
+        val clazz = Class.forName("software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt")
+        val method = clazz.getDeclaredMethod(
+            "loginSso\$default",
+            Class.forName("com.intellij.openapi.project.Project"),
+            Class.forName("java.lang.String"),
+            Class.forName("java.lang.String"),
+            Class.forName("java.util.List"),
+            Class.forName("kotlin.jvm.functions.Function1"),
+            Class.forName("kotlin.jvm.functions.Function1"),
+            Class.forName("kotlin.jvm.functions.Function0"),
+            Class.forName("software.aws.toolkits.jetbrains.core.credentials.ConnectionMetadata"),
+            // can't request primitive type using reflection
+            Integer.TYPE,
+            Class.forName("java.lang.Object"),
+        )
+
+        assertThat(method.returnType).isEqualTo(Class.forName("software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection"))
+    }
+
+    @Test
+    fun `scope static values are available`() {
+        // v1.0.133.0 of internal plugin
+        // $ javap -c -classpath aws-toolkit-amazonq-2024.1.jar <...>.amazonq.AmazonQConnectionService
+        //   public final void authenticateInternal$aws_toolkit_amazonq(kotlin.jvm.functions.Function1<? super java.lang.Boolean, kotlin.Unit>);
+        //      15: invokestatic  #91                 // Method software/aws/toolkits/jetbrains/core/credentials/sono/SonoConstantsKt.getCODEWHISPERER_SCOPES:()Ljava/util/List;
+        //      18: checkcast     #93                 // class java/util/Collection
+        //      21: invokestatic  #96                 // Method software/aws/toolkits/jetbrains/core/credentials/sono/SonoConstantsKt.getQ_SCOPES:()Ljava/util/List;
+
+        // not sure why CODEWHISPERER_SCOPES is being used when Q_SCOPES is a superset
+        val clazz = Class.forName("software.aws.toolkits.jetbrains.core.credentials.sono.SonoConstantsKt")
+
+        // type erasure :/
+        assertThat(clazz.getMethod("getCODEWHISPERER_SCOPES").invoke(null)).isInstanceOf(List::class.java)
+        assertThat(clazz.getMethod("getQ_SCOPES").invoke(null)).isInstanceOf(List::class.java)
+    }
+}

--- a/plugins/core/src/test/kotlin/software/aws/toolkits/jetbrains/core/PluginCoreJvmBinaryCompatabilityTest.kt
+++ b/plugins/core/src/test/kotlin/software/aws/toolkits/jetbrains/core/PluginCoreJvmBinaryCompatabilityTest.kt
@@ -24,6 +24,7 @@ class PluginCoreJvmBinaryCompatabilityTest {
         //           Ljava/lang/Object;
         //       )Lsoftware/aws/toolkits/jetbrains/core/credentials/AwsBearerTokenConnection;
 
+        // loginSso(...)
         val clazz = Class.forName("software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt")
         val method = clazz.getDeclaredMethod(
             "loginSso\$default",
@@ -49,7 +50,6 @@ class PluginCoreJvmBinaryCompatabilityTest {
         // $ javap -c -classpath aws-toolkit-amazonq-2024.1.jar <...>.amazonq.AmazonQConnectionService
         //   public final void authenticateInternal$aws_toolkit_amazonq(kotlin.jvm.functions.Function1<? super java.lang.Boolean, kotlin.Unit>);
         //      15: invokestatic  #91                 // Method software/aws/toolkits/jetbrains/core/credentials/sono/SonoConstantsKt.getCODEWHISPERER_SCOPES:()Ljava/util/List;
-        //      18: checkcast     #93                 // class java/util/Collection
         //      21: invokestatic  #96                 // Method software/aws/toolkits/jetbrains/core/credentials/sono/SonoConstantsKt.getQ_SCOPES:()Ljava/util/List;
 
         // not sure why CODEWHISPERER_SCOPES is being used when Q_SCOPES is a superset


### PR DESCRIPTION
As discussed internally when #4644 was raised, comments are only a good intention and we need a reliable mechanism to enforce this.

Since we have not annotated any of the internally dependent methods with `@JvmDefaultWithCompatibility` (and doing so is a breaking change), the Kotlin compiler is free to generate backwards-compatible bytecode that is resolvable at compile time, but then we get reports of issues at runtime since it is not binary compatible.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
