### PR TITLE
fix(amazonq): clicking on generated test file does not open file diff

### DIFF
--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
@@ -513,7 +513,7 @@ export class Connector {
                 this.featureDevChatConnector.onOpenDiff(tabID, filePath, deleted)
                 break
             case 'codetest':
-                this.codeTestChatConnector.onFileClick(tabID, filePath, deleted, messageId)
+                this.codeTestChatConnector.onFormButtonClick(tabID, messageId ?? '', {id: "utg_view_diff"})
                 break
         }
     }

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/connector.ts
@@ -512,6 +512,10 @@ export class Connector {
             case 'featuredev':
                 this.featureDevChatConnector.onOpenDiff(tabID, filePath, deleted)
                 break
+            /*
+            TODO: This is for temporary solution to show correct viewdiff panel by clicking the filename
+            Would re-factor it later for the next task
+             */
             case 'codetest':
                 this.codeTestChatConnector.onFormButtonClick(tabID, messageId ?? '', {id: "utg_view_diff"})
                 break


### PR DESCRIPTION
…nerated test file

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Fix the issue that user can not open the file diff by clicking the generated test file. 

## Implementation
I updated the connector so that when a user clicks on the generated file, it now triggers the same functionality as clicking the "View Diff" button.

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
