### PR TITLE
Fix: force reauth when client registration is not found in cache

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/DiskCache.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/DiskCache.kt
@@ -114,6 +114,9 @@ class DiskCache(
                 reason = "Failed to load Client Registration",
                 reasonDesc = "Load Step:$stage failed. Cache file does not exist"
             )
+            if (source == SsoAccessTokenProvider.SourceOfLoadRegistration.REFRESH_TOKEN.toString()) {
+                throw ClientRegistrationNotFoundException()
+            }
             return null
         }
         return loadClientRegistration(inputStream)
@@ -320,3 +323,5 @@ class DiskCache(
         private val LOG = getLogger<DiskCache>()
     }
 }
+
+class ClientRegistrationNotFoundException : Exception("Client registration file not found")

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoAccessTokenProvider.kt
@@ -436,7 +436,7 @@ class SsoAccessTokenProvider(
                     is PKCEAuthorizationGrantToken -> loadPkceClientRegistration(SourceOfLoadRegistration.REFRESH_TOKEN.toString())
                 }
             } catch (e: ClientRegistrationNotFoundException) {
-                //invalidate tokens to force a reauth
+                // invalidate tokens to force a reauth
                 invalidate()
                 null
             } catch (e: Exception) {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Invalidate SSO tokens when client registration file is missing during refresh

- Added specific handling for missing client registration file during token refresh
- Introduced ClientRegistrationNotFoundException to distinguish between file-not-found and other failure cases
- Forces re-authentication by invalidating tokens when registration file cannot be found
- Leaves telemetry reporting for refresh flow intact

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
