### PR TITLE
Fix missing Rider model imports in Qodana

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,7 +1,7 @@
 version: 1.0
 linter: jetbrains/qodana-jvm-community:latest
 projectJDK: "21"
-bootstrap: ./gradlew :plugin-core:sdk-codegen:generateSdks :plugin-core:jetbrains-community:generateTelemetry
+bootstrap: ./gradlew :plugin-core:sdk-codegen:generateSdks :plugin-core:jetbrains-community:generateTelemetry :plugin-toolkit:jetbrains-rider:generateModels
 profile:
   name: qodana.recommended
 exclude:


### PR DESCRIPTION
Qodana reports: `Unresolved reference software.aws.toolkits.jetbrains.protocol.*`
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
