### PR TITLE
Support more options for running with `runIdeVariant`

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -7,8 +7,16 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 
-
-enum class IdeFlavor { GW, IC, IU, RD }
+/** The subset of [org.jetbrains.intellij.platform.gradle.IntelliJPlatformType] that are relevant to us **/
+enum class IdeFlavor {
+    GW,
+    /* free */
+    AI, IC, PC,
+    /* paid */
+    /* RR is 'non-commerical free' but treat as paid */
+    DB, CL, GO, IU, PS, PY, RM, RR, WS,
+    RD,
+}
 
 object IdeVersions {
     private val commonPlugins = listOf(
@@ -21,7 +29,6 @@ object IdeVersions {
         Profile(
             name = "2023.3",
             community = ProductProfile(
-                sdkFlavor = IdeFlavor.IC,
                 sdkVersion = "2023.3",
                 bundledPlugins = commonPlugins + listOf(
                     "com.intellij.java",
@@ -34,7 +41,6 @@ object IdeVersions {
                 )
             ),
             ultimate = ProductProfile(
-                sdkFlavor = IdeFlavor.IU,
                 sdkVersion = "2023.3",
                 bundledPlugins = commonPlugins + listOf(
                     "JavaScript",
@@ -58,7 +64,6 @@ object IdeVersions {
         Profile(
             name = "2024.1",
             community = ProductProfile(
-                sdkFlavor = IdeFlavor.IC,
                 sdkVersion = "2024.1",
                 bundledPlugins = commonPlugins + listOf(
                     "com.intellij.java",
@@ -72,7 +77,6 @@ object IdeVersions {
                 )
             ),
             ultimate = ProductProfile(
-                sdkFlavor = IdeFlavor.IU,
                 sdkVersion = "2024.1",
                 bundledPlugins = commonPlugins + listOf(
                     "JavaScript",
@@ -97,12 +101,10 @@ object IdeVersions {
         Profile(
             name = "2024.2",
             gateway = ProductProfile(
-                sdkFlavor = IdeFlavor.GW,
                 sdkVersion = "242.20224-EAP-CANDIDATE-SNAPSHOT",
                 bundledPlugins = listOf("org.jetbrains.plugins.terminal")
             ),
             community = ProductProfile(
-                sdkFlavor = IdeFlavor.IC,
                 sdkVersion = "2024.2",
                 bundledPlugins = commonPlugins + listOf(
                     "com.intellij.java",
@@ -116,7 +118,6 @@ object IdeVersions {
                 )
             ),
             ultimate = ProductProfile(
-                sdkFlavor = IdeFlavor.IU,
                 sdkVersion = "2024.2",
                 bundledPlugins = commonPlugins + listOf(
                     "JavaScript",
@@ -151,7 +152,6 @@ object IdeVersions {
 }
 
 open class ProductProfile(
-    val sdkFlavor: IdeFlavor,
     val sdkVersion: String,
     val bundledPlugins: List<String> = emptyList(),
     val marketplacePlugins: List<String> = emptyList()
@@ -164,7 +164,7 @@ class RiderProfile(
     val nugetVersion: String, // https://www.nuget.org/packages/JetBrains.Rider.SDK/
     bundledPlugins: List<String> = emptyList(),
     marketplacePlugins: List<String> = emptyList(),
-) : ProductProfile(IdeFlavor.RD, sdkVersion, bundledPlugins, marketplacePlugins)
+) : ProductProfile(sdkVersion, bundledPlugins, marketplacePlugins)
 
 class Profile(
     val name: String,

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/ToolkitIntelliJExtension.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/ToolkitIntelliJExtension.kt
@@ -20,8 +20,22 @@ abstract class ToolkitIntelliJExtension(private val providers: ProviderFactory) 
 
     fun productProfile(): Provider<out ProductProfile> = ideFlavor.flatMap { flavor ->
         when (flavor) {
-            IdeFlavor.IC -> ideProfile().map { it.community }
-            IdeFlavor.IU -> ideProfile().map { it.ultimate }
+            IdeFlavor.AI,
+            IdeFlavor.IC,
+            IdeFlavor.PC,
+                -> ideProfile().map { it.community }
+
+            IdeFlavor.DB,
+            IdeFlavor.CL,
+            IdeFlavor.GO,
+            IdeFlavor.IU,
+            IdeFlavor.PS,
+            IdeFlavor.PY,
+            IdeFlavor.RM,
+            IdeFlavor.RR,
+            IdeFlavor.WS,
+                -> ideProfile().map { it.ultimate }
+
             IdeFlavor.RD -> ideProfile().map { it.rider }
             IdeFlavor.GW -> ideProfile().map { it.gateway!! }
         }


### PR DESCRIPTION
The `:runIde` task supports swapping out the IDE sandbox, but currently only supports IntelliJ IDEA, Rider, and Gateway.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
