### PR TITLE
Track SessionContext instead of InvocationContext

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -95,7 +95,7 @@ object CodeWhispererEditorUtil {
     }
 
     fun shouldSkipInvokingBasedOnRightContext(editor: Editor): Boolean {
-        val caretContext = runReadAction { CodeWhispererEditorUtil.extractCaretContext(editor) }
+        val caretContext = runReadAction { extractCaretContext(editor) }
         val rightContextLines = caretContext.rightFileContext.split(Regex("\r?\n"))
         val rightContextCurrentLine = if (rightContextLines.isEmpty()) "" else rightContextLines[0]
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/importadder/CodeWhispererImportAdder.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/importadder/CodeWhispererImportAdder.kt
@@ -14,15 +14,15 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhispererProgrammingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
+import software.aws.toolkits.jetbrains.services.codewhisperer.model.PreviewContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.SessionContext
 
 abstract class CodeWhispererImportAdder {
     abstract val supportedLanguages: List<CodeWhispererProgrammingLanguage>
     abstract val dummyFileName: String
 
-    fun insertImportStatements(states: InvocationContext, sessionContext: SessionContext) {
-        val imports = states.recommendationContext.details[sessionContext.selectedIndex]
-            .recommendation.mostRelevantMissingImports()
+    fun insertImportStatements(states: InvocationContext, previews: List<PreviewContext>, sessionContext: SessionContext) {
+        val imports = previews[sessionContext.selectedIndex].detail.recommendation.mostRelevantMissingImports()
         LOG.info { "Adding ${imports.size} imports for completions, sessionId: ${states.responseContext.sessionId}" }
         imports.forEach {
             insertImportStatement(states, it)

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/importadder/CodeWhispererImportAdderListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/importadder/CodeWhispererImportAdderListener.kt
@@ -7,13 +7,14 @@ import com.intellij.openapi.editor.RangeMarker
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
+import software.aws.toolkits.jetbrains.services.codewhisperer.model.PreviewContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.SessionContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.CodeWhispererUserActionListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.settings.CodeWhispererSettings
 
 object CodeWhispererImportAdderListener : CodeWhispererUserActionListener {
     internal val LOG = getLogger<CodeWhispererImportAdderListener>()
-    override fun afterAccept(states: InvocationContext, sessionContext: SessionContext, rangeMarker: RangeMarker) {
+    override fun afterAccept(states: InvocationContext, previews: List<PreviewContext>, sessionContext: SessionContext, rangeMarker: RangeMarker) {
         if (!CodeWhispererSettings.getInstance().isImportAdderEnabled()) {
             LOG.debug { "Import adder not enabled in user settings" }
             return
@@ -28,6 +29,6 @@ object CodeWhispererImportAdderListener : CodeWhispererUserActionListener {
             LOG.debug { "No import adder found for $language" }
             return
         }
-        importAdder.insertImportStatements(states, sessionContext)
+        importAdder.insertImportStatements(states, previews, sessionContext)
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/CodeWhispererInlayManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/inlay/CodeWhispererInlayManager.kt
@@ -6,28 +6,26 @@ package software.aws.toolkits.jetbrains.services.codewhisperer.inlay
 import com.intellij.idea.AppMode
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorCustomElementRenderer
 import com.intellij.openapi.editor.Inlay
-import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.util.Disposer
-import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.RecommendationChunk
+import software.aws.toolkits.jetbrains.services.codewhisperer.model.SessionContext
 
 @Service
 class CodeWhispererInlayManager {
     private val existingInlays = mutableListOf<Inlay<EditorCustomElementRenderer>>()
-    fun updateInlays(states: InvocationContext, chunks: List<RecommendationChunk>) {
-        val editor = states.requestContext.editor
+    fun updateInlays(sessionContext: SessionContext, chunks: List<RecommendationChunk>) {
         clearInlays()
 
         chunks.forEach { chunk ->
-            createCodeWhispererInlays(editor, chunk.inlayOffset, chunk.text, states.popup)
+            createCodeWhispererInlays(sessionContext, chunk.inlayOffset, chunk.text)
         }
     }
 
-    private fun createCodeWhispererInlays(editor: Editor, startOffset: Int, inlayText: String, popup: JBPopup) {
+    private fun createCodeWhispererInlays(sessionContext: SessionContext, startOffset: Int, inlayText: String) {
         if (inlayText.isEmpty()) return
+        val editor = sessionContext.editor
         val firstNewlineIndex = inlayText.indexOf("\n")
         val firstLine: String
         val otherLines: String
@@ -49,7 +47,7 @@ class CodeWhispererInlayManager {
             val inlineInlay = editor.inlayModel.addInlineElement(startOffset, true, firstLineRenderer)
             inlineInlay?.let {
                 existingInlays.add(it)
-                Disposer.register(popup, it)
+                Disposer.register(sessionContext, it)
             }
         }
 
@@ -73,7 +71,7 @@ class CodeWhispererInlayManager {
             )
             blockInlay?.let {
                 existingInlays.add(it)
-                Disposer.register(popup, it)
+                Disposer.register(sessionContext, it)
             }
         }
     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/model/CodeWhispererModel.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/model/CodeWhispererModel.kt
@@ -17,16 +17,12 @@ import software.amazon.awssdk.services.codewhispererruntime.model.GenerateComple
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.PayloadContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhispererProgrammingLanguage
-import software.aws.toolkits.jetbrains.services.codewhisperer.popup.CodeWhispererPopupManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutomatedTriggerType
-import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererIntelliSenseOnHoverListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStatus
-import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.RequestContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.ResponseContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.setIntelliSensePopupAlpha
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CrossFileStrategy
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.SupplementalContextStrategy
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.UtgStrategy
@@ -129,7 +125,7 @@ data class SessionContext(
     var isFirstTimeShowingPopup: Boolean = true,
     var toBeRemovedHighlighter: RangeHighlighter? = null,
     var insertEndOffset: Int = -1,
-    var popupDisplayOffset: Int = -1,
+    var popupOffset: Int = -1,
     val latencyContext: LatencyContext,
     var hasAccepted: Boolean = false
 ) : Disposable {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupListener.kt
@@ -5,30 +5,11 @@ package software.aws.toolkits.jetbrains.services.codewhisperer.popup
 
 import com.intellij.openapi.ui.popup.JBPopupListener
 import com.intellij.openapi.ui.popup.LightweightWindowEvent
-import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
-import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStatus
-import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
-import java.time.Duration
-import java.time.Instant
+import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService
 
-class CodeWhispererPopupListener(private val states: InvocationContext) : JBPopupListener {
-    override fun beforeShown(event: LightweightWindowEvent) {
-        super.beforeShown(event)
-        CodeWhispererInvocationStatus.getInstance().setPopupStartTimestamp()
-    }
+class CodeWhispererPopupListener : JBPopupListener {
     override fun onClosed(event: LightweightWindowEvent) {
         super.onClosed(event)
-        val (requestContext, responseContext, recommendationContext) = states
-
-        CodeWhispererTelemetryService.getInstance().sendUserDecisionEventForAll(
-            requestContext,
-            responseContext,
-            recommendationContext,
-            CodeWhispererPopupManager.getInstance().sessionContext,
-            event.isOk,
-            CodeWhispererInvocationStatus.getInstance().popupStartTimestamp?.let { Duration.between(it, Instant.now()) }
-        )
-
-        CodeWhispererInvocationStatus.getInstance().setPopupActive(false)
+        CodeWhispererService.getInstance().disposeDisplaySession(event.isOk)
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
@@ -27,6 +27,8 @@ import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseMotionListener
 import com.intellij.openapi.editor.event.SelectionEvent
 import com.intellij.openapi.editor.event.SelectionListener
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -39,6 +41,7 @@ import com.intellij.ui.ComponentUtil
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.ui.popup.AbstractPopup
 import com.intellij.ui.popup.PopupFactoryImpl
+import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.messages.Topic
 import com.intellij.util.ui.UIUtil
 import software.amazon.awssdk.services.codewhispererruntime.model.Import
@@ -51,6 +54,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.layout.CodeWhisper
 import software.aws.toolkits.jetbrains.services.codewhisperer.layout.CodeWhispererLayoutConfig.inlineLabelConstraints
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.DetailContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
+import software.aws.toolkits.jetbrains.services.codewhisperer.model.PreviewContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.SessionContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.handlers.CodeWhispererEditorActionHandler
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.handlers.CodeWhispererPopupBackspaceHandler
@@ -65,6 +69,8 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.popup.listeners.Co
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.listeners.CodeWhispererPrevButtonActionListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.listeners.CodeWhispererScrollListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStatus
+import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService
+import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService.Companion
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
 import software.aws.toolkits.jetbrains.services.codewhisperer.toolwindow.CodeWhispererCodeReferenceManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererColorUtil.POPUP_DIM_HEX
@@ -85,10 +91,6 @@ class CodeWhispererPopupManager {
 
     var shouldListenerCancelPopup: Boolean = true
         private set
-    var sessionContext = SessionContext()
-        private set
-
-    private var myPopup: JBPopup? = null
 
     init {
         // Listen for global scheme changes
@@ -115,113 +117,107 @@ class CodeWhispererPopupManager {
         )
     }
 
-    fun changeStates(
-        states: InvocationContext,
-        indexChange: Int,
-        typeaheadChange: String,
-        typeaheadAdded: Boolean,
-        recommendationAdded: Boolean = false
-    ) {
-        val (_, _, recommendationContext, popup) = states
-        val (details) = recommendationContext
-        if (recommendationAdded) {
-            LOG.debug {
-                "Add recommendations to the existing CodeWhisperer session, current number of recommendations: ${details.size}"
-            }
-            ApplicationManager.getApplication().messageBus.syncPublisher(CODEWHISPERER_POPUP_STATE_CHANGED)
-                .recommendationAdded(states, sessionContext)
-            return
-        }
-        val typeaheadOriginal =
-            if (typeaheadAdded) {
-                sessionContext.typeaheadOriginal + typeaheadChange
-            } else {
-                if (typeaheadChange.length > sessionContext.typeaheadOriginal.length) {
-                    cancelPopup(popup)
-                    return
-                }
-                sessionContext.typeaheadOriginal.substring(
-                    0,
-                    sessionContext.typeaheadOriginal.length - typeaheadChange.length
-                )
-            }
-        val isReverse = indexChange < 0
-        val userInput = states.recommendationContext.userInputSinceInvocation
-        val validCount = getValidCount(details, userInput, typeaheadOriginal)
-        val validSelectedIndex = getValidSelectedIndex(details, userInput, sessionContext.selectedIndex, typeaheadOriginal)
+    @RequiresEdt
+    fun changeStatesForNavigation(sessionContext: SessionContext, indexChange: Int) {
+        val validCount = getValidCount()
+        val validSelectedIndex = getValidSelectedIndex(sessionContext.selectedIndex)
         if ((validSelectedIndex == validCount - 1 && indexChange == 1) ||
             (validSelectedIndex == 0 && indexChange == -1)
         ) {
             return
         }
-        val selectedIndex = findNewSelectedIndex(
-            isReverse,
-            details,
-            userInput,
-            sessionContext.selectedIndex + indexChange,
-            typeaheadOriginal
-        )
-        if (selectedIndex == -1 || !isValidRecommendation(details[selectedIndex], userInput, typeaheadOriginal)) {
-            LOG.debug { "None of the recommendation is valid at this point, cancelling the popup" }
-            cancelPopup(popup)
-            return
-        }
-        val typeahead = resolveTypeahead(states, selectedIndex, typeaheadOriginal)
-        val isFirstTimeShowingPopup = indexChange == 0 && typeaheadChange.isEmpty()
-        sessionContext = SessionContext(
-            typeahead,
-            typeaheadOriginal,
-            selectedIndex,
-            sessionContext.seen,
-            isFirstTimeShowingPopup,
-            sessionContext.toBeRemovedHighlighter
-        )
+        val isReverse = indexChange < 0
+        val selectedIndex = findNewSelectedIndex(isReverse, sessionContext.selectedIndex + indexChange)
+
+        sessionContext.selectedIndex = selectedIndex
+        sessionContext.isFirstTimeShowingPopup = false
 
         ApplicationManager.getApplication().messageBus.syncPublisher(CODEWHISPERER_POPUP_STATE_CHANGED).stateChanged(
-            states,
             sessionContext
         )
     }
 
-    private fun resolveTypeahead(states: InvocationContext, selectedIndex: Int, typeahead: String): String {
-        val recommendation = states.recommendationContext.details[selectedIndex].reformatted.content()
-        val userInput = states.recommendationContext.userInputSinceInvocation
-        var indexOfFirstNonWhiteSpace = typeahead.indexOfFirst { !it.isWhitespace() }
-        if (indexOfFirstNonWhiteSpace == -1) {
-            indexOfFirstNonWhiteSpace = typeahead.length
-        }
+    @RequiresEdt
+    fun changeStatesForTypeahead(
+        sessionContext: SessionContext,
+        typeaheadChange: String,
+        typeaheadAdded: Boolean
+    ) {
+        updateTypeahead(typeaheadChange, typeaheadAdded)
+        updateSessionSelectedIndex(sessionContext)
+        sessionContext.isFirstTimeShowingPopup = false
 
-        for (i in 0..indexOfFirstNonWhiteSpace) {
-            val subTypeahead = typeahead.substring(i)
-            if (recommendation.startsWith(userInput + subTypeahead)) return subTypeahead
-        }
-        return typeahead
+        ApplicationManager.getApplication().messageBus.syncPublisher(CODEWHISPERER_POPUP_STATE_CHANGED).stateChanged(
+            sessionContext
+        )
     }
 
-    fun updatePopupPanel(states: InvocationContext, sessionContext: SessionContext) {
-        val userInput = states.recommendationContext.userInputSinceInvocation
-        val details = states.recommendationContext.details
+    @RequiresEdt
+    fun changeStatesForShowing(sessionContext: SessionContext, states: InvocationContext, recommendationAdded: Boolean = false) {
+        sessionContext.isFirstTimeShowingPopup = !recommendationAdded
+        if (recommendationAdded) {
+            ApplicationManager.getApplication().messageBus.syncPublisher(CODEWHISPERER_POPUP_STATE_CHANGED)
+                .recommendationAdded(states, sessionContext)
+            return
+        }
+
+        updateSessionSelectedIndex(sessionContext)
+        if (sessionContext.popupDisplayOffset == -1) {
+            sessionContext.popupDisplayOffset = sessionContext.editor.caretModel.offset
+        }
+
+        ApplicationManager.getApplication().messageBus.syncPublisher(CODEWHISPERER_POPUP_STATE_CHANGED).stateChanged(
+            sessionContext
+        )
+    }
+
+    private fun updateTypeahead(typeaheadChange: String, typeaheadAdded: Boolean) {
+        val recommendations = CodeWhispererService.getInstance().getAllPaginationSessions().values.filterNotNull()
+        recommendations.forEach {
+            val newTypeahead =
+                if (typeaheadAdded) {
+                    it.recommendationContext.typeahead + typeaheadChange
+                } else {
+                    if (typeaheadChange.length > it.recommendationContext.typeahead.length) {
+                        LOG.debug { "Typeahead change is longer than the current typeahead, exiting the session" }
+                        CodeWhispererService.getInstance().disposeDisplaySession(false)
+                        return
+                    }
+                    it.recommendationContext.typeahead.substring(
+                        0,
+                        it.recommendationContext.typeahead.length - typeaheadChange.length
+                    )
+                }
+            it.recommendationContext.typeahead = newTypeahead
+        }
+    }
+
+    private fun updateSessionSelectedIndex(sessionContext: SessionContext) {
+        val selectedIndex = findNewSelectedIndex(false, sessionContext.selectedIndex)
+        if (selectedIndex == -1) {
+            LOG.debug { "None of the recommendation is valid at this point, cancelling the popup" }
+            CodeWhispererService.getInstance().disposeDisplaySession(false)
+            return
+        }
+
+        sessionContext.selectedIndex = selectedIndex
+    }
+
+    fun updatePopupPanel(sessionContext: SessionContext?) {
+        if (sessionContext == null || sessionContext.selectedIndex == -1 || sessionContext.isDisposed()) return
         val selectedIndex = sessionContext.selectedIndex
-        val typeaheadOriginal = sessionContext.typeaheadOriginal
-        val validCount = getValidCount(details, userInput, typeaheadOriginal)
-        val validSelectedIndex = getValidSelectedIndex(details, userInput, selectedIndex, typeaheadOriginal)
+        val previews = CodeWhispererService.getInstance().getAllSuggestionsPreviewInfo()
+        if (selectedIndex >= previews.size) return
+        val validCount = getValidCount()
+        val validSelectedIndex = getValidSelectedIndex(selectedIndex)
         updateSelectedRecommendationLabelText(validSelectedIndex, validCount)
         updateNavigationPanel(validSelectedIndex, validCount)
-        updateImportPanel(details[selectedIndex].recommendation.mostRelevantMissingImports())
-        updateCodeReferencePanel(states.requestContext.project, details[selectedIndex].recommendation.references())
+        updateImportPanel(previews[selectedIndex].detail.recommendation.mostRelevantMissingImports())
+        updateCodeReferencePanel(sessionContext.project, previews[selectedIndex].detail.recommendation.references())
     }
 
-    fun render(
-        states: InvocationContext,
-        sessionContext: SessionContext,
-        overlappingLinesCount: Int,
-        isRecommendationAdded: Boolean,
-        isScrolling: Boolean
-    ) {
-        updatePopupPanel(states, sessionContext)
-
-        val caretPoint = states.requestContext.editor.offsetToXY(states.requestContext.caretPosition.offset)
-        sessionContext.seen.add(sessionContext.selectedIndex)
+    fun render(sessionContext: SessionContext, isRecommendationAdded: Boolean, isScrolling: Boolean) {
+        updatePopupPanel(sessionContext)
 
         // There are four cases that render() is called:
         // 1. Popup showing for the first time, both booleans are false, we should show the popup and update the latency
@@ -232,20 +228,11 @@ class CodeWhispererPopupManager {
         // emit any events.
         // 4. User navigating through the completions or typing as the completion shows. We should not update the latency
         // end time and should not emit any events in this case.
-        if (!isRecommendationAdded) {
-            showPopup(states, sessionContext, states.popup, caretPoint, overlappingLinesCount)
-            if (!isScrolling) {
-                states.requestContext.latencyContext.codewhispererPostprocessingEnd = System.nanoTime()
-                states.requestContext.latencyContext.codewhispererEndToEndEnd = System.nanoTime()
-            }
-        }
-        if (isScrolling ||
-            CodeWhispererInvocationStatus.getInstance().hasExistingInvocation() ||
-            !sessionContext.isFirstTimeShowingPopup
-        ) {
-            return
-        }
-        CodeWhispererTelemetryService.getInstance().sendClientComponentLatencyEvent(states)
+        if (isRecommendationAdded) return
+        showPopup(sessionContext)
+        if (isScrolling) return
+        sessionContext.latencyContext.codewhispererPostprocessingEnd = System.nanoTime()
+        sessionContext.latencyContext.codewhispererEndToEndEnd = System.nanoTime()
     }
 
     fun dontClosePopupAndRun(runnable: () -> Unit) {
@@ -257,84 +244,36 @@ class CodeWhispererPopupManager {
         }
     }
 
-    fun reset() {
-        sessionContext = SessionContext()
-    }
-
-    fun cancelPopup(popup: JBPopup) {
-        popup.cancel()
-        Disposer.dispose(popup)
-    }
-
-    fun closePopup(popup: JBPopup) {
-        popup.closeOk(null)
-        Disposer.dispose(popup)
-    }
-
-    fun closePopup() {
-        myPopup?.let {
-            it.closeOk(null)
-            Disposer.dispose(it)
+    fun showPopup(sessionContext: SessionContext, force: Boolean = false) {
+        val p = sessionContext.editor.offsetToXY(sessionContext.popupDisplayOffset)
+        val popup: JBPopup?
+        if (sessionContext.popup == null) {
+            popup = initPopup()
+            sessionContext.popup = popup
+            CodeWhispererInvocationStatus.getInstance().setPopupStartTimestamp()
+            initPopupListener(sessionContext, popup)
+        } else {
+            popup = sessionContext.popup
         }
-    }
-
-    fun showPopup(
-        states: InvocationContext,
-        sessionContext: SessionContext,
-        popup: JBPopup,
-        p: Point,
-        overlappingLinesCount: Int
-    ) {
-        val editor = states.requestContext.editor
-        val detailContexts = states.recommendationContext.details
-        val userInputOriginal = states.recommendationContext.userInputOriginal
-        val userInput = states.recommendationContext.userInputSinceInvocation
-        val selectedIndex = sessionContext.selectedIndex
-        val typeaheadOriginal = sessionContext.typeaheadOriginal
-        val typeahead = sessionContext.typeahead
+        val editor = sessionContext.editor
+        val previews = CodeWhispererService.getInstance().getAllSuggestionsPreviewInfo()
+        val userInputOriginal = previews[sessionContext.selectedIndex].userInput
         val userInputLines = userInputOriginal.split("\n").size - 1
-        val lineCount = getReformattedRecommendation(detailContexts[selectedIndex], userInput).split("\n").size
-        val additionalLines = typeaheadOriginal.split("\n").size - typeahead.split("\n").size
         val popupSize = (popup as AbstractPopup).preferredContentSize
-        val yBelowLastLine = p.y + (lineCount + additionalLines + userInputLines - overlappingLinesCount) * editor.lineHeight
-        val yAboveFirstLine = p.y - popupSize.height + (additionalLines + userInputLines) * editor.lineHeight
+        val yAboveFirstLine = p.y - popupSize.height + userInputLines * editor.lineHeight
+        val popupRect = Rectangle(p.x, yAboveFirstLine, popupSize.width, popupSize.height)
         val editorRect = editor.scrollingModel.visibleArea
-        var popupRect = Rectangle(p.x, yBelowLastLine, popupSize.width, popupSize.height)
         var shouldHidePopup = false
 
-        CodeWhispererInvocationStatus.getInstance().setPopupActive(true)
+        CodeWhispererInvocationStatus.getInstance().setDisplaySessionActive(true)
 
-        // Check if the current editor still has focus. If not, don't show the popup.
-        val isSameEditorAsTrigger = if (!AppMode.isRemoteDevHost()) {
-            editor.contentComponent.isFocusOwner
-        } else {
-            FileEditorManager.getInstance(states.requestContext.project).selectedTextEditorWithRemotes.firstOrNull() == editor
-        }
-        if (!isSameEditorAsTrigger) {
-            LOG.debug { "Current editor no longer has focus, not showing the popup" }
-            cancelPopup(popup)
-            return
+        if (!editorRect.contains(popupRect)) {
+            // popup location above first line don't work, so don't show the popup
+            shouldHidePopup = true
         }
 
-        val popupLocation =
-            if (!editorRect.contains(popupRect)) {
-                popupRect = Rectangle(p.x, yAboveFirstLine, popupSize.width, popupSize.height)
-                if (!editorRect.contains(popupRect)) {
-                    // both popup location (below last line and above first line) don't work, so don't show the popup
-                    shouldHidePopup = true
-                }
-                LOG.debug {
-                    "Show popup above the first line of recommendation. " +
-                        "Editor position: $editorRect, popup position: $popupRect"
-                }
-                Point(p.x, yAboveFirstLine)
-            } else {
-                LOG.debug {
-                    "Show popup below the last line of recommendation. " +
-                        "Editor position: $editorRect, popup position: $popupRect"
-                }
-                Point(p.x, yBelowLastLine)
-            }
+        // popup to always display above the current editing line
+        val popupLocation = Point(p.x, yAboveFirstLine)
 
         val relativePopupLocationToEditor = RelativePoint(editor.contentComponent, popupLocation)
 
@@ -347,8 +286,11 @@ class CodeWhispererPopupManager {
             }
         } else {
             if (!AppMode.isRemoteDevHost()) {
-                popup.show(relativePopupLocationToEditor)
+                if (force && !shouldHidePopup) {
+                    popup.show(relativePopupLocationToEditor)
+                }
             } else {
+                // TODO: Fix in remote case the popup should display above the current editing line
                 // TODO: For now, the popup will always display below the suggestions, without checking
                 // if the location the popup is about to show at stays in the editor window or not, due to
                 // the limitation of BackendBeAbstractPopup
@@ -363,22 +305,6 @@ class CodeWhispererPopupManager {
                 editor.putUserData(PopupFactoryImpl.ANCHOR_POPUP_POSITION, popupPositionForRemote)
                 popup.showInBestPositionFor(editor)
             }
-            val perceivedLatency = CodeWhispererInvocationStatus.getInstance().getTimeSinceDocumentChanged()
-            CodeWhispererTelemetryService.getInstance().sendPerceivedLatencyEvent(
-                detailContexts[selectedIndex].requestId,
-                states.requestContext,
-                states.responseContext,
-                perceivedLatency
-            )
-        }
-
-        // popup.popupWindow is null in remote host
-        if (!AppMode.isRemoteDevHost()) {
-            if (shouldHidePopup) {
-                WindowManager.getInstance().setAlphaModeRatio(popup.popupWindow, 1f)
-            } else {
-                WindowManager.getInstance().setAlphaModeRatio(popup.popupWindow, 0.1f)
-            }
         }
     }
 
@@ -386,70 +312,68 @@ class CodeWhispererPopupManager {
         .createComponentPopupBuilder(popupComponents.panel, null)
         .setAlpha(0.1F)
         .setCancelOnClickOutside(true)
-        .setCancelOnOtherWindowOpen(true)
-        .setCancelKeyEnabled(true)
         .setCancelOnWindowDeactivation(true)
-        .createPopup().also {
-            myPopup = it
-        }
+        .createPopup()
 
     fun getReformattedRecommendation(detailContext: DetailContext, userInput: String) =
         detailContext.reformatted.content().substring(userInput.length)
 
-    fun initPopupListener(states: InvocationContext) {
-        addPopupListener(states)
-        states.requestContext.editor.scrollingModel.addVisibleAreaListener(CodeWhispererScrollListener(states), states)
-        addButtonActionListeners(states)
-        addMessageSubscribers(states)
-        setPopupActionHandlers(states)
-        addComponentListeners(states)
+    private fun initPopupListener(sessionContext: SessionContext, popup: JBPopup) {
+        addPopupListener(popup)
+        sessionContext.editor.scrollingModel.addVisibleAreaListener(CodeWhispererScrollListener(sessionContext), sessionContext)
+        addButtonActionListeners(sessionContext)
+        addMessageSubscribers(sessionContext)
+        setPopupActionHandlers(sessionContext)
+        addComponentListeners(sessionContext)
     }
 
-    private fun addPopupListener(states: InvocationContext) {
-        val listener = CodeWhispererPopupListener(states)
-        states.popup.addListener(listener)
-        Disposer.register(states) { states.popup.removeListener(listener) }
+    private fun addPopupListener(popup: JBPopup) {
+        val listener = CodeWhispererPopupListener()
+        popup.addListener(listener)
+        Disposer.register(popup) {
+            popup.removeListener(listener)
+        }
     }
 
-    private fun addMessageSubscribers(states: InvocationContext) {
-        val connect = ApplicationManager.getApplication().messageBus.connect(states)
+    private fun addMessageSubscribers(sessionContext: SessionContext) {
+        val connect = ApplicationManager.getApplication().messageBus.connect(sessionContext)
         connect.subscribe(
             CODEWHISPERER_USER_ACTION_PERFORMED,
             object : CodeWhispererUserActionListener {
-                override fun navigateNext(states: InvocationContext) {
-                    changeStates(states, 1, "", true)
+                override fun navigateNext(sessionContext: SessionContext) {
+                    changeStatesForNavigation(sessionContext, 1)
                 }
 
-                override fun navigatePrevious(states: InvocationContext) {
-                    changeStates(states, -1, "", true)
+                override fun navigatePrevious(sessionContext: SessionContext) {
+                    changeStatesForNavigation(sessionContext, -1)
                 }
 
-                override fun backspace(states: InvocationContext, diff: String) {
-                    changeStates(states, 0, diff, false)
+                override fun backspace(sessionContext: SessionContext, diff: String) {
+                    changeStatesForTypeahead(sessionContext, diff, false)
                 }
 
-                override fun enter(states: InvocationContext, diff: String) {
-                    changeStates(states, 0, diff, true)
+                override fun enter(sessionContext: SessionContext, diff: String) {
+                    changeStatesForTypeahead(sessionContext, diff, true)
                 }
 
-                override fun type(states: InvocationContext, diff: String) {
+                override fun type(sessionContext: SessionContext, diff: String) {
                     // remove the character at primaryCaret if it's the same as the typed character
-                    val caretOffset = states.requestContext.editor.caretModel.primaryCaret.offset
-                    val document = states.requestContext.editor.document
+                    val caretOffset = sessionContext.editor.caretModel.primaryCaret.offset
+                    val document = sessionContext.editor.document
                     val text = document.charsSequence
                     if (caretOffset < text.length && diff == text[caretOffset].toString()) {
-                        WriteCommandAction.runWriteCommandAction(states.requestContext.project) {
+                        WriteCommandAction.runWriteCommandAction(sessionContext.project) {
                             document.deleteString(caretOffset, caretOffset + 1)
                         }
                     }
-                    changeStates(states, 0, diff, true)
+                    changeStatesForTypeahead(sessionContext, diff, true)
                 }
 
-                override fun beforeAccept(states: InvocationContext, sessionContext: SessionContext) {
+                override fun beforeAccept(sessionContext: SessionContext) {
                     dontClosePopupAndRun {
-                        CodeWhispererEditorManager.getInstance().updateEditorWithRecommendation(states, sessionContext)
+                        CodeWhispererEditorManager.getInstance().updateEditorWithRecommendation(sessionContext)
                     }
-                    closePopup(states.popup)
+                    CodeWhispererService.getInstance().disposeDisplaySession(true)
                 }
             }
         )
@@ -492,60 +416,75 @@ class CodeWhispererPopupManager {
         Disposer.register(newHandler.states) { EditorActionManager.getInstance().setActionHandler(id, oldHandler) }
     }
 
-    private fun addComponentListeners(states: InvocationContext) {
-        val editor = states.requestContext.editor
-        val codewhispererSelectionListener: SelectionListener = object : SelectionListener {
+    private fun addComponentListeners(sessionContext: SessionContext) {
+        val editor = sessionContext.editor
+        val codeWhispererSelectionListener: SelectionListener = object : SelectionListener {
             override fun selectionChanged(event: SelectionEvent) {
                 if (shouldListenerCancelPopup) {
-                    cancelPopup(states.popup)
+                    CodeWhispererService.getInstance().disposeDisplaySession(false)
                 }
                 super.selectionChanged(event)
             }
         }
-        editor.selectionModel.addSelectionListener(codewhispererSelectionListener)
-        Disposer.register(states) { editor.selectionModel.removeSelectionListener(codewhispererSelectionListener) }
+        editor.selectionModel.addSelectionListener(codeWhispererSelectionListener)
+        Disposer.register(sessionContext) { editor.selectionModel.removeSelectionListener(codeWhispererSelectionListener) }
 
-        val codewhispererDocumentListener: DocumentListener = object : DocumentListener {
+        val codeWhispererDocumentListener: DocumentListener = object : DocumentListener {
             override fun documentChanged(event: DocumentEvent) {
                 if (shouldListenerCancelPopup) {
-                    cancelPopup(states.popup)
+                    // handle IntelliSense accept case
+                    // TODO: handle bulk delete (delete word) case
+                    if (editor.document == event.document &&
+                        editor.caretModel.offset == event.offset &&
+                        event.newLength > event.oldLength
+                    ) {
+                        dontClosePopupAndRun {
+                            super.documentChanged(event)
+                            editor.caretModel.moveCaretRelatively(event.newLength, 0, false, false, true)
+                            changeStatesForTypeahead(sessionContext, event.newFragment.toString(), true)
+                        }
+                        return
+                    } else {
+                        CodeWhispererService.getInstance().disposeDisplaySession(false)
+                    }
                 }
                 super.documentChanged(event)
             }
         }
-        editor.document.addDocumentListener(codewhispererDocumentListener, states)
+        editor.document.addDocumentListener(codeWhispererDocumentListener, sessionContext)
 
-        val codewhispererCaretListener: CaretListener = object : CaretListener {
+        val codeWhispererCaretListener: CaretListener = object : CaretListener {
             override fun caretPositionChanged(event: CaretEvent) {
                 if (shouldListenerCancelPopup) {
-                    cancelPopup(states.popup)
+                    CodeWhispererService.getInstance().disposeDisplaySession(false)
                 }
                 super.caretPositionChanged(event)
             }
         }
-        editor.caretModel.addCaretListener(codewhispererCaretListener)
-        Disposer.register(states) { editor.caretModel.removeCaretListener(codewhispererCaretListener) }
+        editor.caretModel.addCaretListener(codeWhispererCaretListener)
+        Disposer.register(sessionContext) { editor.caretModel.removeCaretListener(codeWhispererCaretListener) }
 
         val editorComponent = editor.contentComponent
         if (editorComponent.isShowing) {
             val window = ComponentUtil.getWindow(editorComponent)
             val windowListener: ComponentListener = object : ComponentAdapter() {
-                override fun componentMoved(event: ComponentEvent) {
-                    cancelPopup(states.popup)
+                override fun componentMoved(e: ComponentEvent) {
+                    CodeWhispererService.getInstance().disposeDisplaySession(false)
+                    super.componentMoved(e)
                 }
 
                 override fun componentShown(e: ComponentEvent?) {
-                    cancelPopup(states.popup)
+                    CodeWhispererService.getInstance().disposeDisplaySession(false)
                     super.componentShown(e)
                 }
             }
             window?.addComponentListener(windowListener)
-            Disposer.register(states) { window?.removeComponentListener(windowListener) }
+            Disposer.register(sessionContext) { window?.removeComponentListener(windowListener) }
         }
     }
 
     private fun updateSelectedRecommendationLabelText(validSelectedIndex: Int, validCount: Int) {
-        if (CodeWhispererInvocationStatus.getInstance().hasExistingInvocation()) {
+        if (CodeWhispererInvocationStatus.getInstance().hasExistingServiceInvocation()) {
             popupComponents.recommendationInfoLabel.text = message("codewhisperer.popup.pagination_info")
             LOG.debug { "Pagination in progress. Current total: $validCount" }
         } else {
@@ -622,14 +561,10 @@ class CodeWhispererPopupManager {
         ParameterInfoController.existsWithVisibleHintForEditor(editor, true) ||
             LookupManager.getActiveLookup(editor) != null
 
-    private fun findNewSelectedIndex(
-        isReverse: Boolean,
-        detailContexts: List<DetailContext>,
-        userInput: String,
-        start: Int,
-        typeahead: String
-    ): Int {
-        val count = detailContexts.size
+    fun findNewSelectedIndex(isReverse: Boolean, selectedIndex: Int): Int {
+        val start = if (selectedIndex == -1) 0 else selectedIndex
+        val previews = CodeWhispererService.getInstance().getAllSuggestionsPreviewInfo()
+        val count = previews.size
         val unit = if (isReverse) -1 else 1
         var currIndex: Int
         for (i in 0 until count) {
@@ -637,45 +572,34 @@ class CodeWhispererPopupManager {
             if (currIndex < 0) {
                 currIndex += count
             }
-            if (isValidRecommendation(detailContexts[currIndex], userInput, typeahead)) {
+            if (isValidRecommendation(previews[currIndex])) {
                 return currIndex
             }
         }
         return -1
     }
 
-    private fun getValidCount(detailContexts: List<DetailContext>, userInput: String, typeahead: String): Int =
-        detailContexts.filter { isValidRecommendation(it, userInput, typeahead) }.size
+    private fun getValidCount(): Int =
+        CodeWhispererService.getInstance().getAllSuggestionsPreviewInfo().filter { isValidRecommendation(it) }.size
 
-    private fun getValidSelectedIndex(
-        detailContexts: List<DetailContext>,
-        userInput: String,
-        selectedIndex: Int,
-        typeahead: String
-    ): Int {
-        var currIndexIgnoreInvalid = 0
-        detailContexts.forEachIndexed { index, value ->
+    private fun getValidSelectedIndex(selectedIndex: Int): Int {
+        var curr = 0
+
+        val previews = CodeWhispererService.getInstance().getAllSuggestionsPreviewInfo()
+        previews.forEachIndexed { index, preview ->
             if (index == selectedIndex) {
-                return currIndexIgnoreInvalid
+                return curr
             }
-            if (isValidRecommendation(value, userInput, typeahead)) {
-                currIndexIgnoreInvalid++
+            if (isValidRecommendation(preview)) {
+                curr++
             }
         }
         return -1
     }
 
-    private fun isValidRecommendation(detailContext: DetailContext, userInput: String, typeahead: String): Boolean {
-        if (detailContext.isDiscarded) return false
-        if (detailContext.recommendation.content().isEmpty()) return false
-        val indexOfFirstNonWhiteSpace = typeahead.indexOfFirst { !it.isWhitespace() }
-        if (indexOfFirstNonWhiteSpace == -1) return true
-
-        for (i in 0..indexOfFirstNonWhiteSpace) {
-            val subTypeahead = typeahead.substring(i)
-            if (detailContext.reformatted.content().startsWith(userInput + subTypeahead)) return true
-        }
-        return false
+    private fun isValidRecommendation(preview: PreviewContext): Boolean {
+        if (preview.detail.isDiscarded) return false
+        return preview.detail.recommendation.content().startsWith(preview.userInput + preview.typeahead)
     }
 
     companion object {
@@ -693,17 +617,17 @@ class CodeWhispererPopupManager {
 }
 
 interface CodeWhispererPopupStateChangeListener {
-    fun stateChanged(states: InvocationContext, sessionContext: SessionContext) {}
-    fun scrolled(states: InvocationContext, sessionContext: SessionContext) {}
+    fun stateChanged(sessionContext: SessionContext) {}
+    fun scrolled(sessionContext: SessionContext) {}
     fun recommendationAdded(states: InvocationContext, sessionContext: SessionContext) {}
 }
 
 interface CodeWhispererUserActionListener {
-    fun backspace(states: InvocationContext, diff: String) {}
-    fun enter(states: InvocationContext, diff: String) {}
-    fun type(states: InvocationContext, diff: String) {}
-    fun navigatePrevious(states: InvocationContext) {}
-    fun navigateNext(states: InvocationContext) {}
-    fun beforeAccept(states: InvocationContext, sessionContext: SessionContext) {}
-    fun afterAccept(states: InvocationContext, sessionContext: SessionContext, rangeMarker: RangeMarker) {}
+    fun backspace(sessionContext: SessionContext, diff: String) {}
+    fun enter(sessionContext: SessionContext, diff: String) {}
+    fun type(sessionContext: SessionContext, diff: String) {}
+    fun navigatePrevious(sessionContext: SessionContext) {}
+    fun navigateNext(sessionContext: SessionContext) {}
+    fun beforeAccept(sessionContext: SessionContext) {}
+    fun afterAccept(states: InvocationContext, previews: List<PreviewContext>, sessionContext: SessionContext, rangeMarker: RangeMarker) {}
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
@@ -27,16 +27,12 @@ import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.editor.event.DocumentListener
-import com.intellij.openapi.editor.event.EditorMouseEvent
-import com.intellij.openapi.editor.event.EditorMouseMotionListener
 import com.intellij.openapi.editor.event.SelectionEvent
 import com.intellij.openapi.editor.event.SelectionListener
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.util.Disposer
-import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.ComponentUtil
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.ui.popup.AbstractPopup
@@ -70,8 +66,6 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.popup.listeners.Co
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.listeners.CodeWhispererScrollListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererInvocationStatus
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService
-import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService.Companion
-import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
 import software.aws.toolkits.jetbrains.services.codewhisperer.toolwindow.CodeWhispererCodeReferenceManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererColorUtil.POPUP_DIM_HEX
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.POPUP_INFO_TEXT_SIZE
@@ -162,8 +156,8 @@ class CodeWhispererPopupManager {
         }
 
         updateSessionSelectedIndex(sessionContext)
-        if (sessionContext.popupDisplayOffset == -1) {
-            sessionContext.popupDisplayOffset = sessionContext.editor.caretModel.offset
+        if (sessionContext.popupOffset == -1) {
+            sessionContext.popupOffset = sessionContext.editor.caretModel.offset
         }
 
         ApplicationManager.getApplication().messageBus.syncPublisher(CODEWHISPERER_POPUP_STATE_CHANGED).stateChanged(
@@ -245,7 +239,7 @@ class CodeWhispererPopupManager {
     }
 
     fun showPopup(sessionContext: SessionContext, force: Boolean = false) {
-        val p = sessionContext.editor.offsetToXY(sessionContext.popupDisplayOffset)
+        val p = sessionContext.editor.offsetToXY(sessionContext.popupOffset)
         val popup: JBPopup?
         if (sessionContext.popup == null) {
             popup = initPopup()

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererRecommendationManager.kt
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.VisibleForTesting
 import software.amazon.awssdk.services.codewhispererruntime.model.Completion
 import software.amazon.awssdk.services.codewhispererruntime.model.Span
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.DetailContext
+import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.RecommendationChunk
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getCompletionType
 import kotlin.math.max
@@ -63,7 +64,7 @@ class CodeWhispererRecommendationManager {
         userInput: String,
         recommendations: List<Completion>,
         requestId: String,
-    ): List<DetailContext> {
+    ): MutableList<DetailContext> {
         val seen = mutableSetOf<String>()
         return recommendations.map {
             val isDiscardedByUserInput = !it.content().startsWith(userInput) || it.content() == userInput
@@ -126,7 +127,7 @@ class CodeWhispererRecommendationManager {
                 overlap,
                 getCompletionType(it)
             )
-        }
+        }.toMutableList()
     }
 
     fun findRightContextOverlap(

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.services.codewhisperer.service
 import com.intellij.codeInsight.hint.HintManager
 import com.intellij.notification.NotificationAction
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.DataKey
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
@@ -15,16 +16,17 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.VisualPosition
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.util.Disposer
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.messages.Topic
+import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -46,7 +48,6 @@ import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.core.utils.warn
-import software.aws.toolkits.jetbrains.core.coroutines.disposableCoroutineScope
 import software.aws.toolkits.jetbrains.core.coroutines.getCoroutineBgContext
 import software.aws.toolkits.jetbrains.core.coroutines.projectCoroutineScope
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
@@ -64,6 +65,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.model.DetailContex
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.FileContextInfo
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.LatencyContext
+import software.aws.toolkits.jetbrains.services.codewhisperer.model.PreviewContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.RecommendationContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.SessionContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.SupplementalContextInfo
@@ -94,6 +96,10 @@ import java.util.concurrent.TimeUnit
 class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
     private val codeInsightSettingsFacade = CodeInsightsSettingsFacade()
     private var refreshFailure: Int = 0
+    private val ongoingRequests = mutableMapOf<Int, InvocationContext?>()
+    val ongoingRequestsContext = mutableMapOf<Int, RequestContext>()
+    private var jobId = 0
+    private var sessionContext: SessionContext? = null
 
     init {
         Disposer.register(this, codeInsightSettingsFacade)
@@ -161,18 +167,27 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         val isInjectedFile = runReadAction { psiFile.isInjectedText() }
         if (isInjectedFile) return
 
+        val currentJobId = jobId++
         val requestContext = try {
-            getRequestContext(triggerTypeInfo, editor, project, psiFile, latencyContext)
+            getRequestContext(triggerTypeInfo, editor, project, psiFile)
         } catch (e: Exception) {
             LOG.debug { e.message.toString() }
             CodeWhispererTelemetryService.getInstance().sendFailedServiceInvocationEvent(project, e::class.simpleName)
             return
         }
+        val caretContext = requestContext.fileContextInfo.caretContext
+        ongoingRequestsContext.forEach { (k, v) ->
+            val vCaretContext = v.fileContextInfo.caretContext
+            if (vCaretContext == caretContext) {
+                LOG.debug { "same caretContext found from job: $k, left context ${vCaretContext.leftContextOnCurrentLine}, jobId: $currentJobId" }
+                return
+            }
+        }
 
         val language = requestContext.fileContextInfo.programmingLanguage
         val leftContext = requestContext.fileContextInfo.caretContext.leftFileContext
         if (!language.isCodeCompletionSupported() || (checkLeftContextKeywordsForJsonAndYaml(leftContext, language.languageId))) {
-            LOG.debug { "Programming language $language is not supported by CodeWhisperer" }
+            LOG.debug { "Programming language $language is not supported by CodeWhisperer, jobId: $currentJobId" }
             if (triggerTypeInfo.triggerType == CodewhispererTriggerType.OnDemand) {
                 showCodeWhispererInfoHint(
                     requestContext.editor,
@@ -183,7 +198,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         }
 
         LOG.debug {
-            "Calling CodeWhisperer service, trigger type: ${triggerTypeInfo.triggerType}" +
+            "Calling CodeWhisperer service, jobId: $currentJobId, trigger type: ${triggerTypeInfo.triggerType}" +
                 if (triggerTypeInfo.triggerType == CodewhispererTriggerType.AutoTrigger) {
                     ", auto-trigger type: ${triggerTypeInfo.automatedTriggerType}"
                 } else {
@@ -191,26 +206,30 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                 }
         }
 
-        val invocationStatus = CodeWhispererInvocationStatus.getInstance()
-        if (invocationStatus.checkExistingInvocationAndSet()) {
-            return
-        }
+        CodeWhispererInvocationStatus.getInstance().startInvocation()
 
-        invokeCodeWhispererInBackground(requestContext)
+        invokeCodeWhispererInBackground(requestContext, currentJobId, latencyContext)
     }
 
-    internal fun invokeCodeWhispererInBackground(requestContext: RequestContext): Job {
-        val popup = CodeWhispererPopupManager.getInstance().initPopup()
-        Disposer.register(popup) { CodeWhispererInvocationStatus.getInstance().finishInvocation() }
+    internal fun invokeCodeWhispererInBackground(requestContext: RequestContext, currentJobId: Int, latencyContext: LatencyContext): Job? {
+        ongoingRequestsContext[currentJobId] = requestContext
+        val sessionContext = sessionContext ?: SessionContext(requestContext.project, requestContext.editor, latencyContext = latencyContext)
+
+        // In rare cases when there's an ongoing session and subsequent triggers are from a different project or editor --
+        // we will cancel the existing session(since we've already moved to a different project or editor simply return.
+        if (requestContext.project != sessionContext.project || requestContext.editor != sessionContext.editor) {
+            disposeDisplaySession(false)
+            return null
+        }
+        this.sessionContext = sessionContext
 
         val workerContexts = mutableListOf<WorkerContext>()
         // When popup is disposed we will cancel this coroutine. The only places popup can get disposed should be
         // from CodeWhispererPopupManager.cancelPopup() and CodeWhispererPopupManager.closePopup().
         // It's possible and ok that coroutine will keep running until the next time we check it's state.
         // As long as we don't show to the user extra info we are good.
-        val coroutineScope = disposableCoroutineScope(popup)
+        val coroutineScope = projectCoroutineScope(requestContext.project)
 
-        var states: InvocationContext? = null
         var lastRecommendationIndex = -1
 
         val job = coroutineScope.launch {
@@ -224,8 +243,8 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                 )
 
                 var startTime = System.nanoTime()
-                requestContext.latencyContext.codewhispererPreprocessingEnd = System.nanoTime()
-                requestContext.latencyContext.paginationAllCompletionsStart = System.nanoTime()
+                latencyContext.codewhispererPreprocessingEnd = System.nanoTime()
+                latencyContext.paginationAllCompletionsStart = System.nanoTime()
                 CodeWhispererInvocationStatus.getInstance().setInvocationStart()
                 var requestCount = 0
                 for (response in responseIterable) {
@@ -236,13 +255,13 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                     val requestId = response.responseMetadata().requestId()
                     val sessionId = response.sdkHttpResponse().headers().getOrDefault(KET_SESSION_ID, listOf(requestId))[0]
                     if (requestCount == 1) {
-                        requestContext.latencyContext.codewhispererPostprocessingStart = System.nanoTime()
-                        requestContext.latencyContext.paginationFirstCompletionTime = latency
-                        requestContext.latencyContext.firstRequestId = requestId
+                        latencyContext.codewhispererPostprocessingStart = System.nanoTime()
+                        latencyContext.paginationFirstCompletionTime = latency
+                        latencyContext.firstRequestId = requestId
                         CodeWhispererInvocationStatus.getInstance().setInvocationSessionId(sessionId)
                     }
                     if (response.nextToken().isEmpty()) {
-                        requestContext.latencyContext.paginationAllCompletionsEnd = System.nanoTime()
+                        latencyContext.paginationAllCompletionsEnd = System.nanoTime()
                     }
                     val responseContext = ResponseContext(sessionId)
                     logServiceInvocation(requestId, requestContext, responseContext, response.completions(), latency, null)
@@ -250,6 +269,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                     ApplicationManager.getApplication().messageBus.syncPublisher(CODEWHISPERER_CODE_COMPLETION_PERFORMED)
                         .onSuccess(requestContext.fileContextInfo)
                     CodeWhispererTelemetryService.getInstance().sendServiceInvocationEvent(
+                        currentJobId,
                         requestId,
                         requestContext,
                         responseContext,
@@ -271,11 +291,11 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                         // task hasn't been finished yet, in this case simply add another task to the queue. If they
                         // see worker queue is empty, the previous tasks must have been finished before this. In this
                         // case render CodeWhisperer UI directly.
-                        val workerContext = WorkerContext(requestContext, responseContext, validatedResponse, popup)
+                        val workerContext = WorkerContext(requestContext, responseContext, validatedResponse)
                         if (workerContexts.isNotEmpty()) {
                             workerContexts.add(workerContext)
                         } else {
-                            if (states == null && !popup.isDisposed &&
+                            if (ongoingRequests.values.filterNotNull().isEmpty() &&
                                 !CodeWhispererInvocationStatus.getInstance().hasEnoughDelayToShowCodeWhisperer()
                             ) {
                                 // It's the first response, and no enough delay before showing
@@ -285,7 +305,16 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                                     }
                                     runInEdt {
                                         workerContexts.forEach {
-                                            states = processCodeWhispererUI(it, states)
+                                            processCodeWhispererUI(
+                                                sessionContext,
+                                                it,
+                                                ongoingRequests[currentJobId],
+                                                coroutineScope,
+                                                currentJobId
+                                            )
+                                            if (!ongoingRequests.contains(currentJobId)) {
+                                                coroutineScope.coroutineContext.cancel()
+                                            }
                                         }
                                         workerContexts.clear()
                                     }
@@ -293,14 +322,25 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                                 workerContexts.add(workerContext)
                             } else {
                                 // Have enough delay before showing for the first response, or it's subsequent responses
-                                states = processCodeWhispererUI(workerContext, states)
+                                processCodeWhispererUI(
+                                    sessionContext,
+                                    workerContext,
+                                    ongoingRequests[currentJobId],
+                                    coroutineScope,
+                                    currentJobId
+                                )
                             }
                         }
                     }
                     if (!isActive) {
                         // If job is cancelled before we do another request, don't bother making
                         // another API call to save resources
-                        LOG.debug { "Skipping sending remaining requests on CodeWhisperer session exit" }
+                        LOG.debug { "Skipping sending remaining requests on inactive CodeWhisperer session exit" }
+                        return@launch
+                    }
+                    if (requestCount >= PAGINATION_REQUEST_COUNT_ALLOWED) {
+                        LOG.debug { "Only $PAGINATION_REQUEST_COUNT_ALLOWED request per pagination session for now" }
+                        CodeWhispererInvocationStatus.getInstance().finishInvocation()
                         break
                     }
                 }
@@ -321,6 +361,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                     val responseContext = ResponseContext(sessionId)
 
                     CodeWhispererTelemetryService.getInstance().sendServiceInvocationEvent(
+                        currentJobId,
                         requestId,
                         requestContext,
                         responseContext,
@@ -350,7 +391,6 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                         )
                     )
                     CodeWhispererInvocationStatus.getInstance().finishInvocation()
-                    CodeWhispererInvocationStatus.getInstance().setInvocationComplete()
 
                     requestContext.customizationArn?.let { CodeWhispererModelConfigurator.getInstance().invalidateCustomization(it) }
 
@@ -358,7 +398,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                         showRecommendationsInPopup(
                             requestContext.editor,
                             requestContext.triggerTypeInfo,
-                            requestContext.latencyContext
+                            latencyContext
                         )
                     }
                     return@launch
@@ -366,7 +406,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                     requestId = e.requestId() ?: ""
                     sessionId = e.awsErrorDetails().sdkHttpResponse().headers().getOrDefault(KET_SESSION_ID, listOf(requestId))[0]
                     displayMessage = e.awsErrorDetails().errorMessage() ?: message("codewhisperer.trigger.error.server_side")
-                } else if (e is software.amazon.awssdk.services.codewhispererruntime.model.CodeWhispererRuntimeException) {
+                } else if (e is CodeWhispererRuntimeException) {
                     requestId = e.requestId() ?: ""
                     sessionId = e.awsErrorDetails().sdkHttpResponse().headers().getOrDefault(KET_SESSION_ID, listOf(requestId))[0]
                     displayMessage = e.awsErrorDetails().errorMessage() ?: message("codewhisperer.trigger.error.server_side")
@@ -389,6 +429,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                 CodeWhispererInvocationStatus.getInstance().setInvocationSessionId(sessionId)
                 logServiceInvocation(requestId, requestContext, responseContext, emptyList(), null, exceptionType)
                 CodeWhispererTelemetryService.getInstance().sendServiceInvocationEvent(
+                    currentJobId,
                     requestId,
                     requestContext,
                     responseContext,
@@ -410,7 +451,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                         // We should only show error hint when CodeWhisperer popup is not visible,
                         // and make it silent if CodeWhisperer popup is showing.
                         runInEdt {
-                            if (!CodeWhispererInvocationStatus.getInstance().isPopupActive()) {
+                            if (!CodeWhispererInvocationStatus.getInstance().isDisplaySessionActive()) {
                                 showCodeWhispererErrorHint(requestContext.editor, displayMessage)
                             }
                         }
@@ -418,15 +459,8 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                 }
                 CodeWhispererInvocationStatus.getInstance().finishInvocation()
                 runInEdt {
-                    states?.let {
-                        CodeWhispererPopupManager.getInstance().updatePopupPanel(
-                            it,
-                            CodeWhispererPopupManager.getInstance().sessionContext
-                        )
-                    }
+                    CodeWhispererPopupManager.getInstance().updatePopupPanel(sessionContext)
                 }
-            } finally {
-                CodeWhispererInvocationStatus.getInstance().setInvocationComplete()
             }
         }
 
@@ -434,61 +468,66 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
     }
 
     @RequiresEdt
-    private fun processCodeWhispererUI(workerContext: WorkerContext, currStates: InvocationContext?): InvocationContext? {
+    private fun processCodeWhispererUI(
+        sessionContext: SessionContext,
+        workerContext: WorkerContext,
+        currStates: InvocationContext?,
+        coroutine: CoroutineScope,
+        jobId: Int
+    ) {
         val requestContext = workerContext.requestContext
         val responseContext = workerContext.responseContext
         val response = workerContext.response
-        val popup = workerContext.popup
         val requestId = response.responseMetadata().requestId()
 
         // At this point when we are in EDT, the state of the popup will be thread-safe
         // across this thread execution, so if popup is disposed, we will stop here.
         // This extra check is needed because there's a time between when we get the response and
         // when we enter the EDT.
-        if (popup.isDisposed) {
-            LOG.debug { "Stop showing CodeWhisperer recommendations on CodeWhisperer session exit. RequestId: $requestId" }
-            return null
+        if (!coroutine.isActive || sessionContext.isDisposed()) {
+            LOG.debug { "Stop showing CodeWhisperer recommendations on CodeWhisperer session exit. RequestId: $requestId, jobId: $jobId" }
+            return
         }
 
         if (requestContext.editor.isDisposed) {
-            LOG.debug { "Stop showing CodeWhisperer recommendations since editor is disposed. RequestId: $requestId" }
-            CodeWhispererPopupManager.getInstance().cancelPopup(popup)
-            return null
+            LOG.debug { "Stop showing all CodeWhisperer recommendations since editor is disposed. RequestId: $requestId, jobId: $jobId" }
+            disposeDisplaySession(false)
+            return
         }
 
-        if (response.nextToken().isEmpty()) {
-            CodeWhispererInvocationStatus.getInstance().finishInvocation()
-        }
+        CodeWhispererInvocationStatus.getInstance().finishInvocation()
 
         val caretMovement = CodeWhispererEditorManager.getInstance().getCaretMovement(
             requestContext.editor,
             requestContext.caretPosition
         )
-        val isPopupShowing: Boolean
+        val isPopupShowing = checkRecommendationsValidity(currStates, false)
         val nextStates: InvocationContext?
         if (currStates == null) {
-            // first response
-            nextStates = initStates(requestContext, responseContext, response, caretMovement, popup)
-            isPopupShowing = false
+            // first response for the jobId
+            nextStates = initStates(jobId, requestContext, responseContext, response, caretMovement, coroutine)
 
-            // receiving a null state means caret has moved backward or there's a conflict with
-            // Intellisense popup, so we are going to cancel the job
+            // receiving a null state means caret has moved backward,
+            // so we are going to cancel the current job
             if (nextStates == null) {
-                LOG.debug { "Cancelling popup and exiting CodeWhisperer session. RequestId: $requestId" }
-                CodeWhispererPopupManager.getInstance().cancelPopup(popup)
-                return null
+                return
             }
         } else {
-            // subsequent responses
+            // subsequent responses for the jobId
             nextStates = updateStates(currStates, response)
-            isPopupShowing = checkRecommendationsValidity(currStates, false)
         }
+        LOG.debug { "Adding ${response.completions().size} completions to the session. RequestId: $requestId, jobId: $jobId" }
 
-        val hasAtLeastOneValid = checkRecommendationsValidity(nextStates, response.nextToken().isEmpty())
+        // TODO: may have bug when it's a mix of auto-trigger + manual trigger
+        val hasAtLeastOneValid = checkRecommendationsValidity(nextStates, true)
+        val allSuggestions = ongoingRequests.values.filterNotNull().flatMap { it.recommendationContext.details }
+        val valid = allSuggestions.filter { !it.isDiscarded }.size
+        LOG.debug { "Suggestions status: valid: $valid, discarded: ${allSuggestions.size - valid}" }
 
         // If there are no recommendations at all in this session, we need to manually send the user decision event here
         // since it won't be sent automatically later
-        if (nextStates.recommendationContext.details.isEmpty() && response.nextToken().isEmpty()) {
+        // TODO: may have bug; visit later
+        if (nextStates.recommendationContext.details.isEmpty()) {
             LOG.debug { "Received just an empty list from this session, requestId: $requestId" }
             CodeWhispererTelemetryService.getInstance().sendUserDecisionEvent(
                 requestContext,
@@ -508,38 +547,42 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
             )
         }
         if (!hasAtLeastOneValid) {
-            if (response.nextToken().isEmpty()) {
-                LOG.debug { "None of the recommendations are valid, exiting CodeWhisperer session" }
-                CodeWhispererPopupManager.getInstance().cancelPopup(popup)
-                return null
+            LOG.debug { "None of the recommendations are valid, exiting current CodeWhisperer pagination session" }
+            // If there's only one ongoing request, after disposing this, the entire session will also end
+            if (ongoingRequests.keys.size == 1) {
+                disposeDisplaySession(false)
+            } else {
+                disposeJob(jobId)
+                sessionContext.selectedIndex = CodeWhispererPopupManager.getInstance().findNewSelectedIndex(true, sessionContext.selectedIndex)
             }
         } else {
-            updateCodeWhisperer(nextStates, isPopupShowing)
+            updateCodeWhisperer(sessionContext, nextStates, isPopupShowing)
         }
-        return nextStates
     }
 
     private fun initStates(
+        jobId: Int,
         requestContext: RequestContext,
         responseContext: ResponseContext,
         response: GenerateCompletionsResponse,
         caretMovement: CaretMovement,
-        popup: JBPopup
+        coroutine: CoroutineScope,
     ): InvocationContext? {
         val requestId = response.responseMetadata().requestId()
         val recommendations = response.completions()
         val visualPosition = requestContext.editor.caretModel.visualPosition
 
-        if (CodeWhispererPopupManager.getInstance().hasConflictingPopups(requestContext.editor)) {
-            LOG.debug { "Detect conflicting popup window with CodeWhisperer popup, not showing CodeWhisperer popup" }
-            sendDiscardedUserDecisionEventForAll(requestContext, responseContext, recommendations)
-            return null
-        }
         if (caretMovement == CaretMovement.MOVE_BACKWARD) {
-            LOG.debug { "Caret moved backward, discarding all of the recommendations. Request ID: $requestId" }
-            sendDiscardedUserDecisionEventForAll(requestContext, responseContext, recommendations)
+            LOG.debug { "Caret moved backward, discarding all of the recommendations and exiting the session. Request ID: $requestId, jobId: $jobId" }
+            val detailContexts = recommendations.map {
+                DetailContext("", it, it, true, false, "", getCompletionType(it))
+            }.toMutableList()
+            val recommendationContext = RecommendationContext(detailContexts, "", "", VisualPosition(0, 0), jobId)
+            ongoingRequests[jobId] = buildInvocationContext(requestContext, responseContext, recommendationContext, coroutine)
+            disposeDisplaySession(false)
             return null
         }
+
         val userInputOriginal = CodeWhispererEditorManager.getInstance().getUserInputSinceInvocation(
             requestContext.editor,
             requestContext.caretPosition.offset
@@ -563,8 +606,9 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
             recommendations,
             requestId
         )
-        val recommendationContext = RecommendationContext(detailContexts, userInputOriginal, userInput, visualPosition)
-        return buildInvocationContext(requestContext, responseContext, recommendationContext, popup)
+        val recommendationContext = RecommendationContext(detailContexts, userInputOriginal, userInput, visualPosition, jobId)
+        ongoingRequests[jobId] = buildInvocationContext(requestContext, responseContext, recommendationContext, coroutine)
+        return ongoingRequests[jobId]
     }
 
     private fun updateStates(
@@ -572,24 +616,19 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         response: GenerateCompletionsResponse
     ): InvocationContext {
         val recommendationContext = states.recommendationContext
-        val details = recommendationContext.details
         val newDetailContexts = CodeWhispererRecommendationManager.getInstance().buildDetailContext(
             states.requestContext,
             recommendationContext.userInputSinceInvocation,
             response.completions(),
             response.responseMetadata().requestId()
         )
-        Disposer.dispose(states)
 
-        val updatedStates = states.copy(
-            recommendationContext = recommendationContext.copy(details = details + newDetailContexts)
-        )
-        Disposer.register(states.popup, updatedStates)
-        CodeWhispererPopupManager.getInstance().initPopupListener(updatedStates)
-        return updatedStates
+        recommendationContext.details.addAll(newDetailContexts)
+        return states
     }
 
-    private fun checkRecommendationsValidity(states: InvocationContext, showHint: Boolean): Boolean {
+    private fun checkRecommendationsValidity(states: InvocationContext?, showHint: Boolean): Boolean {
+        if (states == null) return false
         val details = states.recommendationContext.details
 
         // set to true when at least one is not discarded or empty
@@ -604,35 +643,48 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         return hasAtLeastOneValid
     }
 
-    private fun updateCodeWhisperer(states: InvocationContext, recommendationAdded: Boolean) {
-        CodeWhispererPopupManager.getInstance().changeStates(states, 0, "", true, recommendationAdded)
+    private fun updateCodeWhisperer(sessionContext: SessionContext, states: InvocationContext, recommendationAdded: Boolean) {
+        CodeWhispererPopupManager.getInstance().changeStatesForShowing(sessionContext, states, recommendationAdded)
     }
 
-    private fun sendDiscardedUserDecisionEventForAll(
-        requestContext: RequestContext,
-        responseContext: ResponseContext,
-        recommendations: List<Completion>
-    ) {
-        val detailContexts = recommendations.map {
-            DetailContext("", it, it, true, false, "", getCompletionType(it))
+    @RequiresEdt
+    private fun disposeJob(jobId: Int) {
+        ongoingRequests[jobId]?.let { Disposer.dispose(it) }
+        ongoingRequests.remove(jobId)
+        ongoingRequestsContext.remove(jobId)
+    }
+
+    @RequiresEdt
+    fun disposeDisplaySession(accept: Boolean) {
+        // avoid duplicate session disposal logic
+        if (sessionContext == null || sessionContext?.isDisposed() == true) return
+
+        sessionContext?.let {
+            it.hasAccepted = accept
+            Disposer.dispose(it)
         }
-        val recommendationContext = RecommendationContext(detailContexts, "", "", VisualPosition(0, 0))
-
-        CodeWhispererTelemetryService.getInstance().sendUserDecisionEventForAll(
-            requestContext,
-            responseContext,
-            recommendationContext,
-            SessionContext(),
-            false
-        )
+        sessionContext = null
+        val jobIds = ongoingRequests.keys.toList()
+        jobIds.forEach { jobId -> disposeJob(jobId) }
+        ongoingRequests.clear()
+        ongoingRequestsContext.clear()
     }
+
+    fun getAllSuggestionsPreviewInfo() =
+        ongoingRequests.values.filterNotNull().flatMap { element ->
+            val context = element.recommendationContext
+            context.details.map {
+                PreviewContext(context.jobId, it, context.userInputSinceInvocation, context.typeahead)
+            }
+        }
+
+    fun getAllPaginationSessions() = ongoingRequests
 
     fun getRequestContext(
         triggerTypeInfo: TriggerTypeInfo,
         editor: Editor,
         project: Project,
-        psiFile: PsiFile,
-        latencyContext: LatencyContext
+        psiFile: PsiFile
     ): RequestContext {
         // 1. file context
         val fileContext: FileContextInfo = runReadAction { FileContextProvider.getInstance(project).extractFileContext(editor, psiFile) }
@@ -657,7 +709,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         // 5. customization
         val customizationArn = CodeWhispererModelConfigurator.getInstance().activeCustomization(project)?.arn
 
-        return RequestContext(project, editor, triggerTypeInfo, caretPosition, fileContext, supplementalContext, connection, latencyContext, customizationArn)
+        return RequestContext(project, editor, triggerTypeInfo, caretPosition, fileContext, supplementalContext, connection, customizationArn)
     }
 
     fun validateResponse(response: GenerateCompletionsResponse): GenerateCompletionsResponse {
@@ -683,26 +735,18 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         requestContext: RequestContext,
         responseContext: ResponseContext,
         recommendationContext: RecommendationContext,
-        popup: JBPopup
+        coroutine: CoroutineScope
     ): InvocationContext {
-        addPopupChildDisposables(popup)
         // Creating a disposable for managing all listeners lifecycle attached to the popup.
         // previously(before pagination) we use popup as the parent disposable.
         // After pagination, listeners need to be updated as states are updated, for the same popup,
         // so disposable chain becomes popup -> disposable -> listeners updates, and disposable gets replaced on every
         // state update.
-        val states = InvocationContext(requestContext, responseContext, recommendationContext, popup)
-        Disposer.register(popup, states)
-        CodeWhispererPopupManager.getInstance().initPopupListener(states)
-        return states
-    }
-
-    private fun addPopupChildDisposables(popup: JBPopup) {
-        codeInsightSettingsFacade.disableCodeInsightUntil(popup)
-
-        Disposer.register(popup) {
-            CodeWhispererPopupManager.getInstance().reset()
+        val states = InvocationContext(requestContext, responseContext, recommendationContext)
+        Disposer.register(states) {
+            coroutine.cancel(CancellationException("Cancelling the current coroutine when the pagination session context is disposed"))
         }
+        return states
     }
 
     private fun logServiceInvocation(
@@ -742,13 +786,8 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
             return false
         }
 
-        if (CodeWhispererPopupManager.getInstance().hasConflictingPopups(editor)) {
-            LOG.debug { "Find other active popup windows before triggering CodeWhisperer, not invoking service" }
-            return false
-        }
-
-        if (CodeWhispererInvocationStatus.getInstance().isPopupActive()) {
-            LOG.debug { "Find an existing CodeWhisperer popup window before triggering CodeWhisperer, not invoking service" }
+        if (CodeWhispererInvocationStatus.getInstance().isDisplaySessionActive()) {
+            LOG.debug { "Find an existing CodeWhisperer session before triggering CodeWhisperer, not invoking service" }
             return false
         }
         return true
@@ -767,11 +806,13 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
     companion object {
         private val LOG = getLogger<CodeWhispererService>()
         private const val MAX_REFRESH_ATTEMPT = 3
+        private const val PAGINATION_REQUEST_COUNT_ALLOWED = 1
 
         val CODEWHISPERER_CODE_COMPLETION_PERFORMED: Topic<CodeWhispererCodeCompletionServiceListener> = Topic.create(
             "CodeWhisperer code completion service invoked",
             CodeWhispererCodeCompletionServiceListener::class.java
         )
+        val DATA_KEY_SESSION = DataKey.create<SessionContext>("codewhisperer.session")
 
         fun getInstance(): CodeWhispererService = service()
         const val KET_SESSION_ID = "x-amzn-SessionId"
@@ -828,7 +869,6 @@ data class RequestContext(
     val fileContextInfo: FileContextInfo,
     private val supplementalContextDeferred: Deferred<SupplementalContextInfo?>,
     val connection: ToolkitConnection?,
-    val latencyContext: LatencyContext,
     val customizationArn: String?
 ) {
     // TODO: should make the entire getRequestContext() suspend function instead of making supplemental context only
@@ -842,7 +882,6 @@ data class RequestContext(
                     null
                 }
             }
-
             else -> field
         }
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererCodeCoverageTracker.kt
@@ -24,6 +24,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.customization.Code
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhispererProgrammingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.FileContextInfo
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
+import software.aws.toolkits.jetbrains.services.codewhisperer.model.PreviewContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.SessionContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.CodeWhispererPopupManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.CodeWhispererUserActionListener
@@ -80,7 +81,7 @@ abstract class CodeWhispererCodeCoverageTracker(
         conn.subscribe(
             CodeWhispererPopupManager.CODEWHISPERER_USER_ACTION_PERFORMED,
             object : CodeWhispererUserActionListener {
-                override fun afterAccept(states: InvocationContext, sessionContext: SessionContext, rangeMarker: RangeMarker) {
+                override fun afterAccept(states: InvocationContext, previews: List<PreviewContext>, sessionContext: SessionContext, rangeMarker: RangeMarker) {
                     if (states.requestContext.fileContextInfo.programmingLanguage != language) return
                     rangeMarkers.add(rangeMarker)
                     val originalRecommendation = extractRangeMarkerString(rangeMarker) ?: return

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceActionListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceActionListener.kt
@@ -5,14 +5,14 @@ package software.aws.toolkits.jetbrains.services.codewhisperer.toolwindow
 
 import com.intellij.openapi.editor.RangeMarker
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
+import software.aws.toolkits.jetbrains.services.codewhisperer.model.PreviewContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.SessionContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.CodeWhispererUserActionListener
 
 class CodeWhispererCodeReferenceActionListener : CodeWhispererUserActionListener {
-    override fun afterAccept(states: InvocationContext, sessionContext: SessionContext, rangeMarker: RangeMarker) {
-        val (project, editor) = states.requestContext
-        val manager = CodeWhispererCodeReferenceManager.getInstance(project)
-        manager.insertCodeReference(states, sessionContext.selectedIndex)
-        manager.addListeners(editor)
+    override fun afterAccept(states: InvocationContext, previews: List<PreviewContext>, sessionContext: SessionContext, rangeMarker: RangeMarker) {
+        val manager = CodeWhispererCodeReferenceManager.getInstance(sessionContext.project)
+        manager.insertCodeReference(states, previews, sessionContext.selectedIndex)
+        manager.addListeners(sessionContext.editor)
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/toolwindow/CodeWhispererCodeReferenceManager.kt
@@ -31,6 +31,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhisper
 import software.aws.toolkits.jetbrains.services.codewhisperer.layout.CodeWhispererLayoutConfig.horizontalPanelConstraints
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretPosition
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.InvocationContext
+import software.aws.toolkits.jetbrains.services.codewhisperer.model.PreviewContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererColorUtil.EDITOR_CODE_REFERENCE_HOVER
 import software.aws.toolkits.resources.message
 import javax.swing.JLabel
@@ -109,11 +110,15 @@ class CodeWhispererCodeReferenceManager(private val project: Project) {
         }
     }
 
-    fun insertCodeReference(states: InvocationContext, selectedIndex: Int) {
-        val (requestContext, _, recommendationContext) = states
-        val (_, editor, _, caretPosition) = requestContext
-        val (_, detail, reformattedDetail) = recommendationContext.details[selectedIndex]
-        insertCodeReference(detail.content(), reformattedDetail.references(), editor, caretPosition, detail)
+    fun insertCodeReference(states: InvocationContext, previews: List<PreviewContext>, selectedIndex: Int) {
+        val detail = previews[selectedIndex].detail
+        insertCodeReference(
+            detail.recommendation.content(),
+            detail.reformatted.references(),
+            states.requestContext.editor,
+            states.requestContext.caretPosition,
+            detail.recommendation
+        )
     }
 
     fun getReferenceLineNums(editor: Editor, start: Int, end: Int): String {


### PR DESCRIPTION
1. Since the shift from displaying one trigger at a time to displaying multiple triggers at a time, use SessionContext as the disposable for the session states.
2. Introduce the concept of "display session" which can show multiple triggers at a time and sessionContext is to hold states for that session.
3. ongoingRequests will be a map of <jobId, InvocationContext> where InvocationContext is the state of each trigger.
4. Managed these states globally by dynamically adding Trigger states into ongoingRequests and whenever the user made a decision(accept or reject), conclude decisions for all the ongoing triggers and clear ongoingRequest, so that a new display session can start later.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
