### PR TITLE
fix(amazonq): Regression using onCodeBlockActionClicked function, replaced with onCopyCodeToClipboard function in chat

### DIFF
--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
@@ -453,54 +453,31 @@ export const createMynahUI = (ideApi: any, featureDevInitEnabled: boolean, codeT
                 content: 'Thanks for your feedback.',
             })
         },
-        onCodeBlockActionClicked: (
-            tabId: string,
-            messageId: string,
-            actionId: string,
-            data?: string,
-            code?: string,
-            type?: CodeSelectionType,
-            referenceTrackerInformation?: ReferenceTrackerInformation[],
-            eventId?: string,
-            codeBlockIndex?: number,
-            totalCodeBlocks?: number
+        onCodeInsertToCursorPosition: connector.onCodeInsertToCursorPosition,
+        onCopyCodeToClipboard: (
+            tabId,
+            messageId,
+            code,
+            type,
+            referenceTrackerInfo,
+            eventId,
+            codeBlockIndex,
+            totalCodeBlocks
         ) => {
-            switch (actionId) {
-                case 'insert-to-cursor':
-                    connector.onCodeInsertToCursorPosition(
-                        tabId,
-                        messageId,
-                        code,
-                        type,
-                        referenceTrackerInformation,
-                        eventId,
-                        codeBlockIndex,
-                        totalCodeBlocks,
-                        responseMetadata.get(messageId)?.[0] ?? undefined,
-                        responseMetadata.get(messageId)?.[1] ?? undefined
-                    )
-                    break
-                case 'copy':
-                    connector.onCopyCodeToClipboard(
-                        tabId,
-                        messageId,
-                        code,
-                        type,
-                        referenceTrackerInformation,
-                        eventId,
-                        codeBlockIndex,
-                        totalCodeBlocks,
-                        responseMetadata.get(messageId)?.[0] ?? undefined,
-                        responseMetadata.get(messageId)?.[1] ?? undefined
-                    )
-                    mynahUI.notify({
-                        type: NotificationType.SUCCESS,
-                        content: 'Selected code is copied to clipboard',
-                    })
-                    break
-                default:
-                    break
-            }
+            connector.onCopyCodeToClipboard(
+                tabId,
+                messageId,
+                code,
+                type,
+                referenceTrackerInfo,
+                eventId,
+                codeBlockIndex,
+                totalCodeBlocks
+            )
+            mynahUI.notify({
+                type: NotificationType.SUCCESS,
+                content: 'Selected code is copied to clipboard',
+            })
         },
         onChatItemEngagement: connector.triggerSuggestionEngagement,
         onSourceLinkClick: (tabId, messageId, link, mouseEvent) => {


### PR DESCRIPTION


<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Drop found in customer interaction with chat message because of replacing deprecated `onCodeInsertToCursorPosition` and `onCopyCodeToClipboard`  functions with `onCodeBlockActionClicked`  function. Commit [Reference](https://github.com/aws/aws-toolkit-jetbrains/commit/8f9c157a4ed3143ed7a21b84a09fade9e0285895#diff-deb4fc333346795314beae818407e5aa42d7cb6b7e4714862e591f8814fccfeaR446-R491).

Reverted these deprecated `onCodeInsertToCursorPosition` and `onCopyCodeToClipboard`  functions

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
