### PR TITLE
fix: Chosing cancel on confirmation no longer deletes profiles (#5167)

### DIFF
--- a/.changes/next-release/bugfix-1507b9a1-02ba-426c-b08d-e8ac8ca1e83d.json
+++ b/.changes/next-release/bugfix-1507b9a1-02ba-426c-b08d-e8ac8ca1e83d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : " Chosing cancel on sign out confirmation now cancels the sign out and does not delete profiles from ~/.aws/config ([#5167](https://github.com/aws/aws-toolkit-jetbrains/issues/5167))"
+}

--- a/.changes/next-release/bugfix-1507b9a1-02ba-426c-b08d-e8ac8ca1e83d.json
+++ b/.changes/next-release/bugfix-1507b9a1-02ba-426c-b08d-e8ac8ca1e83d.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : " Chosing cancel on sign out confirmation now cancels the sign out and does not delete profiles from ~/.aws/config ([#5167](https://github.com/aws/aws-toolkit-jetbrains/issues/5167))"
+  "description" : " Chosing cancel on sign out confirmation now cancels the sign out and does not delete profiles from ~/.aws/config (#5167)"
 }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/actions/SsoLogoutAction.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/actions/SsoLogoutAction.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.ui.MessageDialogBuilder
 import software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection
 import software.aws.toolkits.jetbrains.core.credentials.ProfileSsoManagedBearerSsoConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManagerListener
-import software.aws.toolkits.jetbrains.core.credentials.deleteSsoConnection
 import software.aws.toolkits.jetbrains.core.credentials.logoutFromSsoConnection
 import software.aws.toolkits.resources.AwsCoreBundle
 import software.aws.toolkits.telemetry.UiTelemetry

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/actions/SsoLogoutAction.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/actions/SsoLogoutAction.kt
@@ -23,8 +23,8 @@ class SsoLogoutAction(private val value: AwsBearerTokenConnection) : DumbAwareAc
                 AwsCoreBundle.message("gettingstarted.auth.idc.sign.out.confirmation.title"),
                 AwsCoreBundle.message("gettingstarted.auth.idc.sign.out.confirmation")
             ).yesText(AwsCoreBundle.message("general.confirm")).ask(e.project)
-            if (confirmDeletion) {
-                deleteSsoConnection(value)
+            if (!confirmDeletion) {
+                return
             }
         }
         logoutFromSsoConnection(e.project, value)


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Fixes #5167 

If the user selects cancel in the confirmation dialog, the sign out will now be aborted.

The method logoutFromSsoConnection also calls deleteSsoConnection() if connection is ProfileSsoManagedBearerSsoConnection, so removing that call from SsoLogoutAction.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
