### PR TITLE
fix(amazonq): zip entry contains invalid characters

### DIFF
--- a/.changes/next-release/bugfix-02a84512-83ae-4fbe-a527-292ba072e3e0.json
+++ b/.changes/next-release/bugfix-02a84512-83ae-4fbe-a527-292ba072e3e0.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "/review: Improved success rate of code reviews for certain workspace configurations"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/sessionconfig/CodeScanSessionConfig.kt
@@ -38,6 +38,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.DEFAULT_PAYLOAD_LIMIT_IN_BYTES
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.FILE_SCAN_PAYLOAD_SIZE_LIMIT_IN_BYTES
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.FILE_SCAN_TIMEOUT_IN_SECONDS
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.isWithin
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CodewhispererLanguage
 import java.io.File
@@ -106,7 +107,7 @@ class CodeScanSessionConfig(
                 null -> getProjectPayloadMetadata()
                 else -> when (scope) {
                     CodeAnalysisScope.PROJECT -> getProjectPayloadMetadata()
-                    CodeAnalysisScope.FILE -> if (selectedFile.path.startsWith(projectRoot.path)) {
+                    CodeAnalysisScope.FILE -> if (selectedFile.isWithin(projectRoot)) {
                         getFilePayloadMetadata(selectedFile, true)
                     } else {
                         projectRoot = selectedFile.parent

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -153,9 +153,7 @@ fun VirtualFile.toCodeChunk(path: String): Sequence<Chunk> = sequence {
     }
 }
 
-fun VirtualFile.isWithin(ancestor: VirtualFile): Boolean {
-    return VfsUtilCore.isAncestor(ancestor, this, false)
-}
+fun VirtualFile.isWithin(ancestor: VirtualFile): Boolean = VfsUtilCore.isAncestor(ancestor, this, false)
 
 object CodeWhispererUtil {
     fun getCompletionType(completion: Completion): CodewhispererCompletionType {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtil.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.impl.EditorImpl
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.ComponentUtil
@@ -150,6 +151,10 @@ fun VirtualFile.toCodeChunk(path: String): Sequence<Chunk> = sequence {
             yield(Chunk(content = lastChunk, path = path, nextChunk = lastChunk))
         }
     }
+}
+
+fun VirtualFile.isWithin(ancestor: VirtualFile): Boolean {
+    return VfsUtilCore.isAncestor(ancestor, this, false)
 }
 
 object CodeWhispererUtil {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererUtilTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererUtilTest.kt
@@ -24,6 +24,7 @@ import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getCompletionType
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getTelemetryOptOutPreference
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererUtil.getUnmodifiedAcceptedCharsCount
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.isWithin
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.runIfIdcConnectionOrTelemetryEnabled
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.toCodeChunk
 import software.aws.toolkits.jetbrains.settings.AwsSettings
@@ -236,5 +237,26 @@ class CodeWhispererUtilTest {
         modifiedRecommendation = "x, y):\n$pythonCommentAddedByUser\treturn x + y"
         unmodifiedCharsCount = getUnmodifiedAcceptedCharsCount(originalRecommendation, modifiedRecommendation)
         assertThat(unmodifiedCharsCount).isEqualTo(originalRecommendation.length)
+    }
+
+    @Test
+    fun `test isWithin() returns true if file is within the given directory`() {
+        val projectRoot = fixture.tempDirFixture.findOrCreateDir("workspace/projectA")
+        val file = fixture.addFileToProject("workspace/projectA/src/Sample.java", "").virtualFile
+        assertThat(file.isWithin(projectRoot)).isTrue()
+    }
+
+    @Test
+    fun `test isWithin() returns false if file is not within the given directory`() {
+        val projectRoot = fixture.tempDirFixture.findOrCreateDir("workspace/projectA")
+        val file = fixture.addFileToProject("workspace/projectB/src/Sample.java", "").virtualFile
+        assertThat(file.isWithin(projectRoot)).isFalse()
+    }
+
+    @Test
+    fun `test isWithin() returns false if file is not within the given directory but has the same prefix`() {
+        val projectRoot = fixture.tempDirFixture.findOrCreateDir("workspace/projectA")
+        val file = fixture.addFileToProject("workspace/projectA1/src/Sample.java", "").virtualFile
+        assertThat(file.isWithin(projectRoot)).isFalse()
     }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Code reviews sometimes fail due to invalid zip entry path error for certain workspace configurations.

Root cause: 
The condition `selectedFile.path.startsWith(projectRoot.path)` string comparison incorrectly returns true if the selected file is not in the projectRoot but has a partial path prefix match of the projectRoot.

For example:
```
projectRoot.path = "/home/user/project"
selectedFile.path = "/home/user/project2/some/file.java"
```

Solution:
Use built-in VirtualFile util method to check if the file is actually within the projectRoot.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
