### PR TITLE
fix(amazonq): Correct amazon q documentation updating flow progress text

### DIFF
--- a/.changes/next-release/bugfix-3e9ee812-d817-4c0d-9389-7b32d4049441.json
+++ b/.changes/next-release/bugfix-3e9ee812-d817-4c0d-9389-7b32d4049441.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Corrects an issue where documentation updating progress text was erroneously replaced with generation flow text."
+  "description" : "Fix incorrect text shown while updating documentation in /doc"
 }

--- a/.changes/next-release/bugfix-3e9ee812-d817-4c0d-9389-7b32d4049441.json
+++ b/.changes/next-release/bugfix-3e9ee812-d817-4c0d-9389-7b32d4049441.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Corrects an issue where documentation updating progress text was erroneously replaced with generation flow text."
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
@@ -110,7 +110,7 @@ fun getIconForStep(targetStep: DocGenerationStep, currentStep: DocGenerationStep
     else -> checkIcons["wait"]
 }
 
-fun docGenerationProgressMessage(currentStep: DocGenerationStep, mode: Mode): String {
+fun docGenerationProgressMessage(currentStep: DocGenerationStep, mode: Mode?): String {
     val isCreationMode = mode == Mode.CREATE
     val baseLine = if (isCreationMode) message("amazonqDoc.progress_message.creating") else message("amazonqDoc.progress_message.updating")
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocGenerationState.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocGenerationState.kt
@@ -64,8 +64,8 @@ class DocGenerationState(
                 message = action.msg,
                 intent = Intent.DOC
             )
-
-            val codeGenerationResult = generateCode(codeGenerationId = response.codeGenerationId(), token)
+            val mode = if (action.msg == message("amazonqDoc.session.create")) Mode.CREATE else null
+            val codeGenerationResult = generateCode(codeGenerationId = response.codeGenerationId(), mode, token)
             numberOfReferencesGenerated = codeGenerationResult.references.size
             numberOfFilesGenerated = codeGenerationResult.newFiles.size
             codeGenerationRemainingIterationCount = codeGenerationResult.codeGenerationRemainingIterationCount
@@ -138,7 +138,7 @@ fun getFileSummaryPercentage(input: String): Double {
     return percentage
 }
 
-private suspend fun DocGenerationState.generateCode(codeGenerationId: String, token: CancellationTokenSource?): CodeGenerationResult {
+private suspend fun DocGenerationState.generateCode(codeGenerationId: String, mode: Mode?, token: CancellationTokenSource?): CodeGenerationResult {
     val pollCount = 180
     val requestDelay = 10000L
 
@@ -214,7 +214,7 @@ private suspend fun DocGenerationState.generateCode(codeGenerationId: String, to
                             } else {
                                 DocGenerationStep.GENERATING_ARTIFACTS
                             },
-                            mode = Mode.CREATE
+                            mode
                         )
                     )
                 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [✓ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Corrects an issue where documentation updating progress text was 
erroneously replaced with generation flow text.
<!--- If appropriate, providing screenshots will help us review your contribution -->
After the fix, the updating flow progress text correctly displays 
"Okay, I'm updating the README to reflect your code changes", 
aligning with the expected behavior:

<img width="517" alt="image" src="https://github.com/user-attachments/assets/91184d1b-85a3-40a9-9ec3-025df1af80b2" />

<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ✓ ] My code follows the code style of this project
- [ ✓] I have added tests to cover my changes
- [ ✓ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
