### PR TITLE
fix inline completion not supported language UI is rendered in background thread

### DIFF
--- a/.changes/next-release/bugfix-34500b24-b177-49b2-a740-3b89dfb1f702.json
+++ b/.changes/next-release/bugfix-34500b24-b177-49b2-a740-3b89dfb1f702.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "fix UI hints when users trigger inline suggestion within a file where Q doesn't support is rendered within background thread"
+  "description" : "Fix error occuring when Amazon Q attempts to show UI hints on manually triggerred inline suggestion (#4929)"
 }

--- a/.changes/next-release/bugfix-34500b24-b177-49b2-a740-3b89dfb1f702.json
+++ b/.changes/next-release/bugfix-34500b24-b177-49b2-a740-3b89dfb1f702.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "fix UI hints when users trigger inline suggestion within a file where Q doesn't support is rendered within background thread"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -409,10 +409,8 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
                     if (requestContext.triggerTypeInfo.triggerType == CodewhispererTriggerType.OnDemand) {
                         // We should only show error hint when CodeWhisperer popup is not visible,
                         // and make it silent if CodeWhisperer popup is showing.
-                        runInEdt {
-                            if (!CodeWhispererInvocationStatus.getInstance().isPopupActive()) {
-                                showCodeWhispererErrorHint(requestContext.editor, displayMessage)
-                            }
+                        if (!CodeWhispererInvocationStatus.getInstance().isPopupActive()) {
+                            showCodeWhispererErrorHint(requestContext.editor, displayMessage)
                         }
                     }
                 }
@@ -754,12 +752,16 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
         return true
     }
 
-    fun showCodeWhispererInfoHint(editor: Editor, message: String) {
-        HintManager.getInstance().showInformationHint(editor, message, HintManager.UNDER)
+    private fun showCodeWhispererInfoHint(editor: Editor, message: String) {
+        runInEdt {
+            HintManager.getInstance().showInformationHint(editor, message, HintManager.UNDER)
+        }
     }
 
-    fun showCodeWhispererErrorHint(editor: Editor, message: String) {
-        HintManager.getInstance().showErrorHint(editor, message, HintManager.UNDER)
+    private fun showCodeWhispererErrorHint(editor: Editor, message: String) {
+        runInEdt {
+            HintManager.getInstance().showErrorHint(editor, message, HintManager.UNDER)
+        }
     }
 
     override fun dispose() {}


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
#4929
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

the following 3 UI calls were not invoked within EDT

https://github.com/aws/aws-toolkit-jetbrains/blob/main/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt#L157

https://github.com/aws/aws-toolkit-jetbrains/blob/main/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt#L177


https://github.com/aws/aws-toolkit-jetbrains/blob/main/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt#L599

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
