### PR TITLE
Fix case where user gets stuck while logging into Builder ID

### DIFF
--- a/.changes/next-release/bugfix-566abe4c-547f-413b-b1c8-838282782550.json
+++ b/.changes/next-release/bugfix-566abe4c-547f-413b-b1c8-838282782550.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue where a user may never be able to login to Builder ID again"
+}

--- a/.changes/next-release/bugfix-566abe4c-547f-413b-b1c8-838282782550.json
+++ b/.changes/next-release/bugfix-566abe4c-547f-413b-b1c8-838282782550.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Fix issue where a user may never be able to login to Builder ID again"
+  "description" : "Fix issue where a user may get stuck while attempting to login to Builder ID"
 }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitConnectionManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitConnectionManager.kt
@@ -98,8 +98,7 @@ class DefaultToolkitConnectionManager : ToolkitConnectionManager, PersistentStat
     }
 
     override fun getState() = ToolkitConnectionManagerState(
-//        connection?.id
-        null
+        connection?.id
     )
 
     override fun loadState(state: ToolkitConnectionManagerState) {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitConnectionManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitConnectionManager.kt
@@ -60,6 +60,10 @@ class DefaultToolkitConnectionManager : ToolkitConnectionManager, PersistentStat
             return null
         }
 
+    @Deprecated(
+        "Fragile API. Probably leads to unexpected behavior. Use only for toolkit explorer dropdown state.",
+        replaceWith = ReplaceWith("activeConnectionForFeature(feature)")
+    )
     @Synchronized
     override fun activeConnection() = connection ?: defaultConnection
 
@@ -71,11 +75,11 @@ class DefaultToolkitConnectionManager : ToolkitConnectionManager, PersistentStat
         }
 
         return connection?.let {
-            if (feature.supportsConnectionType(it)) {
-                return it
+            return@let if (feature.supportsConnectionType(it)) {
+                it
+            } else {
+                null
             }
-
-            null
         } ?: defaultConnection?.let {
             if (ApplicationInfo.getInstance().build.productCode == "GW") return null
             if (feature.supportsConnectionType(it)) {
@@ -94,7 +98,8 @@ class DefaultToolkitConnectionManager : ToolkitConnectionManager, PersistentStat
     }
 
     override fun getState() = ToolkitConnectionManagerState(
-        connection?.id
+//        connection?.id
+        null
     )
 
     override fun loadState(state: ToolkitConnectionManagerState) {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitConnectionManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitConnectionManager.kt
@@ -19,6 +19,16 @@ import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenPr
 // TODO: unify with AwsConnectionManager
 @State(name = "connectionManager", storages = [Storage("aws.xml")])
 class DefaultToolkitConnectionManager : ToolkitConnectionManager, PersistentStateComponent<ToolkitConnectionManagerState> {
+    private val project: Project?
+
+    constructor(project: Project) {
+        this.project = project
+    }
+
+    constructor() {
+        this.project = null
+    }
+
     init {
         ApplicationManager.getApplication().messageBus.connect(this).subscribe(
             BearerTokenProviderListener.TOPIC,
@@ -33,19 +43,10 @@ class DefaultToolkitConnectionManager : ToolkitConnectionManager, PersistentStat
         )
     }
 
-    private val project: Project?
-
-    constructor(project: Project) {
-        this.project = project
-    }
-
-    constructor() {
-        this.project = null
-    }
-
     private var connection: ToolkitConnection? = null
 
-    private val pinningManager: ConnectionPinningManager = ConnectionPinningManager.getInstance()
+    private val pinningManager
+        get() = ConnectionPinningManager.getInstance()
 
     private val defaultConnection: ToolkitConnection?
         get() {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
@@ -89,7 +89,10 @@ interface ToolkitStartupAuthFactory {
 }
 
 interface ToolkitConnectionManager : Disposable {
-    @Deprecated("Fragile API. Probably leads to unexpected behavior. Use only for toolkit explorer dropdown state.", ReplaceWith("activeConnectionForFeature(feature)"))
+    @Deprecated(
+        "Fragile API. Probably leads to unexpected behavior. Use only for toolkit explorer dropdown state.",
+        ReplaceWith("activeConnectionForFeature(feature)")
+    )
     fun activeConnection(): ToolkitConnection?
 
     fun activeConnectionForFeature(feature: FeatureWithPinnedConnection): ToolkitConnection?

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
@@ -180,7 +180,8 @@ fun loginSso(
             project = project,
             connection = connection,
             onPendingToken = onPendingToken,
-            isReAuth = true
+            isReAuth = true,
+            source = metadata?.sourceId,
         )
         return@let connection
     }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -220,8 +220,6 @@ abstract class LoginBrowser(
             Login
                 .BuilderId(scopes, onPendingToken, onError, onSuccess)
                 .login(project)
-
-            // TODO refresh the pane here for case when provider is no-op (i.e. provider exists and has a valid token), to fix issue where user is stuck waiting for browser
         }
     }
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -220,6 +220,8 @@ abstract class LoginBrowser(
             Login
                 .BuilderId(scopes, onPendingToken, onError, onSuccess)
                 .login(project)
+
+            // TODO refresh the pane here for case when provider is no-op (i.e. provider exists and has a valid token), to fix issue where user is stuck waiting for browser
         }
     }
 


### PR DESCRIPTION
If user ends up in state where they have a connection, but extension doesn't think it's valid for Q, then the sign-in flow will never complete and they need to restart the IDE for the new token to be picked up
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
