### PR TITLE
fix(amazonq): /test fails for files outside project scope

### DIFF
--- a/.changes/next-release/bugfix-8c6afa32-afe4-41f2-a216-10d8bf5e2486.json
+++ b/.changes/next-release/bugfix-8c6afa32-afe4-41f2-a216-10d8bf5e2486.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q /test: Fix to redirect /test to generate tests in chat for external files out of project scope."
+}

--- a/.changes/next-release/bugfix-8c6afa32-afe4-41f2-a216-10d8bf5e2486.json
+++ b/.changes/next-release/bugfix-8c6afa32-afe4-41f2-a216-10d8bf5e2486.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Amazon Q /test: Fix to redirect /test to generate tests in chat for external files out of project scope."
+  "description" : "Amazon Q /test: Test generation fails for files outside the project"
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
@@ -512,6 +512,7 @@ class CodeWhispererUTGChatManager(val project: Project, private val cs: Coroutin
                 AmazonqTelemetry.utgGenerateTests(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
+                    isSupportedFile = true,
                     isSupportedLanguage = true,
                     credentialStartUrl = getStartUrl(project),
                     jobGroup = session.testGenerationJobGroupName,

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
@@ -512,7 +512,7 @@ class CodeWhispererUTGChatManager(val project: Project, private val cs: Coroutin
                 AmazonqTelemetry.utgGenerateTests(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
-                    isSupportedFile = true,
+                    isFileInWorkspace = true,
                     isSupportedLanguage = true,
                     credentialStartUrl = getStartUrl(project),
                     jobGroup = session.testGenerationJobGroupName,

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -241,7 +241,7 @@ class CodeTestChatController(
                     "language I support specialized unit test generation for at the moment.</b><br></span>The languages " +
                     "I support now are Python and Java. I can still provide examples, instructions and code suggestions."
             } else {
-                "<span style=\"color: #EE9D28;\">&#9888;<b> I can't generate tests for ${fileInfo.fileName} because it's outside the project directory. I can still provide examples, instructions and code suggestions."
+                "<span style=\"color: #EE9D28;\">&#9888;<b> I can't generate tests for ${fileInfo.fileName} because it's outside the project directory.</b><br></span> I can still provide examples, instructions and code suggestions."
             }
 
             codeTestChatHelper.addNewMessage(

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -241,7 +241,9 @@ class CodeTestChatController(
                     "language I support specialized unit test generation for at the moment.</b><br></span>The languages " +
                     "I support now are Python and Java. I can still provide examples, instructions and code suggestions."
             } else {
-                "<span style=\"color: #EE9D28;\">&#9888;<b> I can't generate tests for ${fileInfo.fileName} because it's outside the project directory.</b><br></span> I can still provide examples, instructions and code suggestions."
+                "<span style=\"color: #EE9D28;\">&#9888;<b> I can't generate tests for ${fileInfo.fileName}" +
+                    " because it's outside the project directory.</b><br></span> " +
+                    "I can still provide examples, instructions and code suggestions."
             }
 
             codeTestChatHelper.addNewMessage(

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -241,9 +241,7 @@ class CodeTestChatController(
                     "language I support specialized unit test generation for at the moment.</b><br></span>The languages " +
                     "I support now are Python and Java. I can still provide examples, instructions and code suggestions."
             } else {
-                "<span style=\"color: #EE9D28;\">&#9888;<b>External File Detected: ${fileInfo.fileName} \n" +
-                    " is outside the project directory.</b><br></span>" +
-                    "However, I can still help you create unit tests for ${fileInfo.fileName} here"
+                "<span style=\"color: #EE9D28;\">&#9888;<b> I can't generate tests for ${fileInfo.fileName} because it's outside the project directory. I can still provide examples, instructions and code suggestions."
             }
 
             codeTestChatHelper.addNewMessage(

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -299,7 +299,7 @@ class CodeTestChatController(
                 AmazonqTelemetry.utgGenerateTests(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
-                    isSupportedFile = fileInfo.filePath.startsWith(projectRoot.toString()),
+                    isFileInWorkspace = fileInfo.filePath.startsWith(projectRoot.toString()),
                     isSupportedLanguage = isLanguageSupported(fileInfo.fileLanguage.languageId),
                     credentialStartUrl = getStartUrl(project),
                     result = MetricResult.Succeeded,
@@ -601,7 +601,7 @@ class CodeTestChatController(
                 AmazonqTelemetry.utgGenerateTests(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
-                    isSupportedFile = true,
+                    isFileInWorkspace = true,
                     isSupportedLanguage = true,
                     credentialStartUrl = getStartUrl(project = context.project),
                     jobGroup = session.testGenerationJobGroupName,
@@ -796,7 +796,7 @@ class CodeTestChatController(
                 AmazonqTelemetry.utgGenerateTests(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
-                    isSupportedFile = true,
+                    isFileInWorkspace = true,
                     isSupportedLanguage = true,
                     credentialStartUrl = getStartUrl(project = context.project),
                     jobGroup = session.testGenerationJobGroupName,

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -299,7 +299,8 @@ class CodeTestChatController(
                 AmazonqTelemetry.utgGenerateTests(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
-                    isSupportedLanguage = false,
+                    isSupportedFile = fileInfo.filePath.startsWith(projectRoot.toString()),
+                    isSupportedLanguage = isLanguageSupported(fileInfo.fileLanguage.languageId),
                     credentialStartUrl = getStartUrl(project),
                     result = MetricResult.Succeeded,
                     perfClientLatency = (Instant.now().toEpochMilli() - session.startTimeOfTestGeneration),
@@ -600,6 +601,7 @@ class CodeTestChatController(
                 AmazonqTelemetry.utgGenerateTests(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
+                    isSupportedFile = true,
                     isSupportedLanguage = true,
                     credentialStartUrl = getStartUrl(project = context.project),
                     jobGroup = session.testGenerationJobGroupName,
@@ -794,6 +796,7 @@ class CodeTestChatController(
                 AmazonqTelemetry.utgGenerateTests(
                     cwsprChatProgrammingLanguage = session.programmingLanguage.languageId,
                     hasUserPromptSupplied = session.hasUserPromptSupplied,
+                    isSupportedFile = true,
                     isSupportedLanguage = true,
                     credentialStartUrl = getStartUrl(project = context.project),
                     jobGroup = session.testGenerationJobGroupName,

--- a/plugins/core/jetbrains-community/resources/telemetryOverride.json
+++ b/plugins/core/jetbrains-community/resources/telemetryOverride.json
@@ -218,7 +218,7 @@
         {
             "name": "isFileInWorkspace",
             "type": "boolean",
-            "description": "Indicate if the file is supported based on file path"
+            "description": "Indicate if the file is in the current workspace."
         },
         {
             "name": "isSupportedLanguage",

--- a/plugins/core/jetbrains-community/resources/telemetryOverride.json
+++ b/plugins/core/jetbrains-community/resources/telemetryOverride.json
@@ -216,6 +216,11 @@
             "description": "True if user selected code snippet as input else false"
         },
         {
+            "name": "isSupportedFile",
+            "type": "boolean",
+            "description": "Indicate if the file is supported based on file path"
+        },
+        {
             "name": "isSupportedLanguage",
             "type": "boolean",
             "description": "Indicate if the language is supported"
@@ -572,6 +577,9 @@
                 {
                     "type": "isCodeBlockSelected",
                     "required": false
+                },
+                {
+                    "type": "isSupportedFile"
                 },
                 {
                     "type": "isSupportedLanguage"

--- a/plugins/core/jetbrains-community/resources/telemetryOverride.json
+++ b/plugins/core/jetbrains-community/resources/telemetryOverride.json
@@ -216,7 +216,7 @@
             "description": "True if user selected code snippet as input else false"
         },
         {
-            "name": "isSupportedFile",
+            "name": "isFileInWorkspace",
             "type": "boolean",
             "description": "Indicate if the file is supported based on file path"
         },
@@ -579,7 +579,7 @@
                     "required": false
                 },
                 {
-                    "type": "isSupportedFile"
+                    "type": "isFileInWorkspace"
                 },
                 {
                     "type": "isSupportedLanguage"


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
/test fails for files outside of project scope because of service side failures due to path discrepancies. This fix will redirect the unit test generation for such files using conversation APIs in chat instead of running /test workflow.

Added override telemetry metrics. Will amend and add the metrics in toolkit-common once VSCode also merges.
## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
