### PR TITLE
Make CW popup showing on hover and IntelliSense popup non-conflicting

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/model/CodeWhispererModel.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/model/CodeWhispererModel.kt
@@ -135,7 +135,7 @@ data class SessionContext(
 ) : Disposable {
     private var isDisposed = false
     init {
-        project.messageBus.connect().subscribe(
+        project.messageBus.connect(this).subscribe(
             CodeWhispererService.CODEWHISPERER_INTELLISENSE_POPUP_ON_HOVER,
             object : CodeWhispererIntelliSenseOnHoverListener {
                 override fun onEnter() {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
@@ -507,9 +507,7 @@ class CodeWhispererPopupManager {
                 if (e.inlay != null) {
                     showPopup(sessionContext, force = true)
                 } else {
-                    sessionContext.project.messageBus.syncPublisher(
-                        CodeWhispererService.CODEWHISPERER_INTELLISENSE_POPUP_ON_HOVER,
-                    ).onEnter()
+                    bringSuggestionInlayToFront(sessionContext.editor, sessionContext.popup, opposite = true)
                 }
                 super.mouseMoved(e)
             }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManager.kt
@@ -29,12 +29,15 @@ import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseMotionListener
 import com.intellij.openapi.editor.event.SelectionEvent
 import com.intellij.openapi.editor.event.SelectionListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.ComponentUtil
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.ui.popup.AbstractPopup
@@ -306,6 +309,20 @@ class CodeWhispererPopupManager {
                 popup.showInBestPositionFor(editor)
             }
         }
+
+        bringSuggestionInlayToFront(editor, popup, !force)
+    }
+
+    fun bringSuggestionInlayToFront(editor: Editor, popup: JBPopup?, opposite: Boolean = false) {
+        val qInlinePopupAlpha = if (opposite) 1f else 0.1f
+        val intelliSensePopupAlpha = if (opposite) 0f else 0.8f
+
+        (popup as AbstractPopup?)?.popupWindow?.let {
+            WindowManager.getInstance().setAlphaModeRatio(it, qInlinePopupAlpha)
+        }
+        ComponentUtil.getWindow(LookupManager.getActiveLookup(editor)?.component)?.let {
+            WindowManager.getInstance().setAlphaModeRatio(it, intelliSensePopupAlpha)
+        }
     }
 
     fun initPopup(): JBPopup = JBPopupFactory.getInstance()
@@ -484,6 +501,20 @@ class CodeWhispererPopupManager {
             window?.addComponentListener(windowListener)
             Disposer.register(sessionContext) { window?.removeComponentListener(windowListener) }
         }
+
+        val suggestionHoverEnterListener: EditorMouseMotionListener = object : EditorMouseMotionListener {
+            override fun mouseMoved(e: EditorMouseEvent) {
+                if (e.inlay != null) {
+                    showPopup(sessionContext, force = true)
+                } else {
+                    sessionContext.project.messageBus.syncPublisher(
+                        CodeWhispererService.CODEWHISPERER_INTELLISENSE_POPUP_ON_HOVER,
+                    ).onEnter()
+                }
+                super.mouseMoved(e)
+            }
+        }
+        editor.addEditorMouseMotionListener(suggestionHoverEnterListener, sessionContext)
     }
 
     private fun updateSelectedRecommendationLabelText(validSelectedIndex: Int, validCount: Int) {
@@ -559,10 +590,6 @@ class CodeWhispererPopupManager {
             it.font = it.font.deriveFont(POPUP_INFO_TEXT_SIZE)
         }
     }
-
-    fun hasConflictingPopups(editor: Editor): Boolean =
-        ParameterInfoController.existsWithVisibleHintForEditor(editor, true) ||
-            LookupManager.getActiveLookup(editor) != null
 
     fun findNewSelectedIndex(isReverse: Boolean, selectedIndex: Int): Int {
         val start = if (selectedIndex == -1) 0 else selectedIndex

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -226,6 +226,10 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
 
         val workerContexts = mutableListOf<WorkerContext>()
 
+        // When session is disposed we will cancel this coroutine. The only places session can get disposed should be
+        // from CodeWhispererService.disposeDisplaySession().
+        // It's possible and ok that coroutine will keep running until the next time we check it's state.
+        // As long as we don't show to the user extra info we are good.
         var lastRecommendationIndex = -1
 
         val job = cs.launch {
@@ -808,6 +812,10 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
             "CodeWhisperer code completion service invoked",
             CodeWhispererCodeCompletionServiceListener::class.java
         )
+        val CODEWHISPERER_INTELLISENSE_POPUP_ON_HOVER: Topic<CodeWhispererIntelliSenseOnHoverListener> = Topic.create(
+            "CodeWhisperer intelliSense popup on hover",
+            CodeWhispererIntelliSenseOnHoverListener::class.java
+        )
         val KEY_SESSION_CONTEXT = Key.create<SessionContext>("codewhisperer.session")
 
         fun getInstance(): CodeWhispererService = service()
@@ -893,4 +901,8 @@ data class ResponseContext(
 
 interface CodeWhispererCodeCompletionServiceListener {
     fun onSuccess(fileContextInfo: FileContextInfo) {}
+}
+
+interface CodeWhispererIntelliSenseOnHoverListener {
+    fun onEnter() {}
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererIntelliSenseAutoTriggerListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/startup/CodeWhispererIntelliSenseAutoTriggerListener.kt
@@ -8,8 +8,13 @@ import com.intellij.codeInsight.lookup.LookupEvent
 import com.intellij.codeInsight.lookup.LookupListener
 import com.intellij.codeInsight.lookup.LookupManagerListener
 import com.intellij.codeInsight.lookup.impl.LookupImpl
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.observable.util.addMouseHoverListener
+import com.intellij.ui.hover.HoverListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutoTriggerService
 import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererAutomatedTriggerType
+import software.aws.toolkits.jetbrains.services.codewhisperer.service.CodeWhispererService
+import java.awt.Component
 
 object CodeWhispererIntelliSenseAutoTriggerListener : LookupManagerListener {
     override fun activeLookupChanged(oldLookup: Lookup?, newLookup: Lookup?) {
@@ -35,5 +40,20 @@ object CodeWhispererIntelliSenseAutoTriggerListener : LookupManagerListener {
                 newLookup.removeLookupListener(this)
             }
         })
+
+        (newLookup as LookupImpl).component.addMouseHoverListener(
+            newLookup,
+            object : HoverListener() {
+                override fun mouseEntered(component: Component, x: Int, y: Int) {
+                    runReadAction {
+                        newLookup.project.messageBus.syncPublisher(
+                            CodeWhispererService.CODEWHISPERER_INTELLISENSE_POPUP_ON_HOVER,
+                        ).onEnter()
+                    }
+                }
+                override fun mouseMoved(component: Component, x: Int, y: Int) {}
+                override fun mouseExited(component: Component) {}
+            }
+        )
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
@@ -117,7 +117,7 @@ class CodeWhispererStatusBarWidget(project: Project) :
             AllIcons.General.BalloonWarning
         } else if (!isQConnected(project)) {
             AllIcons.RunConfigurations.TestState.Run
-        } else if (CodeWhispererInvocationStatus.getInstance().hasExistingInvocation()) {
+        } else if (CodeWhispererInvocationStatus.getInstance().hasExistingServiceInvocation()) {
             // AnimatedIcon can't serialize over remote host
             if (!AppMode.isRemoteDevHost()) {
                 AnimatedIcon.Default()

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
@@ -27,7 +27,7 @@ object CodeWhispererConstants {
     const val LEFT_CONTEXT_ON_CURRENT_LINE = 50
     const val POPUP_INFO_TEXT_SIZE = 11f
     const val POPUP_BUTTON_TEXT_SIZE = 12f
-    const val POPUP_DELAY: Long = 250
+    const val POPUP_DELAY: Long = 50
     const val POPUP_DELAY_CHECK_INTERVAL: Long = 25
     const val IDLE_TIME_CHECK_INTERVAL: Long = 25
     const val SUPPLEMENTAL_CONTEXT_TIMEOUT = 50L

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer.util
 
+import com.intellij.codeInsight.lookup.LookupManager
 import com.intellij.ide.BrowserUtil
 import com.intellij.notification.NotificationAction
 import com.intellij.openapi.application.ApplicationManager
@@ -12,6 +13,8 @@ import com.intellij.openapi.editor.impl.EditorImpl
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.ui.ComponentUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -305,6 +308,12 @@ object CodeWhispererUtil {
                 delay(waitMs)
                 destinationFunction(param)
             }
+        }
+    }
+
+    fun setIntelliSensePopupAlpha(editor: Editor, alpha: Float) {
+        ComponentUtil.getWindow(LookupManager.getActiveLookup(editor)?.component)?.let {
+            WindowManager.getInstance().setAlphaModeRatio(it, alpha)
         }
     }
 }


### PR DESCRIPTION
1. CW popup is hidden by default, on hovering over the suggestion text it will show.
2. On hovering over the suggestion, IntelliSense popup(if it's showing) will increase it's alpha to 0.8
3. Upon typing, make CW hidden and IntelliSense not transparent.


https://github.com/user-attachments/assets/367c5c2e-5132-4230-a712-6dc2cd5149a9



<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
