### PR TITLE
fix(amazonq): Normalize generated file paths in feature dev.

### DIFF
--- a/.changes/next-release/bugfix-fd7f4f61-241e-40a6-b92a-3e4fe7e832db.json
+++ b/.changes/next-release/bugfix-fd7f4f61-241e-40a6-b92a-3e4fe7e832db.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q /dev: Fix error when accepting changes if leading slash is present."
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
@@ -258,7 +258,8 @@ private suspend fun CodeGenerationState.generateCode(
 fun registerNewFiles(newFileContents: Map<String, String>): List<NewFileZipInfo> =
     newFileContents.map {
         NewFileZipInfo(
-            zipFilePath = it.key,
+            // Note: When managing file state, we normalize file paths returned from the agent in order to ensure they are handled as relative paths.
+            zipFilePath = it.key.removePrefix("/"),
             fileContent = it.value,
             rejected = false,
             changeApplied = false
@@ -268,7 +269,8 @@ fun registerNewFiles(newFileContents: Map<String, String>): List<NewFileZipInfo>
 fun registerDeletedFiles(deletedFiles: List<String>): List<DeletedFileInfo> =
     deletedFiles.map {
         DeletedFileInfo(
-            zipFilePath = it,
+            // Note: When managing file state, we normalize file paths returned from the agent in order to ensure they are handled as relative paths.
+            zipFilePath = it.removePrefix("/"),
             rejected = false,
             changeApplied = false
         )


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

The agent may generate files with or without a leading slash in the generated file path. In JetBrains, this results in an exception thrown when attempting to write to the root directory on MacOS. (Various other failure modes may occur due to lack of normalization, depending on OS.)

This change normalized handling within /dev, to avoid breakage or other side effects of non-normalized file paths.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
