### PR TITLE
fix(amazonq): `@workspace` command shown in all tab types

### DIFF
--- a/.changes/next-release/bugfix-0150eb94-2d05-40f5-8473-b2ee1fd6bf09.json
+++ b/.changes/next-release/bugfix-0150eb94-2d05-40f5-8473-b2ee1fd6bf09.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Amazon Q chat: @workspace command shown in all tab types"
+  "description" : "Amazon Q chat: `@workspace` command shown in all tab types"
 }

--- a/.changes/next-release/bugfix-0150eb94-2d05-40f5-8473-b2ee1fd6bf09.json
+++ b/.changes/next-release/bugfix-0150eb94-2d05-40f5-8473-b2ee1fd6bf09.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q chat: @workspace command shown in all tab types"
+}

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/commands.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/commands.ts
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import { QuickActionCommandGroup } from "@aws/mynah-ui-chat"
 
 type MessageCommand =
     | 'chat-prompt'
@@ -47,3 +48,13 @@ type MessageCommand =
     | 'store-code-result-message-id'
 
 export type ExtensionMessage = Record<string, any> & { command: MessageCommand }
+
+export const workspaceCommand: QuickActionCommandGroup = {
+    groupName: 'Mention code',
+    commands: [
+        {
+            command: '@workspace',
+            description: '(BETA) Reference all code in workspace.',
+        },
+    ],
+}

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/tabs/generator.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/tabs/generator.ts
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatItemType, MynahUIDataModel } from '@aws/mynah-ui-chat'
+import { ChatItemType, MynahUIDataModel, QuickActionCommandGroup } from '@aws/mynah-ui-chat'
 import { TabType } from '../storages/tabsStorage'
 import { FollowUpGenerator } from '../followUps/generator'
 import { QuickActionGenerator } from '../quickActions/generator'
+import { workspaceCommand } from '../commands'
 
 export interface TabDataGeneratorProps {
     isFeatureDevEnabled: boolean
@@ -60,6 +61,10 @@ I can help you upgrade your Java 8 and 11 codebases to Java 17.
         ],
     ])
 
+    private tabContextCommand: Map<TabType, QuickActionCommandGroup[]> = new Map([
+        ['cwc', [workspaceCommand]],
+    ])
+
     constructor(props: TabDataGeneratorProps) {
         this.followUpsGenerator = new FollowUpGenerator()
         this.quickActionsGenerator = new QuickActionGenerator({
@@ -75,17 +80,7 @@ I can help you upgrade your Java 8 and 11 codebases to Java 17.
                 'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
             quickActionCommands: this.quickActionsGenerator.generateForTab(tabType),
             promptInputPlaceholder: this.tabInputPlaceholder.get(tabType),
-            contextCommands: [
-                {
-                    groupName: 'Mention code',
-                    commands: [
-                        {
-                            command: '@workspace',
-                            description: '(BETA) Reference all code in workspace.',
-                        },
-                    ],
-                },
-            ],
+            contextCommands: this.tabContextCommand.get(tabType),
             chatItems: needWelcomeMessages
                 ? [
                       {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Problem
The `@workspace` [context command](https://github.com/aws/mynah-ui/blob/main/docs/DATAMODEL.md#contextcommands-default-) is being shown in all tab types, even though it is only relevant to Amazon Q chat ('cwc' tabType). 

## Solution
Update getTabData function to allow each tab type to specify its own contextCommands


## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
