### PR TITLE
Cache Gradle wrapper in Linux Unit CI

### DIFF
--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -13,6 +13,9 @@ env:
 phases:
   install:
     commands:
+      - cat /etc/passwd
+      - getent group
+      - id codebuild-user
       - useradd codebuild-user
       - dnf install -y acl
       - chown -R codebuild-user:codebuild-user /codebuild/output
@@ -21,6 +24,7 @@ phases:
       - mkdir /tmp/testArtifacts; chmod 777 /tmp/testArtifacts
       - export AWS_CODEARTIFACT_NUGET_LOGFILE=/tmp/testArtifacts/codeArtifactNuGet.log
       # (CVE-2022-24765) fatal: detected dubious ownership in repository
+      - ls -alh /home/codebuild-user/
       - su codebuild-user -c "git config --global --add safe.directory \"$CODEBUILD_SRC_DIR\""
 
   build:

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -3,7 +3,7 @@ version: 0.2
 cache:
   paths:
 #    - '/root/.gradle/caches/**/*'
-    - '/root/.gradle/wrapper/**/*'
+    - '/home/codebuild-user/.gradle/wrapper/**/*'
 
 env:
   variables:
@@ -35,7 +35,7 @@ phases:
 
       - chmod +x gradlew
       - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME check coverageReport --info --console plain --continue"
-      - ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME buildPlugin
+      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME buildPlugin"
       - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
       - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
       - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -13,18 +13,15 @@ env:
 phases:
   install:
     commands:
-      - cat /etc/passwd
-      - getent group
-      - id codebuild-user
       - useradd codebuild-user
       - dnf install -y acl
       - chown -R codebuild-user:codebuild-user /codebuild/output
       - chown -R codebuild-user:codebuild-user /codebuild/local-cache
+      - chown -R codebuild-user:codebuild-user /home/codebuild-user
       - setfacl -m d:o::rwx,o::rwx /root
       - mkdir /tmp/testArtifacts; chmod 777 /tmp/testArtifacts
       - export AWS_CODEARTIFACT_NUGET_LOGFILE=/tmp/testArtifacts/codeArtifactNuGet.log
       # (CVE-2022-24765) fatal: detected dubious ownership in repository
-      - ls -alh /home/codebuild-user/
       - su codebuild-user -c "git config --global --add safe.directory \"$CODEBUILD_SRC_DIR\""
 
   build:


### PR DESCRIPTION
Try to reduce amount of:
```
Downloading https://services.gradle.org/distributions/gradle-8.9-bin.zip
......
Exception in thread "main" java.net.SocketException: Connection reset
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
