### PR TITLE
fix(amazonq): Skip including deleted files for FeatureDev context.

### DIFF
--- a/.changes/next-release/bugfix-6a2d9629-1cc1-4143-8950-cfd117fcabe3.json
+++ b/.changes/next-release/bugfix-6a2d9629-1cc1-4143-8950-cfd117fcabe3.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q /dev: Fix issue when files are deleted while preparing context"
+}

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
@@ -189,8 +189,12 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
 
         createTemporaryZipFileAsync { zipOutput ->
             filesToIncludeFlow.collect { file ->
-                val relativePath = Path(file.path).relativeTo(projectRoot.toNioPath())
-                zipOutput.putNextEntry(relativePath.toString(), Path(file.path))
+                try {
+                    val relativePath = Path(file.path).relativeTo(projectRoot.toNioPath())
+                    zipOutput.putNextEntry(relativePath.toString(), Path(file.path))
+                } catch (e: NoSuchFileException) {
+                    // Noop: Skip if file was deleted
+                }
             }
         }
     }.toFile()


### PR DESCRIPTION
Fixes issue when files are deleted while preparing context.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

**Problem:** When zipping context for `/dev`, customer build processes (file watchers, etc.) may delete build artifacts we’ve already enumerated but have not added to the archive. As a best practice, customers should `.gitignore` these types of files, but in the event they don't, this has the potential to block `/dev` from running.

**Solution:** Skip affected files, which are not found when adding to zip context for Feature Dev.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
