### PR TITLE
fix (Amazon Q): Pass context specific intent and trigger type to chat

### DIFF
--- a/.changes/next-release/bugfix-25a96fb5-3f37-4583-a502-63c6dd1a42bc.json
+++ b/.changes/next-release/bugfix-25a96fb5-3f37-4583-a502-63c6dd1a42bc.json
@@ -1,4 +1,0 @@
-{
-  "type" : "bugfix",
-  "description" : "Fix to pass context specific user intent and trigger type to Amazon Q chat"
-}

--- a/.changes/next-release/bugfix-25a96fb5-3f37-4583-a502-63c6dd1a42bc.json
+++ b/.changes/next-release/bugfix-25a96fb5-3f37-4583-a502-63c6dd1a42bc.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix to pass context specific user intent and trigger type to Amazon Q chat"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/ChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/ChatController.kt
@@ -367,8 +367,8 @@ class ChatController private constructor(
             triggerId = triggerId,
             message = inputPrompt,
             activeFileContext = fileContext,
-            userIntent = intentRecognizer.getUserIntentFromContextMenuCommand(EditorContextCommand.ExplainCodeScanIssue),
-            TriggerType.CodeScanButton,
+            userIntent = intentRecognizer.getUserIntentFromContextMenuCommand(message.command),
+            triggerType = message.command.triggerType,
             projectContextQueryResult = emptyList()
         )
     }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

Fixes bug where static user intent (`UserIntent.EXPLAIN_CODE_SELECTION`) and trigger type (`TriggerType.CodeScanButton`) are sent Amazon Q chat rather than the context specific inputs gathered from the prompt.

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
