### PR TITLE
fix(amazonq): skip initial refresh

### DIFF
--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/utils/CodeTransformApiUtils.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/utils/CodeTransformApiUtils.kt
@@ -58,10 +58,6 @@ suspend fun JobId.pollTransformationStatusAndPlan(
     val maxRefreshes = 10
     var numRefreshes = 0
 
-    // We refresh token at the start of polling, but for some long jobs that runs for 30 minutes plus, tokens may need to be
-    // refreshed again when AccessDeniedException or InvalidGrantException are caught.
-    refreshToken(project)
-
     try {
         waitUntil(
             succeedOn = { result -> result in succeedOn },


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Don't do the initial `refreshToken` as we are experiencing a cache-related issue, and either way, this is not necessary since we know that the user is actively invoking `/transform` almost immediately before this point.
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
