### PR TITLE
Fix ProcessCancelledException swallowed in reauthConnectionIfNeeded

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.core.credentials
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.service
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import migration.software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.amazon.awssdk.services.ssooidc.model.SsoOidcException
@@ -259,18 +260,21 @@ fun reauthConnectionIfNeeded(
                 }
             } catch (e: Exception) {
                 if (isReAuth) {
+                    val result = if (e is ProcessCanceledException) Result.Cancelled else Result.Failed
                     recordLoginWithBrowser(
                         credentialStartUrl = startUrl,
                         credentialSourceId = getCredentialIdForTelemetry(connection),
                         isReAuth = true,
-                        result = Result.Failed
+                        result = result
                     )
                     recordAddConnection(
                         credentialSourceId = getCredentialIdForTelemetry(connection),
                         isReAuth = true,
-                        result = Result.Failed
+                        result = result
                     )
                 }
+
+                throw e
             }
         }
     }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -52,6 +52,7 @@ import software.aws.toolkits.telemetry.Result
 import java.time.Duration
 import java.util.Timer
 import java.util.TimerTask
+import java.util.concurrent.CancellationException
 import java.util.concurrent.Future
 import java.util.function.Function
 
@@ -368,14 +369,11 @@ abstract class LoginBrowser(
     }
 
     protected fun isUserCancellation(e: Exception): Boolean {
-        if (e !is ProcessCanceledException ||
-            e.cause !is IllegalStateException ||
-            e.message?.contains(AwsCoreBundle.message("credentials.pending.user_cancel.message")) == false
-        ) {
-            return false
+        if (e is ProcessCanceledException || e is CancellationException) {
+            LOG.debug(e) { "User canceled login" }
+            return true
         }
-        LOG.debug(e) { "User canceled login" }
-        return true
+        return false
     }
 
     companion object {


### PR DESCRIPTION
This fixes an issue where it is assumed that authentication has succeeded if a user cancels the reauth flow


https://github.com/user-attachments/assets/f13eb24f-3fd8-401e-875b-391a0528f606


 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
