### PR TITLE
Fix flaky `DefaultToolkitConnectionManagerTest`

### DIFF
--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
@@ -68,6 +68,7 @@ class DefaultToolkitAuthManagerTest {
     fun setUp(@TestDisposable disposable: Disposable) {
         mockClientManager.create<SsoOidcClient>()
         sut = DefaultToolkitAuthManager()
+        ApplicationManager.getApplication().replaceService(ToolkitAuthManager::class.java, sut, disposable)
         connectionManager = DefaultToolkitConnectionManager()
         batcher = mock()
         telemetryService = spy(TestTelemetryService(batcher = batcher))


### PR DESCRIPTION
`DefaultToolkitAuthManagerTest` polluted `ToolkitAuthManager` state causing failures that succeed on first retry

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
