### PR TITLE
Fix region selector drop-down getting cut off by page

### DIFF
--- a/.changes/next-release/bugfix-d9d08006-1735-45dc-b030-ca52ed6808ad.json
+++ b/.changes/next-release/bugfix-d9d08006-1735-45dc-b030-ca52ed6808ad.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue where the SSO region selector dropdown was getting cut off at the bottom of the window"
+}

--- a/plugins/core/webview/src/q-ui/components/ssoLoginForm.vue
+++ b/plugins/core/webview/src/q-ui/components/ssoLoginForm.vue
@@ -39,6 +39,10 @@
                 name="regions"
                 v-model="selectedRegion"
                 @change="handleRegionInput"
+                size="1"
+                onfocus='this.size=10;'
+                onblur='this.size=1;'
+                onchange='this.size=1; this.blur();'
                 tabindex="0"
             >
                 <option v-for="region in regions" :key="region.id" :value="region.id">
@@ -156,6 +160,26 @@ export default defineComponent({
     margin-bottom: 5px;
     margin-top: 5px;
     font-size: 12px;
+}
+
+.region-select {
+    height: auto;
+    box-sizing: border-box;
+    border-radius: 4px;
+    padding: 5px;
+}
+
+.region-select option {
+    padding: 5px;
+    cursor: pointer;
+    width: auto;
+    box-sizing: border-box;
+}
+
+.region-select:focus {
+    width: auto !important;
+    outline: none;
+    position: absolute;
 }
 
 .invalid-start-url {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Changed the behavior of the select element in the WebView for SSO login pages-- this fix applies both to the Q SSO and the Toolkit SSO pages.

Previously the dropdown could render the bottom of the list offscreen where users could not select the bottom options with their mouse. This fix allows users to now be able to see and scroll to the bottom of the list.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
