### PR TITLE
Preserve file permissions in the zip archive, fix bugs in gitignore matching and keep mvm and gradle files

### DIFF
--- a/.changes/next-release/bugfix-2df57233-310e-4788-be6c-f3b37767e60a.json
+++ b/.changes/next-release/bugfix-2df57233-310e-4788-be6c-f3b37767e60a.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Preserve file permissions in the zip archive, fix bugs in gitignore matching and keep mvm and gradle files"
+  "description" : "Amazon Q can update mvn and gradle build files"
 }

--- a/.changes/next-release/bugfix-2df57233-310e-4788-be6c-f3b37767e60a.json
+++ b/.changes/next-release/bugfix-2df57233-310e-4788-be6c-f3b37767e60a.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Preserve file permissions in the zip archive, fix bugs in gitignore matching and keep mvm and gradle files"
+}

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
@@ -63,10 +63,11 @@ class FeatureDevSessionContextTest : FeatureDevTestBase(HeavyJavaCodeInsightTest
 
     @Test
     fun testAllowedFilePath() {
-        val allowedPaths = listOf("gradlew", "build.gradle", "gradle.properties", ".mvn/wrapper/maven-wrapper.properties")
+        val allowedPaths = listOf("build.gradle", "gradle.properties", ".mvn/wrapper/maven-wrapper.properties")
         allowedPaths.forEach({
             val txtFile = mock<VirtualFile>()
             whenever(txtFile.path).thenReturn(it)
+            whenever(txtFile.extension).thenReturn(it.split(".").last())
             assertTrue(featureDevSessionContext.isFileExtensionAllowed(txtFile))
         })
     }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
@@ -40,6 +40,7 @@ class FeatureDevSessionContextTest : FeatureDevTestBase() {
     fun testWithValidFile() {
         val ktFile = mock<VirtualFile>()
         whenever(ktFile.extension).thenReturn("kt")
+        whenever(ktFile.path).thenReturn("code.kt")
         assertTrue(featureDevSessionContext.isFileExtensionAllowed(ktFile))
     }
 
@@ -47,6 +48,17 @@ class FeatureDevSessionContextTest : FeatureDevTestBase() {
     fun testWithInvalidFile() {
         val txtFile = mock<VirtualFile>()
         whenever(txtFile.extension).thenReturn("txt")
+        whenever(txtFile.path).thenReturn("file.txt")
         assertFalse(featureDevSessionContext.isFileExtensionAllowed(txtFile))
+    }
+
+    @Test
+    fun testAllowedFilePath() {
+        val allowedPaths = listOf("Dockerfile", "Dockerfile.build", "gradlew", "build.gradle", "gradle.properties", ".mvn/wrapper/maven-wrapper.properties")
+        allowedPaths.forEach({
+            val txtFile = mock<VirtualFile>()
+            whenever(txtFile.path).thenReturn(it)
+            assertTrue(featureDevSessionContext.isFileExtensionAllowed(txtFile))
+        })
     }
 }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
@@ -1,10 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import com.intellij.openapi.project.guessProjectDir
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.VirtualFileVisitor
 import com.intellij.testFramework.RuleChain
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -18,11 +15,7 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTest
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.util.FeatureDevService
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.addFileToModule
-import java.nio.file.Paths
 import java.util.zip.ZipFile
-import kotlin.io.path.Path
-import kotlin.io.path.relativeTo
-
 
 class FeatureDevSessionContextTest : FeatureDevTestBase(HeavyJavaCodeInsightTestFixtureRule()) {
 

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
@@ -54,7 +54,7 @@ class FeatureDevSessionContextTest : FeatureDevTestBase() {
 
     @Test
     fun testAllowedFilePath() {
-        val allowedPaths = listOf("Dockerfile", "Dockerfile.build", "gradlew", "build.gradle", "gradle.properties", ".mvn/wrapper/maven-wrapper.properties")
+        val allowedPaths = listOf("gradlew", "build.gradle", "gradle.properties", ".mvn/wrapper/maven-wrapper.properties")
         allowedPaths.forEach({
             val txtFile = mock<VirtualFile>()
             whenever(txtFile.path).thenReturn(it)

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererProjectCodeScanTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererProjectCodeScanTest.kt
@@ -372,6 +372,6 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
         // Adding gitignore file and gitignore file member for testing.
         // The tests include the markdown file but not these two files.
         projectRule.fixture.addFileToProject("/.gitignore", "node_modules\n.idea\n.vscode\n.DS_Store").virtualFile
-        projectRule.fixture.addFileToProject("test.idea", "ref: refs/heads/main")
+        projectRule.fixture.addFileToProject("/.idea/ref", "ref: refs/heads/main")
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererProjectCodeScanTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererProjectCodeScanTest.kt
@@ -373,7 +373,7 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
 
         // Adding gitignore file and gitignore file member for testing.
         // The tests include the markdown file but not these two files.
-        projectRule.fixture.addFileToProject("${fileSeparator}.gitignore", "node_modules\n.idea\n.vscode\n.DS_Store").virtualFile
-        projectRule.fixture.addFileToProject("${fileSeparator}.idea${fileSeparator}ref", "ref: refs/heads/main")
+        projectRule.fixture.addFileToProject("$fileSeparator.gitignore", "node_modules\n.idea\n.vscode\n.DS_Store").virtualFile
+        projectRule.fixture.addFileToProject("$fileSeparator.idea${fileSeparator}ref", "ref: refs/heads/main")
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererProjectCodeScanTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererProjectCodeScanTest.kt
@@ -19,6 +19,7 @@ import software.aws.toolkits.jetbrains.utils.rules.addFileToModule
 import software.aws.toolkits.jetbrains.utils.rules.addModule
 import software.aws.toolkits.telemetry.CodewhispererLanguage
 import java.io.BufferedInputStream
+import java.io.File
 import java.util.zip.ZipInputStream
 import kotlin.io.path.relativeTo
 import kotlin.test.assertNotNull
@@ -109,11 +110,12 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
     }
 
     private fun setupCsharpProject() {
+        val fileSeparator = File.separator
         val testModule = projectRule.fixture.addModule("testModule")
         val testModule2 = projectRule.fixture.addModule("testModule2")
         testCs = projectRule.fixture.addFileToModule(
             testModule,
-            "/Test.cs",
+            "${fileSeparator}Test.cs",
             """
             using Utils;
             using Helpers.Helper;
@@ -131,7 +133,7 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
 
         utilsCs = projectRule.fixture.addFileToModule(
             testModule,
-            "/Utils.cs",
+            "${fileSeparator}Utils.cs",
             """
             public static class Utils
             {
@@ -157,7 +159,7 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
 
         helperCs = projectRule.fixture.addFileToModule(
             testModule,
-            "/Helpers/Helper.cs",
+            "${fileSeparator}Helpers${fileSeparator}Helper.cs",
             """
             public static class Helper
             {
@@ -201,7 +203,7 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
 
         helpGo = projectRule.fixture.addFileToModule(
             testModule,
-            "/help.go",
+            "${fileSeparator}help.go",
             """
                 package main
 
@@ -217,7 +219,7 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
 
         utilsJs = projectRule.fixture.addFileToModule(
             testModule,
-            "/utils.js",
+            "${fileSeparator}utils.js",
             """
             function add(num1, num2) {
               return num1 + num2;
@@ -247,7 +249,7 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
 
         testJson = projectRule.fixture.addFileToModule(
             testModule,
-            "/helpers/test3Json.json",
+            "${fileSeparator}helpers${fileSeparator}test3Json.json",
             """
                 {
                     "AWSTemplateFormatVersion": "2010-09-09",
@@ -303,7 +305,7 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
 
         helperPy = projectRule.fixture.addFileToModule(
             testModule,
-            "/helpers/helper.py",
+            "${fileSeparator}helpers${fileSeparator}helper.py",
             """
             from helpers import helper as h
             def subtract(num1, num2)
@@ -319,13 +321,13 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
         totalSize += helperPy.length
         totalLines += helperPy.toNioPath().toFile().readLines().size
 
-        readMeMd = projectRule.fixture.addFileToModule(testModule, "/ReadMe.md", "### Now included").virtualFile
+        readMeMd = projectRule.fixture.addFileToModule(testModule, "${fileSeparator}ReadMe.md", "### Now included").virtualFile
         totalSize += readMeMd.length
         totalLines += readMeMd.toNioPath().toFile().readLines().size
 
         testTf = projectRule.fixture.addFileToModule(
             testModule2,
-            "/testTf.tf",
+            "${fileSeparator}testTf.tf",
             """
                 # Create example resource for three S3 buckets using for_each, where the bucket prefix are in variable with list containing [prod, staging, dev]
                 
@@ -345,7 +347,7 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
 
         testYaml = projectRule.fixture.addFileToModule(
             testModule2,
-            "/testYaml.yaml",
+            "${fileSeparator}testYaml.yaml",
             """
                 AWSTemplateFormatVersion: "2010-09-09"
                 
@@ -371,7 +373,7 @@ class CodeWhispererProjectCodeScanTest : CodeWhispererCodeScanTestBase(PythonCod
 
         // Adding gitignore file and gitignore file member for testing.
         // The tests include the markdown file but not these two files.
-        projectRule.fixture.addFileToProject("/.gitignore", "node_modules\n.idea\n.vscode\n.DS_Store").virtualFile
-        projectRule.fixture.addFileToProject("/.idea/ref", "ref: refs/heads/main")
+        projectRule.fixture.addFileToProject("${fileSeparator}.gitignore", "node_modules\n.idea\n.vscode\n.DS_Store").virtualFile
+        projectRule.fixture.addFileToProject("${fileSeparator}.idea${fileSeparator}ref", "ref: refs/heads/main")
     }
 }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
@@ -202,7 +202,7 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
         }
 
         val zipFilePath = createTemporaryZipFileAsync { zipfs ->
-            val isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+            val isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
             filesToIncludeFlow.collect { file ->
                 if (!file.isDirectory) {
                     val externalFilePath = Path(file.path)

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
@@ -146,7 +146,7 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
         return deferredResults.any { it.await() }
     }
 
-    private fun wellKnown(file: VirtualFile): Boolean = wellKnownSourceFiles.contains(file.name)
+    fun wellKnown(file: VirtualFile): Boolean = wellKnownSourceFiles.contains(file.name)
 
     suspend fun zipFiles(projectRoot: VirtualFile): File = withContext(getCoroutineBgContext()) {
         val files = mutableListOf<VirtualFile>()
@@ -222,7 +222,7 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
     private suspend fun createTemporaryZipFileAsync(block: suspend (FileSystem) -> Unit): Path = withContext(getCoroutineBgContext()) {
         // Don't use Files.createTempFile since the file must not be created for ZipFS to work
         val tempFilePath: Path = Paths.get(FileUtils.getTempDirectory().absolutePath, "${UUID.randomUUID()}.zip")
-        val uri = URI.create("jar:file:$tempFilePath")
+        val uri = URI.create("jar:${tempFilePath.toUri()}")
         val env = hashMapOf("create" to "true")
         val zipfs = FileSystems.newFileSystem(uri, env)
         zipfs.use {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
@@ -202,16 +202,18 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
         }
 
         val zipFilePath = createTemporaryZipFileAsync { zipfs ->
+            val isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
             filesToIncludeFlow.collect { file ->
                 if (!file.isDirectory) {
                     val externalFilePath = Path(file.path)
-                    val externalFilePermissions = externalFilePath.getPosixFilePermissions()
                     val relativePath = Path(file.path).relativeTo(projectRootPath)
                     val zipfsPath = zipfs.getPath("/$relativePath")
                     runBlocking {
                         zipfsPath.createParentDirectories()
                         Files.copy(externalFilePath, zipfsPath, StandardCopyOption.REPLACE_EXISTING)
-                        Files.setAttribute(zipfsPath, "zip:permissions", externalFilePermissions)
+                        if (isPosix) {
+                            Files.setAttribute(zipfsPath, "zip:permissions", externalFilePath.getPosixFilePermissions())
+                        }
                     }
                 }
             }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
@@ -218,7 +218,7 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
                     withContext(Dispatchers.IO) {
                         zipfsPath.createParentDirectories()
                         Files.copy(externalFilePath, zipfsPath, StandardCopyOption.REPLACE_EXISTING)
-                        Files.setAttribute(zipfsPath, "zip:permissions", externalFilePermissions);
+                        Files.setAttribute(zipfsPath, "zip:permissions", externalFilePermissions)
                     }
                 }
             }
@@ -228,7 +228,7 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
 
     private suspend fun createTemporaryZipFileAsync(block: suspend (FileSystem) -> Unit): Path = withContext(EDT) {
         // Don't use Files.createTempFile since the file must not be created for ZipFS to work
-        val tempFilePath: Path = Paths.get(FileUtils.getTempDirectory().getAbsolutePath(), "${UUID.randomUUID()}.zip")
+        val tempFilePath: Path = Paths.get(FileUtils.getTempDirectory().absolutePath, "${UUID.randomUUID()}.zip")
         val uri = URI.create("jar:file:${tempFilePath}")
         val env = hashMapOf("create" to "true")
         val zipfs = FileSystems.newFileSystem(uri, env)

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/TelemetryUtils.kt
@@ -16,6 +16,7 @@ val ALLOWED_CODE_EXTENSIONS = setOf(
     "bash",
     "bat",
     "boo",
+    "bms",
     "c",
     "cbl",
     "cc",
@@ -27,6 +28,7 @@ val ALLOWED_CODE_EXTENSIONS = setOf(
     "cljs",
     "cls",
     "cmake",
+    "cmd",
     "cob",
     "cobra",
     "coffee",
@@ -122,11 +124,13 @@ val ALLOWED_CODE_EXTENSIONS = setOf(
     "pike",
     "pir",
     "pl",
+    "pli",
     "pm",
     "pmod",
     "pp",
     "pro",
     "prolog",
+    "properties",
     "ps1",
     "psd1",
     "psm1",
@@ -200,7 +204,7 @@ val ALLOWED_CODE_EXTENSIONS = setOf(
     "xml",
     "yaml",
     "yml",
-    "zig"
+    "zig",
 )
 
 fun scrubNames(messageToBeScrubbed: String, username: String? = getSystemUserName()): String {


### PR DESCRIPTION
Preserve file permissions in the zip archive, fix bugs in gitignore matching and keep mvm and gradle files



## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

* Traditional `ZipOutputStream` doesn't include file permission when archiving. Switching to ZipFS to be able to preserve the permissions on the archives
* Partial matching of gitignore rules would create some false-positive matches. e.g. `settings.gradle` file being ignored due to `.gradle` rule in gitignore. Changed the logic to fix it.
* Many of the files for mvn and gradle build systems would be dropped with the current extension+blocklist+gitignore heuristic. Added some explicit pattern matching to keep them unless matched by gitignore rules.

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
   - some are covered. still need more test coverage.
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [N/A] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
