### PR TITLE
fix(amazonq): fix inline chat can be invoked in non-editor windows

### DIFF
--- a/.changes/next-release/bugfix-4a387896-7a93-4474-a86d-f6dc5d53ab57.json
+++ b/.changes/next-release/bugfix-4a387896-7a93-4474-a86d-f6dc5d53ab57.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix inline chat can be invoked in non-editor windows"
+}

--- a/.changes/next-release/bugfix-4a387896-7a93-4474-a86d-f6dc5d53ab57.json
+++ b/.changes/next-release/bugfix-4a387896-7a93-4474-a86d-f6dc5d53ab57.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Fix inline chat can be invoked in non-editor windows"
+  "description" : "Fix issue where Amazon Q inline chat can be invoked from non-editor windows"
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/OpenChatInputAction.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/OpenChatInputAction.kt
@@ -3,13 +3,17 @@
 
 package software.aws.toolkits.jetbrains.services.cwc.inline
 
+import com.intellij.execution.impl.ConsoleViewImpl
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 
 class OpenChatInputAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
-        val editor = e.getRequiredData(CommonDataKeys.EDITOR)
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val isConsole = editor.document.getUserData(ConsoleViewImpl.IS_CONSOLE_DOCUMENT)
+        if (isConsole == true) return
+        if (!editor.document.isWritable) return
         val project = editor.project ?: return
 
         val inlineChatController = InlineChatController.getInstance(project)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
only allow invoking inline chat if it's from regular file editor

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
