### PR TITLE
Disable Rider tests on Mac GHA workflow

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew check coverageReport -x :jetbrains-rider:test --info --full-stacktrace --console plain
+      run: ./gradlew check coverageReport -x :plugin-toolkit:jetbrains-rider:test --info --full-stacktrace --console plain

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew check coverageReport --info --full-stacktrace --console plain
+      run: ./gradlew check coverageReport -x :jetbrains-rider:test --info --full-stacktrace --console plain


### PR DESCRIPTION
Causes runner to spin for 2 hours and then fail
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
