### PR TITLE
Renamed @aws/dexp to @aws/flare in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,9 @@ codemodernizer/ @aws/elastic-gumby
 codetransform/ @aws/elastic-gumby
 codewhisperer/ @aws/codewhisperer-team
 
-mynah-ui/ @aws/dexp
-mynah-ui/package.json @aws/dexp @aws/elastic-gumby @aws/earlybird @aws/codewhisperer-team
-mynah-ui/package-lock.json @aws/dexp @aws/elastic-gumby @aws/earlybird @aws/codewhisperer-team
+mynah-ui/ @aws/flare
+mynah-ui/package.json @aws/flare @aws/elastic-gumby @aws/earlybird @aws/codewhisperer-team
+mynah-ui/package-lock.json @aws/flare @aws/elastic-gumby @aws/earlybird @aws/codewhisperer-team
 
 # nested within chat/, so needs to be after to take precedence
 amazonqFeatureDev/ @aws/earlybird


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
As part of the renaming of "DEXP" to "Flare", the team name on GitHub has changed, and so the codeowners file in this repository should be updated accordingly.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
