### PR TITLE
Fix rejected files display inconsistency between VS Code and JetBrains

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -294,11 +294,10 @@ class FeatureDevController(
         val prevInsertAction = insertAction()
 
         if (action == "accept-change") {
-            session.insertChangesWithoutUpdateFileComponents(
+            session.insertChanges(
                 filePaths = filePaths.filter { it.zipFilePath == fileToUpdate },
                 deletedFiles = deletedFiles.filter { it.zipFilePath == fileToUpdate },
                 references = references, // Add all references (not attributed per-file)
-                messenger
             )
 
             AmazonqTelemetry.isAcceptedCodeChanges(
@@ -419,10 +418,14 @@ class FeatureDevController(
                 credentialStartUrl = getStartUrl(project = context.project)
             )
 
-            session.insertChangesAndUpdateFileComponents(
+            session.insertChanges(
                 filePaths = filePaths,
                 deletedFiles = deletedFiles,
-                references = references,
+                references = references
+            )
+            session.updateFilesPaths(
+                filePaths = filePaths,
+                deletedFiles = deletedFiles,
                 messenger
             )
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -294,7 +294,7 @@ class FeatureDevController(
         val prevInsertAction = insertAction()
 
         if (action == "accept-change") {
-            session.insertChanges(
+            session.insertChangesWithoutUpdateFileComponents(
                 filePaths = filePaths.filter { it.zipFilePath == fileToUpdate },
                 deletedFiles = deletedFiles.filter { it.zipFilePath == fileToUpdate },
                 references = references, // Add all references (not attributed per-file)
@@ -313,8 +313,6 @@ class FeatureDevController(
             deletedFiles.find { it.zipFilePath == fileToUpdate }?.let { it.rejected = !it.rejected }
         }
 
-        // FIXME: This is a kludge that is hiding the fact that insertChanges is updating the file tree above this point to
-        // an incorrect state. Update the state of the tree view:
         messenger.updateFileComponent(message.tabId, filePaths, deletedFiles, messageId)
 
         // Then, if the accepted file is not a deletion, open a diff to show the changes are applied:
@@ -421,13 +419,9 @@ class FeatureDevController(
                 credentialStartUrl = getStartUrl(project = context.project)
             )
 
-            // Caution: insertChanges has multiple responsibilities.
-            // The filter here results in rejected files being hidden from the tree after continuing, by design.
-            // However, it is critical that we don't hide already-accepted files. Inside insertChanges, it
-            // filters to only update the subset of passed files that aren't accepted or rejected already.
-            session.insertChanges(
-                filePaths = filePaths.filter { !it.rejected },
-                deletedFiles = deletedFiles.filter { !it.rejected },
+            session.insertChangesAndUpdateFileComponents(
+                filePaths = filePaths,
+                deletedFiles = deletedFiles,
                 references = references,
                 messenger
             )

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -201,7 +201,7 @@ class Session(val tabID: String, val project: Project) {
             resolveAndDeleteFile(selectedSourceFolder, it.zipFilePath)
             it.changeApplied = true
         }
-        }
+    }
 
     suspend fun disableFileList(
         filePaths: List<NewFileZipInfo>,

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -193,7 +193,7 @@ class Session(val tabID: String, val project: Project) {
         }
     }
 
-// Suppressing because insertNewFiles needs to be a suspend function in order to be tested
+// Suppressing because applyDeleteFiles needs to be a suspend function in order to be tested
     @Suppress("RedundantSuspendModifier")
     suspend fun applyDeleteFiles(
         deletedFiles: List<DeletedFileInfo>,

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
+import kotlinx.coroutines.yield
 import software.aws.toolkits.jetbrains.common.util.resolveAndCreateOrUpdateFile
 import software.aws.toolkits.jetbrains.common.util.resolveAndDeleteFile
 import software.aws.toolkits.jetbrains.services.amazonq.FeatureDevSessionContext
@@ -186,17 +187,18 @@ class Session(val tabID: String, val project: Project) {
         val selectedSourceFolder = context.selectedSourceFolder.toNioPath()
 
         filePaths.forEach {
+            yield()
             resolveAndCreateOrUpdateFile(selectedSourceFolder, it.zipFilePath, it.fileContent)
             it.changeApplied = true
         }
     }
-
     suspend fun applyDeleteFiles(
         deletedFiles: List<DeletedFileInfo>,
     ) {
         val selectedSourceFolder = context.selectedSourceFolder.toNioPath()
 
         deletedFiles.forEach {
+            yield()
             resolveAndDeleteFile(selectedSourceFolder, it.zipFilePath)
             it.changeApplied = true
         }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -6,7 +6,6 @@ package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
-import kotlinx.coroutines.yield
 import software.aws.toolkits.jetbrains.common.util.resolveAndCreateOrUpdateFile
 import software.aws.toolkits.jetbrains.common.util.resolveAndDeleteFile
 import software.aws.toolkits.jetbrains.services.amazonq.FeatureDevSessionContext
@@ -181,24 +180,27 @@ class Session(val tabID: String, val project: Project) {
         VfsUtil.markDirtyAndRefresh(true, true, true, context.selectedSourceFolder)
     }
 
+// Suppressing because insertNewFiles needs to be a suspend function in order to be tested
+    @Suppress("RedundantSuspendModifier")
     suspend fun insertNewFiles(
         filePaths: List<NewFileZipInfo>,
     ) {
         val selectedSourceFolder = context.selectedSourceFolder.toNioPath()
 
         filePaths.forEach {
-            yield()
             resolveAndCreateOrUpdateFile(selectedSourceFolder, it.zipFilePath, it.fileContent)
             it.changeApplied = true
         }
     }
+
+// Suppressing because insertNewFiles needs to be a suspend function in order to be tested
+    @Suppress("RedundantSuspendModifier")
     suspend fun applyDeleteFiles(
         deletedFiles: List<DeletedFileInfo>,
     ) {
         val selectedSourceFolder = context.selectedSourceFolder.toNioPath()
 
         deletedFiles.forEach {
-            yield()
             resolveAndDeleteFile(selectedSourceFolder, it.zipFilePath)
             it.changeApplied = true
         }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -24,7 +24,6 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.getChange
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.getDiffMetrics
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.readFileToString
 import software.aws.toolkits.jetbrains.services.cwc.controller.ReferenceLogController
-import java.nio.file.Path
 import java.util.HashSet
 
 class Session(val tabID: String, val project: Project) {

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -241,9 +241,9 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                 ),
             )
 
-            doReturn(Unit).`when`(spySession).insertChanges(any(), any(), any())
-            doReturn(Unit).`when`(spySession).insertNewFiles(any())
-            doReturn(Unit).`when`(spySession).applyDeleteFiles(any())
+            doReturn(Unit).whenever(spySession).insertChanges(any(), any(), any())
+            doReturn(Unit).whenever(spySession).insertNewFiles(any())
+            doReturn(Unit).whenever(spySession).applyDeleteFiles(any())
 
             spySession.preloader(userMessage, messenger)
             controller.processFollowupClickedMessage(message)

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -16,7 +16,6 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -31,8 +30,6 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
-import software.aws.toolkits.jetbrains.common.util.resolveAndCreateOrUpdateFile
-import software.aws.toolkits.jetbrains.common.util.resolveAndDeleteFile
 import software.aws.toolkits.jetbrains.common.util.selectFolder
 import software.aws.toolkits.jetbrains.services.amazonq.FeatureDevSessionContext
 import software.aws.toolkits.jetbrains.services.amazonq.apps.AmazonQAppInitContext

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -241,7 +241,8 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                 ),
             )
 
-            doReturn(Unit).`when`(spySession).insertChanges(any(), any(), any(), any())
+            doReturn(Unit).`when`(spySession).insertChangesAndUpdateFileComponents(any(), any(), any(), any())
+            doReturn(Unit).`when`(spySession).insertChanges(any(), any())
 
             spySession.preloader(userMessage, messenger)
             controller.processFollowupClickedMessage(message)
@@ -249,7 +250,7 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
             mockitoVerify(
                 spySession,
                 times(1),
-            ).insertChanges(listOf(newFileContents[0]), listOf(deletedFiles[0]), testReferences, messenger) // insert changes for only non rejected files
+            ).insertChangesAndUpdateFileComponents(newFileContents, deletedFiles, testReferences, messenger) // updates for all files
             coVerifyOrder {
                 AmazonqTelemetry.isAcceptedCodeChanges(
                     amazonqNumberOfFilesAccepted = 2.0, // it should be 2 files per test setup
@@ -257,6 +258,7 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                     enabled = true,
                     createTime = any(),
                 )
+                spySession.insertChanges(listOf(newFileContents[0]), listOf(deletedFiles[0])) // insert changes for only non-rejected files
                 messenger.sendAnswer(
                     tabId = testTabId,
                     message = message("amazonqFeatureDev.code_generation.updated_code"),
@@ -468,7 +470,7 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                 ),
             )
             doReturn(testConversationId).`when`(spySession).conversationId
-            doReturn(Unit).`when`(spySession).insertChanges(any(), any(), any(), any())
+            doReturn(Unit).`when`(spySession).insertChangesWithoutUpdateFileComponents(any(), any(), any(), any())
 
             mockkObject(AmazonqTelemetry)
             every {
@@ -491,7 +493,7 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
             mockitoVerify(
                 spySession,
                 times(1),
-            ).insertChanges(listOf(newFileContents[0]), listOf(), testReferences, messenger)
+            ).insertChangesWithoutUpdateFileComponents(listOf(newFileContents[0]), listOf(), testReferences, messenger)
 
             // Does not continue automatically, because files are remaining:
             mockitoVerify(
@@ -525,7 +527,7 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                 ),
             )
             doReturn(testConversationId).`when`(spySession).conversationId
-            doReturn(Unit).`when`(spySession).insertChanges(any(), any(), any(), any())
+            doReturn(Unit).`when`(spySession).insertChangesWithoutUpdateFileComponents(any(), any(), any(), any())
 
             mockkObject(AmazonqTelemetry)
             every {

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -287,10 +287,6 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                 )
                 messenger.sendUpdatePlaceholder(testTabId, message("amazonqFeatureDev.placeholder.additional_improvements"))
             }
-
-            // insert changes for only non rejected files
-//            verify(exactly = 1) { resolveAndCreateOrUpdateFile(any(), newFileContents[0].zipFilePath, newFileContents[0].fileContent) }
-//            verify(exactly = 1) { resolveAndDeleteFile(any(), deletedFiles[0].zipFilePath) }
         }
 
     @Test

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionTest.kt
@@ -65,7 +65,7 @@ class SessionTest : FeatureDevTestBase() {
     }
 
     @Test
-    fun `test insertChanges`() {
+    fun `test insertChangesAndUpdateFileComponents`() {
         mockkStatic("com.intellij.openapi.vfs.VfsUtil")
         every { VfsUtil.markDirtyAndRefresh(true, true, true, any<VirtualFile>()) } just runs
 
@@ -83,7 +83,7 @@ class SessionTest : FeatureDevTestBase() {
         whenever(session.context.selectedSourceFolder.toNioPath()).thenReturn(Path(""))
 
         runBlocking {
-            session.insertChanges(mockNewFile, mockDeletedFile, emptyList(), messenger)
+            session.insertChangesAndUpdateFileComponents(mockNewFile, mockDeletedFile, emptyList(), messenger)
         }
 
         verify(exactly = 1) { resolveAndDeleteFile(any(), "deletedTest.ts") }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/SessionTest.kt
@@ -65,7 +65,7 @@ class SessionTest : FeatureDevTestBase() {
     }
 
     @Test
-    fun `test insertChangesAndUpdateFileComponents`() {
+    fun `test insertChanges`() {
         mockkStatic("com.intellij.openapi.vfs.VfsUtil")
         every { VfsUtil.markDirtyAndRefresh(true, true, true, any<VirtualFile>()) } just runs
 
@@ -83,7 +83,7 @@ class SessionTest : FeatureDevTestBase() {
         whenever(session.context.selectedSourceFolder.toNioPath()).thenReturn(Path(""))
 
         runBlocking {
-            session.insertChangesAndUpdateFileComponents(mockNewFile, mockDeletedFile, emptyList(), messenger)
+            session.insertChanges(mockNewFile, mockDeletedFile, emptyList())
         }
 
         verify(exactly = 1) { resolveAndDeleteFile(any(), "deletedTest.ts") }


### PR DESCRIPTION
## Description
Originally when a file is rejected in `/dev` and we accepted all other files, VS Code displays the original file trees with the accepted files and rejected files, but JetBrains hides rejected files. This PR aligns JetBrains with VS Code.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
