### PR TITLE
fix getRelativePathToContextRoot invoked without read-lock

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/editor/CodeWhispererEditorUtil.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.codewhisperer.editor
 
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -73,7 +74,7 @@ object CodeWhispererEditorUtil {
     private fun getFileName(psiFile: PsiFile): String =
         psiFile.name.substring(0, psiFile.name.length.coerceAtMost(CodeWhispererConstants.FILENAME_CHARS_LIMIT))
 
-    fun getRelativePathToContentRoot(editor: Editor): String? =
+    fun getRelativePathToContentRoot(editor: Editor): String? = ReadAction.compute<String?, Throwable> {
         editor.project?.let { project ->
             FileDocumentManager.getInstance().getFile(editor.document)?.let { vFile ->
                 val fileIndex = ProjectFileIndex.getInstance(project)
@@ -83,6 +84,7 @@ object CodeWhispererEditorUtil {
                 }
             }
         }
+    }
 
     fun getPopupPositionAboveText(editor: Editor, popup: JBPopup, offset: Int): Point {
         val textAbsolutePosition = editor.offsetToXY(offset)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

#5024 

 

```
java.lang.Throwable: Slow operations are prohibited on EDT. See SlowOperations.assertSlowOperationsAreAllowed javadoc.
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:376)
	at com.intellij.util.SlowOperations.assertSlowOperationsAreAllowed(SlowOperations.java:106)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexDataImpl.ensureIsUpToDate(WorkspaceFileIndexDataImpl.kt:149)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexDataImpl.getFileInfo(WorkspaceFileIndexDataImpl.kt:94)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexImpl.getFileInfo(WorkspaceFileIndexImpl.kt:260)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexImpl.findFileSetWithCustomData(WorkspaceFileIndexImpl.kt:243)
	at com.intellij.openapi.roots.impl.ProjectFileIndexImpl.getContentRootForFile(ProjectFileIndexImpl.java:152)
	at com.intellij.openapi.roots.impl.ProjectFileIndexImpl.getContentRootForFile(ProjectFileIndexImpl.java:146)
	at software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil$getRelativePathToContentRoot$1$1$contentRoot$1.invoke(CodeWhispererEditorUtil.kt:80)
	at software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil$getRelativePathToContentRoot$1$1$contentRoot$1.invoke(CodeWhispererEditorUtil.kt:80)
	at com.intellij.openapi.application.ActionsKt.runReadAction$lambda$3(actions.kt:31)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction$lambda$3(AnyThreadWriteThreadingSupport.kt:219)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction(AnyThreadWriteThreadingSupport.kt:228)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction(AnyThreadWriteThreadingSupport.kt:219)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:852)
	at com.intellij.openapi.application.ActionsKt.runReadAction(actions.kt:31)
	at software.aws.toolkits.jetbrains.services.codewhisperer.editor.CodeWhispererEditorUtil.getRelativePathToContentRoot(CodeWhispererEditorUtil.kt:80)
	at software.aws.toolkits.jetbrains.services.codewhisperer.toolwindow.CodeWhispererCodeReferenceManager.insertCodeReference(CodeWhispererCodeReferenceManager.kt:73)
	at software.aws.toolkits.jetbrains.services.cwc.controller.ReferenceLogController.addReferenceLog(ReferenceLogController.kt:36)
	at software.aws.toolkits.jetbrains.services.cwc.inline.InlineChatController$processNewCode$1$4.invoke(InlineChatController.kt:318)
	at software.aws.toolkits.jetbrains.services.cwc.inline.InlineChatController$processNewCode$1$4.invoke(InlineChatController.kt:314)
	at software.aws.toolkits.jetbrains.services.cwc.inline.InlineChatController$diffAcceptHandler$1$1.invokeSuspend(InlineChatController.kt:173)
```






## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
