### PR TITLE
Support for including 'source' field with loginSso telemetry

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ kotlin.code.style=official
 # Gradle settings
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx1024m
+org.gradle.jvmargs=-Xmx2048m
 kotlin.daemon.jvmargs=-Xmx1024m
 
 # prefer non-enterprise variant of test-retry
@@ -29,5 +29,3 @@ kotlin.build.report.output=file
 
 # don't bundle Kotlin stdlib with plugin
 kotlin.stdlib.default.dependency=false
-
-detekt.use.worker.api=true

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
@@ -443,26 +443,24 @@ class DefaultToolkitAuthManagerTest {
             requestedScopes = listOf("scopes")
         )
         val metricCaptor = argumentCaptor<MetricEvent>()
-        assertMetricEventsContains(metricCaptor.allValues, "awsId")
+        assertThat(metricCaptor.allValues).allSatisfy { event ->
+            assertThat(event.data.all { it.metadata["credentialSourceId"] == "awsId" }).isTrue()
+        }
     }
 
     @Test
-    fun `loginSso telemetry contains provided source ID`() {
+    fun `loginSso telemetry contains provided source`() {
         AwsSettings.getInstance().isTelemetryEnabled = true
         loginSso(
             project = projectRule.project,
             startUrl = "foo",
             region = "us-east-1",
             requestedScopes = listOf("scopes"),
-            metadata = ConnectionMetadata("fooSourceId")
+            metadata = ConnectionMetadata("fooSource")
         )
         val metricCaptor = argumentCaptor<MetricEvent>()
-        assertMetricEventsContains(metricCaptor.allValues, "fooSourceId")
-    }
-
-    private fun assertMetricEventsContains(events: Collection<MetricEvent>, credentialSourceId: String) {
-        assertThat(events).allSatisfy { event ->
-            assertThat(event.data.all { it.metadata["credentialSourceId"] == credentialSourceId }).isTrue()
+        assertThat(metricCaptor.allValues).allSatisfy { event ->
+            assertThat(event.data.all { it.metadata["source"] == "fooSourceId" }).isTrue()
         }
     }
 

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
@@ -449,6 +449,21 @@ class DefaultToolkitAuthManagerTest {
     }
 
     @Test
+    fun `loginSso telemetry contains no source by default`() {
+        AwsSettings.getInstance().isTelemetryEnabled = true
+        loginSso(
+            project = projectRule.project,
+            startUrl = "foo",
+            region = "us-east-1",
+            requestedScopes = listOf("scopes")
+        )
+        val metricCaptor = argumentCaptor<MetricEvent>()
+        assertThat(metricCaptor.allValues).allSatisfy { event ->
+            assertThat(event.data.all { it.metadata["source"] == null }).isTrue()
+        }
+    }
+
+    @Test
     fun `loginSso telemetry contains provided source`() {
         AwsSettings.getInstance().isTelemetryEnabled = true
         loginSso(


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
We previously did not emit a `source` field with `auth_addConnection` or `aws_loginWithBrowser` telemetry events in the loginSso method. The intention of #4659 was to support overriding this field for custom sources but it incorrectly mapped to the `credentialSourceId` field instead. This PR reverts `credentialSourceId` to a static value and instead maps the optionally passed value in `ConnectionMetadata` to `source`.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
