### PR TITLE
Fix deserialization error on Existing Connection Option click in webview

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Toolkit Version
-toolkitVersion=3.26
+toolkitVersion=3.27-SNAPSHOT
 
 # Publish Settings
 publishToken=

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
@@ -196,7 +196,12 @@ class QWebviewBrowser(val project: Project, private val parentDisposable: Dispos
             }
 
             is BrowserMessage.SendUiClickTelemetry -> {
-                UiTelemetry.click(project, message.signInOptionClicked)
+                val signInOption = message.signInOptionClicked
+                if (signInOption.isNullOrEmpty()) {
+                    LOG.warn("Unknown sign in option")
+                } else {
+                    UiTelemetry.click(project, signInOption)
+                }
             }
         }
     }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/BrowserMessage.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/BrowserMessage.kt
@@ -57,5 +57,5 @@ sealed interface BrowserMessage {
 
     object Reauth : BrowserMessage
 
-    data class SendUiClickTelemetry(val signInOptionClicked: String) : BrowserMessage
+    data class SendUiClickTelemetry(val signInOptionClicked: String?) : BrowserMessage
 }

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/BrowserMessageTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/BrowserMessageTest.kt
@@ -15,6 +15,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.ObjectAssert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.mock
 import software.aws.toolkits.jetbrains.core.webview.BrowserMessage
@@ -148,6 +149,18 @@ class BrowserMessageTest {
             }
             """
         )
+
+        assertDeserializedInstanceOf<BrowserMessage.SendUiClickTelemetry>(
+            """
+            {
+                "command": "sendUiClickTelemetry"
+            }
+            """
+        ).isEqualTo(
+            BrowserMessage.SendUiClickTelemetry(
+                signInOptionClicked = null
+            )
+        )
     }
 
     @Test
@@ -272,5 +285,30 @@ class BrowserMessageTest {
             }
             """
         )
+    }
+
+    @Test
+    fun `Nullable fields in sendUiClickTelemetry should not throw exception`() {
+        assertDoesNotThrow {
+            objectMapper.readValue<BrowserMessage>(
+                """
+            {
+                "command": "sendUiClickTelemetry",
+                "signInOptionClicked": null
+            }
+            """
+            )
+        }
+
+        assertDoesNotThrow {
+            objectMapper.readValue<BrowserMessage>(
+                """
+            {
+                "command": "sendUiClickTelemetry"
+             
+            }
+            """
+            )
+        }
     }
 }

--- a/plugins/core/webview/src/q-ui/components/login.vue
+++ b/plugins/core/webview/src/q-ui/components/login.vue
@@ -34,10 +34,14 @@ const authUiClickOptionMap = {
     [LoginIdentifier.ENTERPRISE_SSO]: 'auth_idcOption',
     [LoginIdentifier.IAM_CREDENTIAL]: 'auth_credentialsOption',
     [LoginIdentifier.EXISTING_LOGINS]: 'auth_existingAuthOption',
+    [LoginIdentifier.NONE]: "Unknown"
 }
 
 function getUiClickEvent(loginIdentifier: LoginIdentifier) {
-    return (authUiClickOptionMap as any)[loginIdentifier]
+    if(!Object.keys(authUiClickOptionMap).includes(loginIdentifier)) {
+        return "Unknown"
+    }
+    return (authUiClickOptionMap)[loginIdentifier]
 }
 
 export default defineComponent({

--- a/plugins/core/webview/src/q-ui/components/qOptions.vue
+++ b/plugins/core/webview/src/q-ui/components/qOptions.vue
@@ -56,6 +56,7 @@ import {defineComponent} from 'vue'
 import SelectableItem from "./selectableItem.vue";
 import {AwsBearerTokenConnection, BuilderId, ExistConnection, Feature, LoginIdentifier, SONO_URL, Stage} from "../../model";
 import {AWS_BUILDER_ID_NAME, IDENTITY_CENTER_NAME} from "../../constants"
+import LoginOptions from "@/q-ui/components/loginOptions.vue";
 
 export default defineComponent({
     name: "loginOptions",
@@ -90,8 +91,15 @@ export default defineComponent({
             this.selectedLoginOption = itemId
         },
         emitUiClickMetric(itemId: string) {
-            this.$emit('emitUiClickTelemetry', itemId)
+            const loginIdentifiers = Object.values(LoginIdentifier).map(value => value.toString());
+            if(loginIdentifiers.includes(itemId) ) {
+                 this.$emit('emitUiClickTelemetry', itemId)
+             } else {
+                this.$emit('emitUiClickTelemetry', LoginIdentifier.EXISTING_LOGINS)
+             }
+
         },
+
         handleBackButtonClick() {
             this.$emit('backToMenu')
         },

--- a/plugins/core/webview/src/q-ui/components/qOptions.vue
+++ b/plugins/core/webview/src/q-ui/components/qOptions.vue
@@ -56,7 +56,6 @@ import {defineComponent} from 'vue'
 import SelectableItem from "./selectableItem.vue";
 import {AwsBearerTokenConnection, BuilderId, ExistConnection, Feature, LoginIdentifier, SONO_URL, Stage} from "../../model";
 import {AWS_BUILDER_ID_NAME, IDENTITY_CENTER_NAME} from "../../constants"
-import LoginOptions from "@/q-ui/components/loginOptions.vue";
 
 export default defineComponent({
     name: "loginOptions",
@@ -99,7 +98,6 @@ export default defineComponent({
              }
 
         },
-
         handleBackButtonClick() {
             this.$emit('backToMenu')
         },

--- a/plugins/core/webview/src/q-ui/components/toolkitOptions.vue
+++ b/plugins/core/webview/src/q-ui/components/toolkitOptions.vue
@@ -102,7 +102,12 @@ export default defineComponent({
             this.selectedLoginOption = itemId
         },
         emitUiClickMetric(itemId: string) {
-            this.$emit('emitUiClickTelemetry', itemId)
+            const loginIdentifiers = Object.values(LoginIdentifier).map(value => value.toString());
+            if(loginIdentifiers.includes(itemId) ) {
+                this.$emit('emitUiClickTelemetry', itemId)
+            } else {
+                this.$emit('emitUiClickTelemetry', LoginIdentifier.EXISTING_LOGINS)
+            }
         },
         handleBackButtonClick() {
             this.$emit('backToMenu')

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/webview/ToolkitLoginWebview.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/webview/ToolkitLoginWebview.kt
@@ -237,7 +237,12 @@ class ToolkitWebviewBrowser(val project: Project, private val parentDisposable: 
             }
 
             is BrowserMessage.SendUiClickTelemetry -> {
-                UiTelemetry.click(project, message.signInOptionClicked)
+                val signInOption = message.signInOptionClicked
+                if (signInOption.isNullOrEmpty()) {
+                    LOG.warn("Unknown sign in option")
+                } else {
+                    UiTelemetry.click(project, signInOption)
+                }
             }
         }
     }
@@ -336,6 +341,7 @@ class ToolkitWebviewBrowser(val project: Project, private val parentDisposable: 
     fun component(): JComponent? = jcefBrowser.component
 
     companion object {
+        private val LOG = getLogger<ToolkitWebviewBrowser>()
         private const val WEB_SCRIPT_URI = "http://webview/js/toolkitGetStart.js"
         private const val DOMAIN = "webview"
     }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
The Existing Connection option wasn't mapped to the corresponding LoginIdentifier which resulted in a deserialization error while sending telemetry since the required option didnt exist. This PR associates the correct Login Identifier to the metric and makes provisions to send Unknown as the UI click type in case the sent Login Identifiers are not found.

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
