### PR TITLE
fix(amazonq): improve indexing auto start stop strategy

### DIFF
--- a/.changes/next-release/bugfix-4fee3628-1445-40f3-b164-2b0d3c12bd19.json
+++ b/.changes/next-release/bugfix-4fee3628-1445-40f3-b164-2b0d3c12bd19.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Improve `@workspace` index start stop strategy"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/startup/AmazonQStartupActivity.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/startup/AmazonQStartupActivity.kt
@@ -53,6 +53,7 @@ class AmazonQStartupActivity : ProjectActivity {
         // In the future we will decouple LSP start and indexing start to let LSP perform other tasks.
         val startLspIndexingDuration = Duration.ofMinutes(30)
         project.waitForSmartMode()
+        delay(30_000) // Wait for 30 seconds for systemLoadAverage to be more accurate
         try {
             withTimeout(startLspIndexingDuration) {
                 while (true) {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.jetbrains.core.getTextFromUrl
 
 class ManifestManager {
     private val cloudFrontUrl = "https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json"
-    val currentVersion = "0.1.19"
+    val currentVersion = "0.1.25"
     val currentOs = getOs()
     private val arch = CpuArch.CURRENT
     private val mapper = jacksonObjectMapper()

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.jetbrains.core.getTextFromUrl
 
 class ManifestManager {
     private val cloudFrontUrl = "https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json"
-    val currentVersion = "0.1.25"
+    val currentVersion = "0.1.26"
     val currentOs = getOs()
     private val arch = CpuArch.CURRENT
     private val mapper = jacksonObjectMapper()


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
When multiple IDE instances are opened at the same time, the `@workspace`  indexing can increase CPU usage to a point that system fan needs to engage. IDE can be slow if it is older devices like intel i5 or i7 Mac OS. This PR is to improve indexing auto start-stop strategy, detect CPU usage more frequently and pause indexing more aggressively whenever system total CPU usage goes up. In the mean time, further reduce CPU usage for old Intel i5, i7 devices, make sure one IDE instance at most utilize one physical core and all instance combined cannot exceed 1 for any extended period of time more than a few seconds, unless user explicit allows more CPU usage in settings. Other mechanisms are implemented to stop indexing if system available memory is small.  

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
