### PR TITLE
fix(amazonq): download each job's zip to its own directory

### DIFF
--- a/.changes/next-release/bugfix-f486f12a-cb1a-4986-949f-939d600789ae.json
+++ b/.changes/next-release/bugfix-f486f12a-cb1a-4986-949f-939d600789ae.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix(Amazon Q Code Transformation): always show user latest/correct transformation results"
+}

--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerArtifact.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/model/CodeModernizerArtifact.kt
@@ -19,6 +19,7 @@ import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.codemodernizer.TransformationSummary
 import software.aws.toolkits.jetbrains.services.codemodernizer.utils.unzipFile
 import java.io.File
+import java.util.UUID
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.Path
 import kotlin.io.path.isDirectory
@@ -39,7 +40,7 @@ open class CodeModernizerArtifact(
 
     companion object {
         private const val MAX_SUPPORTED_VERSION = 1.0
-        private val tempDir = createTempDirectory("codeTransformArtifacts", null)
+        private var tempDir = createTempDirectory("codeTransformArtifacts", null)
         private const val MANIFEST_FILE_NAME = "manifest.json"
         private const val SUMMARY_FILE_NAME = "summary.md"
         private const val METRICS_FILE_NAME = "metrics.json"
@@ -52,6 +53,7 @@ open class CodeModernizerArtifact(
          * If anything goes wrong during this process an exception is thrown.
          */
         fun create(zipPath: String): CodeModernizerArtifact {
+            tempDir = createTempDirectory("codeTransformArtifacts-", UUID.randomUUID().toString())
             val path = Path(zipPath)
             if (path.exists()) {
                 if (!unzipFile(path, tempDir.toPath())) {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
When users run consecutive transformations (ex. a Java upgrade with multiple diffs requested, then a SQL conversion), the summary/diff from the 1st transformation would show up when trying to view the summary/diff for the 2nd transformation, because we were re-using a temp directory to store all artifacts.

Solution is to create a new and unique temp directory to hold each transformation job's results.
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
