### PR TITLE
Fix compilation issue with Function<...> in JBCef callback handler

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/gettingstarted/QGettingStartedContent.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/gettingstarted/QGettingStartedContent.kt
@@ -62,7 +62,8 @@ class QGettingStartedContent(val project: Project) : Disposable {
                     AmazonQToolWindow.getStarted(project)
                 }
             }
-            null
+
+            JBCefJSQuery.Response(null)
         }
         receiveMessageQuery.addHandler(handler)
     }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
@@ -8,9 +8,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.ui.jcef.JBCefJSQuery
 import org.cef.CefApp
 import software.aws.toolkits.jetbrains.services.amazonq.util.createBrowser
-import java.util.function.Function
-
-typealias MessageReceiver = Function<String, JBCefJSQuery.Response>
 
 /*
 Displays the web view for the Amazon Q tool window

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -77,7 +77,7 @@ class BrowserConnector(
     private fun addMessageHook(browser: Browser) = callbackFlow {
         val handler = Function<String, Response> {
             trySend(it)
-            null
+            Response(null)
         }
 
         browser.receiveMessageQuery.addHandler(handler)

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -71,7 +71,7 @@ abstract class LoginBrowser(
 
         handleBrowserMessage(obj)
 
-        null
+        JBCefJSQuery.Response(null)
     }
     protected var currentAuthorization: PendingAuthorization? = null
 


### PR DESCRIPTION
```
[TYPE_MISMATCH_WHEN_FLEXIBILITY_CHANGES] Argument type mismatch: actual type is 'kotlin.Nothing?', but 'com.intellij.ui.jcef.JBCefJSQuery.Response' was expected. This will become an error in Kotlin 2.1.
```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
