### PR TITLE
Adding linter rule to ban `import org.gradle.internal.impldep.*`

### DIFF
--- a/detekt-rules/src/software/aws/toolkits/gradle/detekt/rules/BannedImportsRule.kt
+++ b/detekt-rules/src/software/aws/toolkits/gradle/detekt/rules/BannedImportsRule.kt
@@ -50,6 +50,16 @@ class BannedImportsRule : Rule() {
                 )
             }
 
+            if (importedFqName?.startsWith("org.gradle.internal.impldep") == true) {
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.from(element),
+                        message = "Avoid using Gradle's internal implementation classes: not public API and may change without notice."
+                    )
+                )
+            }
+
             if (importedFqName?.contains("kotlinx.coroutines.Dispatchers") == true) {
                 report(
                     CodeSmell(

--- a/detekt-rules/tst/software/aws/toolkits/gradle/detekt/rules/BannedImportsRuleTest.kt
+++ b/detekt-rules/tst/software/aws/toolkits/gradle/detekt/rules/BannedImportsRuleTest.kt
@@ -52,6 +52,15 @@ class BannedImportsRuleTest {
     }
 
     @Test
+    fun `Importing Gradle internal implementation classes fails`() {
+        assertThat(rule.lint("import org.gradle.internal.impldep"))
+            .singleElement()
+            .matches {
+                it.id == "BannedImports" && it.message == "Avoid using Gradle's internal implementation classes: not public API and may change without notice."
+            }
+    }
+
+    @Test
     fun `Importing Dispatchers fails`() {
         assertThat(rule.lint("import kotlinx.coroutines.Dispatchers"))
             .singleElement()

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerTestBase.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerTestBase.kt
@@ -15,7 +15,6 @@ import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.testFramework.replaceService
 import kotlinx.coroutines.Job
-import org.gradle.internal.impldep.com.amazonaws.ResponseMetadata
 import org.junit.Before
 import org.junit.Rule
 import org.mockito.Mockito
@@ -26,6 +25,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata
+import software.amazon.awssdk.awscore.util.AwsHeader
 import software.amazon.awssdk.http.SdkHttpResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.CreateUploadUrlResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.GetTransformationPlanResponse
@@ -133,14 +133,14 @@ open class CodeWhispererCodeModernizerTestBase(
             .uploadUrl("https://smth.com")
             .uploadId("1234")
             .kmsKeyArn("0000000000000000000000000000000000:key/1234abcd")
-            .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(ResponseMetadata.AWS_REQUEST_ID to testRequestId)))
+            .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(AwsHeader.AWS_REQUEST_ID to testRequestId)))
             .sdkHttpResponse(SdkHttpResponse.builder().headers(mapOf(CodeWhispererService.KET_SESSION_ID to listOf(testSessionId))).build())
             .build() as CreateUploadUrlResponse
 
     internal val exampleStartCodeMigrationResponse =
         StartTransformationResponse.builder()
             .transformationJobId(jobId.id)
-            .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(ResponseMetadata.AWS_REQUEST_ID to testRequestId)))
+            .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(AwsHeader.AWS_REQUEST_ID to testRequestId)))
             .sdkHttpResponse(SdkHttpResponse.builder().headers(mapOf(CodeWhispererService.KET_SESSION_ID to listOf(testSessionId))).build())
             .build() as StartTransformationResponse
 
@@ -164,7 +164,7 @@ open class CodeWhispererCodeModernizerTestBase(
                         ),
                     ).build(),
             )
-            .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(ResponseMetadata.AWS_REQUEST_ID to testRequestId)))
+            .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(AwsHeader.AWS_REQUEST_ID to testRequestId)))
             .sdkHttpResponse(SdkHttpResponse.builder().headers(mapOf(CodeWhispererService.KET_SESSION_ID to listOf(testSessionId))).build())
             .build() as GetTransformationPlanResponse
 
@@ -198,7 +198,7 @@ open class CodeWhispererCodeModernizerTestBase(
                     )
                     .build(),
             )
-            .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(ResponseMetadata.AWS_REQUEST_ID to testRequestId)))
+            .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(AwsHeader.AWS_REQUEST_ID to testRequestId)))
             .sdkHttpResponse(SdkHttpResponse.builder().headers(mapOf(CodeWhispererService.KET_SESSION_ID to listOf(testSessionId))).build())
             .build() as GetTransformationResponse
 
@@ -207,7 +207,7 @@ open class CodeWhispererCodeModernizerTestBase(
     fun GetTransformationResponse.replace(status: TransformationStatus) =
         this.copy { response ->
             response.transformationJob(this.transformationJob().copy { it.status(status) })
-                .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(ResponseMetadata.AWS_REQUEST_ID to testRequestId)))
+                .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(AwsHeader.AWS_REQUEST_ID to testRequestId)))
                 .sdkHttpResponse(
                     SdkHttpResponse.builder().headers(mapOf(CodeWhispererService.KET_SESSION_ID to listOf(testSessionId))).build(),
                 )

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererTelemetryTest.kt
@@ -13,7 +13,6 @@ import com.intellij.testFramework.TestActionEvent
 import com.intellij.testFramework.replaceService
 import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
-import org.gradle.internal.impldep.com.amazonaws.ResponseMetadata
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -33,6 +32,7 @@ import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata
+import software.amazon.awssdk.awscore.util.AwsHeader
 import software.amazon.awssdk.http.SdkHttpResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.GenerateCompletionsRequest
 import software.amazon.awssdk.services.codewhispererruntime.model.GenerateCompletionsResponse
@@ -662,7 +662,7 @@ class CodeWhispererTelemetryTest : CodeWhispererTestBase() {
                     CodeWhispererTestUtil.generateMockCompletionDetail("a, b):\n    return a + b"),
                 )
                 .nextToken("")
-                .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(ResponseMetadata.AWS_REQUEST_ID to testRequestId)))
+                .responseMetadata(DefaultAwsResponseMetadata.create(mapOf(AwsHeader.AWS_REQUEST_ID to testRequestId)))
                 .sdkHttpResponse(SdkHttpResponse.builder().headers(mapOf(CodeWhispererService.KET_SESSION_ID to listOf(testSessionId))).build())
                 .build() as GenerateCompletionsResponse
         )


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Added an import rule to the linter to ban gradle shadow imports.
These are to avoid using Gradle's internal implementation classes.
These are not public API and could change without notice.

Only found two test files with these imports and they have been changed to use the appropriate AWS SDK package instead.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
