### PR TITLE
config(chat): try opt in implicit @workspace context once if users are in treatment group

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/startup/AmazonQStartupActivity.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/startup/AmazonQStartupActivity.kt
@@ -17,7 +17,6 @@ import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
-import software.aws.toolkits.jetbrains.core.credentials.sono.isInternalUser
 import software.aws.toolkits.jetbrains.core.gettingstarted.emitUserState
 import software.aws.toolkits.jetbrains.services.amazonq.CodeWhispererFeatureConfigService
 import software.aws.toolkits.jetbrains.services.amazonq.project.ProjectContextController

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/startup/AmazonQStartupActivity.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/startup/AmazonQStartupActivity.kt
@@ -19,6 +19,7 @@ import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
 import software.aws.toolkits.jetbrains.core.credentials.sono.isInternalUser
 import software.aws.toolkits.jetbrains.core.gettingstarted.emitUserState
+import software.aws.toolkits.jetbrains.services.amazonq.CodeWhispererFeatureConfigService
 import software.aws.toolkits.jetbrains.services.amazonq.project.ProjectContextController
 import software.aws.toolkits.jetbrains.services.amazonq.toolwindow.AmazonQToolWindow
 import software.aws.toolkits.jetbrains.services.amazonq.toolwindow.AmazonQToolWindowFactory
@@ -36,7 +37,7 @@ class AmazonQStartupActivity : ProjectActivity {
         if (ApplicationManager.getApplication().isUnitTestMode) return
 
         ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())?.let {
-            if (it is AwsBearerTokenConnection && isInternalUser(it.startUrl)) {
+            if (it is AwsBearerTokenConnection && CodeWhispererFeatureConfigService.getInstance().getChatWSContext()) {
                 CodeWhispererSettings.getInstance().toggleProjectContextEnabled(value = true, passive = true)
             }
         }

--- a/plugins/amazonq/shared/jetbrains-community/resources/software/aws/toolkits/resources/AmazonQBundle.properties
+++ b/plugins/amazonq/shared/jetbrains-community/resources/software/aws/toolkits/resources/AmazonQBundle.properties
@@ -8,4 +8,6 @@ amazonqInlineChat.popup.generating = Generating...
 amazonqInlineChat.popup.reject=Reject \u238B
 amazonqInlineChat.popup.title=Enter Instructions for Q
 amazonq.refresh.panel=Refresh Chat Session
+amazonq.title=Amazon Q
+amazonq.workspace.settings.open.prompt=Workspace index is now enabled. You can disable it from Amazon Q settings.
 q.hello=Hello

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/CodeWhispererFeatureConfigService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/CodeWhispererFeatureConfigService.kt
@@ -117,6 +117,8 @@ class CodeWhispererFeatureConfigService {
 
     fun getInlineCompletion(): Boolean = getFeatureValueForKey(INLINE_COMPLETION).stringValue() == "TREATMENT"
 
+    fun getChatWSContext(): Boolean = getFeatureValueForKey(CHAT_WS_CONTEXT).stringValue() == "TREATMENT"
+
     // Get the feature value for the given key.
     // In case of a misconfiguration, it will return a default feature value of Boolean false.
     private fun getFeatureValueForKey(name: String): FeatureValue =
@@ -136,6 +138,7 @@ class CodeWhispererFeatureConfigService {
         private const val CUSTOMIZATION_ARN_OVERRIDE_NAME = "customizationArnOverride"
         private const val HIGHLIGHT_COMMAND_NAME = "highlightCommand"
         private const val NEW_AUTO_TRIGGER_UX = "newAutoTriggerUX"
+        private const val CHAT_WS_CONTEXT = "WorkspaceContext"
         private val LOG = getLogger<CodeWhispererFeatureConfigService>()
 
         // Also serve as default values in case server-side config isn't there yet
@@ -160,7 +163,12 @@ class CodeWhispererFeatureConfigService {
                 INLINE_COMPLETION,
                 "CONTROL",
                 FeatureValue.builder().stringValue("CONTROL").build()
-            )
+            ),
+            CHAT_WS_CONTEXT to FeatureContext(
+                CHAT_WS_CONTEXT,
+                "CONTROL",
+                FeatureValue.builder().stringValue("CONTROL").build()
+            ),
         )
     }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.annotations.Property
 import software.aws.toolkits.jetbrains.utils.notifyInfo
+import software.aws.toolkits.resources.AmazonQBundle
 
 @Service
 @State(name = "codewhispererSettings", storages = [Storage("aws.xml")])
@@ -53,8 +54,8 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
                 // todo: hack to bypass module dependency issue (codewhisperer -> shared), should pass [CodeWhispererShowSettingsAction] instead when it's resolved
                 ActionManager.getInstance().getAction("codewhisperer.settings")?.let { a ->
                     notifyInfo(
-                        "Amazon Q",
-                        "Workspace index is now enabled. You can disable it from Amazon Q settings.",
+                        AmazonQBundle.message("amazonq.title"),
+                        AmazonQBundle.message("amazonq.workspace.settings.open.prompt"),
                         notificationActions = listOf(a)
                     )
                 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.settings
 
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.components.BaseState
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
@@ -10,7 +11,6 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.annotations.Property
-import software.aws.toolkits.jetbrains.services.codewhisperer.actions.CodeWhispererShowSettingsAction
 import software.aws.toolkits.jetbrains.utils.notifyInfo
 
 @Service
@@ -50,7 +50,14 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
             if (!hasEnabledProjectContextOnce()) {
                 toggleEnabledProjectContextOnce(true)
                 state.value[CodeWhispererConfigurationType.IsProjectContextEnabled] = value
-                notifyInfo("Amazon Q", "Workspace index is now enabled. You can disable it from Amazon Q settings.", notificationActions = listOf(CodeWhispererShowSettingsAction()))
+                // todo: hack to bypass module dependency issue (codewhisperer -> shared), should pass [CodeWhispererShowSettingsAction] instead when it's resolved
+                ActionManager.getInstance().getAction("codewhisperer.settings")?.let { a ->
+                    notifyInfo(
+                        "Amazon Q",
+                        "Workspace index is now enabled. You can disable it from Amazon Q settings.",
+                        notificationActions = listOf(a)
+                    )
+                }
             }
         } else {
             state.value[CodeWhispererConfigurationType.IsProjectContextEnabled] = value

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
@@ -52,13 +52,13 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
                 toggleEnabledProjectContextOnce(true)
                 state.value[CodeWhispererConfigurationType.IsProjectContextEnabled] = value
                 // todo: hack to bypass module dependency issue (codewhisperer -> shared), should pass [CodeWhispererShowSettingsAction] instead when it's resolved
-                ActionManager.getInstance().getAction("codewhisperer.settings")?.let { a ->
-                    notifyInfo(
-                        AmazonQBundle.message("amazonq.title"),
-                        AmazonQBundle.message("amazonq.workspace.settings.open.prompt"),
-                        notificationActions = listOf(a)
-                    )
-                }
+                val actions = ActionManager.getInstance().getAction("codewhisperer.settings")?.let { listOf(it) } ?: emptyList()
+
+                notifyInfo(
+                    AmazonQBundle.message("amazonq.title"),
+                    AmazonQBundle.message("amazonq.workspace.settings.open.prompt"),
+                    notificationActions = actions
+                )
             }
         } else {
             state.value[CodeWhispererConfigurationType.IsProjectContextEnabled] = value

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
@@ -10,6 +10,8 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
 import com.intellij.util.xmlb.annotations.Property
+import software.aws.toolkits.jetbrains.services.codewhisperer.actions.CodeWhispererShowSettingsAction
+import software.aws.toolkits.jetbrains.utils.notifyInfo
 
 @Service
 @State(name = "codewhispererSettings", storages = [Storage("aws.xml")])
@@ -48,6 +50,7 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
             if (!hasEnabledProjectContextOnce()) {
                 toggleEnabledProjectContextOnce(true)
                 state.value[CodeWhispererConfigurationType.IsProjectContextEnabled] = value
+                notifyInfo("Amazon Q", "Workspace index is now enabled. You can disable it from Amazon Q settings.", notificationActions = listOf(CodeWhispererShowSettingsAction()))
             }
         } else {
             state.value[CodeWhispererConfigurationType.IsProjectContextEnabled] = value

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
@@ -52,7 +52,7 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
                 toggleEnabledProjectContextOnce(true)
                 state.value[CodeWhispererConfigurationType.IsProjectContextEnabled] = value
                 // todo: hack to bypass module dependency issue (codewhisperer -> shared), should pass [CodeWhispererShowSettingsAction] instead when it's resolved
-                val actions = ActionManager.getInstance().getAction("codewhisperer.settings")?.let { listOf(it) } ?: emptyList()
+                val actions = ActionManager.getInstance().getAction("codewhisperer.settings")?.let { listOf(it) }.orEmpty()
 
                 notifyInfo(
                     AmazonQBundle.message("amazonq.title"),


### PR DESCRIPTION


https://github.com/user-attachments/assets/a56b5e2f-93c9-4d34-9925-fd4947661a93





## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Most users might have disabled workspace context due to previous sub-process performance issue, therefore #6098 experiment has  too few datapoints. 

As we've been actively working on fixes to improve the amazon q helper sub-process performance,  the team decided to try turn on (only once) workspace context for a small fraction of all users (20%) to collect few more datapoints.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
