### PR TITLE
fix(amazonq): set Q_WORKER_THREADS only when setting is >0

### DIFF
--- a/.changes/next-release/bugfix-a5c03c3c-3d5c-454b-8d52-1d125ca0a5cc.json
+++ b/.changes/next-release/bugfix-a5c03c3c-3d5c-454b-8d52-1d125ca0a5cc.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "fix(amazonq): Amazon Q chat `@workspace` uses more than 20% cpu"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/EncoderServer.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/EncoderServer.kt
@@ -118,10 +118,12 @@ class EncoderServer(val project: Project) : Disposable {
         val map = mutableMapOf<String, String>(
             "PORT" to port.toString(),
             "START_AMAZONQ_LSP" to "true",
-            "Q_WORKER_THREADS" to threadCount.toString(),
             "CACHE_DIR" to cachePath.toString(),
             "MODEL_DIR" to cachePath.resolve("qserver").toString()
         )
+        if (threadCount > 0) {
+            map["Q_WORKER_THREADS"] = threadCount.toString()
+        }
         if (isGpuEnabled) {
             map["Q_ENABLE_GPU"] = "true"
         }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
This change only sets the `Q_WORKER_THREADS` for the amazonq lsp when the value is >0 and <100. This should make it have the same logic as the VSCode plugin: https://github.com/aws/aws-toolkit-vscode/blob/4b3804fd6c5b4106dc7178cb46121d95adf7ff0d/packages/core/src/amazonq/lsp/lspClient.ts#L141C1-L143C13 

This caused the default number of threads used by the lps to be incorrect as setting the value of `Q_WORKER_THREADS=0` caused the runtime to use a different heuristic to determine thread count than when it is unset.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
