### PR TITLE
feat(amazonq): Adding userIntent for insertAtCursor and copyToClipboard events for telemetry.

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/messenger/ChatPromptHandler.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/messenger/ChatPromptHandler.kt
@@ -95,13 +95,13 @@ class ChatPromptHandler(private val telemetryHelper: TelemetryHelper) {
 
                 // Send the Answer message to indicate the end of the response stream
                 val response = ChatMessage(
-                        tabId = tabId,
-                        triggerId = triggerId,
-                        messageId = requestId,
-                        messageType = ChatMessageType.Answer,
-                        followUps = followUps,
-                        userIntent = data.userIntent,
-                    )
+                    tabId = tabId,
+                    triggerId = triggerId,
+                    messageId = requestId,
+                    messageType = ChatMessageType.Answer,
+                    followUps = followUps,
+                    userIntent = data.userIntent,
+                )
 
                 telemetryHelper.setResponseStreamTotalTime(tabId)
                 telemetryHelper.setResponseHasProjectContext(
@@ -133,12 +133,23 @@ class ChatPromptHandler(private val telemetryHelper: TelemetryHelper) {
                 }
             }
             .collect { responseEvent ->
-                processChatEvent(tabId, triggerId, data,
-                    responseEvent, shouldAddIndexInProgressMessage)?.let { emit(it) }
+                processChatEvent(
+                    tabId,
+                    triggerId,
+                    data,
+                    responseEvent,
+                    shouldAddIndexInProgressMessage
+                )?.let { emit(it) }
             }
     }
 
-    private fun processChatEvent(tabId: String, triggerId: String, data: ChatRequestData, event: ChatResponseEvent, shouldAddIndexInProgressMessage: Boolean): ChatMessage? {
+    private fun processChatEvent(
+        tabId: String,
+        triggerId: String,
+        data: ChatRequestData,
+        event: ChatResponseEvent,
+        shouldAddIndexInProgressMessage: Boolean,
+    ): ChatMessage? {
         requestId = event.requestId
         statusCode = event.statusCode
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/messenger/ChatPromptHandler.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/chat/messenger/ChatPromptHandler.kt
@@ -58,7 +58,14 @@ class ChatPromptHandler(private val telemetryHelper: TelemetryHelper) {
             .onStart {
                 // The first thing we always send back is an AnswerStream message to indicate the beginning of a streaming answer
                 val response =
-                    ChatMessage(tabId = tabId, triggerId = triggerId, messageId = requestId, messageType = ChatMessageType.AnswerStream, message = "")
+                    ChatMessage(
+                        tabId = tabId,
+                        triggerId = triggerId,
+                        messageId = requestId,
+                        messageType = ChatMessageType.AnswerStream,
+                        message = "",
+                        userIntent = data.userIntent,
+                    )
 
                 telemetryHelper.setResponseStreamStartTime(tabId)
                 emit(response)
@@ -81,13 +88,20 @@ class ChatPromptHandler(private val telemetryHelper: TelemetryHelper) {
                         messageType = ChatMessageType.AnswerPart,
                         message = responseText.toString(),
                         relatedSuggestions = relatedSuggestions,
+                        userIntent = data.userIntent,
                     )
                     emit(suggestionMessage)
                 }
 
                 // Send the Answer message to indicate the end of the response stream
-                val response =
-                    ChatMessage(tabId = tabId, triggerId = triggerId, messageId = requestId, messageType = ChatMessageType.Answer, followUps = followUps)
+                val response = ChatMessage(
+                        tabId = tabId,
+                        triggerId = triggerId,
+                        messageId = requestId,
+                        messageType = ChatMessageType.Answer,
+                        followUps = followUps,
+                        userIntent = data.userIntent,
+                    )
 
                 telemetryHelper.setResponseStreamTotalTime(tabId)
                 telemetryHelper.setResponseHasProjectContext(
@@ -119,11 +133,12 @@ class ChatPromptHandler(private val telemetryHelper: TelemetryHelper) {
                 }
             }
             .collect { responseEvent ->
-                processChatEvent(tabId, triggerId, responseEvent, shouldAddIndexInProgressMessage)?.let { emit(it) }
+                processChatEvent(tabId, triggerId, data,
+                    responseEvent, shouldAddIndexInProgressMessage)?.let { emit(it) }
             }
     }
 
-    private fun processChatEvent(tabId: String, triggerId: String, event: ChatResponseEvent, shouldAddIndexInProgressMessage: Boolean): ChatMessage? {
+    private fun processChatEvent(tabId: String, triggerId: String, data: ChatRequestData, event: ChatResponseEvent, shouldAddIndexInProgressMessage: Boolean): ChatMessage? {
         requestId = event.requestId
         statusCode = event.statusCode
 
@@ -190,6 +205,7 @@ class ChatPromptHandler(private val telemetryHelper: TelemetryHelper) {
                 messageType = ChatMessageType.AnswerPart,
                 message = message,
                 codeReference = codeReferences,
+                userIntent = data.userIntent,
             )
         } else {
             null

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/messages/CwcMessage.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/messages/CwcMessage.kt
@@ -213,6 +213,7 @@ data class ChatMessage(
     val followUpsHeader: String? = null,
     val relatedSuggestions: List<Suggestion>? = null,
     val codeReference: List<CodeReference>? = null,
+    val userIntent: UserIntent? = null,
 ) : UiMessage(
     tabId = tabId,
     type = "chatMessage",

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/cwChatConnector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/cwChatConnector.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItem, ChatItemAction, ChatItemType, FeedbackPayload } from '@aws/mynah-ui-chat'
+import { ChatItemAction, ChatItemType, FeedbackPayload } from '@aws/mynah-ui-chat'
 import { ExtensionMessage } from '../commands'
 import { CodeReference } from './amazonqCommonsConnector'
 import { TabOpenType, TabsStorage } from '../storages/tabsStorage'
 import { FollowUpGenerator } from '../followUps/generator'
+import { CWCChatItem } from "../connector";
 
 interface ChatPayload {
     chatMessage: string
@@ -17,8 +18,8 @@ interface ChatPayload {
 export interface ConnectorProps {
     sendMessageToExtension: (message: ExtensionMessage) => void
     onMessageReceived?: (tabID: string, messageData: any, needToShowAPIDocsTab: boolean) => void
-    onChatAnswerReceived?: (tabID: string, message: ChatItem) => void
-    onCWCContextCommandMessage: (message: ChatItem, command?: string) => string | undefined
+    onChatAnswerReceived?: (tabID: string, message: CWCChatItem) => void
+    onCWCContextCommandMessage: (message: CWCChatItem, command?: string) => string | undefined
     onError: (tabID: string, message: string, title: string) => void
     onWarning: (tabID: string, message: string, title: string) => void
     onOpenSettingsMessage: (tabID: string) => void
@@ -98,7 +99,8 @@ export class Connector {
         codeReference?: CodeReference[],
         eventId?: string,
         codeBlockIndex?: number,
-        totalCodeBlocks?: number
+        totalCodeBlocks?: number,
+        userIntent?: string,
     ): void => {
         this.sendMessageToExtension({
             tabID: tabID,
@@ -111,6 +113,7 @@ export class Connector {
             eventId,
             codeBlockIndex,
             totalCodeBlocks,
+            userIntent
         })
     }
 
@@ -122,7 +125,8 @@ export class Connector {
         codeReference?: CodeReference[],
         eventId?: string,
         codeBlockIndex?: number,
-        totalCodeBlocks?: number
+        totalCodeBlocks?: number,
+        userIntent?: string,
     ): void => {
         this.sendMessageToExtension({
             tabID: tabID,
@@ -135,6 +139,7 @@ export class Connector {
             eventId,
             codeBlockIndex,
             totalCodeBlocks,
+            userIntent
         })
     }
 
@@ -258,13 +263,14 @@ export class Connector {
                       }
                     : undefined
 
-            const answer: ChatItem = {
+            const answer: CWCChatItem = {
                 type: messageData.messageType,
                 messageId: messageData.messageId ?? messageData.triggerID,
                 body: messageData.message,
                 followUp: followUps,
                 canBeVoted: true,
                 codeReference: messageData.codeReference,
+                userIntent: messageData.userIntent,
             }
 
             // If it is not there we will not set it
@@ -291,12 +297,13 @@ export class Connector {
             return
         }
         if (messageData.messageType === ChatItemType.ANSWER) {
-            const answer: ChatItem = {
+            const answer: CWCChatItem = {
                 type: messageData.messageType,
                 body: undefined,
                 relatedContent: undefined,
                 messageId: messageData.messageId,
                 codeReference: messageData.codeReference,
+                userIntent: messageData.userIntent,
                 followUp:
                     messageData.followUps !== undefined && messageData.followUps.length > 0
                         ? {

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
@@ -30,6 +30,10 @@ export interface ChatPayload {
     chatCommand?: string
 }
 
+export interface CWCChatItem extends ChatItem {
+    userIntent?: string
+}
+
 export interface ConnectorProps {
     sendMessageToExtension: (message: ExtensionMessage) => void
     onMessageReceived?: (tabID: string, messageData: any, needToShowAPIDocsTab: boolean) => void
@@ -230,7 +234,8 @@ export class Connector {
         codeReference?: CodeReference[],
         eventId?: string,
         codeBlockIndex?: number,
-        totalCodeBlocks?: number
+        totalCodeBlocks?: number,
+        userIntent?: string
     ): void => {
         switch (this.tabsStorage.getTab(tabID)?.type) {
             case 'cwc':
@@ -242,7 +247,8 @@ export class Connector {
                     codeReference,
                     eventId,
                     codeBlockIndex,
-                    totalCodeBlocks
+                    totalCodeBlocks,
+                    userIntent
                 )
                 break
             case 'featuredev':
@@ -259,7 +265,8 @@ export class Connector {
         codeReference?: CodeReference[],
         eventId?: string,
         codeBlockIndex?: number,
-        totalCodeBlocks?: number
+        totalCodeBlocks?: number,
+        userIntent?: string
     ): void => {
         switch (this.tabsStorage.getTab(tabID)?.type) {
             case 'cwc':
@@ -271,7 +278,8 @@ export class Connector {
                     codeReference,
                     eventId,
                     codeBlockIndex,
-                    totalCodeBlocks
+                    totalCodeBlocks,
+                    userIntent
                 )
                 break
             case 'featuredev':


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem
`cwsprChatUserIntent` is returning undefined for `amazonq_interactWithMessage` event. This event is emitted for insert_code_at_cursor_position, code_was_copied_to_clipboard etc. 


### Solution
- Storing the mapping of `messageId: UserIntent` and sending this if user clicked on `insert at cursor` or `copy to clipboard` events.
- Replaced deprecated `onCodeInsertToCursorPosition` and `onCopyCodeToClipboard` functions with `onCodeBlockActionClicked`.


## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
