### PR TITLE
fix(amazonq): Removed read-only view from before diff for generated code

### DIFF
--- a/.changes/next-release/bugfix-a1fa678d-47d0-4cb8-bd0c-350f5eaf4ae4.json
+++ b/.changes/next-release/bugfix-a1fa678d-47d0-4cb8-bd0c-350f5eaf4ae4.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue where before diff of generated code is read-only"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# _3.34_ (2024-10-21)
+- **(Bug Fix)** Fix issue where before diff of generated code is read-only
+
 # _3.33_ (2024-10-17)
 - **(Feature)** Add support for 2024.3
 - **(Bug Fix)** `@workspace` cannot properly locate certain folders for certain project setup

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -219,7 +219,6 @@ class FeatureDevController(
                     }
 
                     val request = SimpleDiffRequest(message.filePath, leftDiffContent, rightDiffContent, null, null)
-                    request.putUserData(DiffUserDataKeys.FORCE_READ_ONLY, true)
 
                     DiffManager.getInstance().showDiff(project, request)
                 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Fixed an issue where before diff of agent generated code is read-only. Deleted a line to remove this. 

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
