### PR TITLE
Fix(AmazonQ): CodeWhisperer settings persist across restarts

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
@@ -13,7 +13,7 @@ import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.annotations.Property
 
 @Service
-@State(name = "codewhispererSettings", storages = [Storage("aws.xml", roamingType = RoamingType.DISABLED)])
+@State(name = "codewhispererSettings", storages = [Storage("aws.xml")])
 class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguration> {
     private val state = CodeWhispererConfiguration()
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
@@ -117,10 +117,9 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
 }
 
 class CodeWhispererConfiguration : BaseState() {
-    @get:Property
-    val value by map<CodeWhispererConfigurationType, Boolean>()
-    val intValue by map<CodeWhispererIntConfigurationType, Int>()
-    val stringValue by map<CodeWhispererStringConfigurationType, String>()
+    var value by map<CodeWhispererConfigurationType, Boolean>()
+    var intValue by map<CodeWhispererIntConfigurationType, Int>()
+    var stringValue by map<CodeWhispererStringConfigurationType, String>()
 }
 
 enum class CodeWhispererConfigurationType {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

CodewhispererSettings state component was not saving some of its settings across restarts, this change fixes that, along with setting roamingType to default to avoid sync issues. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

The intValue and StringValue used by the state class were missing the
@get:Property tag that the value property had, which meant they were not being properly serialized in the xml file.

Changing all three of these properties to var instead of val removes the need for this property tag and is more consistent with other state component implementations across this project

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
