### PR TITLE
Fix issue preventing login when running on 2024.2 remote environments

### DIFF
--- a/.changes/next-release/bugfix-cd92f642-5446-4fd0-af24-8cef32527208.json
+++ b/.changes/next-release/bugfix-cd92f642-5446-4fd0-af24-8cef32527208.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue preventing login when running on 2024.2 remote environments"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
@@ -36,6 +36,7 @@ import software.aws.toolkits.jetbrains.isDeveloperMode
 import software.aws.toolkits.jetbrains.services.amazonq.util.createBrowser
 import software.aws.toolkits.jetbrains.utils.isQConnected
 import software.aws.toolkits.jetbrains.utils.isQExpired
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.telemetry.FeatureId
 import software.aws.toolkits.telemetry.UiTelemetry
 import software.aws.toolkits.telemetry.WebviewTelemetry
@@ -87,7 +88,7 @@ class QWebviewPanel private constructor(val project: Project) : Disposable {
     }
 
     private fun init() {
-        if (!JBCefApp.isSupported()) {
+        if (!isQWebviewsAvailable()) {
             // Fallback to an alternative browser-less solution
             webviewContainer.add(JBTextArea("JCEF not supported"))
             browser = null

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
@@ -15,7 +15,6 @@ import com.intellij.ui.components.panels.Wrapper
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
-import com.intellij.ui.jcef.JBCefApp
 import com.intellij.ui.jcef.JBCefJSQuery
 import org.cef.CefApp
 import software.aws.toolkits.core.utils.error

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/explorerActions/SignInToQAction.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/explorerActions/SignInToQAction.kt
@@ -8,13 +8,13 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.wm.ToolWindowManager
-import com.intellij.ui.jcef.JBCefApp
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
 import software.aws.toolkits.jetbrains.core.credentials.reauthConnectionIfNeeded
 import software.aws.toolkits.jetbrains.core.gettingstarted.requestCredentialsForQ
 import software.aws.toolkits.jetbrains.services.amazonq.gettingstarted.openMeetQPage
 import software.aws.toolkits.jetbrains.services.amazonq.toolwindow.AmazonQToolWindowFactory
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.UiTelemetry
 
@@ -23,7 +23,7 @@ class SignInToQAction : SignInToQActionBase(message("q.sign.in")) {
         val project = e.project ?: return
         UiTelemetry.click(project, "auth_start_Q")
 
-        if (!AmazonQToolWindowFactory.shouldBeAvailable()) {
+        if (!isQWebviewsAvailable()) {
             requestCredentialsForQ(project)
         } else {
             ToolWindowManager.getInstance(project).getToolWindow(AmazonQToolWindowFactory.WINDOW_ID)?.show()

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/explorerActions/SignInToQAction.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/explorerActions/SignInToQAction.kt
@@ -23,7 +23,7 @@ class SignInToQAction : SignInToQActionBase(message("q.sign.in")) {
         val project = e.project ?: return
         UiTelemetry.click(project, "auth_start_Q")
 
-        if (!JBCefApp.isSupported()) {
+        if (!AmazonQToolWindowFactory.shouldBeAvailable()) {
             requestCredentialsForQ(project)
         } else {
             ToolWindowManager.getInstance(project).getToolWindow(AmazonQToolWindowFactory.WINDOW_ID)?.show()

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/gettingstarted/QGettingStartedPanel.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/gettingstarted/QGettingStartedPanel.kt
@@ -12,6 +12,7 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.ui.jcef.JBCefApp
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 
 class QGettingStartedPanel(
     val project: Project
@@ -29,7 +30,7 @@ class QGettingStartedPanel(
     }
 
     init {
-        if (!JBCefApp.isSupported()) {
+        if (!isQWebviewsAvailable()) {
             // Fallback to an alternative browser-less solution
             webviewContainer.add(JBTextArea("JCEF not supported"))
             browser = null

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/gettingstarted/QGettingStartedPanel.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/gettingstarted/QGettingStartedPanel.kt
@@ -11,7 +11,6 @@ import com.intellij.ui.components.panels.Wrapper
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
-import com.intellij.ui.jcef.JBCefApp
 import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 
 class QGettingStartedPanel(

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
@@ -26,11 +26,9 @@ import software.aws.toolkits.jetbrains.core.webview.BrowserState
 import software.aws.toolkits.jetbrains.services.amazonq.QWebviewPanel
 import software.aws.toolkits.jetbrains.services.amazonq.RefreshQChatPanelButtonPressedListener
 import software.aws.toolkits.jetbrains.services.amazonq.gettingstarted.openMeetQPage
-import software.aws.toolkits.jetbrains.services.amazonq.isQSupportedInThisVersion
 import software.aws.toolkits.jetbrains.utils.isQConnected
 import software.aws.toolkits.jetbrains.utils.isQExpired
 import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
-import software.aws.toolkits.jetbrains.utils.isRunningOnRemoteBackend
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.FeatureId
 import java.awt.event.ComponentAdapter

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
@@ -29,6 +29,7 @@ import software.aws.toolkits.jetbrains.services.amazonq.gettingstarted.openMeetQ
 import software.aws.toolkits.jetbrains.services.amazonq.isQSupportedInThisVersion
 import software.aws.toolkits.jetbrains.utils.isQConnected
 import software.aws.toolkits.jetbrains.utils.isQExpired
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.jetbrains.utils.isRunningOnRemoteBackend
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.FeatureId
@@ -124,7 +125,7 @@ class AmazonQToolWindowFactory : ToolWindowFactory, DumbAware {
         )
     }
 
-    override fun shouldBeAvailable(project: Project): Boolean = !isRunningOnRemoteBackend() && isQSupportedInThisVersion()
+    override fun shouldBeAvailable(project: Project): Boolean = !isQWebviewsAvailable()
 
     private fun onConnectionChanged(project: Project, newConnection: ToolkitConnection?, toolWindow: ToolWindow) {
         val contentManager = toolWindow.contentManager

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
@@ -123,7 +123,7 @@ class AmazonQToolWindowFactory : ToolWindowFactory, DumbAware {
         )
     }
 
-    override fun shouldBeAvailable(project: Project): Boolean = !isQWebviewsAvailable()
+    override fun shouldBeAvailable(project: Project): Boolean = isQWebviewsAvailable()
 
     private fun onConnectionChanged(project: Project, newConnection: ToolkitConnection?, toolWindow: ToolWindow) {
         val contentManager = toolWindow.contentManager

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -81,7 +81,6 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.FileContextProvider
 import software.aws.toolkits.jetbrains.utils.isInjectedText
 import software.aws.toolkits.jetbrains.utils.isQExpired
-import software.aws.toolkits.jetbrains.utils.isRunningOnCWNotSupportedRemoteBackend
 import software.aws.toolkits.jetbrains.utils.notifyWarn
 import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 import software.aws.toolkits.resources.message
@@ -108,11 +107,6 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         if (!isCodeWhispererEnabled(project)) return
 
         latencyContext.credentialFetchingStart = System.nanoTime()
-
-        if (isRunningOnCWNotSupportedRemoteBackend()) {
-            showCodeWhispererInfoHint(editor, message("codewhisperer.trigger.ide.unsupported"))
-            return
-        }
 
         if (isQExpired(project)) {
             // say the connection is un-refreshable if refresh fails for 3 times

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererProjectStartupActivity.kt
@@ -23,10 +23,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.calculateIfIamIdentityCenterConnection
 import software.aws.toolkits.jetbrains.utils.isQConnected
 import software.aws.toolkits.jetbrains.utils.isQExpired
-import software.aws.toolkits.jetbrains.utils.isRunningOnCWNotSupportedRemoteBackend
-import software.aws.toolkits.jetbrains.utils.notifyWarn
 import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
-import software.aws.toolkits.resources.message
 
 // TODO: add logics to check if we want to remove recommendation suspension date when user open the IDE
 class CodeWhispererProjectStartupActivity : StartupActivity.DumbAware {
@@ -56,8 +53,6 @@ class CodeWhispererProjectStartupActivity : StartupActivity.DumbAware {
 
         if (runOnce) return
 
-        checkRemoteDevVersionAndPromptUpdate()
-
         // Reconnect CodeWhisperer on startup
         promptReAuth(project, isPluginStarting = true)
         if (isQExpired(project)) return
@@ -86,13 +81,5 @@ class CodeWhispererProjectStartupActivity : StartupActivity.DumbAware {
                 delay(FEATURE_CONFIG_POLL_INTERVAL_IN_MS)
             }
         }
-    }
-
-    private fun checkRemoteDevVersionAndPromptUpdate() {
-        if (!isRunningOnCWNotSupportedRemoteBackend()) return
-        notifyWarn(
-            title = message("codewhisperer.notification.remote.ide_unsupported.title"),
-            content = message("codewhisperer.notification.remote.ide_unsupported.message"),
-        )
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidgetFactory.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidgetFactory.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.impl.status.widget.StatusBarEditorBasedWidgetFactory
-import software.aws.toolkits.jetbrains.utils.isRunningOnCWNotSupportedRemoteBackend
 import software.aws.toolkits.resources.message
 
 class CodeWhispererStatusBarWidgetFactory : StatusBarEditorBasedWidgetFactory() {
@@ -16,7 +15,7 @@ class CodeWhispererStatusBarWidgetFactory : StatusBarEditorBasedWidgetFactory() 
 
     override fun getDisplayName(): String = message("codewhisperer.statusbar.display_name")
 
-    override fun isAvailable(project: Project): Boolean = !isRunningOnCWNotSupportedRemoteBackend()
+    override fun isAvailable(project: Project): Boolean = true
 
     override fun createWidget(project: Project): StatusBarWidget = CodeWhispererStatusBarWidget(project)
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
@@ -9,6 +9,7 @@ import com.intellij.ui.jcef.JBCefApp
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.ConfirmUserCodeLoginDialog
 import software.aws.toolkits.jetbrains.utils.computeOnEdt
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.jetbrains.utils.notifyError
 import software.aws.toolkits.resources.AwsCoreBundle
 import software.aws.toolkits.telemetry.AuthType
@@ -31,7 +32,7 @@ class DefaultSsoLoginCallbackProvider : SsoLoginCallbackProvider {
         }
 
         return when {
-            JBCefApp.isSupported() -> SsoPromptWithBrowserSupport
+            isQWebviewsAvailable() -> SsoPromptWithBrowserSupport
             else -> deviceCodeProvider
         }
     }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
@@ -5,7 +5,6 @@ package software.aws.toolkits.jetbrains.core.credentials.sso
 
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.progress.ProcessCanceledException
-import com.intellij.ui.jcef.JBCefApp
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.ConfirmUserCodeLoginDialog
 import software.aws.toolkits.jetbrains.utils.computeOnEdt

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
@@ -240,5 +240,3 @@ fun emitUserState(project: Project) {
 }
 
 const val CODEWHISPERER_AUTH_LEARN_MORE_LINK = "https://docs.aws.amazon.com/codewhisperer/latest/userguide/codewhisperer-auth.html"
-
-fun shouldShowNonWebviewUI(): Boolean = !JBCefApp.isSupported()

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.core.gettingstarted
 
 import com.intellij.openapi.project.Project
-import com.intellij.ui.jcef.JBCefApp
 import software.aws.toolkits.core.utils.tryOrNull
 import software.aws.toolkits.jetbrains.core.credentials.LegacyManagedBearerSsoConnection
 import software.aws.toolkits.jetbrains.core.credentials.ManagedBearerSsoConnection

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
@@ -4,8 +4,6 @@
 package software.aws.toolkits.jetbrains.utils
 
 import com.intellij.idea.AppMode
-import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.openapi.util.BuildNumber
 import com.intellij.ui.jcef.JBCefApp
 
 /**

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
@@ -5,7 +5,6 @@ package software.aws.toolkits.jetbrains.utils
 
 import com.intellij.idea.AppMode
 import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.openapi.extensions.ExtensionNotApplicableException
 import com.intellij.openapi.util.BuildNumber
 import com.intellij.ui.jcef.JBCefApp
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
@@ -18,9 +18,4 @@ fun isRunningOnRemoteBackend() = AppMode.isRemoteDevHost()
  */
 fun isCodeCatalystDevEnv() = System.getenv("__DEV_ENVIRONMENT_ID") != null
 
-// CW can be supported only after at least build 232.9921.47 on remote env
-fun isRunningOnCWNotSupportedRemoteBackend() =
-    ApplicationInfo.getInstance().build.compareTo(BuildNumber.fromStringOrNull("232.9921.47")) < 0 &&
-        AppMode.isRemoteDevHost()
-
 fun isQWebviewsAvailable() = JBCefApp.isSupported() && !isRunningOnRemoteBackend()

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
@@ -7,6 +7,7 @@ import com.intellij.idea.AppMode
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.extensions.ExtensionNotApplicableException
 import com.intellij.openapi.util.BuildNumber
+import com.intellij.ui.jcef.JBCefApp
 
 /**
  * @return true if running in any type of remote environment
@@ -18,13 +19,9 @@ fun isRunningOnRemoteBackend() = AppMode.isRemoteDevHost()
  */
 fun isCodeCatalystDevEnv() = System.getenv("__DEV_ENVIRONMENT_ID") != null
 
-fun disableExtensionIfRemoteBackend() {
-    if (isRunningOnRemoteBackend()) {
-        throw ExtensionNotApplicableException.create()
-    }
-}
-
 // CW can be supported only after at least build 232.9921.47 on remote env
 fun isRunningOnCWNotSupportedRemoteBackend() =
     ApplicationInfo.getInstance().build.compareTo(BuildNumber.fromStringOrNull("232.9921.47")) < 0 &&
         AppMode.isRemoteDevHost()
+
+fun isQWebviewsAvailable() = JBCefApp.isSupported() && !isRunningOnRemoteBackend()

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/actions/ExplorerNewConnectionAction.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/actions/ExplorerNewConnectionAction.kt
@@ -10,8 +10,8 @@ import com.intellij.openapi.project.DumbAwareAction
 import software.aws.toolkits.jetbrains.core.explorer.showWebview
 import software.aws.toolkits.jetbrains.core.explorer.webview.ToolkitWebviewPanel
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel
-import software.aws.toolkits.jetbrains.core.gettingstarted.shouldShowNonWebviewUI
 import software.aws.toolkits.jetbrains.core.webview.BrowserState
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.telemetry.FeatureId
 import software.aws.toolkits.telemetry.UiTelemetry
 
@@ -21,7 +21,7 @@ class ExplorerNewConnectionAction : DumbAwareAction(AllIcons.General.Add) {
     override fun actionPerformed(e: AnActionEvent) {
         e.project?.let {
             runInEdt {
-                if (shouldShowNonWebviewUI()) {
+                if (!isQWebviewsAvailable()) {
                     GettingStartedPanel.openPanel(it)
                 } else {
                     ToolkitWebviewPanel.getInstance(it).browser?.prepareBrowser(BrowserState(FeatureId.AwsExplorer, true))

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/actions/NewConnectionAction.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/actions/NewConnectionAction.kt
@@ -9,8 +9,8 @@ import com.intellij.openapi.project.DumbAwareAction
 import software.aws.toolkits.jetbrains.core.explorer.showWebview
 import software.aws.toolkits.jetbrains.core.explorer.webview.ToolkitWebviewPanel
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel
-import software.aws.toolkits.jetbrains.core.gettingstarted.shouldShowNonWebviewUI
 import software.aws.toolkits.jetbrains.core.webview.BrowserState
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.telemetry.FeatureId
 import software.aws.toolkits.telemetry.UiTelemetry
 
@@ -18,7 +18,7 @@ class NewConnectionAction : DumbAwareAction() {
     override fun actionPerformed(e: AnActionEvent) {
         e.project?.let {
             runInEdt {
-                if (shouldShowNonWebviewUI()) {
+                if (!isQWebviewsAvailable()) {
                     GettingStartedPanel.openPanel(it, connectionInitiatedFromExplorer = true)
                 } else {
                     ToolkitWebviewPanel.getInstance(it).browser?.prepareBrowser(BrowserState(FeatureId.AwsExplorer, true))

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -65,10 +65,10 @@ import software.aws.toolkits.jetbrains.core.explorer.nodes.ResourceLocationNode
 import software.aws.toolkits.jetbrains.core.explorer.webview.ToolkitWebviewPanel
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.GettingStartedPanel
 import software.aws.toolkits.jetbrains.core.gettingstarted.rolePopupFromConnection
-import software.aws.toolkits.jetbrains.core.gettingstarted.shouldShowNonWebviewUI
 import software.aws.toolkits.jetbrains.core.webview.BrowserState
 import software.aws.toolkits.jetbrains.services.dynamic.explorer.DynamicResourceResourceTypeNode
 import software.aws.toolkits.jetbrains.ui.CenteredInfoPanel
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.FeatureId
 import software.aws.toolkits.telemetry.UiTelemetry
@@ -207,7 +207,7 @@ class ExplorerToolWindow(private val project: Project) :
                             CenteredInfoPanel().apply {
                                 addLine(message("gettingstarted.explorer.new.setup.info"))
                                 addDefaultActionButton(message("gettingstarted.explorer.new.setup")) {
-                                    if (shouldShowNonWebviewUI()) {
+                                    if (!isQWebviewsAvailable()) {
                                         GettingStartedPanel.openPanel(project)
                                     } else {
                                         ToolkitWebviewPanel.getInstance(project).browser?.prepareBrowser(BrowserState(FeatureId.AwsExplorer, true))

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/webview/ToolkitLoginWebview.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/webview/ToolkitLoginWebview.kt
@@ -55,6 +55,7 @@ import software.aws.toolkits.jetbrains.core.webview.BrowserState
 import software.aws.toolkits.jetbrains.core.webview.LoginBrowser
 import software.aws.toolkits.jetbrains.core.webview.WebviewResourceHandlerFactory
 import software.aws.toolkits.jetbrains.isDeveloperMode
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.jetbrains.utils.isTookitConnected
 import software.aws.toolkits.telemetry.FeatureId
 import software.aws.toolkits.telemetry.UiTelemetry
@@ -111,7 +112,7 @@ class ToolkitWebviewPanel(val project: Project, private val scope: CoroutineScop
     }
 
     init {
-        if (!JBCefApp.isSupported()) {
+        if (!isQWebviewsAvailable()) {
             // Fallback to an alternative browser-less solution
             webviewContainer.add(JBTextArea("JCEF not supported"))
             browser = null

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/ToolkitGettingStartedAuthUtils.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/ToolkitGettingStartedAuthUtils.kt
@@ -5,7 +5,6 @@ package software.aws.toolkits.jetbrains.core.gettingstarted
 
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.project.Project
-import com.intellij.ui.jcef.JBCefApp
 import software.aws.toolkits.jetbrains.core.credentials.sono.CODECATALYST_SCOPES
 import software.aws.toolkits.jetbrains.core.explorer.showWebview
 import software.aws.toolkits.jetbrains.core.explorer.webview.ToolkitWebviewPanel

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/ToolkitGettingStartedAuthUtils.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/gettingstarted/ToolkitGettingStartedAuthUtils.kt
@@ -15,6 +15,7 @@ import software.aws.toolkits.jetbrains.core.gettingstarted.editor.getEnabledConn
 import software.aws.toolkits.jetbrains.core.gettingstarted.editor.getSourceOfEntry
 import software.aws.toolkits.jetbrains.core.webview.BrowserState
 import software.aws.toolkits.jetbrains.services.caws.CawsEndpoints.CAWS_DOCS
+import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.AuthTelemetry
 import software.aws.toolkits.telemetry.FeatureId
@@ -30,7 +31,7 @@ fun requestCredentialsForCodeCatalyst(
     isFirstInstance: Boolean = false,
     connectionInitiatedFromExplorer: Boolean = false
 ): Boolean? {
-    if (JBCefApp.isSupported() && project != null) {
+    if (isQWebviewsAvailable() && project != null) {
         ToolkitWebviewPanel.getInstance(project).browser?.prepareBrowser(BrowserState(FeatureId.Codecatalyst, true)) // TODO: consume data
         showWebview(project)
 
@@ -122,7 +123,7 @@ fun requestCredentialsForExplorer(
     isFirstInstance: Boolean = false,
     connectionInitiatedFromExplorer: Boolean = false
 ): Boolean? {
-    if (JBCefApp.isSupported()) {
+    if (isQWebviewsAvailable()) {
         ToolkitWebviewPanel.getInstance(project).browser?.prepareBrowser(BrowserState(FeatureId.AwsExplorer, true)) // TODO: consume data
         showWebview(project)
         return null


### PR DESCRIPTION
Login flows had inconsistent behavior gating on webview availability vs running on a remote environment

This was fine <242, but JetBrains enabled JBCefApp on remote in 242+

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
