### PR TITLE
Fix deadlock in CodeWhispererStatusBarWidget

### DIFF
--- a/.changes/next-release/bugfix-bcf4a2c9-230b-440b-93ed-8b2fb96929be.json
+++ b/.changes/next-release/bugfix-bcf4a2c9-230b-440b-93ed-8b2fb96929be.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix an IDE deadlock that may occur while attempting to initialize Amazon Q UI elements (#4966)"
+}


### PR DESCRIPTION
`CodeWhispererStatusBarWidget#getSelectedValue` is called under EDT, but may cause `ProfileWatcher` to be indirectly initialized on the background through `ToolkitConnectionManager#activeConnectionForFeature`. However `ProfileWatcher` requires EDT to initialize correctly since it relies on VFS events to propagate on EDT before it returns

## Description
#4966
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
