### PR TITLE
feat(amazonq): use detector library url from server

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
@@ -506,7 +506,7 @@ data class Description(val text: String, val markdown: String)
 
 data class Remediation(val recommendation: Recommendation, val suggestedFixes: List<SuggestedFix>)
 
-data class Recommendation(val text: String, val url: String)
+data class Recommendation(val text: String, val url: String?)
 
 data class SuggestedFix(val description: String, val code: String)
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
@@ -92,11 +92,7 @@ class CodeWhispererCodeScanEditorMouseMotionListener(private val project: Projec
             "-"
         }
 
-        val detectorLibraryLink = if (issue.recommendation.url != null) {
-            "<a href=\"${issue.recommendation.url}\">${issue.detectorName}</a>"
-        } else {
-            "-"
-        }
+        val detectorLibraryLink = issue.recommendation.url?.let { "<a href=\"${issue.recommendation.url}\">${issue.detectorName}</a>" } ?: "-"
         val detectorSection = """
             <br />
             <hr />

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
@@ -92,10 +92,11 @@ class CodeWhispererCodeScanEditorMouseMotionListener(private val project: Projec
             "-"
         }
 
-        val detectorLibraryLink = "<a href=\"https://docs.aws.amazon.com/codeguru/detector-library/${
-            issue.detectorId.split("@").first()
-        }\">${issue.detectorName}</a>"
-
+        val detectorLibraryLink = if (issue.recommendation.url != null) {
+            "<a href=\"${issue.recommendation.url}\">${issue.detectorName}</a>"
+        } else {
+            "-"
+        }
         val detectorSection = """
             <br />
             <hr />


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Improvement to use detector library url from server, otherwise if null then show `-`

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
