### PR TITLE
fix(amazonq): raise max @workspace indexing size to 4GB

### DIFF
--- a/.changes/next-release/bugfix-e76aa3d8-3d9a-4887-8ce6-018ed4c7c443.json
+++ b/.changes/next-release/bugfix-e76aa3d8-3d9a-4887-8ce6-018ed4c7c443.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Raise max @workspace indexing size to 4GB"
+  "description" : "Raise max `@workspace` indexing size to 4GB"
 }

--- a/.changes/next-release/bugfix-e76aa3d8-3d9a-4887-8ce6-018ed4c7c443.json
+++ b/.changes/next-release/bugfix-e76aa3d8-3d9a-4887-8ce6-018ed4c7c443.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Raise max @workspace indexing size to 4GB"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererConfigurable.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererConfigurable.kt
@@ -124,7 +124,7 @@ class CodeWhispererConfigurable(private val project: Project) :
 
             row(message("aws.settings.codewhisperer.project_context_index_max_size")) {
                 intTextField(
-                    range = IntRange(1, 250)
+                    range = IntRange(1, 4096)
                 ).bindIntText(codeWhispererSettings::getProjectContextIndexMaxSize, codeWhispererSettings::setProjectContextIndexMaxSize)
                     .align(AlignX.FILL).apply {
                         connect.subscribe(

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererSettings.kt
@@ -87,7 +87,7 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
 
     fun getProjectContextIndexMaxSize(): Int = state.intValue.getOrDefault(
         CodeWhispererIntConfigurationType.ProjectContextIndexMaxSize,
-        200
+        250
     )
 
     fun setProjectContextIndexMaxSize(value: Int) {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
1. The maximum allowed indexing sizes should not be 250MB. Tentatively setting it to 4GB. 
2. Raise the default `@workspace` indexing size to 250MB. 

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
