### PR TITLE
telemetry(amazonq): Adding credentialUrl to differentiate the Internal Users vs External users

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
@@ -41,6 +41,7 @@ import software.aws.toolkits.jetbrains.services.codemodernizer.utils.calculateTo
 import software.aws.toolkits.jetbrains.services.codewhisperer.codetest.sessionconfig.CodeTestSessionConfig
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererClientAdaptor
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.promptReAuth
+import software.aws.toolkits.jetbrains.services.cwc.controller.chat.telemetry.getStartUrl
 import software.aws.toolkits.jetbrains.services.cwc.messages.ChatMessageType
 import software.aws.toolkits.jetbrains.services.cwc.messages.CodeReference
 import software.aws.toolkits.jetbrains.settings.CodeWhispererSettings
@@ -511,6 +512,7 @@ class CodeWhispererUTGChatManager(val project: Project, private val cs: Coroutin
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
                     isSupportedLanguage = true,
+                    credentialStartUrl = getStartUrl(project),
                     jobGroup = session.testGenerationJobGroupName,
                     jobId = session.testGenerationJob,
                     result = if (e.message == message("testgen.message.cancelled")) MetricResult.Cancelled else MetricResult.Failed,

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -77,6 +77,7 @@ import software.aws.toolkits.jetbrains.services.cwc.clients.chat.model.TriggerTy
 import software.aws.toolkits.jetbrains.services.cwc.clients.chat.v1.ChatSessionV1.Companion.validLanguages
 import software.aws.toolkits.jetbrains.services.cwc.controller.chat.StaticPrompt
 import software.aws.toolkits.jetbrains.services.cwc.controller.chat.StaticTextResponse
+import software.aws.toolkits.jetbrains.services.cwc.controller.chat.telemetry.getStartUrl
 import software.aws.toolkits.jetbrains.services.cwc.editor.context.ActiveFileContext
 import software.aws.toolkits.jetbrains.services.cwc.editor.context.ActiveFileContextExtractor
 import software.aws.toolkits.jetbrains.services.cwc.editor.context.ExtractionTriggerType
@@ -285,6 +286,7 @@ class CodeTestChatController(
                 cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                 hasUserPromptSupplied = session.hasUserPromptSupplied,
                 isSupportedLanguage = false,
+                credentialStartUrl = getStartUrl(project),
                 result = MetricResult.Succeeded,
                 perfClientLatency = (Instant.now().toEpochMilli() - session.startTimeOfTestGeneration)
             )
@@ -583,6 +585,7 @@ class CodeTestChatController(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
                     isSupportedLanguage = true,
+                    credentialStartUrl = getStartUrl(project = context.project),
                     jobGroup = session.testGenerationJobGroupName,
                     jobId = session.testGenerationJob,
                     acceptedCount = session.numberOfUnitTestCasesGenerated?.toLong(),
@@ -775,6 +778,7 @@ class CodeTestChatController(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
                     isSupportedLanguage = true,
+                    credentialStartUrl = getStartUrl(project = context.project),
                     jobGroup = session.testGenerationJobGroupName,
                     jobId = session.testGenerationJob,
                     acceptedCount = 0,


### PR DESCRIPTION


<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Problem
- UTG toolkit telemetry can not differentiate the users from builderID users vs internal IAM IDC users vs external enterprise users.

## Solution
- Adding `credentialUrl = AuthUtil.instance.startUrl` field to differentiate the builderID users vs internal IAM IDC users vs external enterprise users.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
