### PR TITLE
Run detekt on Gradle workers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ kotlin.code.style=official
 # Gradle settings
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx1024m
 kotlin.daemon.jvmargs=-Xmx1024m
 
 # prefer non-enterprise variant of test-retry
@@ -29,3 +29,5 @@ kotlin.build.report.output=file
 
 # don't bundle Kotlin stdlib with plugin
 kotlin.stdlib.default.dependency=false
+
+detekt.use.worker.api=true


### PR DESCRIPTION
Reduce the amount of RAM consumed by the root gradle daemon by offloading detekt into its own process

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
