### PR TITLE
Use JetBrains CloudFront distributions directly to avoid gateway 502s from cache-redirector

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -41,6 +41,16 @@ tasks.withType<Detekt>().configureEach {
         html.required.set(true) // Human readable report
         xml.required.set(true) // Checkstyle like format for CI tool integrations
     }
+
+    doLast {
+        System.gc()
+    }
+
+    doLast {
+        exec {
+            commandLine("sh", "-c", "ps -eo pmem,pcpu,vsize,pid,command | sort -k 1 -nr | head -5")
+        }
+    }
 }
 
 tasks.withType<DetektCreateBaselineTask>().configureEach {

--- a/buildSrc/src/main/kotlin/toolkit-intellij-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-plugin.gradle.kts
@@ -1,10 +1,12 @@
 // Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import org.jetbrains.intellij.platform.gradle.Constants
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.aware.TestableAware
 import software.aws.toolkits.gradle.ciOnly
 import software.aws.toolkits.gradle.intellij.ToolkitIntelliJExtension
+import java.net.URI
 
 private val toolkitIntelliJ = project.extensions.create<ToolkitIntelliJExtension>("intellijToolkit")
 
@@ -19,8 +21,13 @@ intellijPlatform {
 // there is an issue if this is declared more than once in a project (either directly or through script plugins)
 repositories {
     intellijPlatform {
-        defaultRepositories()
-        jetbrainsRuntime()
+        jetbrainsIdeInstallers()
+        localPlatformArtifacts()
+        intellijDependencies { url = URI(Constants.Locations.INTELLIJ_DEPENDENCIES_REPOSITORY) }
+        releases { url = URI(Constants.Locations.INTELLIJ_REPOSITORY_RELEASES) }
+        snapshots { url = URI(Constants.Locations.INTELLIJ_REPOSITORY_SNAPSHOTS) }
+        marketplace { url = URI("https://dtahfujkndrht.cloudfront.net/plugins.jetbrains.com/maven/") }
+        jetbrainsRuntime { url = URI("https://d2xrhe97vsfxuc.cloudfront.net") }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,5 +29,3 @@ kotlin.build.report.output=file
 
 # don't bundle Kotlin stdlib with plugin
 kotlin.stdlib.default.dependency=false
-
-detekt.use.worker.api=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ kotlin.code.style=official
 # Gradle settings
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx1024m
+org.gradle.jvmargs=-Xmx2048m
 kotlin.daemon.jvmargs=-Xmx1024m
 
 # prefer non-enterprise variant of test-retry


### PR DESCRIPTION
Getting a lot of 502 errors, likely due to CI making lots of requests

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
