### PR TITLE
Adds capability to send new context commands to AB groups

### DIFF
--- a/.changes/next-release/feature-fab622c6-240e-49a2-9750-dee956759a0a.json
+++ b/.changes/next-release/feature-fab622c6-240e-49a2-9750-dee956759a0a.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Adds capability to send new context commands to AB groups"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindow.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindow.kt
@@ -24,6 +24,7 @@ import software.aws.toolkits.jetbrains.services.amazonq.messages.AmazonQMessage
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessageConnector
 import software.aws.toolkits.jetbrains.services.amazonq.onboarding.OnboardingPageInteraction
 import software.aws.toolkits.jetbrains.services.amazonq.onboarding.OnboardingPageInteractionType
+import software.aws.toolkits.jetbrains.services.amazonq.util.highlightCommand
 import software.aws.toolkits.jetbrains.services.amazonq.webview.BrowserConnector
 import software.aws.toolkits.jetbrains.services.amazonq.webview.FqnWebviewAdapter
 import software.aws.toolkits.jetbrains.services.amazonq.webview.theme.EditorThemeAdapter
@@ -125,7 +126,8 @@ class AmazonQToolWindow private constructor(
             isFeatureDevAvailable = isFeatureDevAvailable(project),
             isCodeScanAvailable = isCodeScanAvailable(project),
             isCodeTestAvailable = isCodeTestAvailable(project),
-            isDocAvailable = isDocAvailable(project)
+            isDocAvailable = isDocAvailable(project),
+            highlightCommand = highlightCommand()
         )
 
         scope.launch {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/util/HighlightCommand.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/util/HighlightCommand.kt
@@ -1,0 +1,16 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.util
+
+import software.aws.toolkits.jetbrains.services.amazonq.CodeWhispererFeatureConfigService
+
+data class HighlightCommand(val command: String, val description: String)
+
+fun highlightCommand(): HighlightCommand? {
+    val feature = CodeWhispererFeatureConfigService.getInstance().getHighlightCommandFeature()
+
+    if (feature == null || feature.value.stringValue().isEmpty()) return null
+
+    return HighlightCommand(feature.value.stringValue(), feature.variation)
+}

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/main.ts
@@ -10,7 +10,7 @@ import {
     MynahUI,
     MynahUIDataModel,
     NotificationType,
-    ProgressField,
+    ProgressField, QuickActionCommand,
     ReferenceTrackerInformation
 } from '@aws/mynah-ui-chat'
 import './styles/dark.scss'
@@ -40,7 +40,8 @@ export const createMynahUI = (
     codeTransformInitEnabled: boolean,
     docInitEnabled: boolean,
     codeScanEnabled: boolean,
-    codeTestEnabled: boolean
+    codeTestEnabled: boolean,
+    highlightCommand?: QuickActionCommand,
 ) => {
     let disclaimerCardActive = !disclaimerAcknowledged
 
@@ -87,6 +88,7 @@ export const createMynahUI = (
         isDocEnabled,
         isCodeScanEnabled,
         isCodeTestEnabled,
+        highlightCommand
     })
 
     // eslint-disable-next-line prefer-const

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/CodeWhispererFeatureConfigService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/CodeWhispererFeatureConfigService.kt
@@ -111,6 +111,8 @@ class CodeWhispererFeatureConfigService {
 
     fun getCustomizationFeature(): FeatureContext? = getFeature(CUSTOMIZATION_ARN_OVERRIDE_NAME)
 
+    fun getHighlightCommandFeature(): FeatureContext? = getFeature(HIGHLIGHT_COMMAND_NAME)
+
     fun getNewAutoTriggerUX(): Boolean = getFeatureValueForKey(NEW_AUTO_TRIGGER_UX).stringValue() == "TREATMENT"
 
     fun getInlineCompletion(): Boolean = getFeatureValueForKey(INLINE_COMPLETION).stringValue() == "TREATMENT"
@@ -131,7 +133,8 @@ class CodeWhispererFeatureConfigService {
         fun getInstance(): CodeWhispererFeatureConfigService = service()
         private const val TEST_FEATURE_NAME = "testFeature"
         private const val INLINE_COMPLETION = "ProjectContextV2"
-        const val CUSTOMIZATION_ARN_OVERRIDE_NAME = "customizationArnOverride"
+        private const val CUSTOMIZATION_ARN_OVERRIDE_NAME = "customizationArnOverride"
+        private const val HIGHLIGHT_COMMAND_NAME = "highlightCommand"
         private const val NEW_AUTO_TRIGGER_UX = "newAutoTriggerUX"
         private val LOG = getLogger<CodeWhispererFeatureConfigService>()
 


### PR DESCRIPTION
Add the ability to send a new command that will appear when a user types @ in the chat window

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
