### PR TITLE
Fix wildcard import rule allowing java.util.*

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -42,7 +42,7 @@ ij_kotlin_allow_trailing_comma = true
 ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
 ij_kotlin_name_count_to_use_star_import = 2147483647
 ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
-ij_kotlin_packages_to_use_import_on_demand = unset
+ij_kotlin_packages_to_use_import_on_demand = ""
 
 [{*.markdown,*.md}]
 ij_markdown_force_one_space_after_blockquote_symbol = true

--- a/detekt-rules/detekt.yml
+++ b/detekt-rules/detekt.yml
@@ -72,7 +72,7 @@ formatting:
     maxLineLength: 160
     ignoreBackTickedIdentifier: true
   NoWildcardImports:
-    # no `packagesToUseImportOnDemandProperty` because we don't want to allow any star imports
+    packagesToUseImportOnDemandProperty: ""
     active: true
   ParameterListWrapping:
     active: true

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererCodeTestSession.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererCodeTestSession.kt
@@ -23,7 +23,7 @@ import software.aws.toolkits.jetbrains.utils.assertIsNonDispatchThread
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import kotlin.coroutines.coroutineContext
 
 // TODO: Refactor with CodeWhispererCodeScanSession code since both are about zip CreateUploadUrl logic

--- a/plugins/core/jetbrains-community/src/migration/software/aws/toolkits/jetbrains/settings/AwsSettings.kt
+++ b/plugins/core/jetbrains-community/src/migration/software/aws/toolkits/jetbrains/settings/AwsSettings.kt
@@ -6,7 +6,7 @@ package migration.software.aws.toolkits.jetbrains.settings
 import com.intellij.openapi.components.service
 import software.aws.toolkits.jetbrains.settings.ProfilesNotification
 import software.aws.toolkits.jetbrains.settings.UseAwsCredentialRegion
-import java.util.*
+import java.util.UUID
 
 interface AwsSettings {
     var isTelemetryEnabled: Boolean


### PR DESCRIPTION
https://pinterest.github.io/ktlint/1.4.1/faq/#why-is-wildcard-import-javautil-not-reported-by-the-no-wildcard-imports-rule

> Why is wildcard import java.util.* not reported by the no-wildcard-imports rule?¶
> The no-wildcard-imports rule forbids wildcard imports, except for imports defined in .editorconfig property ij_kotlin_packages_to_use_import_on_demand. If this property is not explicitly set, it allows wildcards imports like java.util.* by default to keep in sync with IntelliJ IDEA behavior.


 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
