### PR TITLE
Change logic for customization override to not override if user has manually selected a customization

### DIFF
--- a/.changes/next-release/bugfix-b6572d91-e5b4-4b2d-bb43-6a331aacc79c.json
+++ b/.changes/next-release/bugfix-b6572d91-e5b4-4b2d-bb43-6a331aacc79c.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Prevent customization override if user has manually selected a customization"
+}


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Changes the logic for when a customization will be overridden if the user is part of an AB group that has a customization override. With this change, if the user has manually selected a customization, it will not be overridden by the AB customization.

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
