### PR TITLE
Centralize repository declaration in settings.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,22 +13,6 @@ plugins {
 }
 
 allprojects {
-    repositories {
-        val codeArtifactUrl: Provider<String> = providers.environmentVariable("CODEARTIFACT_URL")
-        val codeArtifactToken: Provider<String> = providers.environmentVariable("CODEARTIFACT_AUTH_TOKEN")
-        if (codeArtifactUrl.isPresent && codeArtifactToken.isPresent) {
-            maven {
-                url = uri(codeArtifactUrl.get())
-                credentials {
-                    username = "aws"
-                    password = codeArtifactToken.get()
-                }
-            }
-        }
-        mavenCentral()
-        gradlePluginPortal()
-    }
-
     configurations.configureEach {
         resolutionStrategy {
             // need to figure out how to fail only on non-platform dependencies

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/ToolkitIntelliJExtension.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/ToolkitIntelliJExtension.kt
@@ -3,7 +3,6 @@
 
 package software.aws.toolkits.gradle.intellij
 
-import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider

--- a/buildSrc/src/main/kotlin/toolkit-intellij-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-plugin.gradle.kts
@@ -1,12 +1,10 @@
 // Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
-import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.aware.SandboxAware
 import software.aws.toolkits.gradle.ciOnly
 import software.aws.toolkits.gradle.intellij.ToolkitIntelliJExtension
 
-private val toolkitIntelliJ = project.extensions.create<ToolkitIntelliJExtension>("intellijToolkit")
+project.extensions.create<ToolkitIntelliJExtension>("intellijToolkit")
 
 plugins {
     id("org.jetbrains.intellij.platform.module")
@@ -14,14 +12,6 @@ plugins {
 
 intellijPlatform {
     instrumentCode = false
-}
-
-// there is an issue if this is declared more than once in a project (either directly or through script plugins)
-repositories {
-    intellijPlatform {
-        defaultRepositories()
-        jetbrainsRuntime()
-    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ awsSdk = "2.26.25"
 commonmark = "0.22.0"
 detekt = "1.23.6"
 intellijExt = "1.1.8"
+# match with <root>/settings.gradle.kts
 intellijGradle = "2.0.0"
 intellijRemoteRobot = "0.11.22"
 jackson = "2.16.1"

--- a/ui-tests/build.gradle.kts
+++ b/ui-tests/build.gradle.kts
@@ -7,10 +7,6 @@ import software.aws.toolkits.gradle.jacoco.RemoteCoverage.Companion.enableRemote
 val remoteRobotPort: String by project
 val ideProfileName: String by project
 
-repositories {
-    maven { url = uri("https://cache-redirector.jetbrains.com/intellij-dependencies") }
-}
-
 plugins {
     id("toolkit-kotlin-conventions")
     id("toolkit-testing")


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:centralized-repository-declaration
> Useful for enforcing large teams to use approved repositories only.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
