### PR TITLE
feat(amazonq): loosen inline suggestion restriction for json/yaml files

### DIFF
--- a/.changes/next-release/feature-fd316552-7161-43bf-aaa5-e1ac1330b939.json
+++ b/.changes/next-release/feature-fd316552-7161-43bf-aaa5-e1ac1330b939.json
@@ -1,4 +1,4 @@
 {
   "type" : "feature",
-  "description" : "Loose inline completion support limitation for yaml/json files"
+  "description" : "Loosen inline completion support limitations for YAML/JSON"
 }

--- a/.changes/next-release/feature-fd316552-7161-43bf-aaa5-e1ac1330b939.json
+++ b/.changes/next-release/feature-fd316552-7161-43bf-aaa5-e1ac1330b939.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Loose inline completion support limitation for yaml/json files"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -114,7 +114,7 @@ object CodeWhispererEditorUtil {
     fun isSupportedJsonFormat(fileName: String, leftContext: String, language: CodeWhispererProgrammingLanguage): Boolean =
         (language is CodeWhispererJson) &&
             (
-                JsonConfigFileNamingConvention.contains(fileName) ||
+                JsonConfigFileNamingConvention.contains(fileName.lowercase()) ||
                     AWSTemplateKeyWordsRegex.containsMatchIn(leftContext) ||
                     AWSTemplateCaseInsensitiveKeyWordsRegex.containsMatchIn(leftContext.lowercase(Locale.getDefault()))
                 )

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -111,7 +111,7 @@ object CodeWhispererEditorUtil {
     /**
      * Checks if the language is json and checks if left context contains keywords
      */
-    fun isConfigFileIfJsonFile(fileName: String, leftContext: String, language: CodeWhispererProgrammingLanguage): Boolean =
+    fun isSupportedJsonFormat(fileName: String, leftContext: String, language: CodeWhispererProgrammingLanguage): Boolean =
         (language is CodeWhispererJson) &&
             (
                 JsonConfigFileNamingConvention.contains(fileName) ||

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -19,9 +19,12 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretPosition
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.FileContextInfo
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.AWSTemplateCaseInsensitiveKeyWordsRegex
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.AWSTemplateKeyWordsRegex
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.JsonConfigFileNamingConvention
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.LEFT_CONTEXT_ON_CURRENT_LINE
 import java.awt.Point
+import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 
@@ -108,8 +111,13 @@ object CodeWhispererEditorUtil {
     /**
      * Checks if the language is json and checks if left context contains keywords
      */
-    fun isConfigFileIfJsonFile(fileName: String, language: CodeWhispererProgrammingLanguage): Boolean =
-        (language is CodeWhispererJson) && JsonConfigFileNamingConvention.contains(fileName)
+    fun isConfigFileIfJsonFile(fileName: String, leftContext: String, language: CodeWhispererProgrammingLanguage): Boolean =
+        (language is CodeWhispererJson) &&
+            (
+                JsonConfigFileNamingConvention.contains(fileName) ||
+                    AWSTemplateKeyWordsRegex.containsMatchIn(leftContext) ||
+                    AWSTemplateCaseInsensitiveKeyWordsRegex.containsMatchIn(leftContext.lowercase(Locale.getDefault()))
+                )
 
     /**
      * Checks if the [otherRange] overlaps this TextRange. Note that the comparison is `<` because the endOffset of TextRange is exclusive.

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -111,13 +111,12 @@ object CodeWhispererEditorUtil {
     /**
      * Checks if the language is json and checks if left context contains keywords
      */
-    fun isSupportedJsonFormat(fileName: String, leftContext: String, language: CodeWhispererProgrammingLanguage): Boolean =
-        (language is CodeWhispererJson) &&
-            (
-                JsonConfigFileNamingConvention.contains(fileName.lowercase()) ||
-                    AWSTemplateKeyWordsRegex.containsMatchIn(leftContext) ||
-                    AWSTemplateCaseInsensitiveKeyWordsRegex.containsMatchIn(leftContext.lowercase(Locale.getDefault()))
-                )
+    fun isSupportedJsonFormat(fileName: String, leftContext: String, language: CodeWhispererProgrammingLanguage): Boolean {
+        assert(language is CodeWhispererJson)
+        return JsonConfigFileNamingConvention.contains(fileName.lowercase()) ||
+            AWSTemplateKeyWordsRegex.containsMatchIn(leftContext) ||
+            AWSTemplateCaseInsensitiveKeyWordsRegex.containsMatchIn(leftContext.lowercase(Locale.getDefault()))
+    }
 
     /**
      * Checks if the [otherRange] overlaps this TextRange. Note that the comparison is `<` because the endOffset of TextRange is exclusive.

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -12,8 +12,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.psi.PsiFile
 import com.intellij.ui.popup.AbstractPopup
-import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhispererProgrammingLanguage
-import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererJson
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.programmingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretPosition
@@ -109,14 +107,12 @@ object CodeWhispererEditorUtil {
     }
 
     /**
-     * Checks if the language is json and checks if left context contains keywords
+     * Check if left context contains keywords or file name follow config json file naming pattern
      */
-    fun isSupportedJsonFormat(fileName: String, leftContext: String, language: CodeWhispererProgrammingLanguage): Boolean {
-        assert(language is CodeWhispererJson)
-        return JsonConfigFileNamingConvention.contains(fileName.lowercase()) ||
+    fun isSupportedJsonFormat(fileName: String, leftContext: String): Boolean =
+        JsonConfigFileNamingConvention.contains(fileName.lowercase()) ||
             AWSTemplateKeyWordsRegex.containsMatchIn(leftContext) ||
             AWSTemplateCaseInsensitiveKeyWordsRegex.containsMatchIn(leftContext.lowercase(Locale.getDefault()))
-    }
 
     /**
      * Checks if the [otherRange] overlaps this TextRange. Note that the comparison is `<` because the endOffset of TextRange is exclusive.

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -12,16 +12,16 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.psi.PsiFile
 import com.intellij.ui.popup.AbstractPopup
+import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhispererProgrammingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererJson
-import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererYaml
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.programmingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretPosition
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.FileContextInfo
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.JsonConfigFileNamingConvention
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.LEFT_CONTEXT_ON_CURRENT_LINE
 import java.awt.Point
-import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 
@@ -106,16 +106,10 @@ object CodeWhispererEditorUtil {
     }
 
     /**
-     * Checks if the language is json or yaml and checks if left context contains keywords
+     * Checks if the language is json and checks if left context contains keywords
      */
-    fun checkLeftContextKeywordsForJsonAndYaml(leftContext: String, language: String): Boolean = (
-        (language == CodeWhispererJson.INSTANCE.languageId) ||
-            (language == CodeWhispererYaml.INSTANCE.languageId)
-        ) &&
-        (
-            (!CodeWhispererConstants.AWSTemplateKeyWordsRegex.containsMatchIn(leftContext)) &&
-                (!CodeWhispererConstants.AWSTemplateCaseInsensitiveKeyWordsRegex.containsMatchIn(leftContext.lowercase(Locale.getDefault())))
-            )
+    fun isConfigFileIfJsonFile(fileName: String, language: CodeWhispererProgrammingLanguage): Boolean =
+        (language is CodeWhispererJson) && JsonConfigFileNamingConvention.contains(fileName)
 
     /**
      * Checks if the [otherRange] overlaps this TextRange. Note that the comparison is `<` because the endOffset of TextRange is exclusive.

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -170,7 +170,8 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         }
 
         val language = requestContext.fileContextInfo.programmingLanguage
-        if (!language.isCodeCompletionSupported() || !(isConfigFileIfJsonFile(requestContext.fileContextInfo.filename, language))) {
+        val leftContext = requestContext.fileContextInfo.caretContext.leftFileContext
+        if (!language.isCodeCompletionSupported() || !isConfigFileIfJsonFile(requestContext.fileContextInfo.filename, leftContext, language)) {
             LOG.debug { "Programming language $language is not supported by CodeWhisperer" }
             if (triggerTypeInfo.triggerType == CodewhispererTriggerType.OnDemand) {
                 showCodeWhispererInfoHint(

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -172,11 +172,13 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
 
         val language = requestContext.fileContextInfo.programmingLanguage
         val leftContext = requestContext.fileContextInfo.caretContext.leftFileContext
-        if (!language.isCodeCompletionSupported() || (language is CodeWhispererJson && !isSupportedJsonFormat(
-                requestContext.fileContextInfo.filename,
-                leftContext,
-                language
-            ))
+        if (!language.isCodeCompletionSupported() || (
+                language is CodeWhispererJson && !isSupportedJsonFormat(
+                    requestContext.fileContextInfo.filename,
+                    leftContext,
+                    language
+                )
+                )
         ) {
             LOG.debug { "Programming language $language is not supported by CodeWhisperer" }
             if (triggerTypeInfo.triggerType == CodewhispererTriggerType.OnDemand) {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -56,7 +56,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWh
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.getCaretPosition
-import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.isConfigFileIfJsonFile
+import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.isSupportedJsonFormat
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhispererEnabled
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretPosition
@@ -171,7 +171,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
 
         val language = requestContext.fileContextInfo.programmingLanguage
         val leftContext = requestContext.fileContextInfo.caretContext.leftFileContext
-        if (!language.isCodeCompletionSupported() || !isConfigFileIfJsonFile(requestContext.fileContextInfo.filename, leftContext, language)) {
+        if (!language.isCodeCompletionSupported() || !isSupportedJsonFormat(requestContext.fileContextInfo.filename, leftContext, language)) {
             LOG.debug { "Programming language $language is not supported by CodeWhisperer" }
             if (triggerTypeInfo.triggerType == CodewhispererTriggerType.OnDemand) {
                 showCodeWhispererInfoHint(

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -55,7 +55,7 @@ import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeWhispererCon
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererClientAdaptor
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorManager
-import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.checkLeftContextKeywordsForJsonAndYaml
+import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.isConfigFileIfJsonFile
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.getCaretPosition
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhispererEnabled
@@ -170,8 +170,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         }
 
         val language = requestContext.fileContextInfo.programmingLanguage
-        val leftContext = requestContext.fileContextInfo.caretContext.leftFileContext
-        if (!language.isCodeCompletionSupported() || (checkLeftContextKeywordsForJsonAndYaml(leftContext, language.languageId))) {
+        if (!language.isCodeCompletionSupported() || !(isConfigFileIfJsonFile(requestContext.fileContextInfo.filename, language))) {
             LOG.debug { "Programming language $language is not supported by CodeWhisperer" }
             if (triggerTypeInfo.triggerType == CodewhispererTriggerType.OnDemand) {
                 showCodeWhispererInfoHint(

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -175,8 +175,7 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         if (!language.isCodeCompletionSupported() || (
                 language is CodeWhispererJson && !isSupportedJsonFormat(
                     requestContext.fileContextInfo.filename,
-                    leftContext,
-                    language
+                    leftContext
                 )
                 )
         ) {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -55,8 +55,8 @@ import software.aws.toolkits.jetbrains.core.credentials.pinning.CodeWhispererCon
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererClientAdaptor
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorManager
-import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.isConfigFileIfJsonFile
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.getCaretPosition
+import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.isConfigFileIfJsonFile
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhispererEnabled
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretPosition

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -59,6 +59,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhisper
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.isSupportedJsonFormat
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.isCodeWhispererEnabled
+import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererJson
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CaretPosition
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.DetailContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.FileContextInfo
@@ -171,7 +172,12 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
 
         val language = requestContext.fileContextInfo.programmingLanguage
         val leftContext = requestContext.fileContextInfo.caretContext.leftFileContext
-        if (!language.isCodeCompletionSupported() || !isSupportedJsonFormat(requestContext.fileContextInfo.filename, leftContext, language)) {
+        if (!language.isCodeCompletionSupported() || (language is CodeWhispererJson && !isSupportedJsonFormat(
+                requestContext.fileContextInfo.filename,
+                leftContext,
+                language
+            ))
+        ) {
             LOG.debug { "Programming language $language is not supported by CodeWhisperer" }
             if (triggerTypeInfo.triggerType == CodewhispererTriggerType.OnDemand) {
                 showCodeWhispererInfoHint(

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
@@ -33,6 +33,9 @@ object CodeWhispererConstants {
     const val SUPPLEMENTAL_CONTEXT_TIMEOUT = 50L
     const val FEATURE_EVALUATION_PRODUCT_NAME = "CodeWhisperer"
 
+    val AWSTemplateKeyWordsRegex = Regex("(AWSTemplateFormatVersion|Resources|AWS::|Description)")
+    val AWSTemplateCaseInsensitiveKeyWordsRegex = Regex("(cloudformation|cfn|template|description)")
+
     val JsonConfigFileNamingConvention = setOf(
         "app.json",
         "appsettings.json",

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
@@ -33,8 +33,19 @@ object CodeWhispererConstants {
     const val SUPPLEMENTAL_CONTEXT_TIMEOUT = 50L
     const val FEATURE_EVALUATION_PRODUCT_NAME = "CodeWhisperer"
 
-    val AWSTemplateKeyWordsRegex = Regex("(AWSTemplateFormatVersion|Resources|AWS::|Description)")
-    val AWSTemplateCaseInsensitiveKeyWordsRegex = Regex("(cloudformation|cfn|template|description)")
+    val JsonConfigFileNamingConvention = setOf(
+        "app.json",
+        "appsettings.json",
+        "bower.json",
+        "composer.json",
+        "db.json",
+        "manifest.json",
+        "package.json",
+        "schema.json",
+        "settings.json",
+        "tsconfig.json",
+        "vcpkg.json"
+    )
 
     // TODO: this is currently set to 2050 to account for the server side 0.5 TPS and and extra 50 ms buffer to
     // avoid ThrottlingException as much as possible.
@@ -131,6 +142,7 @@ object CodeWhispererConstants {
             }
         }
     }
+
     object CrossFile {
         const val CHUNK_SIZE = 60
         const val NUMBER_OF_LINE_IN_CHUNK = 10
@@ -145,7 +157,7 @@ object CodeWhispererConstants {
     object TryExampleFileContent {
 
         private const val AUTO_TRIGGER_CONTENT_JAVA =
-"""import java.util.ArrayList;
+            """import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,7 +179,7 @@ public class Main {
 }"""
 
         private const val MANUAL_TRIGGER_CONTENT_JAVA =
-"""// TODO: Press either Option + C on MacOS or Alt + C on Windows on a new line.
+            """// TODO: Press either Option + C on MacOS or Alt + C on Windows on a new line.
 
 public class S3Uploader {
     
@@ -178,7 +190,7 @@ public class S3Uploader {
 }"""
 
         private const val UNIT_TEST_CONTENT_JAVA =
-"""// TODO: Ask Amazon Q to write unit tests.
+            """// TODO: Ask Amazon Q to write unit tests.
 
 // Write a test case for the sum function.
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
@@ -80,8 +80,8 @@ class CodeWhispererEditorUtilTest {
     }
 
     @Test
-    fun `test for keyword check for json and yaml`() {
-        val result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("foo.json", leftContext_success_Iac, CodeWhispererJson.INSTANCE)
+    fun `test for keyword check for json`() {
+        val result = CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", leftContext_success_Iac, CodeWhispererJson.INSTANCE)
         assertThat(result).isEqualTo(true)
     }
 
@@ -101,17 +101,17 @@ class CodeWhispererEditorUtilTest {
             "vcpkg.json"
         ]
     )
-    fun `isConfigFileIfJsonFile should return true by file name`(fileName: String) {
-        val result = CodeWhispererEditorUtil.isConfigFileIfJsonFile(fileName, "", CodeWhispererJson.INSTANCE)
+    fun `isSupportedJsonFormat should return true by file name`(fileName: String) {
+        val result = CodeWhispererEditorUtil.isSupportedJsonFormat(fileName, "", CodeWhispererJson.INSTANCE)
         assertThat(result).isEqualTo(true)
     }
 
     @Test
-    fun `isConfigFileIfJsonFile should retrun false due to no match`() {
-        var result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("foo.json", "", CodeWhispererJson.INSTANCE)
+    fun `isSupportedJsonFormat should return false due to no match`() {
+        var result = CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", "", CodeWhispererJson.INSTANCE)
         assertThat(result).isEqualTo(false)
 
-        result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("package.json", "", CodeWhispererYaml.INSTANCE)
+        result = CodeWhispererEditorUtil.isSupportedJsonFormat("package.json", "", CodeWhispererYaml.INSTANCE)
         assertThat(result).isEqualTo(false)
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
@@ -11,16 +11,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.leftContext_success_Iac
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonFileName
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonTestLeftContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil
-import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererJson
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererPython
-import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererYaml
 import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
 
 class CodeWhispererEditorUtilTest {
@@ -82,7 +79,7 @@ class CodeWhispererEditorUtilTest {
 
     @Test
     fun `test for keyword check for json`() {
-        val result = CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", leftContext_success_Iac, CodeWhispererJson.INSTANCE)
+        val result = CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", leftContext_success_Iac)
         assertThat(result).isEqualTo(true)
     }
 
@@ -103,20 +100,13 @@ class CodeWhispererEditorUtilTest {
         ]
     )
     fun `isSupportedJsonFormat should return true by file name`(fileName: String) {
-        val result = CodeWhispererEditorUtil.isSupportedJsonFormat(fileName, "", CodeWhispererJson.INSTANCE)
+        val result = CodeWhispererEditorUtil.isSupportedJsonFormat(fileName, "")
         assertThat(result).isEqualTo(true)
     }
 
     @Test
     fun `isSupportedJsonFormat should return false due to no match`() {
-        val result = CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", "", CodeWhispererJson.INSTANCE)
+        val result = CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", "")
         assertThat(result).isEqualTo(false)
-    }
-
-    @Test
-    fun `isSupportedJsonFormat should throw assertion error if language is not JSON`() {
-        assertThrows<AssertionError> {
-            CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", "", CodeWhispererYaml.INSTANCE)
-        }
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
@@ -11,12 +11,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.leftContext_success_Iac
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonFileName
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonTestLeftContext
-import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.yaml_langauge
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil
+import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererJson
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererPython
+import software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererYaml
 import software.aws.toolkits.jetbrains.utils.rules.PythonCodeInsightTestFixtureRule
 
 class CodeWhispererEditorUtilTest {
@@ -76,12 +78,32 @@ class CodeWhispererEditorUtilTest {
         assertThat(caretContext.leftContextOnCurrentLine).isEqualTo(pythonTestLeftContext)
     }
 
-    /**
-     * Test for keyword checks for json and yaml
-     */
+    @ParameterizedTest
+    @ValueSource(
+        strings = ["app.json",
+            "appsettings.json",
+            "bower.json",
+            "composer.json",
+            "db.json",
+            "manifest.json",
+            "package.json",
+            "schema.json",
+            "settings.json",
+            "tsconfig.json",
+            "vcpkg.json"
+        ]
+    )
+    fun `isConfigFileIfJsonFile should return true`(fileName: String) {
+        val result = CodeWhispererEditorUtil.isConfigFileIfJsonFile(fileName, CodeWhispererJson.INSTANCE)
+        assertThat(result).isEqualTo(true)
+    }
+
     @Test
-    fun `test for keyword check for json and yaml`() {
-        val result = CodeWhispererEditorUtil.checkLeftContextKeywordsForJsonAndYaml(leftContext_success_Iac, yaml_langauge)
+    fun `isConfigFileIfJsonFile should retrun false`() {
+        var result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("foo.json", CodeWhispererJson.INSTANCE)
+        assertThat(result).isEqualTo(false)
+
+        result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("package.json", CodeWhispererYaml.INSTANCE)
         assertThat(result).isEqualTo(false)
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
@@ -87,7 +87,8 @@ class CodeWhispererEditorUtilTest {
 
     @ParameterizedTest
     @ValueSource(
-        strings = ["app.json",
+        strings = [
+            "app.json",
             "appsettings.json",
             "bower.json",
             "composer.json",
@@ -107,7 +108,7 @@ class CodeWhispererEditorUtilTest {
 
     @Test
     fun `isConfigFileIfJsonFile should retrun false due to no match`() {
-        var result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("foo.json", "",CodeWhispererJson.INSTANCE)
+        var result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("foo.json", "", CodeWhispererJson.INSTANCE)
         assertThat(result).isEqualTo(false)
 
         result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("package.json", "", CodeWhispererYaml.INSTANCE)

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.leftContext_success_Iac
@@ -108,10 +109,14 @@ class CodeWhispererEditorUtilTest {
 
     @Test
     fun `isSupportedJsonFormat should return false due to no match`() {
-        var result = CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", "", CodeWhispererJson.INSTANCE)
+        val result = CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", "", CodeWhispererJson.INSTANCE)
         assertThat(result).isEqualTo(false)
+    }
 
-        result = CodeWhispererEditorUtil.isSupportedJsonFormat("package.json", "", CodeWhispererYaml.INSTANCE)
-        assertThat(result).isEqualTo(false)
+    @Test
+    fun `isSupportedJsonFormat should throw assertion error if language is not JSON`() {
+        assertThrows<AssertionError> {
+            CodeWhispererEditorUtil.isSupportedJsonFormat("foo.json", "", CodeWhispererYaml.INSTANCE)
+        }
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererEditorUtilTest.kt
@@ -13,6 +13,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.leftContext_success_Iac
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonFileName
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonTestLeftContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil
@@ -78,6 +79,12 @@ class CodeWhispererEditorUtilTest {
         assertThat(caretContext.leftContextOnCurrentLine).isEqualTo(pythonTestLeftContext)
     }
 
+    @Test
+    fun `test for keyword check for json and yaml`() {
+        val result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("foo.json", leftContext_success_Iac, CodeWhispererJson.INSTANCE)
+        assertThat(result).isEqualTo(true)
+    }
+
     @ParameterizedTest
     @ValueSource(
         strings = ["app.json",
@@ -93,17 +100,17 @@ class CodeWhispererEditorUtilTest {
             "vcpkg.json"
         ]
     )
-    fun `isConfigFileIfJsonFile should return true`(fileName: String) {
-        val result = CodeWhispererEditorUtil.isConfigFileIfJsonFile(fileName, CodeWhispererJson.INSTANCE)
+    fun `isConfigFileIfJsonFile should return true by file name`(fileName: String) {
+        val result = CodeWhispererEditorUtil.isConfigFileIfJsonFile(fileName, "", CodeWhispererJson.INSTANCE)
         assertThat(result).isEqualTo(true)
     }
 
     @Test
-    fun `isConfigFileIfJsonFile should retrun false`() {
-        var result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("foo.json", CodeWhispererJson.INSTANCE)
+    fun `isConfigFileIfJsonFile should retrun false due to no match`() {
+        var result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("foo.json", "",CodeWhispererJson.INSTANCE)
         assertThat(result).isEqualTo(false)
 
-        result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("package.json", CodeWhispererYaml.INSTANCE)
+        result = CodeWhispererEditorUtil.isConfigFileIfJsonFile("package.json", "", CodeWhispererYaml.INSTANCE)
         assertThat(result).isEqualTo(false)
     }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

VSC PR https://github.com/aws/aws-toolkit-vscode/pull/5733

YAML files

- Provide completions for all YAML files.

- Remove any current CloudFormation-only restrictions for YAML


JSON files

- Provide completions for a JSON file if the filename matches one of the below names or the file content matches the CloudFormation regexp.
```
    app.json
    appsettings.json
    bower.json
    composer.json
    db.json
    manifest.json
    package.json
    schema.json
    settings.json
    tsconfig.json
    vcpkg.json
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
