### PR TITLE
Fix popup not init in EDT for remote

### DIFF
--- a/.changes/next-release/bugfix-eb803511-b66c-454e-a832-ca189572d1af.json
+++ b/.changes/next-release/bugfix-eb803511-b66c-454e-a832-ca189572d1af.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fixed an issue where Q inline won't appear in JetBrains remote 2024.2+"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/service/CodeWhispererService.kt
@@ -209,9 +209,9 @@ class CodeWhispererService(private val cs: CoroutineScope) : Disposable {
 
     internal suspend fun invokeCodeWhispererInBackground(requestContext: RequestContext): Job {
         val popup = withContext(EDT) {
-            val it = CodeWhispererPopupManager.getInstance().initPopup()
-            Disposer.register(it) { CodeWhispererInvocationStatus.getInstance().finishInvocation() }
-            it
+            CodeWhispererPopupManager.getInstance().initPopup().also {
+                Disposer.register(it) { CodeWhispererInvocationStatus.getInstance().finishInvocation() }
+            }
         }
 
         val workerContexts = mutableListOf<WorkerContext>()


### PR DESCRIPTION
1. BackendComponentBePopupBuilder.createPopup somehow needs to be executed in EDT while recent changes made our initPopup() to happen in BGT.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
