### PR TITLE
fix(amazonq): For security reasons, disabled auto linkify for pure text links

### DIFF
--- a/.changes/next-release/bugfix-5ad182a1-df86-4b08-b7ae-d409fdf2d690.json
+++ b/.changes/next-release/bugfix-5ad182a1-df86-4b08-b7ae-d409fdf2d690.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "fix(amazonq): For security reasons, disabled auto linkify for link texts coming in markdown other than [TEXT](URL) format"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.21.5",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.21.6",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.21.5",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.5.tgz",
-            "integrity": "sha512-Ge7/XADBx/Phm9k2pVgjtYRoB5UOsNcTwZ0VOsWOc2JBGblEIasiT4pNNfHGKgMkLf79AKYUKRSH5IAuQRKpaQ==",
+            "version": "4.21.6",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.6.tgz",
+            "integrity": "sha512-SpWY997696aMDPwbiBqwkBXUCrguDQsJ3RukmgafjAlQuBJAQTIaVAj4GfsEwuTLOsBNR7CJIj9XxhtDo7PvJQ==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.21.5",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.21.6",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "sanitize-html": "^2.12.1",


### PR DESCRIPTION
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem
- Links incoming from Q responses can redirect to a vulnerable site depending on the used context from the files.

### Solution
- Linkify strategy is updated to only accept links with `[TEXT](URL)` format. (through MynahUI version [4.21.6](https://github.com/aws/mynah-ui/releases/tag/v4.21.6))

#### MynahUI PR:
https://github.com/aws/mynah-ui/pull/226
<img width="648" alt="Screenshot 2025-01-23 at 20 13 48" src="https://github.com/user-attachments/assets/edfb2429-d8a1-4800-bc1c-ed6434cb0552" />


## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
