### PR TITLE
Properly redact OAuth tokens when toString() is called

### DIFF
--- a/plugins/core/core/src/software/aws/toolkits/core/utils/SensitiveField.kt
+++ b/plugins/core/core/src/software/aws/toolkits/core/utils/SensitiveField.kt
@@ -29,7 +29,7 @@ fun redactedString(o: Any): String {
             // https://youtrack.jetbrains.com/issue/KT-22265/Support-for-inherited-annotations
             if (
                 prop.hasAnnotation<SensitiveField>() ||
-                clazz.superclasses.flatMap { superClazz -> superClazz.members.filter { it.name == prop.name }}.any { it.hasAnnotation<SensitiveField>() }
+                clazz.superclasses.flatMap { superClazz -> superClazz.members.filter { it.name == prop.name } }.any { it.hasAnnotation<SensitiveField>() }
             ) {
                 if (prop.getter.call(o) == null) {
                     append("null")

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/AccessTokenTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/AccessTokenTest.kt
@@ -1,0 +1,38 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.credentials.sso
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AccessTokenTest {
+    @Test
+    fun `DeviceAuthorizationGrantToken#toString has redacted values`() {
+        val sut = DeviceAuthorizationGrantToken(
+            startUrl = "clearText",
+            region = "clearText",
+            accessToken = "hiddenText",
+            refreshToken = "hiddenText",
+            expiresAt = Instant.EPOCH,
+            createdAt = Instant.EPOCH,
+        )
+
+        assertThat(sut.toString()).doesNotContain("hiddenText")
+    }
+
+    @Test
+    fun `PKCEAuthorizationGrantToken#toString has redacted values`() {
+        val sut = PKCEAuthorizationGrantToken(
+            issuerUrl = "clearText",
+            region = "clearText",
+            accessToken = "hiddenText",
+            refreshToken = "hiddenText",
+            expiresAt = Instant.EPOCH,
+            createdAt = Instant.EPOCH,
+        )
+
+        assertThat(sut.toString()).doesNotContain("hiddenText")
+    }
+}

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/ClientRegistrationTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/ClientRegistrationTest.kt
@@ -25,7 +25,7 @@ class ClientRegistrationTest {
         val sut = PKCEClientRegistration(
             clientId = "clearText",
             clientSecret = "hiddenText",
-            expiresAt =  Instant.EPOCH,
+            expiresAt = Instant.EPOCH,
             scopes = listOf("clearText"),
             issuerUrl = "clearText",
             region = "clearText",

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/ClientRegistrationTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/ClientRegistrationTest.kt
@@ -1,0 +1,39 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.credentials.sso
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class ClientRegistrationTest {
+    @Test
+    fun `DeviceAuthorizationClientRegistration#toString has redacted values`() {
+        val sut = DeviceAuthorizationClientRegistration(
+            clientId = "clearText",
+            clientSecret = "hiddenText",
+            expiresAt = Instant.EPOCH,
+            scopes = listOf("clearText"),
+        )
+
+        assertThat(sut.toString()).doesNotContain("hiddenText")
+    }
+
+    @Test
+    fun `PKCEClientRegistration#toString has redacted values`() {
+        val sut = PKCEClientRegistration(
+            clientId = "clearText",
+            clientSecret = "hiddenText",
+            expiresAt =  Instant.EPOCH,
+            scopes = listOf("clearText"),
+            issuerUrl = "clearText",
+            region = "clearText",
+            clientType = "clearText",
+            grantTypes = listOf("clearText"),
+            redirectUris = listOf("clearText")
+        )
+
+        assertThat(sut.toString()).doesNotContain("hiddenText")
+    }
+}


### PR DESCRIPTION
`@SensitiveField` annotation is not inherited by default
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
