### PR TITLE
fix(amazonq): hide inline chat shortcut hint on remote/gateway

### DIFF
--- a/.changes/next-release/bugfix-bc45640b-9877-43e5-b6cd-8b7dc35c570b.json
+++ b/.changes/next-release/bugfix-bc45640b-9877-43e5-b6cd-8b7dc35c570b.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix inline chat shortcut hint breaks selection on gateway"
+}

--- a/.changes/next-release/bugfix-bc45640b-9877-43e5-b6cd-8b7dc35c570b.json
+++ b/.changes/next-release/bugfix-bc45640b-9877-43e5-b6cd-8b7dc35c570b.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Fix inline chat shortcut hint breaks selection on gateway"
+  "description" : "Fix inline chat shortcut hint breaking text selection on remote editors"
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/listeners/InlineChatSelectionListener.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/listeners/InlineChatSelectionListener.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.cwc.inline.listeners
 
+import com.intellij.idea.AppMode
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.editor.event.SelectionEvent
 import com.intellij.openapi.editor.event.SelectionListener
@@ -14,7 +15,7 @@ class InlineChatSelectionListener : SelectionListener, Disposable {
         val editor = e.editor
         val selectionModel = editor.selectionModel
 
-        if (selectionModel.hasSelection()) {
+        if (selectionModel.hasSelection() && !AppMode.isRemoteDevHost()) {
             inlineChatEditorHint.show(editor)
         } else {
             inlineChatEditorHint.hide()

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/listeners/InlineChatSelectionListener.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/listeners/InlineChatSelectionListener.kt
@@ -12,10 +12,11 @@ import software.aws.toolkits.jetbrains.services.cwc.inline.InlineChatEditorHint
 class InlineChatSelectionListener : SelectionListener, Disposable {
     private val inlineChatEditorHint = InlineChatEditorHint()
     override fun selectionChanged(e: SelectionEvent) {
+        if (AppMode.isRemoteDevHost()) return
         val editor = e.editor
         val selectionModel = editor.selectionModel
 
-        if (selectionModel.hasSelection() && !AppMode.isRemoteDevHost()) {
+        if (selectionModel.hasSelection()) {
             inlineChatEditorHint.show(editor)
         } else {
             inlineChatEditorHint.hide()


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
This hint is inconsistent and might break selection on remote/gateway, so we will not show it for now on gateway

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
