### PR TITLE
Remove footgun from attempting to use application-level ToolkitConnectionManager outside of Gateway

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
@@ -99,7 +99,7 @@ interface ToolkitConnectionManager : Disposable {
     override fun dispose() {}
 
     companion object {
-        fun getInstance(project: Project?) = project?.let { it.service<ToolkitConnectionManager>() } ?: service()
+        fun getInstance(project: Project) = project.service<ToolkitConnectionManager>()
     }
 }
 
@@ -140,7 +140,7 @@ fun loginSso(
             onSuccess()
         }
 
-        ToolkitConnectionManager.getInstance(project).switchConnection(connection)
+        project?.let { ToolkitConnectionManager.getInstance(it).switchConnection(connection) }
         return connection
     }
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialog.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialog.kt
@@ -117,7 +117,7 @@ interface AuthenticationDialog {
 }
 
 class SetupAuthenticationDialog(
-    private val project: Project?,
+    private val project: Project,
     private val scopes: List<String> = emptyList(),
     private val state: SetupAuthenticationDialogState = SetupAuthenticationDialogState(),
     private val tabSettings: Map<SetupAuthenticationTabs, AuthenticationTabSettings> = emptyMap(),
@@ -292,14 +292,12 @@ class SetupAuthenticationDialog(
                 } ?: return
 
                 if (!promptForIdcPermissionSet) {
-                    project?.let { ToolkitConnectionManager.getInstance(it).switchConnection(connection) }
+                    ToolkitConnectionManager.getInstance(project).switchConnection(connection)
                     close(OK_EXIT_CODE)
                     return
                 }
 
                 val tokenProvider = connection.getConnectionSettings().tokenProvider
-
-                if (project == null) error("Not allowed")
 
                 val rolePopup = IdcRolePopup(
                     project,

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialog.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/SetupAuthenticationDialog.kt
@@ -292,7 +292,7 @@ class SetupAuthenticationDialog(
                 } ?: return
 
                 if (!promptForIdcPermissionSet) {
-                    ToolkitConnectionManager.getInstance(project).switchConnection(connection)
+                    project?.let { ToolkitConnectionManager.getInstance(it).switchConnection(connection) }
                     close(OK_EXIT_CODE)
                     return
                 }

--- a/plugins/toolkit/jetbrains-core/resources/META-INF/inactive/plugin-gateway.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/inactive/plugin-gateway.xml
@@ -14,4 +14,9 @@
     <incompatible-with>com.intellij.modules.python</incompatible-with>
     <incompatible-with>com.intellij.modules.ultimate</incompatible-with>
     <incompatible-with>com.intellij.java</incompatible-with>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager"
+                            serviceImplementation="software.aws.toolkits.jetbrains.core.credentials.DefaultToolkitConnectionManager"/>
+    </extensions>
 </idea-plugin>

--- a/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
@@ -190,10 +190,6 @@
         <moduleService serviceImplementation="software.aws.toolkits.jetbrains.settings.SyncSettings"/>
         <applicationService serviceImplementation="software.aws.toolkits.jetbrains.settings.UpdateLambdaState"/>
 
-        <!-- application-level ToolkitConnectionManager is gateway-only -->
-        <applicationService serviceInterface="software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager"
-                            serviceImplementation="software.aws.toolkits.jetbrains.core.credentials.DefaultToolkitConnectionManager"/>
-
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.services.dynamic.CreateResourceFileStatusHandler"/>
 
         <statusBarWidgetFactory id="AwsSettingsPanel" implementation="software.aws.toolkits.jetbrains.core.credentials.AwsSettingsPanelInstaller"/>

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ConnectionSettingsMenuBuilder.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ConnectionSettingsMenuBuilder.kt
@@ -246,7 +246,7 @@ class ConnectionSettingsMenuBuilder private constructor() {
                     override fun actionPerformed(e: AnActionEvent) {
                         reauthConnectionIfNeeded(e.project, value, isReAuth = true)
 
-                        ToolkitConnectionManager.getInstance(e.project).switchConnection(value)
+                        e.project?.let { ToolkitConnectionManager.getInstance(it).switchConnection(value) }
                     }
                 },
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sono/CodeCatalystCredentialManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sono/CodeCatalystCredentialManager.kt
@@ -36,9 +36,13 @@ class CodeCatalystCredentialManager {
     }
 
     fun connection() = (
-        ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(CodeCatalystConnection.getInstance())
-            as? AwsBearerTokenConnection
-        )
+        project?.let {
+            ToolkitConnectionManager.getInstance(project)
+        } ?:
+        // only used for gateway
+            service<ToolkitConnectionManager>()
+    ).activeConnectionForFeature(CodeCatalystConnection.getInstance())
+        as? AwsBearerTokenConnection
 
     internal fun provider(conn: AwsBearerTokenConnection) = conn.getConnectionSettings().tokenProvider.delegate as BearerTokenProvider
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sono/CodeCatalystCredentialManager.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/sono/CodeCatalystCredentialManager.kt
@@ -38,11 +38,9 @@ class CodeCatalystCredentialManager {
     fun connection() = (
         project?.let {
             ToolkitConnectionManager.getInstance(project)
-        } ?:
-        // only used for gateway
-            service<ToolkitConnectionManager>()
-    ).activeConnectionForFeature(CodeCatalystConnection.getInstance())
-        as? AwsBearerTokenConnection
+            // app-version only used for gateway
+        } ?: service<ToolkitConnectionManager>()
+        ).activeConnectionForFeature(CodeCatalystConnection.getInstance()) as? AwsBearerTokenConnection
 
     internal fun provider(conn: AwsBearerTokenConnection) = conn.getConnectionSettings().tokenProvider.delegate as BearerTokenProvider
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/GatewaySetupAuthenticationDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/GatewaySetupAuthenticationDialog.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.gettingstarted
 
+import com.intellij.openapi.components.service
 import com.intellij.openapi.observable.properties.PropertyGraph
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
@@ -13,6 +14,7 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.components.BorderLayoutPanel
 import org.jetbrains.annotations.VisibleForTesting
 import software.aws.toolkits.core.region.AwsRegion
+import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.loginSso
 import software.aws.toolkits.jetbrains.core.credentials.sono.IDENTITY_CENTER_ROLE_ACCESS_SCOPE
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_REGION
@@ -164,7 +166,7 @@ class GatewaySetupAuthenticationDialog(
             scopes
         }
 
-        when (selectedTab()) {
+        val connection = when (selectedTab()) {
             GatewaySetupAuthenticationTabs.IDENTITY_CENTER -> {
                 authType = CredentialSourceId.IamIdentityCenter
                 val startUrl = state.idcTabState.startUrl
@@ -177,6 +179,8 @@ class GatewaySetupAuthenticationDialog(
                 loginSso(project, SONO_URL, SONO_REGION, scopes)
             }
         }
+
+        service<ToolkitConnectionManager>().switchConnection(connection)
 
         close(OK_EXIT_CODE)
     }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/ToolkitGettingStartedAuthUtils.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/ToolkitGettingStartedAuthUtils.kt
@@ -51,6 +51,8 @@ fun requestCredentialsForCodeCatalyst(
         }
 
         else -> {
+            requireNotNull(project) { "project must not be null when requesting credentials outside of gateway" }
+
             SetupAuthenticationDialog(
                 project,
                 state = SetupAuthenticationDialogState().also {

--- a/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/CawsConnectionProvider.kt
+++ b/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/CawsConnectionProvider.kt
@@ -7,6 +7,7 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.rd.createNestedDisposable
@@ -107,7 +108,7 @@ class CawsConnectionProvider : GatewayConnectionProvider {
             return null
         }
 
-        val currentConnection = ToolkitConnectionManager.getInstance(null).activeConnectionForFeature(CodeCatalystConnection.getInstance())
+        val currentConnection = service<ToolkitConnectionManager>().activeConnectionForFeature(CodeCatalystConnection.getInstance())
             as AwsBearerTokenConnection?
 
         val ssoSettings = connectionParams.ssoSettings ?: SsoSettings(SONO_URL, SONO_REGION)

--- a/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/CawsConnectorViewPanels.kt
+++ b/plugins/toolkit/jetbrains-gateway/src/software/aws/toolkits/jetbrains/gateway/CawsConnectorViewPanels.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.gateway
 
 import com.intellij.ide.browsers.BrowserLauncher
+import com.intellij.openapi.components.service
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.observable.properties.PropertyGraph
 import com.intellij.openapi.rd.createNestedDisposable
@@ -191,9 +192,8 @@ fun cawsWizard(lifetime: Lifetime, settings: CawsSettings = CawsSettings()) = Mu
                     return@startWithModalProgressAsync
                 }
 
-                val currentConnection = ToolkitConnectionManager.getInstance(
-                    null
-                ).activeConnectionForFeature(CodeCatalystConnection.getInstance()) as AwsBearerTokenConnection?
+                val currentConnection = service<ToolkitConnectionManager>()
+                    .activeConnectionForFeature(CodeCatalystConnection.getInstance()) as AwsBearerTokenConnection?
                     ?: error("Connection cannot be null")
 
                 val parameters = mapOf(


### PR DESCRIPTION
Related: https://github.com/aws/aws-toolkit-jetbrains/issues/4849
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
