### PR TITLE
Declare 'dependencySupport' on AWS CLI instead of Java SDK

### DIFF
--- a/plugins/toolkit/jetbrains-core/resources/META-INF/ext-java.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/ext-java.xml
@@ -5,8 +5,6 @@
     <extensions defaultExtensionNs="com.intellij">
         <codeInsight.lineMarkerProvider language="JAVA" implementationClass="software.aws.toolkits.jetbrains.services.lambda.upload.LambdaLineMarker"/>
         <runConfigurationExtension implementation="software.aws.toolkits.jetbrains.core.execution.JavaAwsConnectionExtension"/>
-        <dependencySupport displayName="AWS SDK for Java" coordinate="com.amazonaws:aws-java-sdk-core" kind="java"/>
-        <dependencySupport displayName="AWS SDK for Java v2" coordinate="software.amazon.awssdk:sdk-core" kind="java"/>
     </extensions>
 
     <extensions defaultExtensionNs="aws.toolkit">

--- a/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
@@ -176,6 +176,8 @@
     </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">
+        <dependencySupport kind="executable" coordinate="aws"/>
+
         <applicationService serviceImplementation="software.aws.toolkits.jetbrains.settings.EcsExecCommandSettings"/>
         <applicationService serviceImplementation="software.aws.toolkits.jetbrains.settings.SamDisplayDevModeWarningSettings"/>
 


### PR DESCRIPTION
Per internal requests from JetBrains
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
