### PR TITLE
fix(amazonq): fix for /test project payload collection filter

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/GitIgnoreFilteringUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/GitIgnoreFilteringUtil.kt
@@ -1,0 +1,100 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.codewhisperer.util
+
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.coroutineContext
+
+class GitIgnoreFilteringUtil(private val moduleDir: VirtualFile) {
+    private var ignorePatternsWithGitIgnore = emptyList<Regex>()
+    private val additionalGitIgnoreRules = setOf(
+        ".aws-sam",
+        ".gem",
+        ".git",
+        ".gitignore",
+        ".gradle",
+        ".hg",
+        ".idea",
+        ".project",
+        ".rvm",
+        ".svn",
+        "*.zip",
+        "*.bin",
+        "*.png",
+        "*.jpg",
+        "*.svg",
+        "*.pyc",
+        "license.txt",
+        "License.txt",
+        "LICENSE.txt",
+        "license.md",
+        "License.md",
+        "LICENSE.md",
+        "node_modules",
+        "build",
+        "dist",
+        "annotation-generated-src",
+        "annotation-generated-tst"
+    )
+
+    init {
+        ignorePatternsWithGitIgnore = try {
+            buildList {
+                addAll(additionalGitIgnoreRules.map { convertGitIgnorePatternToRegex(it) })
+                addAll(parseGitIgnore())
+            }.mapNotNull { pattern ->
+                runCatching { Regex(pattern) }.getOrNull()
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun parseGitIgnore(): Set<String> {
+        val gitignoreFile = moduleDir.findChild(".gitignore")
+        return gitignoreFile?.let {
+            if (it.isValid && it.exists()) {
+                it.inputStream.bufferedReader().readLines()
+                    .filter { line ->
+                        line.isNotBlank() && !line.startsWith("#")
+                    }
+                    .map { pattern ->
+                        convertGitIgnorePatternToRegex(pattern.trim())
+                    }
+                    .toSet()
+            } else {
+                emptySet()
+            }
+        } ?: emptySet()
+    }
+
+    // gitignore patterns are not regex, method update needed.
+    private fun convertGitIgnorePatternToRegex(pattern: String): String = pattern
+        .replace(".", "\\.")
+        .replace("*", ".*")
+        .let { if (it.endsWith("/")) "$it.*" else "$it/.*" } // Add a trailing /* to all patterns. (we add a trailing / to all files when matching)
+
+    suspend fun ignoreFile(file: VirtualFile): Boolean {
+        // this method reads like something a JS dev would write and doesn't do what the author thinks
+        val deferredResults = ignorePatternsWithGitIgnore.map { pattern ->
+            withContext(coroutineContext) {
+                // avoid partial match (pattern.containsMatchIn) since it causes us matching files
+                // against folder patterns. (e.g. settings.gradle ignored by .gradle rule!)
+                // we convert the glob rules to regex, add a trailing /* to all rules and then match
+                // entries against them by adding a trailing /.
+                async { pattern.matches("${getRelativePath(file)}/") }
+            }
+        }
+
+        // this will serially iterate over and block
+        // ideally we race the results https://github.com/Kotlin/kotlinx.coroutines/issues/2867
+        // i.e. Promise.any(...)
+        return deferredResults.any { it.await() }
+    }
+
+    private fun getRelativePath(file: VirtualFile): String = VfsUtil.getRelativePath(file, moduleDir) ?: ""
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codetest/CodeTestSessionConfigTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codetest/CodeTestSessionConfigTest.kt
@@ -1,0 +1,429 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.codewhisperer.codetest
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.modules
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.ApplicationRule
+import com.intellij.testFramework.DisposableRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.stub
+import software.aws.toolkits.jetbrains.core.MockClientManagerRule
+import software.aws.toolkits.jetbrains.services.codewhisperer.codetest.sessionconfig.CodeTestSessionConfig
+import software.aws.toolkits.jetbrains.services.codewhisperer.language.programmingLanguage
+import software.aws.toolkits.jetbrains.utils.rules.CodeInsightTestFixtureRule
+import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
+import software.aws.toolkits.jetbrains.utils.rules.addFileToModule
+import software.aws.toolkits.jetbrains.utils.rules.addModule
+import java.io.BufferedInputStream
+import java.util.zip.ZipInputStream
+
+class CodeTestSessionConfigTest {
+    private lateinit var testJava: VirtualFile
+    private lateinit var utilsJava: VirtualFile
+    private lateinit var helperJava: VirtualFile
+    private lateinit var readMeMd: VirtualFile
+    private lateinit var helpGo: VirtualFile
+    private lateinit var utilsJs: VirtualFile
+    private lateinit var testJson: VirtualFile
+    private lateinit var testYaml: VirtualFile
+    private lateinit var helperPy: VirtualFile
+    private lateinit var testTf: VirtualFile
+
+    private var totalSize: Long = 0
+    private var totalLines: Long = 0
+    private var payloadTestSize: Long = 0
+    private var payloadTestLines: Long = 0
+
+    @Rule
+    @JvmField
+    val applicationRule = ApplicationRule()
+
+    @Rule
+    @JvmField
+    val projectRule: CodeInsightTestFixtureRule = HeavyJavaCodeInsightTestFixtureRule()
+
+    @Rule
+    @JvmField
+    val disposableRule = DisposableRule()
+
+    @Rule
+    @JvmField
+    val mockClientManagerRule = MockClientManagerRule()
+
+    @Rule
+    @JvmField
+    val wireMock = WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort())
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var project: Project
+    private lateinit var codeTestSessionConfig: CodeTestSessionConfig
+
+    @Before
+    fun setUp() {
+        setupTestProject()
+        project = projectRule.project
+        codeTestSessionConfig = spy(CodeTestSessionConfig(testJava, project))
+    }
+
+    @Test
+    fun `test createPayload`() {
+        assertEquals(project.modules.size, 2)
+        val payload = codeTestSessionConfig.createPayload()
+        assertNotNull(payload)
+        assertThat(payload.context.totalFiles).isEqualTo(8)
+
+        assertThat(payload.context.scannedFiles.size).isEqualTo(8)
+        assertThat(payload.context.scannedFiles).contains(
+            testJava,
+            utilsJava,
+            readMeMd,
+            utilsJs,
+            helpGo,
+            testYaml,
+            testTf,
+            helperPy
+        )
+
+        assertThat(payload.context.srcPayloadSize).isEqualTo(payloadTestSize)
+        assertThat(payload.context.totalLines).isEqualTo(payloadTestLines)
+        assertNotNull(payload.srcZip)
+
+        val bufferedInputStream = BufferedInputStream(payload.srcZip.inputStream())
+        val zis = ZipInputStream(bufferedInputStream)
+        var filesInZip = 0
+        while (zis.nextEntry != null) {
+            filesInZip += 1
+        }
+
+        assertThat(filesInZip).isEqualTo(12)
+    }
+
+    @Test
+    fun `getProjectPayloadMetadata()`() {
+        val payloadMetadata = codeTestSessionConfig.getProjectPayloadMetadata()
+        assertNotNull(payloadMetadata)
+        val includedSourceFiles = payloadMetadata.sourceFiles
+        val srcPayloadSize = payloadMetadata.payloadSize
+        val totalLines = payloadMetadata.linesScanned
+        val maxCountLanguage = payloadMetadata.language
+        assertThat(includedSourceFiles.size).isEqualTo(8)
+        assertThat(srcPayloadSize).isEqualTo(payloadTestSize)
+        assertThat(totalLines).isEqualTo(payloadTestLines)
+        assertThat(maxCountLanguage).isEqualTo(testJava.programmingLanguage().toTelemetryType())
+    }
+
+    @Test
+    fun `selected file larger than payload limit throws exception`() {
+        codeTestSessionConfig.stub {
+            onGeneric { getPayloadLimitInBytes() }.thenReturn(10)
+        }
+        assertThrows<CodeTestException> {
+            codeTestSessionConfig.createPayload()
+        }
+    }
+
+    @Test
+    fun `test createPayload should throw CodeWhispererCodeScanException if project size is more than Payload Limit`() {
+        codeTestSessionConfig.stub {
+            onGeneric { getPayloadLimitInBytes() }.thenReturn(1000)
+        }
+
+        assertThrows<CodeTestException> {
+            codeTestSessionConfig.createPayload()
+        }
+    }
+
+    private fun setupTestProject() {
+        val testModule = projectRule.fixture.addModule("testModule")
+        val testModule2 = projectRule.fixture.addModule("testModule2")
+        testJava = projectRule.fixture.addFileToModule(
+            testModule,
+            "/Test.java",
+            """
+            using Utils;
+            using Helpers.Helper;
+
+            int a = 1;
+            int b = 2;
+
+            int c = Utils.Add(a, b);
+            int d = Helper.Subtract(a, b);
+            int e = Utils.Fib(5);
+            """.trimIndent()
+        ).virtualFile
+        totalSize += testJava.length
+        totalLines += testJava.toNioPath().toFile().readLines().size
+
+        utilsJava = projectRule.fixture.addFileToModule(
+            testModule,
+            "/Utils.java",
+            """
+            public class Utils {
+                public static int add(int a, int b) {
+                    return a + b;
+                }
+
+                public static int fib(int n) {
+                    if (n <= 0) return 0;
+                    if (n == 1 || n == 2) {
+                        return 1;
+                    }
+                    return add(fib(n - 1), fib(n - 2));
+                }
+            }
+            """.trimIndent()
+        ).virtualFile
+        totalSize += utilsJava.length
+        totalLines += utilsJava.toNioPath().toFile().readLines().size
+
+        helperJava = projectRule.fixture.addFileToModule(
+            testModule,
+            "/Helpers/Helper.java",
+            """
+            public class Helper {
+                public static int subtract(int a, int b) {
+                    return a - b;
+                }
+
+                public static int multiply(int a, int b) {
+                    return a * b;
+                }
+
+                public static int divide(int a, int b) {
+                    return a / b;
+                }
+
+                public static void bubbleSort(int[] arr) {
+                    int n = arr.length;
+                    for (int i = 0; i < n - 1; i++) {
+                        for (int j = 0; j < n - i - 1; j++) {
+                            if (arr[j] > arr[j + 1]) {
+                                // Swap arr[j] and arr[j + 1]
+                                int temp = arr[j];
+                                arr[j] = arr[j + 1];
+                                arr[j + 1] = temp;
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+        ).virtualFile
+        totalSize += helperJava.length
+        totalLines += helperJava.toNioPath().toFile().readLines().size
+
+        helpGo = projectRule.fixture.addFileToModule(
+            testModule,
+            "/help.go",
+            """
+                package main
+
+                import "fmt"
+
+                func Help() {
+                        fmt.Printf("./main")
+                }
+            """.trimIndent()
+        ).virtualFile
+        totalSize += helpGo.length
+        totalLines += helpGo.toNioPath().toFile().readLines().size
+
+        utilsJs = projectRule.fixture.addFileToModule(
+            testModule,
+            "/utils.js",
+            """
+            function add(num1, num2) {
+              return num1 + num2;
+            }
+
+            function bblSort(arr) {
+                for(var i = 0; i < arr.length; i++) {
+                    // Last i elements are already in place
+                    for(var j = 0; j < ( arr.length - i -1 ); j++) {
+                        // Checking if the item at present iteration
+                        // is greater than the next iteration
+                        if(arr[j] > arr[j+1]) {
+                            // If the condition is true then swap them
+                            var temp = arr[j]
+                            arr[j] = arr[j + 1]
+                            arr[j+1] = temp
+                        }
+                    }
+                }
+                // Print the sorted array
+                console.log(arr);
+            }
+            """.trimIndent()
+        ).virtualFile
+        totalSize += utilsJs.length
+        totalLines += utilsJs.toNioPath().toFile().readLines().size
+
+        testJson = projectRule.fixture.addFileToModule(
+            testModule,
+            "/Helpers/test3Json.json",
+            """
+                {
+                    "AWSTemplateFormatVersion": "2010-09-09",
+                    "Description": "This stack creates a SQS queue using KMS encryption\n",
+                    "Parameters": {
+                        "KmsKey": {
+                            "Description": "The KMS key master ID",
+                            "Type": "String"
+                        }
+                    },
+                    "Resources": {
+                        "Queue": {
+                            "DeletionPolicy": "Retain",
+                            "UpdateReplacePolicy": "Retain",
+                            "Type": "AWS::SQS::Queue",
+                            "Properties": {
+                                "DelaySeconds": 0,
+                                "FifoQueue": false,
+                                "KmsDataKeyReusePeriodSeconds": 300,
+                                "KmsMasterKeyId": {
+                                    "Ref": "KmsKey"
+                                },
+                                "MaximumMessageSize": 262144,
+                                "MessageRetentionPeriod": 345600,
+                                "ReceiveMessageWaitTimeSeconds": 0,
+                                "VisibilityTimeout": 30
+                            }
+                        },
+                        "FifoQueue": {
+                            "DeletionPolicy": "Retain",
+                            "UpdateReplacePolicy": "Retain",
+                            "Type": "AWS::SQS::Queue",
+                            "Properties": {
+                                "ContentBasedDeduplication": true,
+                                "DelaySeconds": 0,
+                                "FifoQueue": true,
+                                "KmsDataKeyReusePeriodSeconds": 300,
+                                "KmsMasterKeyId": {
+                                    "Ref": "KmsKey"
+                                },
+                                "MaximumMessageSize": 262144,
+                                "MessageRetentionPeriod": 345600,
+                                "ReceiveMessageWaitTimeSeconds": 0,
+                                "VisibilityTimeout": 30
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        ).virtualFile
+        totalSize += testJson.length
+        totalLines += testJson.toNioPath().toFile().readLines().size
+
+        helperPy = projectRule.fixture.addFileToModule(
+            testModule,
+            "/HelpersInPython/helper.py", // False positive testing
+            """
+            from helpers import helper as h
+            def subtract(num1, num2)
+                return num1 - num2
+
+            def fib(num):
+                if num == 0: return 0
+                if num in [1,2]: return 1
+                return h.add(fib(num-1), fib(num-2))
+
+            """.trimIndent()
+        ).virtualFile
+        totalSize += helperPy.length
+        totalLines += helperPy.toNioPath().toFile().readLines().size
+
+        readMeMd = projectRule.fixture.addFileToModule(testModule, "/ReadMe.md", "### Now included").virtualFile
+        totalSize += readMeMd.length
+        totalLines += readMeMd.toNioPath().toFile().readLines().size
+
+        testTf = projectRule.fixture.addFileToModule(
+            testModule2,
+            "/testTf.tf",
+            """
+                # Create example resource for three S3 buckets using for_each, where the bucket prefix are in variable with list containing [prod, staging, dev]
+
+                resource "aws_s3_bucket" "example" {
+                  for_each      = toset(var.names)
+                  bucket_prefix = each.value
+                }
+
+                variable "names" {
+                  type    = list(string)
+                  default = ["prod", "staging", "dev"]
+                }
+            """.trimIndent()
+        ).virtualFile
+        totalSize += testTf.length
+        totalLines += testTf.toNioPath().toFile().readLines().size
+
+        testYaml = projectRule.fixture.addFileToModule(
+            testModule2,
+            "/testYaml.yaml",
+            """
+                AWSTemplateFormatVersion: "2010-09-09"
+
+                Description: |
+                  This stack creates a SNS topic using KMS encryption
+
+                Parameters:
+                  KmsKey:
+                    Description: The KMS key master ID
+                    Type: String
+
+                Resources:
+
+                  # A SNS topic
+                  Topic:
+                    Type: AWS::SNS::Topic
+                    Properties:
+                      KmsMasterKeyId: !Ref KmsKey
+            """.trimIndent()
+        ).virtualFile
+        totalSize += testYaml.length
+        totalLines += testYaml.toNioPath().toFile().readLines().size
+
+        // Adding gitignore file and gitignore file member for testing.
+        // The tests include the markdown file but not these two files.
+        projectRule.fixture.addFileToModule(
+            testModule,
+            "/.gitignore",
+            """
+                Helpers
+                .idea
+                .vscode
+                .DS_Store
+            """.trimIndent()
+        ).virtualFile
+
+        projectRule.fixture.addFileToModule(
+            testModule2,
+            "/.gitignore",
+            """
+                Helpers
+                .idea
+                .vscode
+                .DS_Store
+            """.trimIndent()
+        ).virtualFile
+
+        projectRule.fixture.addFileToModule(testModule2, "/.idea/ref", "ref: refs/heads/main") // adding ignored files in second module
+
+        payloadTestSize = totalSize - helperJava.length - testJson.length
+        payloadTestLines = totalLines - helperJava.toNioPath().toFile().readLines().size - testJson.toNioPath().toFile().readLines().size
+    }
+}


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
For both the /test and /review agents, we parse files by looping through each module to ensure all files from the project/workspace are included. The current common utility, FeatureDevSessionContext, is focused on loading the .gitignore file from the project root. While this works in most cases, for internal Amazon workspaces with multiple packages loaded into the same workspace, the .gitignore files are not being loaded to filter out irrelevant files.
Even the default patterns in the utility are not working because each file is checked for the relative path from the project root, which is derived from IntelliJ's utility function guessProjectDir(). This function may provide one of the modules as the root, but that is not always the case, causing the relative path check to fail.

- Decoupled the gitignore logic as seperate class (/dev and /review can also onboard to this class with the same utility of featureDevSessionContext)
- Added unit tests with tests for gitignore in multi module workspaces.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
