### PR TITLE
fix(amazonq): align /doc messages with vscode

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
@@ -66,6 +66,7 @@ import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.updateFileCo
 import software.aws.toolkits.jetbrains.services.amazonqDoc.session.DocSession
 import software.aws.toolkits.jetbrains.services.amazonqDoc.session.PrepareDocGenerationState
 import software.aws.toolkits.jetbrains.services.amazonqDoc.storage.ChatSessionStorage
+import software.aws.toolkits.jetbrains.services.amazonqDoc.util.getFollowUpOptions
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CodeIterationLimitException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MonthlyConversationLimitError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.CodeReferenceGenerated
@@ -813,7 +814,6 @@ class DocController(
 
             when (session.sessionState.phase) {
                 SessionStatePhase.CODEGEN -> {
-                    messenger.sendUpdatePromptProgress(tabId, inProgress(progress = 10))
                     onCodeGeneration(session, message, tabId, mode)
                 }
                 else -> null
@@ -904,29 +904,7 @@ class DocController(
             messenger.sendAnswer(
                 messageType = DocMessageType.SystemPrompt,
                 tabId = followUpMessage.tabId,
-                followUp = listOf(
-                    FollowUp(
-                        pillText = message("amazonqDoc.prompt.review.accept"),
-                        prompt = message("amazonqDoc.prompt.review.accept"),
-                        status = FollowUpStatusType.Success,
-                        type = FollowUpTypes.ACCEPT_CHANGES,
-                        icon = FollowUpIcons.Ok,
-                    ),
-                    FollowUp(
-                        pillText = message("amazonqDoc.prompt.review.changes"),
-                        prompt = message("amazonqDoc.prompt.review.changes"),
-                        status = FollowUpStatusType.Info,
-                        type = FollowUpTypes.MAKE_CHANGES,
-                        icon = FollowUpIcons.Info,
-                    ),
-                    FollowUp(
-                        pillText = message("general.reject"),
-                        prompt = message("general.reject"),
-                        status = FollowUpStatusType.Error,
-                        type = FollowUpTypes.REJECT_CHANGES,
-                        icon = FollowUpIcons.Cancel,
-                    )
-                )
+                followUp = getFollowUpOptions(session.sessionState.phase)
             )
 
             processOpenDiff(

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/util/DocControllerUtil.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/util/DocControllerUtil.kt
@@ -15,19 +15,29 @@ fun getFollowUpOptions(phase: SessionStatePhase?): List<FollowUp> {
         SessionStatePhase.CODEGEN -> {
             return listOf(
                 FollowUp(
-                    pillText = message("amazonqDoc.follow_up.insert_code"),
-                    type = FollowUpTypes.INSERT_CODE,
+                    pillText = message("amazonqDoc.prompt.review.accept"),
+                    prompt = message("amazonqDoc.prompt.review.accept"),
+                    status = FollowUpStatusType.Success,
+                    type = FollowUpTypes.ACCEPT_CHANGES,
                     icon = FollowUpIcons.Ok,
-                    status = FollowUpStatusType.Success
                 ),
                 FollowUp(
-                    pillText = message("amazonqDoc.follow_up.provide_feedback_and_regenerate"),
-                    type = FollowUpTypes.PROVIDE_FEEDBACK_AND_REGENERATE_CODE,
-                    icon = FollowUpIcons.Refresh,
-                    status = FollowUpStatusType.Info
+                    pillText = message("amazonqDoc.prompt.review.changes"),
+                    prompt = message("amazonqDoc.prompt.review.changes"),
+                    status = FollowUpStatusType.Info,
+                    type = FollowUpTypes.MAKE_CHANGES,
+                    icon = FollowUpIcons.Info,
+                ),
+                FollowUp(
+                    pillText = message("general.reject"),
+                    prompt = message("general.reject"),
+                    status = FollowUpStatusType.Error,
+                    type = FollowUpTypes.REJECT_CHANGES,
+                    icon = FollowUpIcons.Cancel,
                 )
             )
         }
+
         else -> return emptyList()
     }
 }

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/docChatConnector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/docChatConnector.ts
@@ -19,7 +19,7 @@ export interface ConnectorProps {
     sendMessageToExtension: (message: ExtensionMessage) => void
     onMessageReceived?: (tabID: string, messageData: any, needToShowAPIDocsTab: boolean) => void
     onUpdatePromptProgress: (tabID: string, progressField: ProgressField) => void
-    onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string) => void
+    onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string, cancelButtonWhenLoading?: boolean) => void
     onChatAnswerReceived?: (tabID: string, message: ChatItem) => void
     sendFeedback?: (tabId: string, feedbackPayload: FeedbackPayload) => void | undefined
     onError: (tabID: string, message: string, title: string) => void

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/featureDevChatConnector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/featureDevChatConnector.ts
@@ -18,7 +18,7 @@ interface ChatPayload {
 export interface ConnectorProps {
     sendMessageToExtension: (message: ExtensionMessage) => void
     onMessageReceived?: (tabID: string, messageData: any, needToShowAPIDocsTab: boolean) => void
-    onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string) => void
+    onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string, cancelButtonWhenLoading?: boolean) => void
     onChatAnswerReceived?: (tabID: string, message: ChatItem) => void
     onChatAnswerUpdated?: (tabID: string, message: ChatItem) => void
     sendFeedback?: (tabId: string, feedbackPayload: FeedbackPayload) => void | undefined
@@ -249,7 +249,7 @@ export class Connector {
         }
 
         if (messageData.type === 'asyncEventProgressMessage') {
-            this.onAsyncEventProgress(messageData.tabID, messageData.inProgress, messageData.message ?? undefined)
+            this.onAsyncEventProgress(messageData.tabID, messageData.inProgress, messageData.message ?? undefined, true)
             return
         }
 

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
@@ -61,7 +61,7 @@ export interface ConnectorProps {
     onCodeTransformMessageUpdate: (tabID: string, messageId: string, chatItem: Partial<ChatItem>) => void
     onRunTestMessageReceived?: (tabID: string, showRunTestMessage: boolean) => void
     onWelcomeFollowUpClicked: (tabID: string, welcomeFollowUpType: WelcomeFollowupType) => void
-    onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string | undefined) => void
+    onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string | undefined, cancelButtonWhenLoading?: boolean) => void
     onCWCContextCommandMessage: (message: ChatItem, command?: string) => string | undefined
     onCWCOnboardingPageInteractionMessage: (message: ChatItem) => string | undefined
     onOpenSettingsMessage: (tabID: string) => void

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
@@ -184,12 +184,12 @@ export const createMynahUI = (
                 promptInputDisabledState: tabsStorage.isTabDead(tabID) || !enabled,
             })
         },
-        onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string | undefined) => {
+        onAsyncEventProgress: (tabID: string, inProgress: boolean, message: string | undefined, cancelButtonWhenLoading: boolean = false) => {
             if (inProgress) {
                 mynahUI.updateStore(tabID, {
                     loadingChat: true,
                     promptInputDisabledState: true,
-                    cancelButtonWhenLoading: true,
+                    cancelButtonWhenLoading,
                 })
                 if (message) {
                     mynahUI.updateLastChatAnswer(tabID, {

--- a/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -38,8 +38,11 @@ action.aws.toolkit.toolwindow.newConnection.text=Add Another Connection...
 action.dynamic.open.text=Open Resource...
 action.q.openchat.text=Open Chat Panel
 amazonqChat.project_context.index_in_progress=By the way, I'm still indexing this project for full context from your workspace. I may have a better response in a few minutes when it's complete if you'd like to try again then.
-amazonqDoc.edit.message=Please describe the changes you would like to make to your documentation. For example, you can ask me to add a section, remove a section, make a correction, expand upon something, etc.
-amazonqDoc.edit.placeholder=Describe your documentation request
+amazonqDoc.answer.codeResult=You can accept the changes to your files, or describe any additional changes you'd like me to make.
+amazonqDoc.answer.readmeCreated=I've created a README for your code.
+amazonqDoc.answer.readmeUpdated=I've updated your README.
+amazonqDoc.edit.message=Okay, let's work on your README. Describe the changes you would like to make. For example, you can ask me to:\n- Correct something\n- Expand on something\n- Add a section\n- Remove a section
+amazonqDoc.edit.placeholder=Describe documentation changes
 amazonqDoc.error.generating=Unable to generate changes.
 amazonqDoc.error_text=I'm sorry, I ran into an issue while trying to generate your documentation. Please try again.
 amazonqDoc.exception.content_length_error=Your workspace is too large for me to review. Your workspace must be within the quota, even if you choose a smaller folder. For more information on quotas, see the <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/doc-generation.html#quotas" target="_blank">Amazon Q Developer documentation.</a>


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
This PR:
* Aligns a few /doc chat messages with strings from the vscode extension
* Fixes a bug where the checklist progress view wasn't showing up 
  * As part of this, I added support for disabling the "Stop" button at the bottom of the chat window when an async event is in progress. Similar to this vscode commit: https://github.com/aws/aws-toolkit-vscode/commit/9c89c53a5a337d6b8b19c2e4252e080ae282d11a#diff-8eb911f0ec050013422c6b3bd03c793a30f8c6ecf0eb63297cf4f10611b0274dR3
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
