### PR TITLE
telemetry(amazonq): Add JetBrains IdeCategory for enterprise telemetry

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
+import software.amazon.awssdk.services.codewhispererruntime.model.IdeCategory
 import software.amazon.awssdk.services.codewhispererruntime.model.Position
 import software.amazon.awssdk.services.codewhispererruntime.model.Range
 import software.amazon.awssdk.services.codewhispererruntime.model.Reference
@@ -571,6 +572,7 @@ class CodeTestChatController(
                     session.testGenerationJob,
                     session.testGenerationJobGroupName,
                     session.programmingLanguage,
+                    IdeCategory.JETBRAINS,
                     session.numberOfUnitTestCasesGenerated,
                     session.numberOfUnitTestCasesGenerated,
                     session.linesOfCodeGenerated,
@@ -766,6 +768,7 @@ class CodeTestChatController(
                     session.testGenerationJob,
                     session.testGenerationJobGroupName,
                     session.programmingLanguage,
+                    IdeCategory.JETBRAINS,
                     session.numberOfUnitTestCasesGenerated,
                     0,
                     session.linesOfCodeGenerated,

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/credentials/CodeWhispererClientAdaptor.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/credentials/CodeWhispererClientAdaptor.kt
@@ -27,6 +27,7 @@ import software.amazon.awssdk.services.codewhispererruntime.model.GenerateComple
 import software.amazon.awssdk.services.codewhispererruntime.model.GetCodeFixJobRequest
 import software.amazon.awssdk.services.codewhispererruntime.model.GetCodeFixJobResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.GetTestGenerationResponse
+import software.amazon.awssdk.services.codewhispererruntime.model.IdeCategory
 import software.amazon.awssdk.services.codewhispererruntime.model.InlineChatUserDecision
 import software.amazon.awssdk.services.codewhispererruntime.model.ListAvailableCustomizationsRequest
 import software.amazon.awssdk.services.codewhispererruntime.model.ListFeatureEvaluationsResponse
@@ -199,6 +200,7 @@ interface CodeWhispererClientAdaptor : Disposable {
         jobId: String,
         groupName: String,
         language: CodeWhispererProgrammingLanguage?,
+        ideCategory: IdeCategory?,
         numberOfUnitTestCasesGenerated: Int?,
         numberOfUnitTestCasesAccepted: Int?,
         linesOfCodeGenerated: Int?,
@@ -668,6 +670,7 @@ open class CodeWhispererClientAdaptorImpl(override val project: Project) : CodeW
         jobId: String,
         groupName: String,
         language: CodeWhispererProgrammingLanguage?,
+        ideCategory: IdeCategory?,
         numberOfUnitTestCasesGenerated: Int?,
         numberOfUnitTestCasesAccepted: Int?,
         linesOfCodeGenerated: Int?,
@@ -682,6 +685,7 @@ open class CodeWhispererClientAdaptorImpl(override val project: Project) : CodeW
                 }
                 it.jobId(jobId)
                 it.groupName(groupName)
+                it.ideCategory(ideCategory)
                 it.numberOfUnitTestCasesGenerated(numberOfUnitTestCasesGenerated)
                 it.numberOfUnitTestCasesAccepted(numberOfUnitTestCasesAccepted)
                 it.linesOfCodeGenerated(linesOfCodeGenerated)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

- Currently in the cloudwatch logs, the TestGenerationIdeCategory field is empty when it should be JETBRAINS
- This change will now emit the JETBRAINS TestGenerationIdeCategory so that this field is not empty
- Tested by emitting metrics in cloudwatch


## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
