### PR TITLE
telemetry(amazonq): Adding requestId for amazonq_utgGenerateTests event

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
@@ -124,6 +124,7 @@ class CodeWhispererUTGChatManager(val project: Project, private val cs: Coroutin
         )
 
         val job = startTestGenerationResponse.testGenerationJob()
+        session.startTestGenerationRequestId = startTestGenerationResponse.responseMetadata().requestId()
         session.testGenerationJobGroupName = job.testGenerationJobGroupName()
         session.testGenerationJob = job.testGenerationJobId()
         throwIfCancelled(session)
@@ -522,7 +523,8 @@ class CodeWhispererUTGChatManager(val project: Project, private val cs: Coroutin
                     isCodeBlockSelected = session.isCodeBlockSelected,
                     artifactsUploadDuration = session.artifactUploadDuration,
                     buildPayloadBytes = session.srcPayloadSize,
-                    buildZipFileBytes = session.srcZipFileSize
+                    buildZipFileBytes = session.srcZipFileSize,
+                    requestId = session.startTestGenerationRequestId
                 )
                 session.isGeneratingTests = false
             } finally {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -282,14 +282,18 @@ class CodeTestChatController(
             val request = requestData.toChatRequest()
             client.generateAssistantResponse(request, responseHandler).await()
             // TODO: Need to send isCodeBlockSelected field
-            AmazonqTelemetry.utgGenerateTests(
-                cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
-                hasUserPromptSupplied = session.hasUserPromptSupplied,
-                isSupportedLanguage = false,
-                credentialStartUrl = getStartUrl(project),
-                result = MetricResult.Succeeded,
-                perfClientLatency = (Instant.now().toEpochMilli() - session.startTimeOfTestGeneration)
-            )
+            requestId.let { id ->
+                LOG.debug { "$FEATURE_NAME: Unit test generation requestId: $id" }
+                AmazonqTelemetry.utgGenerateTests(
+                    cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
+                    hasUserPromptSupplied = session.hasUserPromptSupplied,
+                    isSupportedLanguage = false,
+                    credentialStartUrl = getStartUrl(project),
+                    result = MetricResult.Succeeded,
+                    perfClientLatency = (Instant.now().toEpochMilli() - session.startTimeOfTestGeneration),
+                    requestId = id
+                )
+            }
             session.isGeneratingTests = false
             codeTestChatHelper.updateUI(
                 loadingChat = false,
@@ -599,7 +603,8 @@ class CodeTestChatController(
                     isCodeBlockSelected = session.isCodeBlockSelected,
                     artifactsUploadDuration = session.artifactUploadDuration,
                     buildPayloadBytes = session.srcPayloadSize,
-                    buildZipFileBytes = session.srcZipFileSize
+                    buildZipFileBytes = session.srcZipFileSize,
+                    requestId = session.startTestGenerationRequestId
                 )
                 codeTestChatHelper.addAnswer(
                     CodeTestChatMessageContent(
@@ -792,7 +797,8 @@ class CodeTestChatController(
                     isCodeBlockSelected = session.isCodeBlockSelected,
                     artifactsUploadDuration = session.artifactUploadDuration,
                     buildPayloadBytes = session.srcPayloadSize,
-                    buildZipFileBytes = session.srcZipFileSize
+                    buildZipFileBytes = session.srcZipFileSize,
+                    requestId = session.startTestGenerationRequestId
                 )
                 sessionCleanUp(message.tabId)
             }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/session/Session.kt
@@ -20,6 +20,7 @@ data class Session(val tabId: String) {
     var programmingLanguage: CodeWhispererProgrammingLanguage = CodeWhispererUnknownLanguage.INSTANCE
     var testGenerationJob: String = ""
     var testGenerationJobGroupName: String = ""
+    var startTestGenerationRequestId: String = ""
 
     // Telemetry
     var hasUserPromptSupplied: Boolean = false


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Problem
- Missing data if job fails at `StartTestGeneration` API.

## Solution
- Adding requestId for `amazonq_utgGenerateTests` event, which helps ti debug the reason for job failures from the backend.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
