### PR TITLE
Include `contents: read` permission in Qodana workflow

### DIFF
--- a/.github/workflows/qodana-check.yml
+++ b/.github/workflows/qodana-check.yml
@@ -15,6 +15,7 @@ jobs:
   qodana:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # PR check
       checks: write
       # PR comments


### PR DESCRIPTION
Required for private forks

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
