### PR TITLE
Don't publish Gradle build scans by default

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,6 +55,9 @@ plugins {
 
 develocity {
     buildScan {
+        // only publish with `--scan` argument
+        publishing.onlyIf { false }
+
         if (System.getenv("CI") == "true") {
             termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
             termsOfUseAgree = "yes"


### PR DESCRIPTION

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
