### PR TITLE
Fix Container Disposed in Q sign-in

### DIFF
--- a/.changes/next-release/bugfix-bbe9cb20-22ff-474d-92f0-ee5327113a04.json
+++ b/.changes/next-release/bugfix-bbe9cb20-22ff-474d-92f0-ee5327113a04.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix 'ContainerDisposedException' when attempting to sign-in to Amazon Q"
+}

--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformChatApp.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformChatApp.kt
@@ -123,7 +123,8 @@ class CodeTransformChatApp : AmazonQApp {
                 isProcessingAuthChanged.set(false)
             }
         }
-        ApplicationManager.getApplication().messageBus.connect().subscribe(
+
+        ApplicationManager.getApplication().messageBus.connect(this).subscribe(
             BearerTokenProviderListener.TOPIC,
             object : BearerTokenProviderListener {
                 override fun onChange(providerId: String, newScopes: List<String>?) {


### PR DESCRIPTION
Project service creates listener that is not disposed

```
Failed to authenticate: message: com.intellij.platform.instanceContainer.internal.ContainerDisposedException: Container 'ProjectImpl@480400585 services' was disposed; profile: UserConfigSsoSessionProfile(configSessionName=amzn, ssoRegion=us-east-1, startUrl=https://amzn.awsapps.com/start, scopes=[codewhisperer:conversations, codewhisperer:transformations, codewhisperer:taskassist, codewhisperer:completions, codewhisperer:analysis])

com.intellij.openapi.progress.ProcessCanceledException: com.intellij.platform.instanceContainer.internal.ContainerDisposedException: Container 'ProjectImpl@480400585 services' was disposed
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:717)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:690)
	at software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager$Companion.getInstance(ToolkitAuthManager.kt:353)
	at software.aws.toolkits.jetbrains.services.codemodernizer.utils.CodeTransformUtilsKt.getQTokenProvider(CodeTransformUtils.kt:49)
	at software.aws.toolkits.jetbrains.services.codemodernizer.CodeTransformChatApp$init$2.onChange(CodeTransformChatApp.kt:130)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeMethod(MessageBusImpl.kt:722)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeListener(MessageBusImpl.kt:682)
	at com.intellij.util.messages.impl.MessageBusImplKt.deliverMessage(MessageBusImpl.kt:445)
	at com.intellij.util.messages.impl.MessageBusImplKt.pumpWaiting(MessageBusImpl.kt:424)
	at com.intellij.util.messages.impl.MessageBusImplKt.access$pumpWaiting(MessageBusImpl.kt:1)
	at com.intellij.util.messages.impl.MessagePublisher.invoke(MessageBusImpl.kt:483)
	at jdk.proxy11/jdk.proxy11.$Proxy320.onChange(Unknown Source)
	at software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener.onChange$default(BearerTokenProviderListener.kt:11)
	at software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener$Companion.notifyCredUpdate(BearerTokenProviderListener.kt:20)
	at software.aws.toolkits.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider.invalidate(BearerTokenProvider.kt:179)
	at software.aws.toolkits.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider.reauthenticate(BearerTokenProvider.kt:184)
	at software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt$reauthConnectionIfNeeded$2$1.invoke(ToolkitAuthManager.kt:251)
	at software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt$reauthConnectionIfNeeded$2$1.invoke(ToolkitAuthManager.kt:250)
	at software.aws.toolkits.jetbrains.utils.ThreadingUtilsKt.runUnderProgressIfNeeded(ThreadingUtils.kt:32)
	at software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt$reauthConnectionIfNeeded$2.invoke(ToolkitAuthManager.kt:250)
	at software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt$reauthConnectionIfNeeded$2.invoke(ToolkitAuthManager.kt:249)
	at software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt.maybeReauthProviderIfNeeded(ToolkitAuthManager.kt:267)
	at software.aws.toolkits.jetbrains.core.credentials.ToolkitAuthManagerKt.reauthConnectionIfNeeded(ToolkitAuthManager.kt:249)
	at software.aws.toolkits.jetbrains.core.credentials.LoginUtilsKt$authAndUpdateConfig$connection$1.invoke(LoginUtils.kt:181)
	at software.aws.toolkits.jetbrains.core.credentials.LoginUtilsKt$authAndUpdateConfig$connection$1.invoke(LoginUtils.kt:180)
	at software.aws.toolkits.jetbrains.core.credentials.DefaultToolkitAuthManager.tryCreateTransientSsoConnection(DefaultToolkitAuthManager.kt:90)
	at software.aws.toolkits.jetbrains.core.credentials.LoginUtilsKt.authAndUpdateConfig(LoginUtils.kt:180)
	at software.aws.toolkits.jetbrains.core.credentials.Login$IdC.loginIdc(LoginUtils.kt:76)
	at software.aws.toolkits.jetbrains.core.webview.LoginBrowser$loginIdC$1.invoke(LoginBrowser.kt:253)
	at software.aws.toolkits.jetbrains.core.webview.LoginBrowser$loginIdC$1.invoke(LoginBrowser.kt:250)
	at software.aws.toolkits.jetbrains.core.webview.LoginBrowser$loginWithBackgroundContext$1$1$1$1.invoke(LoginBrowser.kt:303)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContextInner(coroutines.kt:339)
	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invokeSuspend(coroutines.kt:232)
	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invoke(coroutines.kt)
	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invoke(coroutines.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:261)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContext(coroutines.kt:231)
	at software.aws.toolkits.jetbrains.core.webview.LoginBrowser$loginWithBackgroundContext$1$1$1.invokeSuspend(LoginBrowser.kt:302)
	at software.aws.toolkits.jetbrains.core.webview.LoginBrowser$loginWithBackgroundContext$1$1$1.invoke(LoginBrowser.kt)
	at software.aws.toolkits.jetbrains.core.webview.LoginBrowser$loginWithBackgroundContext$1$1$1.invoke(LoginBrowser.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:163)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at com.intellij.platform.util.progress.ProgressPipeImpl.collectProgressUpdates(ProgressPipe.kt:43)
	at com.intellij.openapi.progress.impl.PlatformTaskSupport$withBackgroundProgressInternal$2.invokeSuspend(PlatformTaskSupport.kt:82)
	at com.intellij.openapi.progress.impl.PlatformTaskSupport$withBackgroundProgressInternal$2.invoke(PlatformTaskSupport.kt)
	at com.intellij.openapi.progress.impl.PlatformTaskSupport$withBackgroundProgressInternal$2.invoke(PlatformTaskSupport.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:261)
	at com.intellij.openapi.progress.impl.PlatformTaskSupport.withBackgroundProgressInternal(PlatformTaskSupport.kt:76)
	at com.intellij.platform.ide.progress.TasksKt.withBackgroundProgress(tasks.kt:56)
	at com.intellij.platform.ide.progress.TasksKt.withBackgroundProgress(tasks.kt:21)
	at software.aws.toolkits.jetbrains.core.webview.LoginBrowser$loginWithBackgroundContext$1$1.invokeSuspend(LoginBrowser.kt:301)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:277)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:111)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$BuildersKt__BuildersKt(Builders.kt:84)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:52)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:48)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at software.aws.toolkits.jetbrains.core.webview.LoginBrowser$loginWithBackgroundContext$1.invoke(LoginBrowser.kt:300)
	at software.aws.toolkits.jetbrains.utils.ThreadingUtilsKt.pluginAwareExecuteOnPooledThread$lambda$3(ThreadingUtils.kt:86)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport$executeOnPooledThread$2.call(AnyThreadWriteThreadingSupport.kt:162)
	at com.intellij.util.concurrency.ContextCallable.call(ContextCallable.java:32)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:27)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:735)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:732)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:732)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: com.intellij.platform.instanceContainer.internal.ContainerDisposedException: Container 'ProjectImpl@480400585 services' was disposed
	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.state(InstanceContainerImpl.kt:60)
	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.state(InstanceContainerImpl.kt:40)
	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.getInstanceHolder(InstanceContainerImpl.kt:271)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:712)
	... 75 more
Caused by: com.intellij.platform.instanceContainer.internal.DisposalTrace
	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.dispose(InstanceContainerImpl.kt:260)
	at com.intellij.serviceContainer.ComponentManagerImpl.dispose(ComponentManagerImpl.kt:1153)
	at com.intellij.openapi.project.impl.ProjectImpl.dispose(ProjectImpl.kt:321)
	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:131)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:163)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:205)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:193)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$lambda$15(ProjectManagerImpl.kt:423)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction$lambda$4(AnyThreadWriteThreadingSupport.kt:318)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction(AnyThreadWriteThreadingSupport.kt:328)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction(AnyThreadWriteThreadingSupport.kt:318)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:890)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject(ProjectManagerImpl.kt:406)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$default(ProjectManagerImpl.kt:328)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeAndDispose(ProjectManagerImpl.kt:435)
	at com.intellij.openapi.wm.impl.CloseProjectWindowHelper.closeProjectAndShowWelcomeFrameIfNoProjectOpened(CloseProjectWindowHelper.kt:57)
	at com.intellij.openapi.wm.impl.CloseProjectWindowHelper.windowClosing(CloseProjectWindowHelper.kt:44)
	at com.intellij.openapi.wm.impl.ProjectFrameHelper.windowClosing(ProjectFrameHelper.kt:428)
	at com.intellij.openapi.wm.impl.WindowCloseListener.windowClosing(ProjectFrameHelper.kt:451)
	at java.desktop/java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:357)
	at java.desktop/java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:357)
	at java.desktop/java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:357)
	at java.desktop/java.awt.Window.processWindowEvent(Window.java:2115)
	at java.desktop/javax.swing.JFrame.processWindowEvent(JFrame.java:298)
	at java.desktop/java.awt.Window.processEvent(Window.java:2074)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5032)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2810)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4860)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:783)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:728)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:98)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:755)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:753)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:752)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:696)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$16(IdeEventQueue.kt:590)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithoutImplicitRead(AnyThreadWriteThreadingSupport.kt:117)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:590)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:73)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:357)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:356)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:843)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:356)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:351)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke$lambda$0(IdeEventQueue.kt:1035)
	at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:84)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:910)
	at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
	at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:1036)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:114)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1036)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$10(IdeEventQueue.kt:351)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:397)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
