### PR TITLE
Prune duplicate telemetry override entries

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QLoginWebview.kt
@@ -145,7 +145,7 @@ class QWebviewBrowser(val project: Project, private val parentDisposable: Dispos
 
         when (message) {
             is BrowserMessage.PrepareUi -> {
-                this.prepareBrowser(BrowserState(FeatureId.Q, false))
+                this.prepareBrowser(BrowserState(FeatureId.AmazonQ, false))
                 WebviewTelemetry.amazonqSignInOpened(
                     project,
                     reAuth = isQExpired(project)

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
@@ -95,7 +95,7 @@ class AmazonQToolWindowFactory : ToolWindowFactory, DumbAware {
         val component = if (isQConnected(project) && !isQExpired(project)) {
             AmazonQToolWindow.getInstance(project).component
         } else {
-            QWebviewPanel.getInstance(project).browser?.prepareBrowser(BrowserState(FeatureId.Q))
+            QWebviewPanel.getInstance(project).browser?.prepareBrowser(BrowserState(FeatureId.AmazonQ))
             QWebviewPanel.getInstance(project).component
         }
 
@@ -141,7 +141,7 @@ class AmazonQToolWindowFactory : ToolWindowFactory, DumbAware {
             openMeetQPage(project)
         }
 
-        QWebviewPanel.getInstance(project).browser?.prepareBrowser(BrowserState(FeatureId.Q))
+        QWebviewPanel.getInstance(project).browser?.prepareBrowser(BrowserState(FeatureId.AmazonQ))
 
         // isQConnected alone is not robust and there is race condition (read/update connection states)
         val component = if (isNewConnectionForQ || (isQConnected(project) && !isQExpired(project))) {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/InlineChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/InlineChatController.kt
@@ -585,7 +585,7 @@ class InlineChatController(
                 requestCredentialsForQ(project, isReauth = false)
             } else {
                 runInEdt {
-                    QWebviewPanel.getInstance(project).browser?.prepareBrowser(BrowserState(FeatureId.Q))
+                    QWebviewPanel.getInstance(project).browser?.prepareBrowser(BrowserState(FeatureId.AmazonQ))
                     ToolWindowManager.getInstance(project).getToolWindow(AMAZON_Q_WINDOW_ID)?.activate(null, false)
                     ToolWindowManager.getInstance(project).getToolWindow(AMAZON_Q_WINDOW_ID)?.show()
                 }

--- a/plugins/core/jetbrains-community/resources/telemetryOverride.json
+++ b/plugins/core/jetbrains-community/resources/telemetryOverride.json
@@ -1,90 +1,6 @@
 {
     "types": [
         {
-            "name": "codecatalyst_createDevEnvironmentRepoType",
-            "type": "string",
-            "description": "Type of Git repository provided to the Amazon CodeCatalyst dev environment create wizard",
-            "allowedValues": [
-                "linked",
-                "unlinked",
-                "none"
-            ]
-        },
-        {
-            "name": "codecatalyst_updateDevEnvironmentLocationType",
-            "type": "string",
-            "description": "Locality of the Amazon CodeCatalyst update dev environment request (i.e., from the thin client or the local IDE instance)",
-            "allowedValues": [
-                "remote",
-                "local"
-            ]
-        },
-        {
-            "name": "userId",
-            "type": "string",
-            "description": "Opaque AWS ID identifier"
-        },
-        {
-            "name": "codecatalyst_devEnvironmentWorkflowError",
-            "type": "string",
-            "description": "Workflow error name"
-        },
-        {
-            "name": "codecatalyst_devEnvironmentWorkflowStep",
-            "type": "string",
-            "description": "Workflow step name"
-        },
-        {
-            "name": "cwsprChatTriggerInteraction",
-            "type": "string",
-            "allowedValues": [
-                "hotkeys",
-                "click",
-                "contextMenu"
-            ],
-            "description": "Identifies the specific interaction that opens the chat panel"
-        },
-        {
-            "name": "cwsprChatConversationId",
-            "type": "string",
-            "description": "Unique identifier for each conversation"
-        },
-        {
-            "name": "cwsprChatUserIntent",
-            "type": "string",
-            "allowedValues": [
-                "suggestAlternateImplementation",
-                "applyCommonBestPractices",
-                "improveCode",
-                "showExample",
-                "citeSources",
-                "explainLineByLine",
-                "explainCodeSelection",
-                "generateUnitTests"
-            ],
-            "description": "Explict user intent associated with a chat message"
-        },
-        {
-            "name": "connectionState",
-            "type": "string",
-            "description": "A detailed state of a specific auth connection. Use `authStatus` for a higher level view of an extension's general connection."
-        },
-        {
-            "name": "cwsprChatHasCodeSnippet",
-            "type": "boolean",
-            "description": "true if user has selected code snippet, false otherwise."
-        },
-        {
-            "name": "cwsprChatHasProjectContext",
-            "type": "boolean",
-            "description": "true if query has project level context."
-        },
-        {
-            "name": "cwsprChatProjectContextQueryMs",
-            "type": "int",
-            "description": "query latency in ms for local project context"
-        },
-        {
             "name": "amazonqIndexFileSizeInMB",
             "type": "int",
             "description": "Index size in MB"
@@ -105,6 +21,61 @@
             "description": "Cpu usage of LSP server"
         },
         {
+            "name": "authRefreshSource",
+            "type": "string",
+            "description": "Source triggering token refresh"
+        },
+        {
+            "name": "component",
+            "allowedValues": [
+                "editor",
+                "viewer",
+                "filesystem",
+                "explorer",
+                "infobar",
+                "hover",
+                "webview",
+                "quickfix",
+                "Manage Extensions",
+                "Got It",
+                "Read More",
+                "Install",
+                "Dismiss"
+            ],
+            "description": "The IDE or OS component used for the action. (Examples: S3 download to filesystem, S3 upload from editor, ...)"
+        },
+        {
+            "name": "connectionState",
+            "type": "string",
+            "description": "A detailed state of a specific auth connection. Use `authStatus` for a higher level view of an extension's general connection."
+        },
+        {
+            "name": "cwsprChatActiveEditorImportCount",
+            "type": "int",
+            "description": "Number of import statements in the active editor"
+        },
+        {
+            "name": "cwsprChatActiveEditorTotalCharacters",
+            "type": "int",
+            "description": "Total number of characters in the active editor"
+        },
+        {
+            "name": "cwsprChatCommandName",
+            "type": "string",
+            "description": "Type of chat command name executed"
+        },
+        {
+            "name": "cwsprChatCommandType",
+            "type": "string",
+            "allowedValues": [
+                "clear",
+                "help",
+                "transform",
+                "auth"
+            ],
+            "description": "Type of chat command (/command) executed"
+        },
+        {
             "name": "cwsprChatConversationType",
             "type": "string",
             "allowedValues": [
@@ -115,34 +86,14 @@
             "description": "Identifies the type of conversation"
         },
         {
-            "name": "cwsprChatMessageId",
-            "type": "string",
-            "description": "Unique identifier for each message in an conversation"
+            "name": "cwsprChatHasCodeSnippet",
+            "type": "boolean",
+            "description": "true if user has selected code snippet, false otherwise."
         },
         {
-            "name": "cwsprChatActiveEditorTotalCharacters",
-            "type": "int",
-            "description": "Total number of characters in the active editor"
-        },
-        {
-            "name": "cwsprChatActiveEditorImportCount",
-            "type": "int",
-            "description": "Number of import statements in the active editor"
-        },
-        {
-            "name": "cwsprChatResponseCodeSnippetCount",
-            "type": "int",
-            "description": "Number of code snippets in response"
-        },
-        {
-            "name": "cwsprChatResponseCode",
-            "type": "int",
-            "description": "HTTP response code for message API invocation"
-        },
-        {
-            "name": "cwsprChatSourceLinkCount",
-            "type": "int",
-            "description": "Number of links in response"
+            "name": "cwsprChatModificationPercentage",
+            "type": "double",
+            "description": "Percentage of characters edited by user after copying/inserting code from a message"
         },
         {
             "name": "cwsprChatReferencesCount",
@@ -170,6 +121,11 @@
             "description": "Time taken to get the full response in ms"
         },
         {
+            "name": "cwsprChatProjectContextQueryMs",
+            "type": "int",
+            "description": "query latency in ms for local project context"
+        },
+        {
             "name": "cwsprChatResponseLength",
             "type": "int",
             "description": "Number of characters in response"
@@ -180,127 +136,29 @@
             "description": "Number of characters in request"
         },
         {
-            "name": "cwsprChatInteractionType",
-            "allowedValues": [
-                "insertAtCursor",
-                "copySnippet",
-                "copy",
-                "clickLink",
-                "clickFollowUp",
-                "hoverReference",
-                "upvote",
-                "downvote",
-                "clickBodyLink"
-            ],
-            "type": "string",
-            "description": "Indicates the specific interaction type with a message in a conversation"
-        },
-        {
-            "name": "cwsprChatInteractionTarget",
-            "type": "string",
-            "description": "Identifies the entity within the message that user interacts with."
-        },
-        {
-            "name": "cwsprChatCodeBlockIndex",
+            "name": "cwsprChatResponseCode",
             "type": "int",
-            "description": "Index of the code block inside a message in the conversation."
+            "description": "HTTP response code for message API invocation"
         },
         {
-            "name": "cwsprChatTotalCodeBlocks",
+            "name": "cwsprChatResponseCodeSnippetCount",
             "type": "int",
-            "description": "Total number of code blocks inside a message in the conversation."
+            "description": "Number of code snippets in response"
         },
         {
-            "name": "cwsprChatAcceptedCharactersLength",
+            "name": "cwsprChatSourceLinkCount",
             "type": "int",
-            "description": "Count of code characters copied to the editor"
+            "description": "Number of links in response"
         },
         {
-            "name": "cwsprChatAcceptedNumberOfLines",
-            "type": "int",
-            "description": "Count of lines of code copied to the editor"
-        },
-        {
-            "name": "cwsprChatHasReference",
-            "type": "boolean",
-            "description": "True if the code snippet that user interacts with has a reference."
-        },
-        {
-            "name": "cwsprChatModificationPercentage",
-            "type": "double",
-            "description": "Percentage of characters edited by user after copying/inserting code from a message"
-        },
-        {
-            "name": "cwsprChatCommandType",
+            "name": "cwsprChatTriggerInteraction",
             "type": "string",
             "allowedValues": [
-                "clear",
-                "help",
-                "transform",
-                "auth"
+                "hotkeys",
+                "click",
+                "contextMenu"
             ],
-            "description": "Type of chat command (/command) executed"
-        },
-        {
-            "name": "cwsprChatCommandName",
-            "type": "string",
-            "description": "Type of chat command name executed"
-        },
-        {
-            "name": "featureId",
-            "type": "string",
-            "description": "The id of the feature the user is interacting in.",
-            "allowedValues": [
-                "awsExplorer",
-                "codewhisperer",
-                "codecatalyst",
-                "q",
-                "codewhispererQ"
-            ]
-        },
-        {
-            "name": "authStatus",
-            "type": "string",
-            "allowedValues": [
-                "connected",
-                "notConnected",
-                "expired"
-            ],
-            "description": "Status of the an auth connection."
-        },
-        {
-            "name": "authEnabledFeatures",
-            "type": "string",
-            "description": "Comma-delimited list of features for which auth is enabled."
-        },
-        {
-            "name": "authEnabledConnections",
-            "type": "string",
-            "description": "Comma-delimited list of enabled auths."
-        },
-        {
-            "name": "authRefreshSource",
-            "type": "string",
-            "description": "Source triggering token refresh"
-        },
-        {
-            "name": "component",
-            "allowedValues": [
-                "editor",
-                "viewer",
-                "filesystem",
-                "explorer",
-                "infobar",
-                "hover",
-                "webview",
-                "quickfix",
-                "Manage Extensions",
-                "Got It",
-                "Read More",
-                "Install",
-                "Dismiss"
-            ],
-            "description": "The IDE or OS component used for the action. (Examples: S3 download to filesystem, S3 upload from editor, ...)"
+            "description": "Identifies the specific interaction that opens the chat panel"
         },
         {
             "name": "reAuth",
@@ -314,181 +172,9 @@
                 "reloaded"
             ],
             "description": "Toolkit run state."
-        },
-        {
-            "name": "authType",
-            "allowedValues": [
-                "PKCE",
-                "DeviceCode",
-                "IAM"
-            ],
-            "description": "Login is with Legacy device code or newer PKCE flow"
-        },
-        {
-            "name": "tabId",
-            "type": "string",
-            "description": "The unique identifier of a tab"
         }
     ],
     "metrics": [
-        {
-            "name": "aws_openLocalTerminal",
-            "description": "Open local terminal with aws connection injected",
-            "metadata": [
-                {
-                    "type": "result"
-                }
-            ]
-        },
-        {
-            "name": "codecatalyst_createDevEnvironment",
-            "description": "Create an Amazon CodeCatalyst Dev Environment",
-            "metadata": [
-                {
-                    "type": "userId"
-                },
-                {
-                    "type": "result"
-                },
-                {
-                    "type": "codecatalyst_createDevEnvironmentRepoType",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "codecatalyst_updateDevEnvironmentSettings",
-            "description": "Update properties of a Amazon CodeCatalyst Dev Environment",
-            "metadata": [
-                {
-                    "type": "userId"
-                },
-                {
-                    "type": "result"
-                },
-                {
-                    "type": "codecatalyst_updateDevEnvironmentLocationType"
-                }
-            ]
-        },
-        {
-            "name": "codecatalyst_updateDevfile",
-            "description": "Trigger a devfile update on a Amazon CodeCatalyst dev environment",
-            "metadata": [
-                {
-                    "type": "userId"
-                },
-                {
-                    "type": "result"
-                }
-            ]
-        },
-        {
-            "name": "codecatalyst_localClone",
-            "description": "Clone a Amazon CodeCatalyst code repository locally",
-            "metadata": [
-                {
-                    "type": "userId"
-                },
-                {
-                    "type": "result"
-                }
-            ]
-        },
-        {
-            "name": "codecatalyst_connect",
-            "description": "Connect to a Amazon CodeCatalyst dev environment",
-            "metadata": [
-                {
-                    "type": "userId"
-                },
-                {
-                    "type": "result"
-                },
-                {
-                    "type": "reason",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "codecatalyst_devEnvironmentWorkflowStatistic",
-            "description": "Workflow statistic for connecting to a dev environment",
-            "passive": true,
-            "metadata": [
-                {
-                    "type": "userId"
-                },
-                {
-                    "type": "result"
-                },
-                {
-                    "type": "duration"
-                },
-                {
-                    "type": "codecatalyst_devEnvironmentWorkflowStep"
-                },
-                {
-                    "type": "codecatalyst_devEnvironmentWorkflowError",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "amazonq_openChat",
-            "description": "When user opens CWSPR chat panel"
-        },
-        {
-            "name": "amazonq_enterFocusChat",
-            "description": "When chat panel comes into focus"
-        },
-        {
-            "name": "amazonq_exitFocusChat",
-            "description": "When chat panel goes out of focus"
-        },
-        {
-            "name": "amazonq_closeChat",
-            "description": "When chat panel is closed"
-        },
-        {
-            "name": "amazonq_startConversation",
-            "description": "When user starts a new conversation",
-            "metadata": [
-                {
-                    "type": "cwsprChatConversationId"
-                },
-                {
-                    "type": "cwsprChatTriggerInteraction"
-                },
-                {
-                    "type": "cwsprChatUserIntent",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatHasCodeSnippet",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatProgrammingLanguage",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatConversationType"
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatHasProjectContext",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatProjectContextQueryMs",
-                    "required": false
-                }
-            ]
-        },
         {
             "name": "amazonq_addMessage",
             "description": "When a message is added to the conversation",
@@ -609,6 +295,55 @@
             ]
         },
         {
+            "name": "amazonq_modifyCode",
+            "description": "Percentage of code modified by the user after copying/inserting code from a message",
+            "metadata": [
+                {
+                    "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "cwsprChatMessageId"
+                },
+                {
+                    "type": "cwsprChatModificationPercentage"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_closeChat",
+            "description": "When chat panel is closed"
+        },
+        {
+            "name": "amazonq_enterFocusChat",
+            "description": "When chat panel comes into focus"
+        },
+        {
+            "name": "amazonq_enterFocusConversation",
+            "description": "When a conversation comes into focus",
+            "metadata": [
+                {
+                    "type": "cwsprChatConversationId"
+                }
+            ]
+        },
+        {
+            "name": "amazonq_exitFocusChat",
+            "description": "When chat panel goes out of focus"
+        },
+        {
+            "name": "amazonq_exitFocusConversation",
+            "description": "When a conversation goes out of focus",
+            "metadata": [
+                {
+                    "type": "cwsprChatConversationId"
+                }
+            ]
+        },
+        {
             "name": "amazonq_messageResponseError",
             "description": "When an error has occured in response to a prompt",
             "metadata": [
@@ -655,41 +390,8 @@
             ]
         },
         {
-            "name": "amazonq_modifyCode",
-            "description": "Percentage of code modified by the user after copying/inserting code from a message",
-            "metadata": [
-                {
-                    "type": "cwsprChatConversationId"
-                },
-                {
-                    "type": "cwsprChatMessageId"
-                },
-                {
-                    "type": "cwsprChatModificationPercentage"
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "amazonq_enterFocusConversation",
-            "description": "When a conversation comes into focus",
-            "metadata": [
-                {
-                    "type": "cwsprChatConversationId"
-                }
-            ]
-        },
-        {
-            "name": "amazonq_exitFocusConversation",
-            "description": "When a conversation goes out of focus",
-            "metadata": [
-                {
-                    "type": "cwsprChatConversationId"
-                }
-            ]
+            "name": "amazonq_openChat",
+            "description": "When user opens CWSPR chat panel"
         },
         {
             "name": "amazonq_runCommand",
@@ -704,6 +406,45 @@
                 },
                 {
                     "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_startConversation",
+            "description": "When user starts a new conversation",
+            "metadata": [
+                {
+                    "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "cwsprChatTriggerInteraction"
+                },
+                {
+                    "type": "cwsprChatUserIntent",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatHasCodeSnippet",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProgrammingLanguage",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatConversationType"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatHasProjectContext",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProjectContextQueryMs",
                     "required": false
                 }
             ]
@@ -756,6 +497,25 @@
             "passive": true
         },
         {
+            "name": "auth_sourceOfRefresh",
+            "description": "Source of user triggered refresh",
+            "metadata": [
+                {
+                    "type": "authRefreshSource",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "aws_openLocalTerminal",
+            "description": "Open local terminal with aws connection injected",
+            "metadata": [
+                {
+                    "type": "result"
+                }
+            ]
+        },
+        {
             "name": "webview_amazonqSignInOpened",
             "description": "Called when a Amazon Q sign in webview is opened.",
             "metadata": [
@@ -765,103 +525,6 @@
                 }
             ],
             "passive": true
-        },
-        {
-            "name": "aws_loginWithBrowser",
-            "description": "Called when a connection requires login using the browser",
-            "metadata": [
-                {
-                    "type": "credentialSourceId",
-                    "required": false
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "credentialType",
-                    "required": false
-                },
-                {
-                    "type": "isReAuth",
-                    "required": false
-                },
-                {
-                    "type": "reason",
-                    "required": false
-                },
-                {
-                    "type": "result"
-                },
-                {
-                    "type": "authType"
-                }
-            ]
-        },
-        {
-            "name": "auth_addConnection",
-            "description": "Captures the result of adding a new connection in the 'Add New Connection' workflow",
-            "metadata": [
-                {
-                    "type": "attempts",
-                    "required": false
-                },
-                {
-                    "type": "credentialSourceId"
-                },
-                {
-                    "type": "featureId",
-                    "required": false
-                },
-                {
-                    "type": "invalidInputFields",
-                    "required": false
-                },
-                {
-                    "type": "isAggregated",
-                    "required": false
-                },
-                {
-                    "type": "reason",
-                    "required": false
-                },
-                {
-                    "type": "result"
-                },
-                {
-                    "type": "source",
-                    "required": false
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "isReAuth",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "amazonq_stopCodeGeneration",
-            "description": "User stopped the code generation",
-            "metadata": [
-                {
-                    "type": "tabId",
-                    "required": true
-                }
-            ]
-        },
-        {
-            "name": "auth_sourceOfRefresh",
-            "description": "Source of user triggered refresh",
-            "metadata": [
-                {
-                    "type": "authRefreshSource",
-                    "required": false
-                }
-            ]
         }
-
     ]
 }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
@@ -39,12 +39,12 @@ class DefaultSsoLoginCallbackProvider : SsoLoginCallbackProvider {
 
 interface SsoPrompt : SsoLoginCallback {
     override fun tokenRetrieved() {
-        AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.SsoProfile, authType = AuthType.DeviceCode)
+        AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.SsoProfile, authType = AuthType.DeviceCode, source= "")
     }
 
     override fun tokenRetrievalFailure(e: Exception) {
         e.notifyError(AwsCoreBundle.message("credentials.sso.login.failed"))
-        AwsTelemetry.loginWithBrowser(project = null, result = Result.Failed, credentialType = CredentialType.SsoProfile, authType = AuthType.DeviceCode)
+        AwsTelemetry.loginWithBrowser(project = null, result = Result.Failed, credentialType = CredentialType.SsoProfile, authType = AuthType.DeviceCode, source= "")
     }
 }
 
@@ -64,7 +64,8 @@ object DefaultSsoPrompt : SsoPrompt {
                     project = null,
                     result = Result.Cancelled,
                     credentialType = CredentialType.SsoProfile,
-                    authType = AuthType.DeviceCode
+                    authType = AuthType.DeviceCode,
+                    source= "",
                 )
                 throw ProcessCanceledException(IllegalStateException(AwsCoreBundle.message("credentials.sso.login.cancelled")))
             }
@@ -82,11 +83,11 @@ object SsoPromptWithBrowserSupport : SsoPrompt {
 
 interface BearerTokenPrompt : SsoLoginCallback {
     override fun tokenRetrieved() {
-        AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.BearerToken, authType = AuthType.DeviceCode)
+        AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.BearerToken, authType = AuthType.DeviceCode, source= "",)
     }
 
     override fun tokenRetrievalFailure(e: Exception) {
-        AwsTelemetry.loginWithBrowser(project = null, result = Result.Failed, credentialType = CredentialType.BearerToken, authType = AuthType.DeviceCode)
+        AwsTelemetry.loginWithBrowser(project = null, result = Result.Failed, credentialType = CredentialType.BearerToken, authType = AuthType.DeviceCode, source= "",)
     }
 }
 
@@ -106,7 +107,8 @@ object DefaultBearerTokenPrompt : BearerTokenPrompt {
                     project = null,
                     result = Result.Cancelled,
                     credentialType = CredentialType.BearerToken,
-                    authType = AuthType.DeviceCode
+                    authType = AuthType.DeviceCode,
+                    source= "",
                 )
             }
         }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
@@ -67,7 +67,6 @@ object DefaultSsoPrompt : SsoPrompt {
             val result = ConfirmUserCodeLoginDialog(
                 authorization.userCode,
                 AwsCoreBundle.message("credentials.sso.login.title"),
-                CredentialType.SsoProfile
             ).showAndGet()
 
             if (result) {
@@ -122,7 +121,6 @@ object DefaultBearerTokenPrompt : BearerTokenPrompt {
             val codeCopied = ConfirmUserCodeLoginDialog(
                 authorization.userCode,
                 AwsCoreBundle.message("credentials.sono.login"),
-                CredentialType.BearerToken
             ).showAndGet()
 
             if (codeCopied) {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/SsoLoginCallbackProvider.kt
@@ -7,6 +7,7 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.progress.ProcessCanceledException
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.ConfirmUserCodeLoginDialog
+import software.aws.toolkits.jetbrains.core.gettingstarted.editor.SourceOfEntry
 import software.aws.toolkits.jetbrains.utils.computeOnEdt
 import software.aws.toolkits.jetbrains.utils.isQWebviewsAvailable
 import software.aws.toolkits.jetbrains.utils.notifyError
@@ -39,12 +40,24 @@ class DefaultSsoLoginCallbackProvider : SsoLoginCallbackProvider {
 
 interface SsoPrompt : SsoLoginCallback {
     override fun tokenRetrieved() {
-        AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.SsoProfile, authType = AuthType.DeviceCode, source= "")
+        AwsTelemetry.loginWithBrowser(
+            project = null,
+            result = Result.Succeeded,
+            credentialType = CredentialType.SsoProfile,
+            authType = AuthType.DeviceCode,
+            source = SourceOfEntry.UNKNOWN.toString(),
+        )
     }
 
     override fun tokenRetrievalFailure(e: Exception) {
         e.notifyError(AwsCoreBundle.message("credentials.sso.login.failed"))
-        AwsTelemetry.loginWithBrowser(project = null, result = Result.Failed, credentialType = CredentialType.SsoProfile, authType = AuthType.DeviceCode, source= "")
+        AwsTelemetry.loginWithBrowser(
+            project = null,
+            result = Result.Failed,
+            credentialType = CredentialType.SsoProfile,
+            authType = AuthType.DeviceCode,
+            source = SourceOfEntry.UNKNOWN.toString(),
+        )
     }
 }
 
@@ -65,7 +78,7 @@ object DefaultSsoPrompt : SsoPrompt {
                     result = Result.Cancelled,
                     credentialType = CredentialType.SsoProfile,
                     authType = AuthType.DeviceCode,
-                    source= "",
+                    source = SourceOfEntry.UNKNOWN.toString(),
                 )
                 throw ProcessCanceledException(IllegalStateException(AwsCoreBundle.message("credentials.sso.login.cancelled")))
             }
@@ -83,11 +96,23 @@ object SsoPromptWithBrowserSupport : SsoPrompt {
 
 interface BearerTokenPrompt : SsoLoginCallback {
     override fun tokenRetrieved() {
-        AwsTelemetry.loginWithBrowser(project = null, result = Result.Succeeded, credentialType = CredentialType.BearerToken, authType = AuthType.DeviceCode, source= "",)
+        AwsTelemetry.loginWithBrowser(
+            project = null,
+            result = Result.Succeeded,
+            credentialType = CredentialType.BearerToken,
+            authType = AuthType.DeviceCode,
+            source = "",
+        )
     }
 
     override fun tokenRetrievalFailure(e: Exception) {
-        AwsTelemetry.loginWithBrowser(project = null, result = Result.Failed, credentialType = CredentialType.BearerToken, authType = AuthType.DeviceCode, source= "",)
+        AwsTelemetry.loginWithBrowser(
+            project = null,
+            result = Result.Failed,
+            credentialType = CredentialType.BearerToken,
+            authType = AuthType.DeviceCode,
+            source = "",
+        )
     }
 }
 
@@ -108,7 +133,7 @@ object DefaultBearerTokenPrompt : BearerTokenPrompt {
                     result = Result.Cancelled,
                     credentialType = CredentialType.BearerToken,
                     authType = AuthType.DeviceCode,
-                    source= "",
+                    source = SourceOfEntry.UNKNOWN.toString(),
                 )
             }
         }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/ConfirmUserCodeLoginDialog.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/ConfirmUserCodeLoginDialog.kt
@@ -19,14 +19,12 @@ import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.components.BorderLayoutPanel
 import software.aws.toolkits.core.utils.tryOrNull
 import software.aws.toolkits.resources.AwsCoreBundle
-import software.aws.toolkits.telemetry.CredentialType
 import java.awt.datatransfer.StringSelection
 import javax.swing.JComponent
 
 class ConfirmUserCodeLoginDialog(
     private val authCode: String,
-    private val dialogTitle: String,
-    private val credentialType: CredentialType,
+    dialogTitle: String,
 ) : DialogWrapper(null) {
 
     private val pane = panel {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/ConfirmUserCodeLoginDialog.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/ConfirmUserCodeLoginDialog.kt
@@ -19,10 +19,7 @@ import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.components.BorderLayoutPanel
 import software.aws.toolkits.core.utils.tryOrNull
 import software.aws.toolkits.resources.AwsCoreBundle
-import software.aws.toolkits.telemetry.AuthType
-import software.aws.toolkits.telemetry.AwsTelemetry
 import software.aws.toolkits.telemetry.CredentialType
-import software.aws.toolkits.telemetry.Result
 import java.awt.datatransfer.StringSelection
 import javax.swing.JComponent
 
@@ -67,7 +64,6 @@ class ConfirmUserCodeLoginDialog(
 
     override fun doCancelAction() {
         super.doCancelAction()
-        AwsTelemetry.loginWithBrowser(project = null, result = Result.Cancelled, credentialType = credentialType, authType = AuthType.DeviceCode)
     }
 }
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/pkce/ToolkitOAuthService.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/pkce/ToolkitOAuthService.kt
@@ -31,6 +31,7 @@ import software.aws.toolkits.jetbrains.core.credentials.sso.AccessToken
 import software.aws.toolkits.jetbrains.core.credentials.sso.PKCEAuthorizationGrantToken
 import software.aws.toolkits.jetbrains.core.credentials.sso.PKCEClientRegistration
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.buildUnmanagedSsoOidcClient
+import software.aws.toolkits.jetbrains.core.gettingstarted.editor.SourceOfEntry
 import software.aws.toolkits.resources.AwsCoreBundle
 import software.aws.toolkits.telemetry.AuthType
 import software.aws.toolkits.telemetry.AwsTelemetry
@@ -206,7 +207,8 @@ internal class ToolkitOAuthCallbackHandler : OAuthCallbackHandlerBase() {
                 result = MetricResult.Failed,
                 reason = error,
                 reasonDesc = errorDescription,
-                authType = AuthType.PKCE
+                authType = AuthType.PKCE,
+                source = "",
             )
 
             mapOf(

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/pkce/ToolkitOAuthService.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/pkce/ToolkitOAuthService.kt
@@ -208,7 +208,7 @@ internal class ToolkitOAuthCallbackHandler : OAuthCallbackHandlerBase() {
                 reason = error,
                 reasonDesc = errorDescription,
                 authType = AuthType.PKCE,
-                source = "",
+                source = SourceOfEntry.UNKNOWN.toString(),
             )
 
             mapOf(

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/gettingstarted/GettingStartedAuthUtils.kt
@@ -187,7 +187,7 @@ fun requestCredentialsForQ(
         scopes = Q_SCOPES,
         promptForIdcPermissionSet = false,
         sourceOfEntry = SourceOfEntry.Q,
-        featureId = FeatureId.Q, // TODO: Update Q  in common
+        featureId = FeatureId.AmazonQ,
         connectionInitiatedFromQChatPanel = connectionInitiatedFromQChatPanel
     )
 
@@ -196,7 +196,7 @@ fun requestCredentialsForQ(
         AuthTelemetry.addConnection(
             project,
             source = getSourceOfEntry(SourceOfEntry.Q, isFirstInstance, connectionInitiatedFromExplorer, connectionInitiatedFromQChatPanel),
-            featureId = FeatureId.Q,
+            featureId = FeatureId.AmazonQ,
             credentialSourceId = authenticationDialog.authType,
             isAggregated = true,
             attempts = authenticationDialog.attempts + 1,
@@ -217,7 +217,7 @@ fun requestCredentialsForQ(
         AuthTelemetry.addConnection(
             project,
             source = getSourceOfEntry(SourceOfEntry.Q, isFirstInstance, connectionInitiatedFromExplorer, connectionInitiatedFromQChatPanel),
-            featureId = FeatureId.Q,
+            featureId = FeatureId.AmazonQ,
             credentialSourceId = authenticationDialog.authType,
             isAggregated = false,
             attempts = authenticationDialog.attempts + 1,

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -101,16 +101,17 @@ abstract class LoginBrowser(
                         result = Result.Failed,
                         reason = "Browser authentication idle for more than 15min",
                         credentialSourceId = if (startUrl == SONO_URL) CredentialSourceId.AwsId else CredentialSourceId.IamIdentityCenter,
-                        authType = getAuthType(ssoRegion)
+                        authType = getAuthType(ssoRegion),
+                        source = SourceOfEntry.LOGIN_BROWSER.toString(),
                     )
                     AuthTelemetry.addConnection(
                         result = Result.Failed,
                         reason = "Browser authentication idle for more than 15min",
                         credentialSourceId = if (startUrl == SONO_URL) CredentialSourceId.AwsId else CredentialSourceId.IamIdentityCenter,
                         isAggregated = false,
-                        source = SourceOfEntry.LOGIN_BROWSER.toString(),
                         featureId = getFeatureId(scopes),
-                        isReAuth = isReAuth(scopes, startUrl)
+                        isReAuth = isReAuth(scopes, startUrl),
+                        source = SourceOfEntry.LOGIN_BROWSER.toString(),
                     )
                     stopAndClearBrowserOpenTimer()
                 }
@@ -198,7 +199,8 @@ abstract class LoginBrowser(
                 reason = e.message,
                 credentialSourceId = CredentialSourceId.AwsId,
                 isReAuth = isReauth,
-                authType = getAuthType(SONO_REGION)
+                authType = getAuthType(SONO_REGION),
+                source = SourceOfEntry.LOGIN_BROWSER.toString(),
             )
             AuthTelemetry.addConnection(
                 result = Result.Failed,
@@ -218,7 +220,8 @@ abstract class LoginBrowser(
                 result = Result.Succeeded,
                 credentialSourceId = CredentialSourceId.AwsId,
                 isReAuth = isReauth,
-                authType = getAuthType(SONO_REGION)
+                authType = getAuthType(SONO_REGION),
+                source = SourceOfEntry.LOGIN_BROWSER.toString(),
             )
             AuthTelemetry.addConnection(
                 result = Result.Succeeded,
@@ -276,7 +279,8 @@ abstract class LoginBrowser(
                 result = result,
                 reason = message,
                 credentialSourceId = CredentialSourceId.IamIdentityCenter,
-                authType = getAuthType(region.name)
+                authType = getAuthType(region.name),
+                source = SourceOfEntry.LOGIN_BROWSER.toString()
             )
             AuthTelemetry.addConnection(
                 result = result,
@@ -297,7 +301,8 @@ abstract class LoginBrowser(
                 credentialType = CredentialType.BearerToken,
                 credentialStartUrl = url,
                 credentialSourceId = CredentialSourceId.IamIdentityCenter,
-                authType = getAuthType(region.name)
+                authType = getAuthType(region.name),
+                source = SourceOfEntry.LOGIN_BROWSER.toString(),
             )
             AuthTelemetry.addConnection(
                 project = null,
@@ -324,7 +329,8 @@ abstract class LoginBrowser(
                         result = Result.Failed,
                         reason = error.message,
                         credentialType = CredentialType.StaticProfile,
-                        authType = AuthType.IAM
+                        authType = AuthType.IAM,
+                        source = "",
                     )
                     LOG.error(error) { "Profile file error" }
                     Messages.showErrorDialog(jcefBrowser.component, error.message, AwsCoreBundle.message("gettingstarted.auth.failed"))
@@ -334,7 +340,8 @@ abstract class LoginBrowser(
                         project = null,
                         result = Result.Failed,
                         reason = "Profile already exists",
-                        authType = AuthType.IAM
+                        authType = AuthType.IAM,
+                        source = "",
                     )
                 },
                 { error ->
@@ -343,7 +350,8 @@ abstract class LoginBrowser(
                         project = null,
                         result = Result.Failed,
                         reason = reason,
-                        authType = AuthType.IAM
+                        authType = AuthType.IAM,
+                        source = "",
                     )
                     LOG.error(error) { reason }
                     Messages.showErrorDialog(jcefBrowser.component, error.message, AwsCoreBundle.message("gettingstarted.auth.failed"))
@@ -356,7 +364,8 @@ abstract class LoginBrowser(
                     project = null,
                     result = Result.Succeeded,
                     credentialType = CredentialType.StaticProfile,
-                    authType = AuthType.IAM
+                    authType = AuthType.IAM,
+                    source = "",
                 )
             }
         }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/LoginBrowser.kt
@@ -330,7 +330,7 @@ abstract class LoginBrowser(
                         reason = error.message,
                         credentialType = CredentialType.StaticProfile,
                         authType = AuthType.IAM,
-                        source = "",
+                        source = SourceOfEntry.LOGIN_BROWSER.toString(),
                     )
                     LOG.error(error) { "Profile file error" }
                     Messages.showErrorDialog(jcefBrowser.component, error.message, AwsCoreBundle.message("gettingstarted.auth.failed"))
@@ -341,7 +341,7 @@ abstract class LoginBrowser(
                         result = Result.Failed,
                         reason = "Profile already exists",
                         authType = AuthType.IAM,
-                        source = "",
+                        source = SourceOfEntry.LOGIN_BROWSER.toString(),
                     )
                 },
                 { error ->
@@ -351,7 +351,7 @@ abstract class LoginBrowser(
                         result = Result.Failed,
                         reason = reason,
                         authType = AuthType.IAM,
-                        source = "",
+                        source = SourceOfEntry.LOGIN_BROWSER.toString(),
                     )
                     LOG.error(error) { reason }
                     Messages.showErrorDialog(jcefBrowser.component, error.message, AwsCoreBundle.message("gettingstarted.auth.failed"))
@@ -365,7 +365,7 @@ abstract class LoginBrowser(
                     result = Result.Succeeded,
                     credentialType = CredentialType.StaticProfile,
                     authType = AuthType.IAM,
-                    source = "",
+                    source = SourceOfEntry.LOGIN_BROWSER.toString(),
                 )
             }
         }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/WebviewTelemetryUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/webview/WebviewTelemetryUtils.kt
@@ -20,7 +20,7 @@ fun getAuthType(region: String): AuthType {
 
 fun getFeatureId(scopes: List<String>): FeatureId =
     if (scopes.intersect(Q_SCOPES.toSet()).isNotEmpty()) {
-        FeatureId.Q
+        FeatureId.AmazonQ
     } else if (scopes.intersect(CODECATALYST_SCOPES.toSet()).isNotEmpty()) {
         FeatureId.Codecatalyst
     } else {


### PR DESCRIPTION
When feasible, metrics should be added in common and consumed instead of only declared in the local override
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
