### PR TITLE
fix(amazonq): /doc Ask for user prompt if error occurs when user updates documentation

### DIFF
--- a/.changes/next-release/bugfix-9a5972a0-db20-47a8-8b0d-b8ae31506e7e.json
+++ b/.changes/next-release/bugfix-9a5972a0-db20-47a8-8b0d-b8ae31506e7e.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "AmazonQ doc agent: Enable text input in edit mode for retries and use it instead of retry button"
+}

--- a/.changes/next-release/bugfix-9a5972a0-db20-47a8-8b0d-b8ae31506e7e.json
+++ b/.changes/next-release/bugfix-9a5972a0-db20-47a8-8b0d-b8ae31506e7e.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "AmazonQ doc agent: Enable text input in edit mode for retries and use it instead of retry button"
+  "description" : "Amazon Q /doc: Ask for user prompt if error occurs while updating documentation"
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocConstants.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocConstants.kt
@@ -3,6 +3,11 @@
 
 package software.aws.toolkits.jetbrains.services.amazonqDoc
 
+import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.FollowUp
+import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.FollowUpStatusType
+import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.FollowUpTypes
+import software.aws.toolkits.resources.message
+
 const val FEATURE_EVALUATION_PRODUCT_NAME = "DocGeneration"
 
 const val FEATURE_NAME = "Amazon Q Documentation Generation"
@@ -25,3 +30,16 @@ enum class ModifySourceFolderErrorReason(
 
     override fun toString(): String = reasonText
 }
+
+val NEW_SESSION_FOLLOWUPS: List<FollowUp> = listOf(
+    FollowUp(
+        pillText = message("amazonqDoc.prompt.reject.new_task"),
+        type = FollowUpTypes.NEW_TASK,
+        status = FollowUpStatusType.Info
+    ),
+    FollowUp(
+        pillText = message("amazonqDoc.prompt.reject.close_session"),
+        type = FollowUpTypes.CLOSE_SESSION,
+        status = FollowUpStatusType.Info
+    )
+)

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocExceptions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocExceptions.kt
@@ -8,7 +8,8 @@ import software.aws.toolkits.resources.message
 open class DocException(
     override val message: String?,
     override val cause: Throwable? = null,
-    val remainingIterations: Int? = null) : RuntimeException()
+    val remainingIterations: Int? = null,
+) : RuntimeException()
 
 class ZipFileError(override val message: String, override val cause: Throwable?) : RuntimeException()
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocExceptions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocExceptions.kt
@@ -5,17 +5,17 @@ package software.aws.toolkits.jetbrains.services.amazonqDoc
 
 import software.aws.toolkits.resources.message
 
-open class DocException(override val message: String?, override val cause: Throwable? = null) : RuntimeException()
+open class DocException(
+    override val message: String?,
+    override val cause: Throwable? = null,
+    val remainingIterations: Int? = null) : RuntimeException()
 
 class ZipFileError(override val message: String, override val cause: Throwable?) : RuntimeException()
 
 class CodeIterationLimitError(override val message: String, override val cause: Throwable?) : RuntimeException()
 
-internal fun docServiceError(message: String?): Nothing =
-    throw DocException(message)
-
-internal fun codeGenerationFailedError(): Nothing =
-    throw DocException(message("amazonqFeatureDev.code_generation.failed_generation"))
+internal fun docServiceError(message: String?, cause: Throwable? = null, remainingIterations: Int? = null): Nothing =
+    throw DocException(message, cause, remainingIterations)
 
 internal fun conversationIdNotFound(): Nothing =
     throw DocException(message("amazonqFeatureDev.exception.conversation_not_found"))

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
@@ -53,12 +53,12 @@ import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendAuthenti
 import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendChatInputEnabledMessage
 import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendCodeResult
 import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendError
+import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendErrorToUser
 import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendFolderConfirmationMessage
 import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendMonthlyLimitError
 import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendSystemPrompt
 import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendUpdatePlaceholder
 import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendUpdatePromptProgress
-import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.sendErrorToUser
 import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.updateFileComponent
 import software.aws.toolkits.jetbrains.services.amazonqDoc.session.DocSession
 import software.aws.toolkits.jetbrains.services.amazonqDoc.session.PrepareDocGenerationState
@@ -380,7 +380,7 @@ class DocController(
                     tabId = message.tabId,
                     errMessage = message("amazonqFeatureDev.exception.open_diff_failed"),
                     retries = 0,
-                    conversationId = session.conversationIdUnsafe,
+                    conversationId = session.conversationIdUnsafe
                 )
             }
         }
@@ -428,10 +428,9 @@ class DocController(
             messenger.sendUpdatePlaceholder(tabId, message("amazonqDoc.prompt.placeholder"))
         } catch (err: Exception) {
             val message = createUserFacingErrorMessage(err.message)
-            messenger.sendError(
+            messenger.sendErrorToUser(
                 tabId = tabId,
                 errMessage = message ?: message("amazonqFeatureDev.exception.request_failed"),
-                retries = retriesRemaining(session),
                 conversationId = session?.conversationIdUnsafe,
             )
         }
@@ -725,7 +724,7 @@ class DocController(
             }
         } catch (err: Exception) {
             // For non edit mode lock the chat input until they explicitly click one of the follow-ups
-            var isEnableChatInput = false;
+            var isEnableChatInput = false
             if (err is DocException && Mode.EDIT == mode) {
                 isEnableChatInput = err.remainingIterations != null && err.remainingIterations > 0
             }
@@ -887,7 +886,7 @@ class DocController(
                 tabId = tabId,
                 errMessage = message ?: message("amazonqFeatureDev.exception.retry_request_failed"),
                 retries = retriesRemaining(session),
-                conversationId = session?.conversationIdUnsafe
+                conversationId = session?.conversationIdUnsafe,
             )
         } finally {
             // Finish processing the event

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocGenerationState.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocGenerationState.kt
@@ -172,17 +172,18 @@ private suspend fun DocGenerationState.generateCode(codeGenerationId: String, mo
 
             CodeGenerationWorkflowStatus.FAILED -> {
                 messenger.sendUpdatePromptProgress(tabId = tabID, progressField = null)
+                val remainingIterations = codeGenerationResultState.codeGenerationRemainingIterationCount()
 
                 when (true) {
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "README_TOO_LARGE"
                     ),
-                    -> docServiceError(message("amazonqDoc.exception.readme_too_large"))
+                    -> docServiceError(message("amazonqDoc.exception.readme_too_large"), remainingIterations=remainingIterations)
 
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "README_UPDATE_TOO_LARGE"
                     ),
-                    -> docServiceError(message("amazonqDoc.exception.readme_update_too_large"))
+                    -> docServiceError(message("amazonqDoc.exception.readme_update_too_large"), remainingIterations=remainingIterations)
 
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "WORKSPACE_TOO_LARGE"
@@ -197,17 +198,17 @@ private suspend fun DocGenerationState.generateCode(codeGenerationId: String, mo
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "PROMPT_UNRELATED"
                     ),
-                    -> docServiceError(message("amazonqDoc.exception.prompt_unrelated"))
+                    -> docServiceError(message("amazonqDoc.exception.prompt_unrelated"), remainingIterations = remainingIterations)
 
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "PROMPT_TOO_VAGUE"
                     ),
-                    -> docServiceError(message("amazonqDoc.exception.prompt_too_vague"))
+                    -> docServiceError(message("amazonqDoc.exception.prompt_too_vague"), remainingIterations=remainingIterations)
 
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "PromptRefusal"
                     ),
-                    -> docServiceError(message("amazonqFeatureDev.exception.prompt_refusal"))
+                    -> docServiceError(message("amazonqFeatureDev.exception.prompt_refusal"), remainingIterations=remainingIterations)
 
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "Guardrails"

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocGenerationState.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocGenerationState.kt
@@ -178,12 +178,12 @@ private suspend fun DocGenerationState.generateCode(codeGenerationId: String, mo
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "README_TOO_LARGE"
                     ),
-                    -> docServiceError(message("amazonqDoc.exception.readme_too_large"), remainingIterations=remainingIterations)
+                    -> docServiceError(message("amazonqDoc.exception.readme_too_large"), remainingIterations = remainingIterations)
 
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "README_UPDATE_TOO_LARGE"
                     ),
-                    -> docServiceError(message("amazonqDoc.exception.readme_update_too_large"), remainingIterations=remainingIterations)
+                    -> docServiceError(message("amazonqDoc.exception.readme_update_too_large"), remainingIterations = remainingIterations)
 
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "WORKSPACE_TOO_LARGE"
@@ -203,12 +203,12 @@ private suspend fun DocGenerationState.generateCode(codeGenerationId: String, mo
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "PROMPT_TOO_VAGUE"
                     ),
-                    -> docServiceError(message("amazonqDoc.exception.prompt_too_vague"), remainingIterations=remainingIterations)
+                    -> docServiceError(message("amazonqDoc.exception.prompt_too_vague"), remainingIterations = remainingIterations)
 
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "PromptRefusal"
                     ),
-                    -> docServiceError(message("amazonqFeatureDev.exception.prompt_refusal"), remainingIterations=remainingIterations)
+                    -> docServiceError(message("amazonqFeatureDev.exception.prompt_refusal"), remainingIterations = remainingIterations)
 
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "Guardrails"


### PR DESCRIPTION
Amazon Q /doc: Ask for user prompt if error occurs when user updates documentation
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Instead of "Retry" button allow user to enter a text to retry making a change to documentation if error occurs. 

![retry-1](https://github.com/user-attachments/assets/18417f33-1703-4ce1-8728-01e0266fc425)



When retries amount reached the limit propose user "Start a new documentation task" and "End session" buttons

![retry-10](https://github.com/user-attachments/assets/48b42377-bd41-4219-bdb8-7f8244402351)



## Checklist
- [ X  ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
