### PR TITLE
fix(amazonq): wrongly formatted supplemental context for inline suggestion

### DIFF
--- a/.changes/next-release/bugfix-4dc2263c-25fa-4d07-a6e1-69389f5ec001.json
+++ b/.changes/next-release/bugfix-4dc2263c-25fa-4d07-a6e1-69389f5ec001.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "fix wrongly formatted supplemental context for inline suggestion"
+  "description" : "Fix poor inline suggestions from Amazon Q caused by improperly formatted supplemental context"
 }

--- a/.changes/next-release/bugfix-4dc2263c-25fa-4d07-a6e1-69389f5ec001.json
+++ b/.changes/next-release/bugfix-4dc2263c-25fa-4d07-a6e1-69389f5ec001.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "fix wrongly formatted supplemental context for inline suggestion"
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.jetbrains.core.getTextFromUrl
 
 class ManifestManager {
     private val cloudFrontUrl = "https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json"
-    val currentVersion = "0.1.26"
+    val currentVersion = "0.1.27"
     val currentOs = getOs()
     private val arch = CpuArch.CURRENT
     private val mapper = jacksonObjectMapper()


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->



## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->


List of fixes:
- `def func (a) :` -> `def func(a):`
- `class (A) :` -> `class(A):`
- for python, change `// Function definitions to # Function definitions` ,` // Class definitions`  to `# Class definitions`
- for js/ts: `function findMax (arr: number[]) : number | undefined{.`  ->  `function findMax(arr: number[]): number | undefined {.`
- for all language: `// File path: a.ts`  -> `//File path a.ts`  
- for js/ts: `String privateString ;`  -> `String privateString;` 







 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
