### PR TITLE
Fix sign out button in reauth panel in Q chat

### DIFF
--- a/.changes/next-release/bugfix-e43f051f-5a66-4a46-ac6f-3f351f76cf6e.json
+++ b/.changes/next-release/bugfix-e43f051f-5a66-4a46-ac6f-3f351f76cf6e.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix inability to sign out in reauth view in Q chat panel"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.services.amazonq
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -177,13 +178,15 @@ class QWebviewBrowser(val project: Project, private val parentDisposable: Dispos
                     ToolkitConnectionManager.getInstance(project)
                         .activeConnectionForFeature(QConnection.getInstance()) as? AwsBearerTokenConnection
                     )?.let { connection ->
-                    SsoLogoutAction(connection).actionPerformed(
-                        AnActionEvent.createFromDataContext(
-                            "qBrowser",
-                            null,
-                            DataContext.EMPTY_CONTEXT
+                    runInEdt {
+                        SsoLogoutAction(connection).actionPerformed(
+                            AnActionEvent.createFromDataContext(
+                                "qBrowser",
+                                null,
+                                DataContext.EMPTY_CONTEXT
+                            )
                         )
-                    )
+                    }
                 }
             }
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/actions/SsoLogoutAction.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/actions/SsoLogoutAction.kt
@@ -13,9 +13,11 @@ import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.deleteSsoConnection
 import software.aws.toolkits.jetbrains.core.credentials.logoutFromSsoConnection
 import software.aws.toolkits.resources.AwsCoreBundle
+import software.aws.toolkits.telemetry.UiTelemetry
 
 class SsoLogoutAction(private val value: AwsBearerTokenConnection) : DumbAwareAction(AwsCoreBundle.message("credentials.individual_identity.signout")) {
     override fun actionPerformed(e: AnActionEvent) {
+        UiTelemetry.click(e.project, "signOut")
         if (value is ProfileSsoManagedBearerSsoConnection) {
             val confirmDeletion = MessageDialogBuilder.okCancel(
                 AwsCoreBundle.message("gettingstarted.auth.idc.sign.out.confirmation.title"),


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

1) Fix sign out button in reauth panel in Q chat 
2) Add ui click telemetry for signout
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
