### PR TITLE
fix(amazonq): Fix bug for @workspace cannot properly locate certain folders for certain project setup

### DIFF
--- a/.changes/next-release/bugfix-9e318f1e-baa7-4d10-98de-edfa70fcd7e0.json
+++ b/.changes/next-release/bugfix-9e318f1e-baa7-4d10-98de-edfa70fcd7e0.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "\"fix wrong project root for @workspace for multi-folder project setup"
+  "description" : "\"@workspace cannot properly locate certain folders for certain project setup"
 }

--- a/.changes/next-release/bugfix-9e318f1e-baa7-4d10-98de-edfa70fcd7e0.json
+++ b/.changes/next-release/bugfix-9e318f1e-baa7-4d10-98de-edfa70fcd7e0.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "\"fix wrong project root for @workspace for multi-folder project setup"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/editor/context/project/ProjectContextProvider.kt
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileVisitor
@@ -130,7 +129,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
     }
 
     private fun initEncryption(): Boolean {
-        logger.info { "project context: init key for ${project.guessProjectDir()} on port ${encoderServer.port}" }
+        logger.info { "project context: init key for ${project.basePath} on port ${encoderServer.port}" }
         val url = URL("http://localhost:${encoderServer.port}/initialize")
         val payload = encoderServer.getEncryptionRequest()
         val connection = url.openConnection() as HttpURLConnection
@@ -148,7 +147,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
         var duration = (System.currentTimeMillis() - indexStartTime).toDouble()
         logger.debug { "project context file collection time: ${duration}ms" }
         logger.debug { "list of files collected: ${filesResult.files.joinToString("\n")}" }
-        val projectRoot = project.guessProjectDir()?.path ?: return false
+        val projectRoot = project.basePath ?: return false
         val payload = IndexRequestPayload(filesResult.files, projectRoot, false)
         val payloadJson = mapper.writeValueAsString(payload)
         val encrypted = encoderServer.encrypt(payloadJson)
@@ -275,7 +274,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
         var currentTotalFileSize = 0L
         val featureDevSessionContext = FeatureDevSessionContext(project)
         val allFiles = mutableListOf<VirtualFile>()
-        project.guessProjectDir()?.let {
+        project.baseDir?.let {
             VfsUtilCore.visitChildrenRecursively(
                 it,
                 object : VirtualFileVisitor<Unit>(NO_FOLLOW_SYMLINKS) {


### PR DESCRIPTION

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
When the project root is removed as the module but src folders are promoted to the modules level, the @workspace indexing cannot properly resolve the project root folder, causing indexing to only apply to a subset of the workspace.

The guessDir function does not work as expected, we should use basePath

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
