### PR TITLE
fix(amazonq): broken citation links

### DIFF
--- a/.changes/next-release/bugfix-12a3f427-f34b-49aa-b36f-5335039ef0be.json
+++ b/.changes/next-release/bugfix-12a3f427-f34b-49aa-b36f-5335039ef0be.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "fix(amazonq): Citation links are not clickable as numbers, but appear as non-clickable texts"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.21.6",
+                "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.22.1",
                 "@types/node": "^14.18.5",
                 "fs-extra": "^10.0.1",
                 "sanitize-html": "^2.12.1",
@@ -57,9 +57,9 @@
         },
         "node_modules/@aws/mynah-ui-chat": {
             "name": "@aws/mynah-ui",
-            "version": "4.21.6",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.21.6.tgz",
-            "integrity": "sha512-SpWY997696aMDPwbiBqwkBXUCrguDQsJ3RukmgafjAlQuBJAQTIaVAj4GfsEwuTLOsBNR7CJIj9XxhtDo7PvJQ==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.22.1.tgz",
+            "integrity": "sha512-6mWD5Fp4VDVSKIv3sRKopoeh3GeiXEp2gWXmUWSVE9ccnnnavPyKSebV6vJiHJHtuS1da7i6ZLVednpsV9I49Q==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/plugins/amazonq/mynah-ui/package.json
+++ b/plugins/amazonq/mynah-ui/package.json
@@ -12,7 +12,7 @@
         "lintfix": "eslint -c .eslintrc.js --fix --ext .ts ."
     },
     "dependencies": {
-        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.21.6",
+        "@aws/mynah-ui-chat": "npm:@aws/mynah-ui@4.22.1",
         "@types/node": "^14.18.5",
         "fs-extra": "^10.0.1",
         "sanitize-html": "^2.12.1",


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem
- The citation links are broken after the [linkify structure change](https://github.com/aws/aws-toolkit-vscode/pull/6449).
<img width="663" alt="Screenshot 2025-02-03 at 13 01 43" src="https://github.com/user-attachments/assets/6b223b58-0c76-4914-8e9f-3e0ad7a8fb2b" />

### Solution
- Updated link check pattern to accept `[[TEXT]](LINK)` format too which is used for citations. **[MynahUI v4.22.1](https://github.com/aws/mynah-ui/releases/tag/v4.22.1)**

[MynahUI PR](https://github.com/aws/mynah-ui/pull/228)

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
