### PR TITLE
Fix UI freeze when rendering CodeScan CVE popups

### DIFF
--- a/.changes/next-release/bugfix-b645d4bd-5f65-49cc-bae1-ab866bd6eb3a.json
+++ b/.changes/next-release/bugfix-b645d4bd-5f65-49cc-bae1-ab866bd6eb3a.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix UI freeze that occurs when viewing an Amazon Q code security scanning finding"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
@@ -23,7 +23,6 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.ui.JBColor
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.ui.components.JBScrollPane
-import com.intellij.util.TimeoutUtil.sleep
 import icons.AwsIcons
 import software.amazon.awssdk.services.codewhispererruntime.model.CodeWhispererRuntimeException
 import software.aws.toolkits.core.utils.convertMarkdownToHTML
@@ -39,7 +38,6 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhisp
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.programmingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererColorUtil.getHexString
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.CODE_SCAN_ISSUE_POPUP_DELAY_IN_SECONDS
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.CODE_SCAN_ISSUE_TITLE_MAX_LENGTH
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIdcConnectionOrTelemetryEnabled
 import software.aws.toolkits.jetbrains.utils.applyPatch
@@ -377,7 +375,6 @@ class CodeWhispererCodeScanEditorMouseMotionListener(private val project: Projec
         // Only add popup if the issue is still valid. If the issue has gone stale or invalid because
         // the user has made some edits, we don't need to show the popup for the stale or invalid issues.
         if (!issuesInRange.first().isInvalid) {
-            sleep(CODE_SCAN_ISSUE_POPUP_DELAY_IN_SECONDS)
             showPopup(issuesInRange, e)
         }
     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
@@ -66,7 +66,6 @@ object CodeWhispererConstants {
     const val TOTAL_SECONDS_IN_MINUTE: Long = 60L
     const val ACCOUNTLESS_START_URL = "accountless"
     const val FEATURE_CONFIG_POLL_INTERVAL_IN_MS: Long = 30 * 60 * 1000L // 30 mins
-    const val CODE_SCAN_ISSUE_POPUP_DELAY_IN_SECONDS: Long = 1500 // 1.5 seconds
     const val USING: String = "using"
     const val GLOBAL_USING: String = "global using"
     const val STATIC: String = "static"


### PR DESCRIPTION
`sleep()` was being called on UI thread
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
