### PR TITLE
feat(amazonq) change legal text in prompt UI footer

### DIFF
--- a/.changes/next-release/feature-7c035aa7-49fc-4179-8287-bb94928249e2.json
+++ b/.changes/next-release/feature-7c035aa7-49fc-4179-8287-bb94928249e2.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Updated legal disclaimer text"
+}

--- a/.changes/next-release/feature-7c035aa7-49fc-4179-8287-bb94928249e2.json
+++ b/.changes/next-release/feature-7c035aa7-49fc-4179-8287-bb94928249e2.json
@@ -1,4 +1,4 @@
 {
   "type" : "feature",
-  "description" : "Updated legal disclaimer text"
+  "description" : "Amazon Q Developer: Updated legal disclaimer text"
 }

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/tabs/generator.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/tabs/generator.ts
@@ -72,7 +72,7 @@ I can help you upgrade your Java 8 and 11 codebases to Java 17.
         return {
             tabTitle: taskName ?? this.tabTitle.get(tabType),
             promptInputInfo:
-                'Use of Amazon Q is subject to the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
+                'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
             quickActionCommands: this.quickActionsGenerator.generateForTab(tabType),
             promptInputPlaceholder: this.tabInputPlaceholder.get(tabType),
             contextCommands: [


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Updated the legal disclaimer text in the footer of the chat client. This is done as a clarification of compliant use according to the AWS AI policy.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
