### PR TITLE
build: fix 251 build failure from resolving ui-tests-starter dependencies

### DIFF
--- a/ui-tests-starter/build.gradle.kts
+++ b/ui-tests-starter/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("toolkit-kotlin-conventions")
     id("toolkit-intellij-plugin")
 
-    id("org.jetbrains.intellij.platform.module")
+    id("org.jetbrains.intellij.platform.base")
 }
 
 val ideProfile = IdeVersions.ideProfile(project)
@@ -30,11 +30,12 @@ intellijPlatform {
 val testPlugins by configurations.registering
 
 dependencies {
-    testImplementation(platform("com.jetbrains.intellij.tools:ide-starter-squashed"))
     // should really be set by the BOM, but too much work to figure out right now
     testImplementation("org.kodein.di:kodein-di-jvm:7.20.2")
     intellijPlatform {
-        testFramework(TestFrameworkType.Starter, ideProfile.community.sdkVersion)
+        // shouldn't be needed? but IsolationException
+        intellijIdeaCommunity(ideProfile.community.sdkVersion)
+        testFramework(TestFrameworkType.Starter)
     }
 
     testPlugins(project(":plugin-amazonq", "pluginZip"))

--- a/ui-tests-starter/build.gradle.kts
+++ b/ui-tests-starter/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("toolkit-kotlin-conventions")
     id("toolkit-intellij-plugin")
 
-    id("org.jetbrains.intellij.platform")
+    id("org.jetbrains.intellij.platform.module")
 }
 
 val ideProfile = IdeVersions.ideProfile(project)
@@ -34,9 +34,7 @@ dependencies {
     // should really be set by the BOM, but too much work to figure out right now
     testImplementation("org.kodein.di:kodein-di-jvm:7.20.2")
     intellijPlatform {
-        intellijIdeaCommunity(IdeVersions.ideProfile(providers).map { it.name })
-
-        testFramework(TestFrameworkType.Starter)
+        testFramework(TestFrameworkType.Starter, ideProfile.community.sdkVersion)
     }
 
     testPlugins(project(":plugin-amazonq", "pluginZip"))


### PR DESCRIPTION
ui-tests-starter attempts to resolve the IDE distribution and fails, but it should not actually be required to build/execute
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
