### PR TITLE
Revert "Attach parent PluginResolver to plugin tracked coroutines (#4641)"

### DIFF
--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/coroutines/ScopeTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/coroutines/ScopeTest.kt
@@ -28,7 +28,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.rules.TestName
-import software.aws.toolkits.jetbrains.services.telemetry.PluginResolver
 import software.aws.toolkits.jetbrains.utils.isInstanceOf
 import java.time.Duration
 import java.util.concurrent.CancellationException
@@ -152,18 +151,6 @@ class ScopeTest {
     @Test
     fun `disposableCoroutineScope can't take an application`() {
         assertThatThrownBy { disposableCoroutineScope(ApplicationManager.getApplication()) }.isInstanceOf<IllegalStateException>()
-    }
-
-    @Test
-    fun `coroutine inherits PluginResolver from parent`() {
-        val pluginResolver = PluginResolver.fromCurrentThread()
-        PluginResolver.setThreadLocal(pluginResolver)
-
-        runBlocking {
-            withContext(applicationCoroutineScope().coroutineContext) {
-                assertThat(PluginResolver.fromCurrentThread()).isEqualTo(pluginResolver)
-            }
-        }
     }
 
     private fun createFakePluginScope(componentManager: ComponentManager = ApplicationManager.getApplication()): Disposable {


### PR DESCRIPTION
This reverts commit bc8e338d58480b8d1ac137fe47f3ac7a9b7c5cb3

Since the logic is in `core`, `coroutineContext` is consistently being initialized with "Toolkit" as the resolved plugin. Instead the resolver needs to be evaluated at the top of a coroutine stack, which needs some investigation given that we are moving to a platform-injected parent `CoroutineScope`

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
