### PR TITLE
fix(amazonq): /test align placeholder text across IDEs

### DIFF
--- a/.changes/next-release/bugfix-8c569cf5-1a06-4bdc-b39b-91e04a6084b7.json
+++ b/.changes/next-release/bugfix-8c569cf5-1a06-4bdc-b39b-91e04a6084b7.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : " /test placeholder text aligned across IDEs"
+}

--- a/.changes/next-release/bugfix-8c569cf5-1a06-4bdc-b39b-91e04a6084b7.json
+++ b/.changes/next-release/bugfix-8c569cf5-1a06-4bdc-b39b-91e04a6084b7.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : " /test placeholder text aligned across IDEs"
+  "description" : "/test placeholder text aligned across IDEs"
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
@@ -575,7 +575,7 @@ class CodeWhispererUTGChatManager(val project: Project, private val cs: Coroutin
                     codeTestChatHelper.deleteSession(session.tabId)
                     codeTestChatHelper.updateUI(
                         promptInputDisabledState = false,
-                        promptInputPlaceholder = message("testgen.placeholder.newtab"),
+                        promptInputPlaceholder = message("testgen.placeholder.enter_slash_quick_actions"),
                     )
                 }
                 session.isGeneratingTests = false

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -627,7 +627,7 @@ class CodeTestChatController(
                 sessionCleanUp(session.tabId)
                 codeTestChatHelper.updateUI(
                     promptInputDisabledState = false,
-                    promptInputPlaceholder = message("testgen.placeholder.waiting_on_your_inputs"),
+                    promptInputPlaceholder = message("testgen.placeholder.enter_slash_quick_actions"),
                 )
                 /*
                 val taskContext = session.buildAndExecuteTaskContext
@@ -1004,7 +1004,7 @@ class CodeTestChatController(
         codeTestChatHelper.updateUI(
             promptInputDisabledState = false
         )
-        codeTestChatHelper.sendUpdatePlaceholder(tabId, message("testgen.placeholder.newtab"))
+        codeTestChatHelper.sendUpdatePlaceholder(tabId, message("testgen.placeholder.enter_slash_quick_actions"))
     }
 
     private fun openOrCreateTestFileAndApplyDiff(

--- a/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -2072,6 +2072,7 @@ testgen.message.failed=Sorry, Test generation failed. Please try again in few mi
 testgen.message.regenerate_input=Sure thing. Please provide new instructions for me to generate the tests, and select the function(s) you would like to test.
 testgen.message.success=Unit test generation completed.
 testgen.no_file_found=Sorry, there isn't a source file open right now that I can generate a test for. Make sure you open a source file so I can generate tests.
+testgen.placeholder.enter_slash_quick_actions=Enter "/" for quick actions
 testgen.placeholder.newtab=Ask any coding question or type \u0022/\u0022 for actions
 testgen.placeholder.select_an_option = Please select an action to proceed (Accept or Reject)
 testgen.placeholder.view_diff=Select View Diff to see the generated unit tests


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
- Placeholder texts are different between VSC and JB for /test
- this updates the placeholder text so it is consistent for both after UTG Completion, UTG Reject, UTG Cancel

![Screenshot 2025-02-03 at 2 42 22 PM](https://github.com/user-attachments/assets/cebf10b1-4104-47d8-85b7-450a969b4fed)
![Screenshot 2025-02-03 at 2 43 30 PM](https://github.com/user-attachments/assets/4a05cf0e-fc20-49e0-892d-450d24b07817)
![Screenshot 2025-02-03 at 2 43 52 PM](https://github.com/user-attachments/assets/52f74ecb-4249-4ef8-b0ef-05fa5b4d2626)


## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
