### PR TITLE
fix(amazonq): add boundary check to UserModificationTracker to prevent IndexOutOfBoundsException

### DIFF
--- a/.changes/next-release/bugfix-24d6621e-32d3-45c5-a996-66232724e425.json
+++ b/.changes/next-release/bugfix-24d6621e-32d3-45c5-a996-66232724e425.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q: Prevent IndexOutOfBoundsException by adding boundary checks for invalid range markers"
+}

--- a/.changes/next-release/bugfix-24d6621e-32d3-45c5-a996-66232724e425.json
+++ b/.changes/next-release/bugfix-24d6621e-32d3-45c5-a996-66232724e425.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Amazon Q: Prevent IndexOutOfBoundsException by adding boundary checks for invalid range markers"
+  "description" : "Amazon Q: Prevent IndexOutOfBoundsException by adding boundary checks for invalid range markers (#5187)"
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererUserModificationTracker.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererUserModificationTracker.kt
@@ -167,10 +167,6 @@ class CodeWhispererUserModificationTracker(private val project: Project) : Dispo
             val end = acceptedSuggestion.range.endOffset
             if (document != null) {
                 if (start < 0 || end < start || end > document.textLength) {
-                    LOG.warn {
-                        "Invalid range for suggestion ${acceptedSuggestion.requestId}: " +
-                            "start=$start, end=$end, docLength=${document.textLength}"
-                    }
                     sendModificationTelemetry(acceptedSuggestion, null)
                     sendUserModificationTelemetryToServiceAPI(acceptedSuggestion)
                     return

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererUserModificationTracker.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererUserModificationTracker.kt
@@ -167,6 +167,10 @@ class CodeWhispererUserModificationTracker(private val project: Project) : Dispo
             val end = acceptedSuggestion.range.endOffset
             if (document != null) {
                 if (start < 0 || end < start || end > document.textLength) {
+                    LOG.warn {
+                        "Invalid range for suggestion ${acceptedSuggestion.requestId}: " +
+                            "start=$start, end=$end, docLength=${document.textLength}"
+                    }
                     sendModificationTelemetry(acceptedSuggestion, null)
                     sendUserModificationTelemetryToServiceAPI(acceptedSuggestion)
                     return

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererUserModificationTracker.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererUserModificationTracker.kt
@@ -19,6 +19,7 @@ import org.assertj.core.util.VisibleForTesting
 import software.amazon.awssdk.services.codewhispererruntime.model.CodeWhispererRuntimeException
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
+import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererClientAdaptor
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
@@ -154,7 +155,7 @@ class CodeWhispererUserModificationTracker(private val project: Project) : Dispo
     private fun emitTelemetryOnSuggestion(acceptedSuggestion: AcceptedSuggestionEntry) {
         val file = acceptedSuggestion.vFile
 
-        if (file == null || (!file.isValid)) {
+        if (file == null || (!file.isValid) || !acceptedSuggestion.range.isValid) {
             sendModificationTelemetry(acceptedSuggestion, null)
             sendUserModificationTelemetryToServiceAPI(acceptedSuggestion)
         } else {
@@ -162,6 +163,20 @@ class CodeWhispererUserModificationTracker(private val project: Project) : Dispo
             val document = runReadAction {
                 FileDocumentManager.getInstance().getDocument(file)
             }
+            val start = acceptedSuggestion.range.startOffset
+            val end = acceptedSuggestion.range.endOffset
+            if (document != null) {
+                if (start < 0 || end < start || end > document.textLength) {
+                    LOG.warn {
+                        "Invalid range for suggestion ${acceptedSuggestion.requestId}: " +
+                            "start=$start, end=$end, docLength=${document.textLength}"
+                    }
+                    sendModificationTelemetry(acceptedSuggestion, null)
+                    sendUserModificationTelemetryToServiceAPI(acceptedSuggestion)
+                    return
+                }
+            }
+
             val currentString = document?.getText(
                 TextRange(acceptedSuggestion.range.startOffset, acceptedSuggestion.range.endOffset)
             )


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
This PR improves the emitTelemetryOnSuggestion method in the CodeWhispererUserModificationTracker class. Specifically:

- Added validation for RangeMarker to ensure it is valid before processing offsets.
- Included checks for invalid offset ranges (e.g., startOffset or endOffset exceeding the document's length or being inconsistent).
- Added logging for invalid scenarios to aid debugging.
- Ensured graceful fallback by reporting telemetry with null modification percentage when encountering invalid ranges or documents.


## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
