### PR TITLE
fix(chat/inline workspace context): fix updating workspace index blocks UI thread

### DIFF
--- a/.changes/next-release/bugfix-970b5a61-5646-4f40-b9fa-65c69ceda73f.json
+++ b/.changes/next-release/bugfix-970b5a61-5646-4f40-b9fa-65c69ceda73f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix UI freeze caused by updating workspace index on non background context"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/ChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/ChatController.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
 import software.amazon.awssdk.services.codewhispererstreaming.model.UserIntent
+import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.core.utils.warn
@@ -152,10 +153,13 @@ class ChatController private constructor(
             } else {
                 sendOpenSettingsMessage(message.tabId)
             }
-        } else if (CodeWhispererSettings.getInstance().isProjectContextEnabled() &&
-            ProjectContextController.getInstance(context.project).getProjectContextIndexComplete()
-        ) {
-            queryResult = ProjectContextController.getInstance(context.project).queryChat(prompt, timeout = CHAT_IMPLICIT_PROJECT_CONTEXT_TIMEOUT)
+        } else if (CodeWhispererSettings.getInstance().isProjectContextEnabled()) {
+            if (ProjectContextController.getInstance(context.project).getProjectContextIndexComplete()) {
+                val projectContextController = ProjectContextController.getInstance(context.project)
+                queryResult = projectContextController.queryChat(prompt, timeout = CHAT_IMPLICIT_PROJECT_CONTEXT_TIMEOUT)
+            } else {
+                logger.debug { "skipping implicit workspace context as index is not ready" }
+            }
         }
 
         handleChat(

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/ChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/controller/ChatController.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import migration.software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
 import software.amazon.awssdk.services.codewhispererstreaming.model.UserIntent
-import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.core.utils.warn
@@ -153,13 +152,10 @@ class ChatController private constructor(
             } else {
                 sendOpenSettingsMessage(message.tabId)
             }
-        } else if (CodeWhispererSettings.getInstance().isProjectContextEnabled()) {
-            if (ProjectContextController.getInstance(context.project).getProjectContextIndexComplete()) {
-                val projectContextController = ProjectContextController.getInstance(context.project)
-                queryResult = projectContextController.queryChat(prompt, timeout = CHAT_IMPLICIT_PROJECT_CONTEXT_TIMEOUT)
-            } else {
-                logger.debug { "skipping implicit workspace context as index is not ready" }
-            }
+        } else if (CodeWhispererSettings.getInstance().isProjectContextEnabled() &&
+            ProjectContextController.getInstance(context.project).getProjectContextIndexComplete()
+        ) {
+            queryResult = ProjectContextController.getInstance(context.project).queryChat(prompt, timeout = CHAT_IMPLICIT_PROJECT_CONTEXT_TIMEOUT)
         }
 
         handleChat(

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextEditorListener.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextEditorListener.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.services.amazonq.project
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 
 class ProjectContextEditorListener : FileEditorManagerListener {
     override fun selectionChanged(event: FileEditorManagerEvent) {
@@ -19,6 +20,8 @@ class ProjectContextEditorListener : FileEditorManagerListener {
         }
 
         val project = event.manager.project
-        ProjectContextController.getInstance(project).updateIndex(listOf(oldFile.path), IndexUpdateMode.UPDATE)
+        pluginAwareExecuteOnPooledThread {
+            ProjectContextController.getInstance(project).updateIndex(listOf(oldFile.path), IndexUpdateMode.UPDATE)
+        }
     }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Wrap  `ProjectContextProvider@updateIndex` inside `pluginAwareExecuteOnPooledThread` to make it execute it in background context instead of EDT

#5296 

## Root cause
`updateIndex()` is executed in blocking context

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
