### PR TITLE
fix(amazonq): Remove the incorrect accept and reject buttons while hovering ov…

### DIFF
--- a/.changes/next-release/bugfix-acc81345-73b6-4f71-856e-76d8e0d451de.json
+++ b/.changes/next-release/bugfix-acc81345-73b6-4f71-856e-76d8e0d451de.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix incorrect accept and reject buttons shows up while hovering over the generated file"
+}

--- a/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/docChatConnector.ts
+++ b/plugins/amazonq/mynah-ui/src/mynah-ui/ui/apps/docChatConnector.ts
@@ -196,7 +196,6 @@ export class Connector {
 
     private processCodeResultMessage = async (messageData: any): Promise<void> => {
         if (this.onChatAnswerReceived !== undefined) {
-            const actions = getActions([...messageData.filePaths, ...messageData.deletedFiles])
             const answer: ChatItem = {
                 type: ChatItemType.ANSWER,
                 relatedContent: undefined,
@@ -209,8 +208,7 @@ export class Connector {
                     fileTreeTitle: 'Documents ready',
                     rootFolderTitle: 'Generated documentation',
                     filePaths: (messageData.filePaths as DiffTreeFileInfo[]).map(path => path.zipFilePath),
-                    deletedFiles: (messageData.deletedFiles as DiffTreeFileInfo[]).map(path => path.zipFilePath),
-                    actions,
+                    deletedFiles: (messageData.deletedFiles as DiffTreeFileInfo[]).map(path => path.zipFilePath)
                 },
                 body: '',
             }


### PR DESCRIPTION
…er the generated file

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [✓] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
remove the incorrect accept and reject buttons while hovering over the generated file

<!--- If appropriate, providing screenshots will help us review your contribution -->
Prior to the modification, hovering over the generated file would display accept and reject buttons adjacent to the file title 'README.md'. This behavior caused a misalignment with our Visual Studio Code version
![image](https://github.com/user-attachments/assets/3612cdbe-3cee-460c-8585-1044ef66a878)


## Checklist
- [✓] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [✓] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
