### PR TITLE
Break out of loop when context process has started

### DIFF
--- a/.changes/next-release/bugfix-b18a6b61-e1e9-42dd-952d-7c32ea7a3a19.json
+++ b/.changes/next-release/bugfix-b18a6b61-e1e9-42dd-952d-7c32ea7a3a19.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix pointless busy loop in Amazon Q wasting CPU cycles (#5000)"
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -55,7 +55,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
                     initAndIndex()
                     break
                 } else {
-                    yield()
+                    break
                 }
             }
         }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -55,7 +55,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
                     initAndIndex()
                     break
                 } else {
-                    break
+                    delay(10000)
                 }
             }
         }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -47,10 +47,16 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
                 return@launch
             }
 
-            while (!encoderServer.isNodeProcessRunning()) {
-                // TODO: need better solution for this
-                delay(10000)
-                initAndIndex()
+            // TODO: need better solution for this
+            @Suppress("LoopWithTooManyJumpStatements")
+            while (true) {
+                if (encoderServer.isNodeProcessRunning()) {
+                    delay(10000)
+                    initAndIndex()
+                    break
+                } else {
+                    break
+                }
             }
         }
     }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.yield
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
@@ -48,15 +47,10 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
                 return@launch
             }
 
-            while (true) {
-                if (encoderServer.isNodeProcessRunning()) {
-                    // TODO: need better solution for this
-                    delay(10000)
-                    initAndIndex()
-                    break
-                } else {
-                    break
-                }
+            while (!encoderServer.isNodeProcessRunning()) {
+                // TODO: need better solution for this
+                delay(10000)
+                initAndIndex()
             }
         }
     }


### PR DESCRIPTION
`yield()` in while-loop is effectively a busy loop and wastes CPU time

#5000
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
