### PR TITLE
fix(amazonq): Amazon Q chat should not mention indexing in progress when indexing finished

### DIFF
--- a/.changes/next-release/bugfix-418aac17-9702-451e-8880-9c41b3441574.json
+++ b/.changes/next-release/bugfix-418aac17-9702-451e-8880-9c41b3441574.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix a bug when Amazon Q responds with still indexing message even when `@workspace` index is done"
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -217,9 +217,9 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
         )
     }
 
-    private fun setConnectionTimeout(connection: HttpURLConnection) {
-        connection.connectTimeout = 5000 // 5 seconds
-        connection.readTimeout = 5000 // 5 second
+    private fun setConnectionTimeout(connection: HttpURLConnection, timeout: Int) {
+        connection.connectTimeout = timeout
+        connection.readTimeout = timeout
     }
 
     private fun setConnectionProperties(connection: HttpURLConnection) {
@@ -310,10 +310,11 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
     private fun sendMsgToLsp(msgType: LspMessage, request: String?): LspResponse {
         logger.info { "sending message: ${msgType.endpoint} to lsp on port ${encoderServer.port}" }
         val url = URL("http://localhost:${encoderServer.port}/${msgType.endpoint}")
-
+        // use 1h as timeout for index, 5 seconds for other APIs
+        val timeoutMs = if (msgType is LspMessage.Index) 3600*1000 else 5000
         return with(url.openConnection() as HttpURLConnection) {
             setConnectionProperties(this)
-            setConnectionTimeout(this)
+            setConnectionTimeout(this, timeoutMs)
             request?.let { r ->
                 setConnectionRequest(this, r)
             }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -35,6 +35,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.minutes
 
 class ProjectContextProvider(val project: Project, private val encoderServer: EncoderServer, private val cs: CoroutineScope) : Disposable {
     private val retryCount = AtomicInteger(0)
@@ -311,7 +312,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
         logger.info { "sending message: ${msgType.endpoint} to lsp on port ${encoderServer.port}" }
         val url = URL("http://localhost:${encoderServer.port}/${msgType.endpoint}")
         // use 1h as timeout for index, 5 seconds for other APIs
-        val timeoutMs = if (msgType is LspMessage.Index) 3600*1000 else 5000
+        val timeoutMs = if (msgType is LspMessage.Index) 60.minutes.inWholeMilliseconds.toInt() else 5000
         return with(url.openConnection() as HttpURLConnection) {
             setConnectionProperties(this)
             setConnectionTimeout(this, timeoutMs)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Fix a bug when Amazon Q responds with still indexing message even when `@workspace` index is done

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
