### PR TITLE
fix(amazonq): reduce frequency of system information polling

### DIFF
--- a/.changes/next-release/bugfix-fef8426e-f36c-425f-af0e-a9811e01e2f5.json
+++ b/.changes/next-release/bugfix-fef8426e-f36c-425f-af0e-a9811e01e2f5.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Reduce frequency of system information query"
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.jetbrains.core.getTextFromUrl
 
 class ManifestManager {
     private val cloudFrontUrl = "https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json"
-    val currentVersion = "0.1.27"
+    val currentVersion = "0.1.32"
     val currentOs = getOs()
     private val arch = CpuArch.CURRENT
     private val mapper = jacksonObjectMapper()


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
The system status (battery, CPU usage) was polled very frequently. https://github.com/aws/aws-toolkit-vscode/issues/6134. The fix is to only poll system status (battery, CPU usage) when vector indexing is in progress. The system cpu/battery poll was to make the vector index pause when system load is high to protect system resources, it is no longer needed after vector index is done.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
