### PR TITLE
Remove log spam from CodeCatalystConnection

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/pinning/CodeCatalystConnection.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/pinning/CodeCatalystConnection.kt
@@ -3,8 +3,8 @@
 
 package software.aws.toolkits.jetbrains.core.credentials.pinning
 
+import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
-import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
 import software.aws.toolkits.jetbrains.core.credentials.sono.CODECATALYST_SCOPES
@@ -14,11 +14,11 @@ class CodeCatalystConnection : FeatureWithPinnedConnection {
     override val featureName: String = "CodeCatalyst"
     override fun supportsConnectionType(connection: ToolkitConnection): Boolean {
         if (connection !is AwsBearerTokenConnection) {
-            LOG.warn { "Rejecting ${connection.id} since it's not a bearer connection" }
+            LOG.debug { "Rejecting ${connection.id} since it's not a bearer connection" }
             return false
         }
         if (!CODECATALYST_SCOPES.all { it in connection.scopes }) {
-            LOG.warn { "Rejecting ${connection.id} since it's missing a required scope" }
+            LOG.debug { "Rejecting ${connection.id} since it's missing a required scope" }
             return false
         }
         return true


### PR DESCRIPTION
`supportsConnectionType` is called very frequently
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
