### PR TITLE
telemetry(amazonq): add fields for code fix events

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ mockitoKotlin = "5.4.0"
 mockk = "1.13.10"
 nimbus-jose-jwt = "9.40"
 node-gradle = "7.0.2"
-telemetryGenerator = "1.0.293"
+telemetryGenerator = "1.0.295"
 testLogger = "4.0.0"
 testRetry = "1.5.10"
 # test-only; platform provides slf4j transitively at runtime

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanIssueDetailsPanel.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanIssueDetailsPanel.kt
@@ -149,7 +149,13 @@ internal class CodeWhispererCodeScanIssueDetailsPanel(
                 if (suggestedFix.code.isNotBlank()) {
                     sendCodeFixGeneratedTelemetryToServiceAPI(issue, false)
                 }
-                CodeWhispererTelemetryService.getInstance().sendCodeScanIssueGenerateFix(Component.Webview, issue, isRegenerate, MetricResult.Succeeded)
+                CodeWhispererTelemetryService.getInstance().sendCodeScanIssueGenerateFix(
+                    Component.Webview,
+                    issue,
+                    isRegenerate,
+                    MetricResult.Succeeded,
+                    includesFix = suggestedFix.code.isNotBlank()
+                )
             }
         }
     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanManager.kt
@@ -997,6 +997,8 @@ data class CodeWhispererCodeScanIssue(
     val isInvalid: Boolean = false,
     var rangeHighlighter: RangeHighlighterEx? = null,
     var isVisible: Boolean = true,
+    val autoDetected: Boolean = false,
+    val scanJobId: String,
 ) {
     override fun toString(): String = title
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
@@ -219,7 +219,7 @@ class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
                 LOG.debug { "Rendering response to display code review results." }
             }
             currentCoroutineContext.ensureActive()
-            val issues = mapToCodeScanIssues(documents, sessionContext.project).filter { it.isVisible }
+            val issues = mapToCodeScanIssues(documents, sessionContext.project, jobId).filter { it.isVisible }
             codeScanResponseContext = codeScanResponseContext.copy(codeScanTotalIssues = issues.count())
             codeScanResponseContext = codeScanResponseContext.copy(codeScanIssuesWithFixes = issues.count { it.suggestedFixes.isNotEmpty() })
             codeScanResponseContext = codeScanResponseContext.copy(reason = "Succeeded")
@@ -304,7 +304,7 @@ class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
         throw codeScanServerException("ListCodeReviewFindingsException: $errorMessage")
     }
 
-    fun mapToCodeScanIssues(recommendations: List<String>, project: Project): List<CodeWhispererCodeScanIssue> {
+    fun mapToCodeScanIssues(recommendations: List<String>, project: Project, jobId: String): List<CodeWhispererCodeScanIssue> {
         val scanRecommendations = recommendations.flatMap { MAPPER.readValue<List<CodeScanRecommendation>>(it) }
         if (isProjectScope()) {
             LOG.debug { "Total code review issues returned from service: ${scanRecommendations.size}" }
@@ -347,6 +347,8 @@ class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
                         suggestedFixes = recommendation.remediation.suggestedFixes,
                         codeSnippet = recommendation.codeSnippet,
                         isVisible = !isIssueIgnored,
+                        autoDetected = isAutoScan(),
+                        scanJobId = jobId
                     )
                 }
             } else {
@@ -361,6 +363,8 @@ class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
     }
 
     private fun isProjectScope(): Boolean = sessionContext.codeAnalysisScope == CodeWhispererConstants.CodeAnalysisScope.PROJECT
+
+    private fun isAutoScan() = sessionContext.codeAnalysisScope == CodeWhispererConstants.CodeAnalysisScope.FILE && !sessionContext.sessionConfig.isInitiatedByChat()
 
     companion object {
         private val LOG = getLogger<CodeWhispererCodeScanSession>()

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
@@ -364,7 +364,8 @@ class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
 
     private fun isProjectScope(): Boolean = sessionContext.codeAnalysisScope == CodeWhispererConstants.CodeAnalysisScope.PROJECT
 
-    private fun isAutoScan() = sessionContext.codeAnalysisScope == CodeWhispererConstants.CodeAnalysisScope.FILE && !sessionContext.sessionConfig.isInitiatedByChat()
+    private fun isAutoScan(): Boolean =
+        sessionContext.codeAnalysisScope == CodeWhispererConstants.CodeAnalysisScope.FILE && !sessionContext.sessionConfig.isInitiatedByChat()
 
     companion object {
         private val LOG = getLogger<CodeWhispererCodeScanSession>()

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
@@ -371,7 +371,9 @@ class CodeWhispererTelemetryService {
             result = result,
             reason = reason,
             credentialStartUrl = getCodeWhispererStartUrl(issue.project),
-            codeFixAction = codeFixAction
+            codeFixAction = codeFixAction,
+            autoDetected = issue.autoDetected,
+            codewhispererCodeScanJobId = issue.scanJobId
         )
     }
 
@@ -402,6 +404,7 @@ class CodeWhispererTelemetryService {
         isRefresh: Boolean,
         result: MetricResult,
         reason: String? = null,
+        includesFix: Boolean? = false,
     ) {
         CodewhispererTelemetry.codeScanIssueGenerateFix(
             component = component,
@@ -411,7 +414,10 @@ class CodeWhispererTelemetryService {
             ruleId = issue.ruleId,
             variant = if (isRefresh) "refresh" else null,
             result = result,
-            reason = reason
+            reason = reason,
+            autoDetected = issue.autoDetected,
+            codewhispererCodeScanJobId = issue.scanJobId,
+            includesFix = includesFix
         )
     }
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeFileScanTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeFileScanTest.kt
@@ -285,7 +285,7 @@ class CodeWhispererCodeFileScanTest : CodeWhispererCodeScanTestBase(PythonCodeIn
             fakeListCodeScanFindingsResponse.codeScanFindings(),
             getFakeRecommendationsOnNonExistentFile()
         )
-        val res = codeScanSessionSpy.mapToCodeScanIssues(recommendations, project)
+        val res = codeScanSessionSpy.mapToCodeScanIssues(recommendations, project, "jobId")
         assertThat(res).hasSize(2)
     }
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanTest.kt
@@ -160,7 +160,7 @@ class CodeWhispererCodeScanTest : CodeWhispererCodeScanTestBase(PythonCodeInsigh
             fakeListCodeScanFindingsResponse.codeScanFindings(),
             getFakeRecommendationsOnNonExistentFile()
         )
-        val res = codeScanSessionSpy.mapToCodeScanIssues(recommendations, project)
+        val res = codeScanSessionSpy.mapToCodeScanIssues(recommendations, project, "jobId")
         assertThat(res).hasSize(2)
     }
 
@@ -169,7 +169,7 @@ class CodeWhispererCodeScanTest : CodeWhispererCodeScanTestBase(PythonCodeInsigh
         val recommendations = listOf(
             fakeListCodeScanFindingsOutOfBoundsIndexResponse.codeScanFindings(),
         )
-        val res = codeScanSessionSpy.mapToCodeScanIssues(recommendations, project)
+        val res = codeScanSessionSpy.mapToCodeScanIssues(recommendations, project, "jobId")
         assertThat(res).hasSize(1)
     }
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanTestBase.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanTestBase.kt
@@ -444,7 +444,8 @@ open class CodeWhispererCodeScanTestBase(projectRule: CodeInsightTestFixtureRule
                     number = 11,
                     content = "processData(unsecureCode)"
                 )
-            )
+            ),
+            scanJobId = "scanJobId"
         )
 
 // You might need these data classes depending on your implementation


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

### Problem

Need to understand:
- How many users are using fix feature from /review (not auto-review)
- How many fixes were generated/applied for each scanJob
- How many code fix requests were unable to generate a fix

### Solution

- Add flag `autoDetected` to be able to filter out auto-review findings
- Add flag `includesFix` to be able to see fix requests that generated no fixes
- Add `codewhispererCodeScanJobId` to associate a fix action with a specific scan that produced the finding


## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
