### PR TITLE
feat(amazonq): Automatically pause and resume @workspace indexing when OS CPU load is high

### DIFF
--- a/.changes/next-release/feature-ac28b77d-4b47-4312-afe7-ece71de355ed.json
+++ b/.changes/next-release/feature-ac28b77d-4b47-4312-afe7-ece71de355ed.json
@@ -1,4 +1,4 @@
 {
-  "type" : "feature",
+  "type" : "bugfix",
   "description" : "Automatically pause and resume @workspace indexing when OS CPU load is high"
 }

--- a/.changes/next-release/feature-ac28b77d-4b47-4312-afe7-ece71de355ed.json
+++ b/.changes/next-release/feature-ac28b77d-4b47-4312-afe7-ece71de355ed.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Automatically pause and resume @workspace indexing when OS CPU load is high"
+  "description" : "Automatically pause and resume `@workspace` indexing when OS CPU load is high"
 }

--- a/.changes/next-release/feature-ac28b77d-4b47-4312-afe7-ece71de355ed.json
+++ b/.changes/next-release/feature-ac28b77d-4b47-4312-afe7-ece71de355ed.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Automatically pause and resume @workspace indexing when OS CPU load is high"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/manifest/ManifestManager.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/manifest/ManifestManager.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.jetbrains.core.getTextFromUrl
 
 class ManifestManager {
     private val cloudFrontUrl = "https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json"
-    val currentVersion = "0.1.10"
+    val currentVersion = "0.1.13"
     val currentOs = getOs()
     private val arch = CpuArch.CURRENT
     private val mapper = jacksonObjectMapper()


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
If the customer machine is under heavy CPU load, the `@workspace` indexing can cause slowness. 

When the user's OS is under heavy load, we pause the `@workspace` indexing and resumes when it is low. This is to avoid slowing down customer's device. If the customer opened multiple intelliJ instances at the same time while all these instances somehow starts vector indexing at the same time, then only the first 1 or 2 instances will get the CPU resource allocation while the others keeps waiting until the CPU load is down to a reasonable rate 



## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
