### PR TITLE
fix(amazonq): missing `@workspace` command on welcome tab

### DIFF
--- a/.changes/next-release/bugfix-4188d9b7-63eb-4e12-b3ee-4aec88b546be.json
+++ b/.changes/next-release/bugfix-4188d9b7-63eb-4e12-b3ee-4aec88b546be.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix `@workspace` missing from the Amazon Q Chat welcome tab"
+}

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/walkthrough/welcome.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/walkthrough/welcome.ts
@@ -10,6 +10,7 @@ export const welcomeScreenTabData = (tabs: TabDataGenerator): MynahUITabStoreTab
     isSelected: true,
     store: {
         quickActionCommands: tabs.quickActionsGenerator.generateForTab('welcome'),
+        contextCommands: tabs.getTabData('cwc', false).contextCommands,
         tabTitle: 'Welcome to Q',
         tabBackground: true,
         chatItems: [


### PR DESCRIPTION
`contextCommands` was not being passed through
 
<img width="326" alt="image" src="https://github.com/user-attachments/assets/2e5615c0-3dda-49d4-8de8-e837c1058167">


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
