### PR TITLE
Fix detekt source override dropping all source

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -16,14 +16,8 @@ dependencies {
     detektPlugins(project(":detekt-rules"))
 }
 
-private val detektFiles = fileTree(projectDir).matching {
-    include("**/*.kt", "**/*.kts")
-    exclude("**/build")
-}
-
 detekt {
     val rulesProject = project(":detekt-rules").projectDir
-    source.setFrom(detektFiles)
     buildUponDefaultConfig = true
     parallel = true
     allRules = false
@@ -46,7 +40,4 @@ tasks.withType<Detekt>().configureEach {
 tasks.withType<DetektCreateBaselineTask>().configureEach {
     jvmTarget = javaVersion.majorVersion
     dependsOn(":detekt-rules:assemble")
-
-    // weird issue where the baseline tasks can't find the source code
-    source.plus(detektFiles)
 }

--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import software.aws.toolkits.gradle.jvmTarget
-import kotlin.jvm.java
 
 plugins {
     id("io.gitlab.arturbosch.detekt")
@@ -53,33 +51,4 @@ tasks.withType<DetektCreateBaselineTask>().configureEach {
 
     // weird issue where the baseline tasks can't find the source code
     source.plus(detektFiles)
-}
-
-tasks.create("aaaa") {
-    doLast {
-        project.extensions.getByType(KotlinJvmProjectExtension::class.java).target.compilations.all { compilation ->
-            val ss = compilation.kotlinSourceSets
-                .map { it.kotlin.sourceDirectories }
-                .fold(project.files() as FileCollection) { collection, next -> collection.plus(next) }
-            ss
-                .forEach { println(it) }
-
-            println("1 / ======")
-            println(ss.files)
-
-            println("pp / ======")
-            ss.forEach { t ->
-                println("pp / $t / ======")
-                exec {
-                    commandLine("ls", "-laR", t.absolutePath).isIgnoreExitValue = true
-                }
-            }
-            true
-        }
-
-        println("source / ======")
-        tasks.named<Detekt>("detektMain").get().source.forEach { println(it) }
-        println("files / ======")
-        println(tasks.named<Detekt>("detektMain").get().source.files)
-    }
 }

--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     detektPlugins(project(":detekt-rules"))
 }
 
+// detekt with type introspection configured in kotlin conventions
 private val detektFiles = fileTree(projectDir).matching {
     include("**/*.kt", "**/*.kts")
     exclude("**/build")
@@ -34,8 +35,6 @@ detekt {
 val javaVersion = project.jvmTarget().get()
 
 tasks.withType<Detekt>().configureEach {
-    setSource(source.filter { it.walkBottomUp().none { c -> c.name == "build" } })
-
     jvmTarget = javaVersion.majorVersion
     dependsOn(":detekt-rules:assemble")
 

--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -16,8 +16,14 @@ dependencies {
     detektPlugins(project(":detekt-rules"))
 }
 
+private val detektFiles = fileTree(projectDir).matching {
+    include("**/*.kt", "**/*.kts")
+    exclude("**/build")
+}
+
 detekt {
     val rulesProject = project(":detekt-rules").projectDir
+    source.setFrom(detektFiles)
     buildUponDefaultConfig = true
     parallel = true
     allRules = false
@@ -28,6 +34,10 @@ detekt {
 val javaVersion = project.jvmTarget().get()
 
 tasks.withType<Detekt>().configureEach {
+    doFirst {
+        detektFiles.forEach { println(it) }
+    }
+
     jvmTarget = javaVersion.majorVersion
     dependsOn(":detekt-rules:assemble")
 
@@ -40,4 +50,7 @@ tasks.withType<Detekt>().configureEach {
 tasks.withType<DetektCreateBaselineTask>().configureEach {
     jvmTarget = javaVersion.majorVersion
     dependsOn(":detekt-rules:assemble")
+
+    // weird issue where the baseline tasks can't find the source code
+    source.plus(detektFiles)
 }

--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -60,15 +60,22 @@ tasks.withType<DetektCreateBaselineTask>().configureEach {
 tasks.create("aaaa") {
     doLast {
         project.extensions.getByType(KotlinJvmProjectExtension::class.java).target.compilations.all { compilation ->
-            compilation.kotlinSourceSets
+            val ss = compilation.kotlinSourceSets
                 .map { it.kotlin.sourceDirectories }
                 .fold(project.files() as FileCollection) { collection, next -> collection.plus(next) }
+            ss
                 .forEach { println(it) }
+
+            println("1 / ======")
+            println(ss.files)
 
             true
         }
 
-        println("======")
+        println("source / ======")
         tasks.named<Detekt>("detektMain").get().source.forEach { println(it) }
+        println("files / ======")
+        println(tasks.named<Detekt>("detektMain").get().source.files)
+
     }
 }

--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -36,9 +36,7 @@ detekt {
 val javaVersion = project.jvmTarget().get()
 
 tasks.withType<Detekt>().configureEach {
-    doFirst {
-        detektFiles.forEach { println(it) }
-    }
+    setSource(source.filter { it.walkBottomUp().none { c -> c.name == "build" } })
 
     jvmTarget = javaVersion.majorVersion
     dependsOn(":detekt-rules:assemble")
@@ -83,6 +81,5 @@ tasks.create("aaaa") {
         tasks.named<Detekt>("detektMain").get().source.forEach { println(it) }
         println("files / ======")
         println(tasks.named<Detekt>("detektMain").get().source.files)
-
     }
 }

--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -67,5 +67,8 @@ tasks.create("aaaa") {
 
             true
         }
+
+        println("======")
+        tasks.named<Detekt>("detektMain").get().source.forEach { println(it) }
     }
 }

--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import software.aws.toolkits.gradle.jvmTarget
+import kotlin.jvm.java
 
 plugins {
     id("io.gitlab.arturbosch.detekt")
@@ -53,4 +55,17 @@ tasks.withType<DetektCreateBaselineTask>().configureEach {
 
     // weird issue where the baseline tasks can't find the source code
     source.plus(detektFiles)
+}
+
+tasks.create("aaaa") {
+    doLast {
+        project.extensions.getByType(KotlinJvmProjectExtension::class.java).target.compilations.all { compilation ->
+            compilation.kotlinSourceSets
+                .map { it.kotlin.sourceDirectories }
+                .fold(project.files() as FileCollection) { collection, next -> collection.plus(next) }
+                .forEach { println(it) }
+
+            true
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -73,7 +73,7 @@ tasks.create("aaaa") {
             ss.forEach { t ->
                 println("pp / $t / ======")
                 exec {
-                    commandLine("ls", "-la", t.absolutePath).isIgnoreExitValue = true
+                    commandLine("ls", "-laR", t.absolutePath).isIgnoreExitValue = true
                 }
             }
             true

--- a/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-detekt.gradle.kts
@@ -69,6 +69,13 @@ tasks.create("aaaa") {
             println("1 / ======")
             println(ss.files)
 
+            println("pp / ======")
+            ss.forEach { t ->
+                println("pp / $t / ======")
+                exec {
+                    commandLine("ls", "-la", t.absolutePath).isIgnoreExitValue = true
+                }
+            }
             true
         }
 

--- a/buildSrc/src/main/kotlin/toolkit-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-kotlin-conventions.gradle.kts
@@ -59,18 +59,3 @@ project.afterEvaluate {
         }
     }
 }
-
-// can't figure out why exclude() doesn't work on the generated source tree, so copy logic from detekt
-project.extensions.getByType(KotlinJvmProjectExtension::class.java).target.compilations.configureEach {
-    val inputSource = kotlinSourceSets
-        .map { it.kotlin.sourceDirectories.filter { !it.path.contains("build") } }
-        .fold(project.files() as FileCollection) { collection, next -> collection.plus(next) }
-
-    tasks.named<Detekt>(DetektPlugin.DETEKT_TASK_NAME + name.capitalize()).configure {
-        setSource(inputSource)
-    }
-
-    tasks.named<DetektCreateBaselineTask>(DetektPlugin.BASELINE_TASK_NAME + name.capitalize()).configure {
-        setSource(inputSource)
-    }
-}

--- a/buildSrc/src/main/kotlin/toolkit-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-kotlin-conventions.gradle.kts
@@ -59,3 +59,20 @@ project.afterEvaluate {
         }
     }
 }
+
+// detekt applies sources directly from source sets in this scenario
+// can't figure out why source is empty in the detekt conventions
+project.extensions.getByType(KotlinJvmProjectExtension::class.java).target.compilations.configureEach {
+    // can't figure out why exclude("build/**") doesn't work
+    fun FileTree.withoutBuild() = filter { f -> f.path.split(File.separatorChar).none { it == "build" } }.asFileTree
+
+    tasks.named<Detekt>(DetektPlugin.DETEKT_TASK_NAME + name.capitalize()).configure {
+        source.forEach { it.walkBottomUp().onEnter { c -> println(c); !c.name.startsWith("build") } }
+        source = source.withoutBuild()
+        println(source.files)
+    }
+
+    tasks.named<DetektCreateBaselineTask>(DetektPlugin.BASELINE_TASK_NAME + name.capitalize()).configure {
+        source = source.withoutBuild()
+    }
+}

--- a/buildSrc/src/main/kotlin/toolkit-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-kotlin-conventions.gradle.kts
@@ -67,9 +67,7 @@ project.extensions.getByType(KotlinJvmProjectExtension::class.java).target.compi
     fun FileTree.withoutBuild() = filter { f -> f.path.split(File.separatorChar).none { it == "build" } }.asFileTree
 
     tasks.named<Detekt>(DetektPlugin.DETEKT_TASK_NAME + name.capitalize()).configure {
-        source.forEach { it.walkBottomUp().onEnter { c -> println(c); !c.name.startsWith("build") } }
         source = source.withoutBuild()
-        println(source.files)
     }
 
     tasks.named<DetektCreateBaselineTask>(DetektPlugin.BASELINE_TASK_NAME + name.capitalize()).configure {

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -35,8 +35,7 @@ phases:
         fi
 
       - chmod +x gradlew
-      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME check coverageReport --info --console plain --continue"
-      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME buildPlugin"
+      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME aaaa --info --console plain --continue"
       - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
       - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
       - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -35,7 +35,8 @@ phases:
         fi
 
       - chmod +x gradlew
-      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME aaaa --info --console plain --continue"
+      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME check coverageReport --info --console plain --continue"
+      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME buildPlugin"
       - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
       - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
       - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManagerNew.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/CodeWhispererPopupManagerNew.kt
@@ -601,7 +601,7 @@ class CodeWhispererPopupManagerNew {
     }
 
     private fun getValidCount(): Int =
-        CodeWhispererServiceNew.getInstance().getAllSuggestionsPreviewInfo().filter { isValidRecommendation(it) }.size
+        CodeWhispererServiceNew.getInstance().getAllSuggestionsPreviewInfo().count { isValidRecommendation(it) }
 
     private fun getValidSelectedIndex(selectedIndex: Int): Int {
         var curr = 0

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererFileContextProvider.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererFileContextProvider.kt
@@ -272,7 +272,7 @@ class DefaultCodeWhispererFileContextProvider(private val project: Project) : Fi
 
     @VisibleForTesting
     suspend fun fetchProjectContext(query: String, psiFile: PsiFile, targetContext: FileContextInfo): SupplementalContextInfo {
-        val response = ProjectContextController.getInstance(project).queryInline(query, psiFile.virtualFile?.path ?: "")
+        val response = ProjectContextController.getInstance(project).queryInline(query, psiFile.virtualFile?.path.orEmpty())
 
         return SupplementalContextInfo(
             isUtg = false,

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/otel/OtelBase.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/otel/OtelBase.kt
@@ -228,8 +228,8 @@ abstract class AbstractBaseSpan<SpanType : AbstractBaseSpan<SpanType>>(internal 
         if (missingFields.isNotEmpty()) {
             when {
                 ApplicationManager.getApplication().isUnitTestMode -> error(message())
-                isDeveloperMode() -> LOG.error(block = message)
-                else -> LOG.error(block = message)
+                isDeveloperMode() -> LOG.error { message() }
+                else -> LOG.error { message() }
             }
         }
     }

--- a/plugins/toolkit/jetbrains-core/src-243+/software/aws/toolkits/jetbrains/services/lambda/python/PyCharmSdkSelectionPanel.kt
+++ b/plugins/toolkit/jetbrains-core/src-243+/software/aws/toolkits/jetbrains/services/lambda/python/PyCharmSdkSelectionPanel.kt
@@ -30,7 +30,7 @@ class PyCharmSdkSelectionPanel(private val projectLocation: TextFieldWithBrowseB
                     NewProjectWizardBaseData.KEY,
                     object : NewProjectWizardBaseData {
                         override val nameProperty = graph.property("")
-                        override val pathProperty = graph.property(projectLocation?.text?.trim() ?: "")
+                        override val pathProperty = graph.property(projectLocation?.text?.trim().orEmpty())
 
                         override var name by nameProperty
                         override var path by pathProperty


### PR DESCRIPTION
In CI, the override just drops all the source because all paths contain `/codebuild`
```
> Task :plugin-amazonq:codewhisperer:jetbrains-community:detektMain NO-SOURCE
Skipping task ':plugin-amazonq:codewhisperer:jetbrains-community:detektMain' as it has no source files and no previous output files.
Resolve mutations for :plugin-core:jetbrains-community:compileTestFixturesJava (Thread[#144,Execution worker Thread 4,5,main]) started.
:plugin-core:jetbrains-community:compileTestFixturesJava (Thread[#144,Execution worker Thread 4,5,main]) started.
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
