### PR TITLE
fix(amazonq): fix UI bugs by bumping mynah-ui version

### DIFF
--- a/.changes/next-release/bugfix-687fa4bc-8244-4b64-873f-c82a0baeec67.json
+++ b/.changes/next-release/bugfix-687fa4bc-8244-4b64-873f-c82a0baeec67.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Fix Tab selection scrollbar visibility which causes tabs half visible if there are several tabs open"
+}

--- a/.changes/next-release/bugfix-b15470b6-0b0d-488f-bcaa-16cf3479a163.json
+++ b/.changes/next-release/bugfix-b15470b6-0b0d-488f-bcaa-16cf3479a163.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: / command selector doesn't work if user pastes the command to prompt and submits"
+}

--- a/.changes/next-release/bugfix-ce359d20-587a-4c55-b89a-1393d0514d0c.json
+++ b/.changes/next-release/bugfix-ce359d20-587a-4c55-b89a-1393d0514d0c.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Related link previews sometimes remain on screen and block the whole Chat UI"
+}

--- a/.changes/next-release/bugfix-ea5b785d-9b08-4b16-ab9d-6430cb9412b7.json
+++ b/.changes/next-release/bugfix-ea5b785d-9b08-4b16-ab9d-6430cb9412b7.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: @ context selector conflicts with some use cases where the user wants use @ character for a word in the prompt itself"
+}

--- a/.changes/next-release/bugfix-eb298e8b-3331-4651-aafd-a9f8a6c5ad19.json
+++ b/.changes/next-release/bugfix-eb298e8b-3331-4651-aafd-a9f8a6c5ad19.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Fix Header items in card bodies don't wrap if they don't contain spaces"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.5",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.6",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.15.5",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.5.tgz",
-            "integrity": "sha512-qLeeyzaHgI9V4zet9AarHR1kL0XhHr23wWvucPfl8DcEi4gpnvL5cAUpYWgdMHv3Pmt1aajVyDjNkEGRpezgmA==",
+            "version": "4.15.6",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.6.tgz",
+            "integrity": "sha512-YzM1l48yYhj1OZvz9yY+CDIT0K5dIcLMf7hubbVjJqHvRyKyNsCotTDF7ZJIq+IWG17mGUlo8X/s2oAhcYvMNg==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.5",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.6",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",


### PR DESCRIPTION
## Problem
- Tab selection scrollbar visibility which causes tabs half visible if there are several tabs open.
- Header items in card bodies don't wrap if they don't contain spaces.
- Related link previews sometimes remain on screen and block the whole Chat UI.
- `@` context selector conflicts with some use cases where the user wants use `@` character for a word in the prompt itself.
- `/` command selector doesn't work if user pastes the command to prompt and submits

### Header item wrapping
<img width="469" alt="image" src="https://github.com/user-attachments/assets/16fefd47-45e0-49f7-9627-be97f88dea4c">

### `/` Command selector
https://github.com/user-attachments/assets/b5ed474d-03d9-4eff-afed-4d0d9e9365a8

### `@` Context selector
https://github.com/user-attachments/assets/68ed9202-7110-4c9f-bc28-8b988ab9182e
## Solution
Updating @aws/mynah-ui to 4.15.6

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
