### PR TITLE
Fix(core): State storage roaming type set to default for notification components

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/notifications/NotificationStateUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/notifications/NotificationStateUtils.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.components.service
 import software.aws.toolkits.core.utils.ETagProvider
 
 @Service
-@State(name = "notificationDismissals", storages = [Storage("aws.xml", roamingType = RoamingType.DISABLED)])
+@State(name = "notificationDismissals", storages = [Storage("aws.xml")])
 class NotificationDismissalState : PersistentStateComponent<NotificationDismissalConfiguration> {
     private val state = NotificationDismissalConfiguration()
 
@@ -41,7 +41,7 @@ data class NotificationDismissalConfiguration(
 )
 
 @Service
-@State(name = "notificationEtag", storages = [Storage("aws.xml", roamingType = RoamingType.DISABLED)])
+@State(name = "notificationEtag", storages = [Storage("aws.xml")])
 class NotificationEtagState : PersistentStateComponent<NotificationEtagConfiguration>, ETagProvider {
     private val state = NotificationEtagConfiguration()
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/notifications/NotificationStateUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/notifications/NotificationStateUtils.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.core.notifications
 
 import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.RoamingType
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Since notification state utils are being stored in aws.xml, they need to have the same roaming type as other state components (which default to roamingType.DEFAULT):

[If there are multiple components that store state in the same file, they must have the same roamingType attribute value.
](https://plugins.jetbrains.com/docs/intellij/persisting-state-of-components.html#defining-the-storage-location)

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
