### PR TITLE
Filter out frequent client error from codegeneration telemetry

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevExceptions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevExceptions.kt
@@ -17,9 +17,11 @@ open class FeatureDevException(override val message: String?, val operation: Str
     fun reason(): String = this.javaClass.simpleName
 
     fun reasonDesc(): String =
-        when (desc) {
-            desc -> "$operation | Description: $desc"
-            else -> operation
+        val finalDesc = desc?.takeIf { it.isNotBlank() } ?: message
+        return if (finalDesc != null) {
+            "$operation | Description: $finalDesc"
+        } else {
+            operation
         }
 }
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerExtensions.kt
@@ -6,13 +6,17 @@ package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.controller
 import com.intellij.notification.NotificationAction
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CODE_GENERATION_RETRY_LIMIT
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CodeIterationLimitException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ContentLengthException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.EmptyPatchException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.GuardrailsException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MetricDataOperationName
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MetricDataResult
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MonthlyConversationLimitError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.NoChangeRequiredException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.PromptRefusalException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ThrottlingException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ZipFileCorruptedException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FeatureDevMessageType
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUp
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUpStatusType
@@ -154,7 +158,15 @@ suspend fun FeatureDevController.onCodeGeneration(
         messenger.sendUpdatePlaceholder(tabId = tabId, newPlaceholder = message("amazonqFeatureDev.placeholder.after_code_generation"))
     } catch (err: Exception) {
         when (err) {
-            is GuardrailsException, is NoChangeRequiredException, is PromptRefusalException, is ThrottlingException -> {
+            is GuardrailsException,
+            is NoChangeRequiredException,
+            is PromptRefusalException,
+            is ThrottlingException,
+            is CodeIterationLimitException,
+            is MonthlyConversationLimitError,
+            is ContentLengthException,
+            is ZipFileCorruptedException,
+            -> {
                 session.sendMetricDataTelemetry(
                     MetricDataOperationName.EndCodeGeneration,
                     MetricDataResult.Error
@@ -167,6 +179,26 @@ suspend fun FeatureDevController.onCodeGeneration(
                 )
             }
             else -> {
+                val CLIENT_ERROR_MESSAGES = setOf(
+                    "Improperly formed request",
+                    "Resource not found",
+                    "StartTaskAssistCodeGeneration reached for this month.",
+                    "The folder you chose did not contain any source files in a supported language. Choose another folder and try again.",
+                    "reached the quota for number of iterations on code generation."
+                )
+                val errorMessage = err.message ?: ""
+
+                if (CLIENT_ERROR_MESSAGES.any { errorMessage.contains(message) } ) {
+                    session.sendMetricDataTelemetry(
+                        MetricDataOperationName.EndCodeGeneration,
+                        MetricDataResult.Error
+                    )
+                } else {
+                    session.sendMetricDataTelemetry(
+                        MetricDataOperationName.EndCodeGeneration,
+                        MetricDataResult.Fault
+                    )
+                }
                 session.sendMetricDataTelemetry(
                     MetricDataOperationName.EndCodeGeneration,
                     MetricDataResult.Fault

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevControllerTest.kt
@@ -38,14 +38,18 @@ import software.aws.toolkits.jetbrains.services.amazonq.apps.AmazonQAppInitConte
 import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthController
 import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededStates
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.CodeIterationLimitException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ContentLengthException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.EmptyPatchException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTestBase
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.GuardrailsException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MetricDataOperationName
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MetricDataResult
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.MonthlyConversationLimitError
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.NoChangeRequiredException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.PromptRefusalException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ThrottlingException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ZipFileCorruptedException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.clients.FeatureDevClient
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FeatureDevMessageType
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.messages.FollowUp
@@ -616,6 +620,26 @@ class FeatureDevControllerTest : FeatureDevTestBase() {
                 ThrottlingException(operation = "GenerateCode", desc = "Request throttled"),
                 MetricDataResult.Error
             ),
+            ErrorTestCase(
+                MonthlyConversationLimitError(message = "Monthly limit reached", operation = "GenerateCode", desc = "Monthly limit reached"),
+                MetricDataResult.Error
+            ),
+            ErrorTestCase(
+                CodeIterationLimitException(operation = "GenerateCode", desc = "Code iteration limit reached"),
+                MetricDataResult.Error
+            ),
+            ErrorTestCase(
+                ContentLengthException(operation = "GenerateCode", desc = "Repo size is exceeding the limits"),
+                MetricDataResult.Error
+            ),
+            ErrorTestCase(
+                ZipFileCorruptedException(operation = "GenerateCode", desc = "Zipped file is corrupted"),
+                MetricDataResult.Error
+            ),
+            ErrorTestCase(
+                FeatureDevException(message = "Improperly formed request", operation = "GenerateCode", desc = null),
+                MetricDataResult.Error
+            )
             ErrorTestCase(
                 RuntimeException("Unknown error"),
                 MetricDataResult.Fault


### PR DESCRIPTION


## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Exclude frequent client errors from faults, they should be errors.

-  exclude toolkit level client error from: https://github.com/aws/aws-toolkit-jetbrains/blob/d148b66f89440afb3053bff2d1f6cba7a910965d/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/util/FeatureDevService.kt#L159
 - exclude default `FeatureDevException` with given client error messages


## Checklist
- [ x] My code follows the code style of this project
- [ x] I have added tests to cover my changes
- [ x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ n/a] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
