### PR TITLE
test(amazonq) should not install and try run encoderserver in test env

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/EncoderServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/EncoderServer.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.process.ProcessCloseUtil
 import com.intellij.util.io.HttpRequests
@@ -56,6 +57,9 @@ class EncoderServer(val project: Project) : Disposable {
     private val mapper = jacksonObjectMapper()
 
     fun downloadArtifactsAndStartServer() {
+        if (ApplicationManager.getApplication().isUnitTestMode) {
+            return
+        }
         downloadArtifactsIfNeeded()
         start()
     }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.BaseProjectDirectories.Companion.getBaseDirectories
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtilCore
@@ -41,6 +42,10 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
 
     init {
         cs.launch {
+            if (ApplicationManager.getApplication().isUnitTestMode) {
+                return@launch
+            }
+
             while (true) {
                 if (encoderServer.isNodeProcessRunning()) {
                     // TODO: need better solution for this


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

```

java.lang.AssertionError: Thread leaked: Thread[#38,DefaultDispatcher-worker-5 @software.aws.toolkits.jetbrains.services.amazonq.project.ProjectContextController#1087,5,main] (alive) WAITING
--- its stacktrace:
 at java.base/sun.nio.ch.Net.poll(Native Method)
 at java.base/sun.nio.ch.NioSocketImpl.park(NioSocketImpl.java:191)
 at java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:280)
 at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:304)
 at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:346)
 at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:796)
 at java.base/java.net.Socket$SocketInputStream.read(Socket.java:1099)
 at java.base/sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:489)
 at java.base/sun.security.ssl.SSLSocketInputRecord.readHeader(SSLSocketInputRecord.java:483)
 at java.base/sun.security.ssl.SSLSocketInputRecord.decode(SSLSocketInputRecord.java:160)
 at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:111)
 at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1506)
 at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1421)
 at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455)
 at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:426)
 at java.base/sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:586)
 at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:187)
 at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1675)
 at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1599)
 at java.base/java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:531)
 at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:307)
 at com.intellij.util.io.HttpRequests.openConnection(HttpRequests.java:626)
 at com.intellij.util.io.HttpRequests$RequestImpl.getConnection(HttpRequests.java:366)
 at com.intellij.util.io.HttpRequests$RequestImpl.doReadBytes(HttpRequests.java:442)
 at com.intellij.util.io.HttpRequests$RequestImpl.readString(HttpRequests.java:431)
 at com.intellij.util.io.RequestBuilder.lambda$readString$5(RequestBuilder.java:85)
 at com.intellij.util.io.HttpRequests.doProcess(HttpRequests.java:529)
 at com.intellij.util.io.HttpRequests.process(HttpRequests.java:511)
 at com.intellij.util.io.HttpRequests$RequestBuilderImpl.connect(HttpRequests.java:340)
 at com.intellij.util.io.RequestBuilder.readString(RequestBuilder.java:85)
 at com.intellij.util.io.RequestBuilder.readString(RequestBuilder.java:89)
 at software.aws.toolkits.jetbrains.core.HttpUtilsKt.getTextFromUrl(HttpUtils.kt:18)
 at software.aws.toolkits.jetbrains.services.amazonq.project.manifest.ManifestManager.fetchFromRemoteAndSave(ManifestManager.kt:100)
 at software.aws.toolkits.jetbrains.services.amazonq.project.manifest.ManifestManager.getManifest(ManifestManager.kt:68)
 at software.aws.toolkits.jetbrains.services.amazonq.project.EncoderServer.downloadArtifactsIfNeeded(EncoderServer.kt:155)
 at software.aws.toolkits.jetbrains.services.amazonq.project.EncoderServer.downloadArtifactsAndStartServer(EncoderServer.kt:59)
 at software.aws.toolkits.jetbrains.services.amazonq.project.ProjectContextController$initJob$1.invokeSuspend(ProjectContextController.kt:28)
 at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
 at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
 at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)
---
(its trace after 10 seconds wait:) Thread[#38,DefaultDispatcher-worker-5 @software.aws.toolkits.jetbrains.services.amazonq.project.ProjectContextController#1087,5,main] (alive) WAITING
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
