### PR TITLE
telemetry(amazonq): sending metric data in onCodeGeneration

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevConstants.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevConstants.kt
@@ -38,3 +38,21 @@ enum class FeatureDevOperation(private val operationName: String) {
 
     override fun toString(): String = operationName
 }
+
+enum class MetricDataOperationName(private val operationName: String) {
+    START_CODE_GENERATION("StartCodeGeneration"),
+    END_CODE_GENERATION("EndCodeGeneration"),
+    ;
+
+    override fun toString(): String = operationName
+}
+
+enum class MetricDataResult(private val resultName: String) {
+    SUCCESS("Success"),
+    FAULT("Fault"),
+    ERROR("Error"),
+    LLMFAILURE("LLMFailure"),
+    ;
+
+    override fun toString(): String = resultName
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevConstants.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevConstants.kt
@@ -40,18 +40,18 @@ enum class FeatureDevOperation(private val operationName: String) {
 }
 
 enum class MetricDataOperationName(private val operationName: String) {
-    START_CODE_GENERATION("StartCodeGeneration"),
-    END_CODE_GENERATION("EndCodeGeneration"),
+    StartCodeGeneration("StartCodeGeneration"),
+    EndCodeGeneration("EndCodeGeneration"),
     ;
 
     override fun toString(): String = operationName
 }
 
 enum class MetricDataResult(private val resultName: String) {
-    SUCCESS("Success"),
-    FAULT("Fault"),
-    ERROR("Error"),
-    LLMFAILURE("LLMFailure"),
+    Success("Success"),
+    Fault("Fault"),
+    Error("Error"),
+    LlmFailure("LLMFailure"),
     ;
 
     override fun toString(): String = resultName

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/clients/FeatureDevClient.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/clients/FeatureDevClient.kt
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.codewhispererruntime.model.ContentChecksu
 import software.amazon.awssdk.services.codewhispererruntime.model.CreateTaskAssistConversationRequest
 import software.amazon.awssdk.services.codewhispererruntime.model.CreateTaskAssistConversationResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.CreateUploadUrlResponse
+import software.amazon.awssdk.services.codewhispererruntime.model.Dimension
 import software.amazon.awssdk.services.codewhispererruntime.model.GetTaskAssistCodeGenerationResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.IdeCategory
 import software.amazon.awssdk.services.codewhispererruntime.model.OperatingSystem
@@ -83,6 +84,33 @@ class FeatureDevClient(
             requestBuilder.telemetryEvent { telemetryEventBuilder ->
                 telemetryEventBuilder.featureDevEvent {
                     it.conversationId(conversationId)
+                }
+            }
+            requestBuilder.optOutPreference(getTelemetryOptOutPreference())
+            requestBuilder.userContext(featureDevUserContext)
+        }
+
+    fun sendFeatureDevMetricData(operationName: String, result: String): SendTelemetryEventResponse =
+        bearerClient().sendTelemetryEvent { requestBuilder ->
+            requestBuilder.telemetryEvent { telemetryEventBuilder ->
+                telemetryEventBuilder.metricData {
+                    it
+                        .metricName("Operation")
+                        .metricValue(1.0)
+                        .timestamp(Instant.now())
+                        .product("Amazon Q For JetBrains")
+                        .dimensions(
+                            listOf(
+                                Dimension.builder()
+                                    .name("operationName")
+                                    .value(operationName)
+                                    .build(),
+                                Dimension.builder()
+                                    .name("result")
+                                    .value(result)
+                                    .build()
+                            )
+                        )
                 }
             }
             requestBuilder.optOutPreference(getTelemetryOptOutPreference())

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/clients/FeatureDevClient.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/clients/FeatureDevClient.kt
@@ -98,7 +98,7 @@ class FeatureDevClient(
                         .metricName("Operation")
                         .metricValue(1.0)
                         .timestamp(Instant.now())
-                        .product("Amazon Q For JetBrains")
+                        .product("FeatureDev")
                         .dimensions(
                             listOf(
                                 Dimension.builder()

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
@@ -169,12 +169,6 @@ suspend fun FeatureDevController.onCodeGeneration(
             }
         }
         throw err
-    } catch (err: Exception) {
-        session.sendMetricDataTelemetry(
-            MetricDataOperationName.EndCodeGeneration,
-            MetricDataResult.Fault
-        )
-        throw err
     } finally {
         if (session.sessionState.token
                 ?.token

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
@@ -72,8 +72,8 @@ suspend fun FeatureDevController.onCodeGeneration(
         messenger.sendUpdatePlaceholder(tabId = tabId, newPlaceholder = message("amazonqFeatureDev.placeholder.generating_code"))
 
         session.sendMetricDataTelemetry(
-            MetricDataOperationName.START_CODE_GENERATION.toString(),
-            MetricDataResult.SUCCESS.toString()
+            MetricDataOperationName.START_CODE_GENERATION,
+            MetricDataResult.SUCCESS
         )
 
         session.send(message) // Trigger code generation
@@ -147,56 +147,51 @@ suspend fun FeatureDevController.onCodeGeneration(
         }
 
         messenger.sendSystemPrompt(tabId = tabId, followUp = getFollowUpOptions(session.sessionState.phase, InsertAction.ALL))
-
-        session.sendMetricDataTelemetry(
-            MetricDataOperationName.END_CODE_GENERATION.toString(),
-            MetricDataResult.SUCCESS.toString()
-        )
         messenger.sendUpdatePlaceholder(tabId = tabId, newPlaceholder = message("amazonqFeatureDev.placeholder.after_code_generation"))
     } catch (err: FeatureDevException) {
         when (true) {
             (err is GuardrailsException) -> {
                 session.sendMetricDataTelemetry(
-                    MetricDataOperationName.END_CODE_GENERATION.toString(),
-                    MetricDataResult.ERROR.toString()
+                    MetricDataOperationName.END_CODE_GENERATION,
+                    MetricDataResult.ERROR
                 )
             }
             (err is PromptRefusalException) -> {
                 session.sendMetricDataTelemetry(
-                    MetricDataOperationName.END_CODE_GENERATION.toString(),
-                    MetricDataResult.ERROR.toString()
+                    MetricDataOperationName.END_CODE_GENERATION,
+                    MetricDataResult.ERROR
                 )
             }
             (err is EmptyPatchException) -> {
                 session.sendMetricDataTelemetry(
-                    MetricDataOperationName.END_CODE_GENERATION.toString(),
-                    MetricDataResult.LLMFAILURE.toString()
+                    MetricDataOperationName.END_CODE_GENERATION,
+                    MetricDataResult.LLMFAILURE
                 )
             }
             (err is NoChangeRequiredException) -> {
                 session.sendMetricDataTelemetry(
-                    MetricDataOperationName.END_CODE_GENERATION.toString(),
-                    MetricDataResult.ERROR.toString()
+                    MetricDataOperationName.END_CODE_GENERATION,
+                    MetricDataResult.ERROR
                 )
             }
             (err is ThrottlingException) -> {
                 session.sendMetricDataTelemetry(
-                    MetricDataOperationName.END_CODE_GENERATION.toString(),
-                    MetricDataResult.ERROR.toString()
+                    MetricDataOperationName.END_CODE_GENERATION,
+                    MetricDataResult.ERROR
                 )
             }
             else -> {
                 session.sendMetricDataTelemetry(
-                    MetricDataOperationName.END_CODE_GENERATION.toString(),
-                    MetricDataResult.FAULT.toString()
+                    MetricDataOperationName.END_CODE_GENERATION,
+                    MetricDataResult.FAULT
                 )
             }
         }
         throw err
     } catch (err: Exception) {
         session.sendMetricDataTelemetry(
-            MetricDataOperationName.END_CODE_GENERATION.toString(),
-            MetricDataResult.FAULT.toString()
+            MetricDataOperationName.END_CODE_GENERATION,
+            MetricDataResult.FAULT
         )
         throw err
     } finally {
@@ -218,6 +213,11 @@ suspend fun FeatureDevController.onCodeGeneration(
             )
         }
     }
+
+    session.sendMetricDataTelemetry(
+        MetricDataOperationName.END_CODE_GENERATION,
+        MetricDataResult.SUCCESS
+    )
 }
 
 private suspend fun disposeToken(

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -14,6 +14,8 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CODE_GENERATIO
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ConversationIdNotFoundException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FEATURE_NAME
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MAX_PROJECT_SIZE_BYTES
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MetricDataOperationName
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MetricDataResult
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.IncomingFeatureDevMessage
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendAsyncEventProgress
@@ -219,8 +221,8 @@ class Session(val tabID: String, val project: Project) {
         this._codeResultMessageId = null
     }
 
-    fun sendMetricDataTelemetry(operationName: String, result: String) {
-        featureDevService.sendFeatureDevMetricData(operationName, result)
+    fun sendMetricDataTelemetry(operationName: MetricDataOperationName, result: MetricDataResult) {
+        featureDevService.sendFeatureDevMetricData(operationName.toString(), result.toString())
     }
 
     suspend fun send(msg: String): Interaction {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/Session.kt
@@ -219,6 +219,10 @@ class Session(val tabID: String, val project: Project) {
         this._codeResultMessageId = null
     }
 
+    fun sendMetricDataTelemetry(operationName: String, result: String) {
+        featureDevService.sendFeatureDevMetricData(operationName, result)
+    }
+
     suspend fun send(msg: String): Interaction {
         // When the task/"thing to do" hasn't been set yet, we want it to be the incoming message
         if (task.isEmpty() && msg.isNotEmpty()) {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FeatureDevService.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FeatureDevService.kt
@@ -232,6 +232,19 @@ class FeatureDevService(val proxyClient: FeatureDevClient, val project: Project)
         }
     }
 
+    fun sendFeatureDevMetricData(operationName: String, result: String) {
+        val sendFeatureDevTelemetryEventResponse: SendTelemetryEventResponse
+        try {
+            sendFeatureDevTelemetryEventResponse = proxyClient.sendFeatureDevMetricData(operationName, result)
+            val requestId = sendFeatureDevTelemetryEventResponse.responseMetadata().requestId()
+            logger.debug {
+                "$FEATURE_NAME: succesfully sent feature dev metric data: OperationName: $operationName Result: $result RequestId: $requestId"
+            }
+        } catch (e: Exception) {
+            logger.warn(e) { "$FEATURE_NAME: failed to send feature dev metric data" }
+        }
+    }
+
     fun sendFeatureDevCodeGenerationEvent(conversationId: String, linesOfCodeGenerated: Int, charactersOfCodeGenerated: Int) {
         val sendFeatureDevTelemetryEventResponse: SendTelemetryEventResponse
         try {

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -22,9 +22,11 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.spy
@@ -36,7 +38,14 @@ import software.aws.toolkits.jetbrains.services.amazonq.apps.AmazonQAppInitConte
 import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthController
 import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededStates
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.EmptyPatchException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTestBase
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.GuardrailsException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MetricDataOperationName
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MetricDataResult
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.NoChangeRequiredException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.PromptRefusalException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ThrottlingException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FeatureDevMessageType
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUp
@@ -50,6 +59,7 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendC
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendSystemPrompt
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.sendUpdatePlaceholder
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.updateFileComponent
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.CodeGenerationState
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.DeletedFileInfo
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.DiffMetricsProcessed
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.Interaction
@@ -422,6 +432,75 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                 messenger.sendChatInputEnabledMessage(testTabId, false)
             }
         }
+
+    @Test
+    fun `test handleChat onCodeGeneration sends correct metrics for different errors`() = runTest {
+        data class ErrorTestCase(
+            val error: Exception,
+            val expectedMetricResult: MetricDataResult,
+        )
+
+        val testCases = listOf(
+            ErrorTestCase(
+                EmptyPatchException("EmptyPatchException", "Empty patch"),
+                MetricDataResult.LLMFAILURE
+            ),
+            ErrorTestCase(
+                GuardrailsException(operation = "GenerateCode", desc = "Failed guardrails"),
+                MetricDataResult.ERROR
+            ),
+            ErrorTestCase(
+                PromptRefusalException(operation = "GenerateCode", desc = "Prompt refused"),
+                MetricDataResult.ERROR
+            ),
+            ErrorTestCase(
+                NoChangeRequiredException(operation = "GenerateCode", desc = "No changes needed"),
+                MetricDataResult.ERROR
+            ),
+            ErrorTestCase(
+                ThrottlingException(operation = "GenerateCode", desc = "Request throttled"),
+                MetricDataResult.ERROR
+            ),
+            ErrorTestCase(
+                RuntimeException("Unknown error"),
+                MetricDataResult.FAULT
+            )
+        )
+
+        testCases.forEach { (error, expectedResult) ->
+            val mockSession = mock<Session>()
+            whenever(mockSession.send(userMessage)).thenThrow(error)
+            whenever(mockSession.sessionState).thenReturn(
+                CodeGenerationState(
+                    testTabId,
+                    "",
+                    mock(),
+                    testUploadId,
+                    0,
+                    0.0,
+                    messenger,
+                    token = CancellationTokenSource(),
+                    diffMetricsProcessed = DiffMetricsProcessed(HashSet(), HashSet())
+                )
+            )
+
+            assertThrows<Exception> {
+                controller.onCodeGeneration(mockSession, userMessage, testTabId)
+            }
+
+            val mockInOrder = inOrder(mockSession)
+
+            mockInOrder.verify(mockSession).sendMetricDataTelemetry(
+                MetricDataOperationName.START_CODE_GENERATION.toString(),
+                MetricDataResult.SUCCESS.toString()
+
+            )
+            mockInOrder.verify(mockSession).sendMetricDataTelemetry(
+                MetricDataOperationName.END_CODE_GENERATION.toString(),
+                expectedResult.toString()
+            )
+        }
+    }
 
     @Test
     fun `test processFileClicked handles file rejection`() =

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -462,13 +462,13 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
         val mockInOrder = inOrder(mockSession)
 
         mockInOrder.verify(mockSession).sendMetricDataTelemetry(
-            MetricDataOperationName.START_CODE_GENERATION.toString(),
-            MetricDataResult.SUCCESS.toString()
+            MetricDataOperationName.START_CODE_GENERATION,
+            MetricDataResult.SUCCESS
 
         )
         mockInOrder.verify(mockSession).sendMetricDataTelemetry(
-            MetricDataOperationName.END_CODE_GENERATION.toString(),
-            MetricDataResult.SUCCESS.toString()
+            MetricDataOperationName.END_CODE_GENERATION,
+            MetricDataResult.SUCCESS
         )
     }
 
@@ -530,13 +530,13 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
             val mockInOrder = inOrder(mockSession)
 
             mockInOrder.verify(mockSession).sendMetricDataTelemetry(
-                MetricDataOperationName.START_CODE_GENERATION.toString(),
-                MetricDataResult.SUCCESS.toString()
+                MetricDataOperationName.START_CODE_GENERATION,
+                MetricDataResult.SUCCESS
 
             )
             mockInOrder.verify(mockSession).sendMetricDataTelemetry(
-                MetricDataOperationName.END_CODE_GENERATION.toString(),
-                expectedResult.toString()
+                MetricDataOperationName.END_CODE_GENERATION,
+                expectedResult
             )
         }
     }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -462,13 +462,13 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
         val mockInOrder = inOrder(mockSession)
 
         mockInOrder.verify(mockSession).sendMetricDataTelemetry(
-            MetricDataOperationName.START_CODE_GENERATION,
-            MetricDataResult.SUCCESS
+            MetricDataOperationName.StartCodeGeneration,
+            MetricDataResult.Success
 
         )
         mockInOrder.verify(mockSession).sendMetricDataTelemetry(
-            MetricDataOperationName.END_CODE_GENERATION,
-            MetricDataResult.SUCCESS
+            MetricDataOperationName.EndCodeGeneration,
+            MetricDataResult.Success
         )
     }
 
@@ -482,27 +482,27 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
         val testCases = listOf(
             ErrorTestCase(
                 EmptyPatchException("EmptyPatchException", "Empty patch"),
-                MetricDataResult.LLMFAILURE
+                MetricDataResult.LlmFailure
             ),
             ErrorTestCase(
                 GuardrailsException(operation = "GenerateCode", desc = "Failed guardrails"),
-                MetricDataResult.ERROR
+                MetricDataResult.Error
             ),
             ErrorTestCase(
                 PromptRefusalException(operation = "GenerateCode", desc = "Prompt refused"),
-                MetricDataResult.ERROR
+                MetricDataResult.Error
             ),
             ErrorTestCase(
                 NoChangeRequiredException(operation = "GenerateCode", desc = "No changes needed"),
-                MetricDataResult.ERROR
+                MetricDataResult.Error
             ),
             ErrorTestCase(
                 ThrottlingException(operation = "GenerateCode", desc = "Request throttled"),
-                MetricDataResult.ERROR
+                MetricDataResult.Error
             ),
             ErrorTestCase(
                 RuntimeException("Unknown error"),
-                MetricDataResult.FAULT
+                MetricDataResult.Fault
             )
         )
 
@@ -530,12 +530,12 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
             val mockInOrder = inOrder(mockSession)
 
             mockInOrder.verify(mockSession).sendMetricDataTelemetry(
-                MetricDataOperationName.START_CODE_GENERATION,
-                MetricDataResult.SUCCESS
+                MetricDataOperationName.StartCodeGeneration,
+                MetricDataResult.Success
 
             )
             mockInOrder.verify(mockSession).sendMetricDataTelemetry(
-                MetricDataOperationName.END_CODE_GENERATION,
+                MetricDataOperationName.EndCodeGeneration,
                 expectedResult
             )
         }


### PR DESCRIPTION
## Problem
This is a part of the task to implement client side alarms in order to track success rate for the client.

## Solution
- Emit metric data telemetry on success/failure.

---

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
