### PR TITLE
fixed inline code block alignments

### DIFF
--- a/.changes/next-release/bugfix-2a296b4e-adf4-4903-8720-5e852c601f33.json
+++ b/.changes/next-release/bugfix-2a296b4e-adf4-4903-8720-5e852c601f33.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q Chat: Fixed inline code blocks are not vertically aligned with texts"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.8",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.9",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,10 +57,11 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.15.8",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.8.tgz",
-            "integrity": "sha512-A0qkACykrhx3Tr0qi15HpY2dCSwVYVZTecp2nXny5uwjh3StYo88daUqUG+4mX2LGL49jIr3X5IUgWYb9/vatg==",
+            "version": "4.15.9",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.15.9.tgz",
+            "integrity": "sha512-iiXEoQ30hugmk+28NVYUwuOwYVJM+zvHQT+rqs+f54mhGkjPIUpQc58L/w7ChCggUY3kXQEp/4lCQsocuSWJkw==",
             "hasInstallScript": true,
+            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.8",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.15.9",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "ts-node": "^10.7.0",


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem
In the latest JetBrains IDEs, Amazon Q Chat inline code block items are not aligned with the texts.

### Solution
Implemented a solution through a [mynah-ui update](https://github.com/aws/mynah-ui/releases/tag/v4.15.9) which specifically adjusts the inline code block items to align in the middle.

### Before
<img width="449" alt="image" src="https://github.com/user-attachments/assets/ffad805c-c380-4c27-b430-02bf583cad98">

### After
<img width="469" alt="Screenshot 2024-09-04 at 11 45 00" src="https://github.com/user-attachments/assets/db2f90e4-a578-4a26-bd89-dbfb9678dbc5">

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
