### PR TITLE
Fix read access without read lock while building supplemental context

### DIFF
--- a/.changes/next-release/bugfix-347b52b8-cbfb-43f3-8c2e-466362af40e6.json
+++ b/.changes/next-release/bugfix-347b52b8-cbfb-43f3-8c2e-466362af40e6.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix \"read access\" error that may occur when Amazon Q Inline Suggestion is building context (#4888) (#4848)"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererFileContextProvider.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererFileContextProvider.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.codewhisperer.util
 
 import com.intellij.ide.actions.CopyContentRootPathProvider
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
@@ -111,7 +112,7 @@ class DefaultCodeWhispererFileContextProvider(private val project: Project) : Fi
      */
     override suspend fun extractSupplementalFileContext(psiFile: PsiFile, targetContext: FileContextInfo, timeout: Long): SupplementalContextInfo? {
         val startFetchingTimestamp = System.currentTimeMillis()
-        val isTst = isTestFile(psiFile)
+        val isTst = readAction { isTestFile(psiFile) }
         return try {
             withTimeout(timeout) {
                 val language = targetContext.programmingLanguage


### PR DESCRIPTION
`isTestFile` needs a read lock, but lost it with commit merged in #4765 
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
