### PR TITLE
Isolate HOME to `build/` directory

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
@@ -70,4 +70,8 @@ tasks.runIde {
     systemProperty("ide.plugins.snapshot.on.unload.fail", true)
     systemProperty("memory.snapshots.path", project.rootDir)
     systemProperty("idea.auto.reload.plugins", false)
+
+    val home = project.layout.buildDirectory.dir("USER_HOME").get()
+    systemProperty("user.home", home)
+    environment("HOME", home)
 }


### PR DESCRIPTION
For testing it is very helpful to isolate sandbox changes to `~/.aws` from the host


 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
