### PR TITLE
Fix chat not retaining history when interaction is through onboarding…

### DIFF
--- a/.changes/next-release/bugfix-f290302a-3c37-4982-ad78-11f0b413c694.json
+++ b/.changes/next-release/bugfix-f290302a-3c37-4982-ad78-11f0b413c694.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix chat not retaining history when interaction is through onboarding tab type (#5189)"
+}

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/storages/tabsStorage.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/storages/tabsStorage.ts
@@ -104,7 +104,10 @@ export class TabsStorage {
 
     public updateTabTypeFromUnknown(tabID: string, tabType: TabType) {
         const currentTabValue = this.tabs.get(tabID)
-        if (currentTabValue === undefined || currentTabValue.type !== 'unknown') {
+        if (
+            currentTabValue === undefined ||
+            (currentTabValue.type !== 'unknown' && currentTabValue.type !== 'welcome')
+        ) {
             return
         }
 


### PR DESCRIPTION
… tab type

When tab type is 'welcome', type is not overwritten with correct tab type after user prompt

#5189

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
