### PR TITLE
fix(amazonq): Correct search text for Amazon Q inline suggestion keybindings

### DIFF
--- a/.changes/next-release/bugfix-9e0be536-a758-466e-8b65-ab2f50331ecd.json
+++ b/.changes/next-release/bugfix-9e0be536-a758-466e-8b65-ab2f50331ecd.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Correct search text for Amazon Q inline suggestion"
+}

--- a/.changes/next-release/bugfix-9e0be536-a758-466e-8b65-ab2f50331ecd.json
+++ b/.changes/next-release/bugfix-9e0be536-a758-466e-8b65-ab2f50331ecd.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Correct search text for Amazon Q inline suggestion"
+  "description" : "Correct search text for Amazon Q inline suggestion keybindings"
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererConfigurable.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererConfigurable.kt
@@ -206,6 +206,6 @@ class CodeWhispererConfigurable(private val project: Project) :
     }
 
     companion object {
-        private const val Q_INLINE_KEYBINDING_SEARCH_TEXT = "inline suggestion"
+        private const val Q_INLINE_KEYBINDING_SEARCH_TEXT = "Amazon Q inline suggestion"
     }
 }


### PR DESCRIPTION

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
When you select - Map Key bindings from Q's status bar - It takes you to a settings panel with setting to change "JB's Inline Suggestion". You must select Q's settings & then update. 

This is to update the search text to Amazon Q inline suggestion to avoid confusion with JB's keybindings

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
