### PR TITLE
Fix broken Gateway / Rider profiles due to missing assets

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -101,7 +101,7 @@ object IdeVersions {
         Profile(
             name = "2024.2",
             gateway = ProductProfile(
-                sdkVersion = "242.20224-EAP-CANDIDATE-SNAPSHOT",
+                sdkVersion = "242.23726-EAP-CANDIDATE-SNAPSHOT",
                 bundledPlugins = listOf("org.jetbrains.plugins.terminal")
             ),
             community = ProductProfile(

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -132,11 +132,11 @@ object IdeVersions {
                 )
             ),
             rider = RiderProfile(
-                sdkVersion = "2024.2-EAP7-SNAPSHOT",
+                sdkVersion = "2024.2",
                 bundledPlugins = commonPlugins,
                 netFrameworkTarget = "net472",
                 rdGenVersion = "2024.1.1",
-                nugetVersion = " 2024.2.0-eap07"
+                nugetVersion = " 2024.2.0"
             )
         ),
         Profile(


### PR DESCRIPTION
JetBrains deleted the .pom from the /snapshots repo

```
Resource missing. [HTTP GET: https://repo.maven.apache.org/maven2/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/maven-metadata.xml]
Resource missing. [HTTP GET: https://repo.maven.apache.org/maven2/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/JetBrainsGateway-242.20224-EAP-CANDIDATE-SNAPSHOT.pom]
Resource missing. [HTTP GET: https://d2cico3c979uwg.cloudfront.net/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/maven-metadata.xml]
Resource missing. [HTTP GET: https://d2cico3c979uwg.cloudfront.net/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/JetBrainsGateway-242.20224-EAP-CANDIDATE-SNAPSHOT.pom]
Resource missing. [HTTP GET: https://d2s4y8xcwt8bet.cloudfront.net/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/maven-metadata.xml]
Resource missing. [HTTP GET: https://d2s4y8xcwt8bet.cloudfront.net/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/JetBrainsGateway-242.20224-EAP-CANDIDATE-SNAPSHOT.pom]
Resource missing. [HTTP GET: https://packages.jetbrains.team/maven/p/ij/intellij-dependencies/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/maven-metadata.xml]
Resource missing. [HTTP GET: https://packages.jetbrains.team/maven/p/ij/intellij-dependencies/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/JetBrainsGateway-242.20224-EAP-CANDIDATE-SNAPSHOT.pom]
Resource missing. [HTTP GET: https://plugins.jetbrains.com/maven/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/maven-metadata.xml]
Resource missing. [HTTP GET: https://plugins.jetbrains.com/maven/com/jetbrains/gateway/JetBrainsGateway/242.20224-EAP-CANDIDATE-SNAPSHOT/JetBrainsGateway-242.20224-EAP-CANDIDATE-SNAPSHOT.pom]

```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
