### PR TITLE
fix(amazonq): open diff in a new tab when another modal is open

### DIFF
--- a/.changes/next-release/bugfix-1a28cd4b-54eb-46bb-b0c6-2f9abc8fa9e6.json
+++ b/.changes/next-release/bugfix-1a28cd4b-54eb-46bb-b0c6-2f9abc8fa9e6.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q /doc: fix open diff in a tab when another modal is open"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
@@ -4,8 +4,10 @@
 package software.aws.toolkits.jetbrains.services.amazonqDoc.controller
 
 import com.intellij.diff.DiffContentFactory
-import com.intellij.diff.DiffManager
+import com.intellij.diff.chains.SimpleDiffRequestChain
 import com.intellij.diff.contents.EmptyContent
+import com.intellij.diff.editor.ChainDiffVirtualFile
+import com.intellij.diff.editor.DiffEditorTabFilesManager
 import com.intellij.diff.requests.SimpleDiffRequest
 import com.intellij.diff.util.DiffUserDataKeys
 import com.intellij.ide.BrowserUtil
@@ -371,7 +373,6 @@ class DocController(
     }
 
     override suspend fun processOpenDiff(message: IncomingDocMessage.OpenDiff) {
-        this.toolWindow?.activate(null)
         val session = getSessionInfo(message.tabId)
 
         val project = context.project
@@ -399,7 +400,8 @@ class DocController(
                     val request = SimpleDiffRequest(message.filePath, leftDiffContent, rightDiffContent, null, null)
                     request.putUserData(DiffUserDataKeys.FORCE_READ_ONLY, true)
 
-                    DiffManager.getInstance().showDiff(project, request)
+                    val newDiff = ChainDiffVirtualFile(SimpleDiffRequestChain(request), message.filePath)
+                    DiffEditorTabFilesManager.getInstance(context.project).showDiffFile(newDiff, true)
                 }
             }
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
@@ -371,6 +371,7 @@ class DocController(
     }
 
     override suspend fun processOpenDiff(message: IncomingDocMessage.OpenDiff) {
+        this.toolWindow?.activate(null)
         val session = getSessionInfo(message.tabId)
 
         val project = context.project


### PR DESCRIPTION
fix(amazonq): /doc agent - fix open diff in a new tab when another modal is open
When another modal is open: Help -> Diagnostic Tools -> Activity Monitor. Keep focus on this modal. Diff was opened in a new modal
![image](https://github.com/user-attachments/assets/7e611900-f8ba-4605-bbe6-a7fb673a4c1c)
After this change, the diff always opens in a new tab.
generate Readme:
![image](https://github.com/user-attachments/assets/23d88a85-2258-40a1-9f6b-faf349e7b986)

generate Readme with chat:
![image](https://github.com/user-attachments/assets/c7260a56-dd95-4dae-9206-495e04715a25)


<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
