### PR TITLE
test(amazonq): update tests for messages at different remaining iteration counts

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -494,7 +494,7 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
         val totalIterations = 10
 
         for (remainingIterations in -1 until totalIterations) {
-            // remainingIterations < 0 to represent the null case
+            // remainingIterations < 0 is to represent the null case
             val message = if (remainingIterations > 2 || remainingIterations < 0) {
                 message("amazonqFeatureDev.code_generation.stopped_code_generation_no_iteration_count_display")
             } else if (remainingIterations > 0) {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Previously the logic of showing different messages at different remaining iteration counts are tested manually. Adding tests to automate the process.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
