### PR TITLE
Fix JSR310 serialization error when preparing login panel

### DIFF
--- a/.changes/next-release/bugfix-213273c1-12a5-47d1-b973-499d25e1d68e.json
+++ b/.changes/next-release/bugfix-213273c1-12a5-47d1-b973-499d25e1d68e.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue where users are unable to login to Amazon Q if they have previously authenticated (#5214)"
+}

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/TelemetryHelperTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/TelemetryHelperTest.kt
@@ -63,6 +63,7 @@ import software.aws.toolkits.jetbrains.services.cwc.messages.LinkType
 import software.aws.toolkits.jetbrains.services.cwc.storage.ChatSessionInfo
 import software.aws.toolkits.jetbrains.services.cwc.storage.ChatSessionStorage
 import software.aws.toolkits.jetbrains.services.telemetry.MockTelemetryServiceExtension
+import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 import software.aws.toolkits.jetbrains.settings.CodeWhispererSettings
 import software.aws.toolkits.telemetry.CwsprChatConversationType
 import software.aws.toolkits.telemetry.CwsprChatInteractionType

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitConnectionImpls.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitConnectionImpls.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.credentials
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
 import software.aws.toolkits.core.TokenConnectionSettings
@@ -73,6 +74,7 @@ sealed class ManagedBearerSsoConnection(
             region
         )
 
+    @JsonIgnore
     override fun getConnectionSettings(): TokenConnectionSettings = provider
 
     override fun dispose() {
@@ -99,6 +101,7 @@ class DetectedDiskSsoSessionConnection(
             region
         )
 
+    @JsonIgnore
     override fun getConnectionSettings(): TokenConnectionSettings = provider
 
     override fun dispose() {

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/DefaultToolkitAuthManagerTest.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.credentials
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.testFramework.ProjectExtension
@@ -451,6 +452,22 @@ class DefaultToolkitAuthManagerTest {
         assertThat(metricCaptor.allValues).allSatisfy { event ->
             assertThat(event.data.all { it.metadata["source"] == "fooSourceId" }).isTrue()
         }
+    }
+
+    @Test
+    fun `serializing LegacyManagedBearerSsoConnection does not include connectionSettings`() {
+        val profile = ManagedSsoProfile("us-east-1", "startUrl000", listOf("scopes"))
+        val connection = sut.createConnection(profile) as LegacyManagedBearerSsoConnection
+
+        assertThat(jacksonObjectMapper().writeValueAsString(connection)).doesNotContain("connectionSettings")
+    }
+
+    @Test
+    fun `serializing ProfileSsoManagedBearerSsoConnection does not include connectionSettings`() {
+        val profile = UserConfigSsoSessionProfile("sessionName", "us-east-1", "startUrl000", listOf("scopes"))
+        val connection = sut.createConnection(profile) as ProfileSsoManagedBearerSsoConnection
+
+        assertThat(jacksonObjectMapper().writeValueAsString(connection)).doesNotContain("connectionSettings")
     }
 
     private companion object {


### PR DESCRIPTION
If a user is somehow in the situtation where they have an `sso-session` defined, with a token in their SSO cache (either valid/invalid), then prepareBrowser fails since it tries to serialize the state of `connectionSettings` without the jackson-jsr310 module.

This is not intended behavior, so fix by configuring this to be an ignored field.

#5214
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
