### PR TITLE
Fix 404 on SSO callback handler

### DIFF
--- a/.changes/next-release/bugfix-10275db3-073a-4531-8559-98071108341f.json
+++ b/.changes/next-release/bugfix-10275db3-073a-4531-8559-98071108341f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue where multiple SSO login attempts in a short time result in 404"
+}

--- a/plugins/core/jetbrains-community/resources/oauthCallback/index.html
+++ b/plugins/core/jetbrains-community/resources/oauthCallback/index.html
@@ -8,6 +8,7 @@
     <title>AWS Authentication</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" media="screen" href="auth.css" />
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
 </head>
 
 <body>


### PR DESCRIPTION
Browsers would attempt to request `favicon.ico` which fail all request chains, leading to platform fallback to `BuiltInWebServer`/`DefaultWebServerPathHandler`.

This would be fine, except the platform webserver respects the browser's `Connection: keep-alive` flag and keep sthe Netty channel open, and subsequent requests to `.../oauthCallback/...` get handled by `DefaultWebServerPathHandler` and always return 404.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
