### PR TITLE
Fix toolkit incorrectly including Gateway plugin.xml

### DIFF
--- a/plugins/toolkit/jetbrains-gateway/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-gateway/build.gradle.kts
@@ -140,6 +140,10 @@ artifacts {
     add(gatewayResources.name, gatewayResourcesDir)
 }
 
+tasks.prepareJarSearchableOptions {
+    enabled = false
+}
+
 tasks.jar {
     duplicatesStrategy = DuplicatesStrategy.WARN
 }

--- a/plugins/toolkit/jetbrains-gateway/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-gateway/build.gradle.kts
@@ -66,8 +66,6 @@ listOf(
 
 dependencies {
     intellijPlatform {
-        pluginModule(project(":plugin-toolkit:jetbrains-core", "gatewayArtifacts"))
-
         pluginVerifier()
 
         testFramework(TestFrameworkType.Bundled)
@@ -75,6 +73,7 @@ dependencies {
 
     // link against :j-c: and rely on :intellij-standalone:composeJar to pull in :j-c:instrumentedJar, but gateway variant when from :jetbrains-gateway
     compileOnly(project(":plugin-toolkit:jetbrains-core"))
+    gatewayOnlyRuntimeOnly(project(":plugin-toolkit:jetbrains-core", "gatewayArtifacts"))
     // delete when fully split
     gatewayOnlyRuntimeOnly(project(":plugin-core:core"))
     gatewayOnlyRuntimeOnly(project(":plugin-core:jetbrains-community"))


### PR DESCRIPTION
`pluginModule` caused `plugin-toolkit` to transitively include Gateway's `plugin.xml`
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
