### PR TITLE
fix(qchat): various fixes from mynah-ui

### DIFF
--- a/.changes/next-release/bugfix-3cd83457-8f62-41f1-9a92-4958a819edcd.json
+++ b/.changes/next-release/bugfix-3cd83457-8f62-41f1-9a92-4958a819edcd.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Fixing issue with the max tabs notification not being dismissible"
+}

--- a/.changes/next-release/bugfix-79bc98f0-1078-4794-8041-e85946396364.json
+++ b/.changes/next-release/bugfix-79bc98f0-1078-4794-8041-e85946396364.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Fixing issue with an incorrect input cursor position in the prompt text box"
+}

--- a/.changes/next-release/bugfix-9df996b9-97d4-4df0-af4c-8c641b4eba16.json
+++ b/.changes/next-release/bugfix-9df996b9-97d4-4df0-af4c-8c641b4eba16.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Showing/hiding the scrollbars is now controlled by the OS settings"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.2",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.4",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,10 +57,11 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.15.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.2.tgz",
-            "integrity": "sha512-z2E8eDAMduM4+Pqpokj5ILyTbsXGV9TTtx9Flwi0JUzo04avZ5CbipIh2zTV6CxO5gmo5eq5u1t+cpFwSAdsag==",
+            "version": "4.15.4",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.4.tgz",
+            "integrity": "sha512-aXKM6l4SSGcCgFjmioyqVX71dlgPqdiQbGaq4pyVR+zv6wTcpkMqSs2pcr+3NKTLO6RWenJVRgdMPB3NVNdTMA==",
             "hasInstallScript": true,
+            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.4",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.5",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.15.4",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.4.tgz",
-            "integrity": "sha512-aXKM6l4SSGcCgFjmioyqVX71dlgPqdiQbGaq4pyVR+zv6wTcpkMqSs2pcr+3NKTLO6RWenJVRgdMPB3NVNdTMA==",
+            "version": "4.15.5",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.5.tgz",
+            "integrity": "sha512-qLeeyzaHgI9V4zet9AarHR1kL0XhHr23wWvucPfl8DcEi4gpnvL5cAUpYWgdMHv3Pmt1aajVyDjNkEGRpezgmA==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.4",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.5",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.2",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.4",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",


### PR DESCRIPTION
## Problem
Q Chat UI:
- Prompt Text box does not accurately display cursor position
![QChatIssueWindows](https://github.com/user-attachments/assets/6a72a7a7-aa5c-428e-8ca3-3e1907a6d100)
- The scrollbars were disabled/invisible
- The max tabs notification couldn't be dismissed
![350022198-c736e164-f232-43d8-8291-c4d9b9e3e118](https://github.com/user-attachments/assets/4af48af8-7006-41cc-94ec-7f1dbe51b127)
- Regression in table styles
Before the latest v4.15.4 release, the markdown table's UI was:
![image](https://github.com/user-attachments/assets/aebcd668-aadd-4cd2-a09e-90833ad27031)
But with v14.5.4 the new style was inadvertently introduced:
![image](https://github.com/user-attachments/assets/cd002d64-e35e-44ec-bc12-13833290e386)

## Solution
Updating @aws/mynah-ui to 4.15.5
https://github.com/aws/mynah-ui/releases/tag/v4.15.4
https://github.com/aws/mynah-ui/releases/tag/v4.15.5

- Fixing issue with an incorrect input cursor position in the prompt text box
- Showing/hiding the scrollbars is now controlled by the OS settings
![image](https://github.com/user-attachments/assets/13b0f4d4-fc8f-4474-8833-bf39b0f5e4a2)
- Fixing issue with the max tabs notification not being dismissible
- Table styles are reverted back


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots (if the pull request is related to UI/UX then please include light and dark theme screenshots)
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.