### PR TITLE
feat(q): stub out Q LSP logic

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/build.gradle.kts
+++ b/plugins/amazonq/shared/jetbrains-community/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(libs.nimbus.jose.jwt)
 
     // FIX_WHEN_MIN_IS_242
-    if (providers.gradleProperty("ideProfileName").get() == "241") {
+    if (providers.gradleProperty("ideProfileName").get() == "2024.1") {
         implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0")
     }
 

--- a/plugins/amazonq/shared/jetbrains-community/build.gradle.kts
+++ b/plugins/amazonq/shared/jetbrains-community/build.gradle.kts
@@ -22,5 +22,10 @@ dependencies {
     implementation(libs.commons.collections)
     implementation(libs.nimbus.jose.jwt)
 
+    // FIX_WHEN_MIN_IS_242
+    if (providers.gradleProperty("ideProfileName").get() == "241") {
+        implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0")
+    }
+
     testFixturesApi(testFixtures(project(":plugin-core:jetbrains-community")))
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
@@ -5,6 +5,9 @@ import org.eclipse.lsp4j.services.LanguageClient
 import java.util.concurrent.CompletableFuture
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.ConnectionMetadata
 
+/**
+ * Requests sent by server to client
+ */
 interface AmazonQLanguageClient : LanguageClient {
     @JsonRequest("aws/credentials/getConnectionMetadata")
     fun getConnectionMetadata(): CompletableFuture<ConnectionMetadata>

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * Requests sent by server to client
  */
+@Suppress("unused")
 interface AmazonQLanguageClient : LanguageClient {
     @JsonRequest("aws/credentials/getConnectionMetadata")
     fun getConnectionMetadata(): CompletableFuture<ConnectionMetadata>

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
@@ -1,9 +1,12 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package software.aws.toolkits.jetbrains.services.amazonq.lsp
 
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 import org.eclipse.lsp4j.services.LanguageClient
-import java.util.concurrent.CompletableFuture
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.ConnectionMetadata
+import java.util.concurrent.CompletableFuture
 
 /**
  * Requests sent by server to client

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
@@ -1,0 +1,11 @@
+package software.aws.toolkits.jetbrains.services.amazonq.lsp
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
+import org.eclipse.lsp4j.services.LanguageClient
+import java.util.concurrent.CompletableFuture
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.ConnectionMetadata
+
+interface AmazonQLanguageClient : LanguageClient {
+    @JsonRequest("aws/credentials/getConnectionMetadata")
+    fun getConnectionMetadata(): CompletableFuture<ConnectionMetadata>
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -1,0 +1,61 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp
+
+import com.intellij.notification.NotificationType
+import org.eclipse.lsp4j.ConfigurationParams
+import org.eclipse.lsp4j.MessageActionItem
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.MessageType
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.ShowMessageRequestParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.ConnectionMetadata
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.SsoProfileData
+import java.util.concurrent.CompletableFuture
+
+class AmazonQLanguageClientImpl : AmazonQLanguageClient {
+    override fun telemetryEvent(`object`: Any) {
+        println(`object`)
+    }
+
+    override fun publishDiagnostics(diagnostics: PublishDiagnosticsParams) {
+        println(diagnostics)
+    }
+
+    override fun showMessage(messageParams: MessageParams) {
+        val type = when (messageParams.type) {
+            MessageType.Error -> NotificationType.ERROR
+            MessageType.Warning -> NotificationType.WARNING
+            MessageType.Info, MessageType.Log -> NotificationType.INFORMATION
+        }
+        println("$type: ${messageParams.message}")
+    }
+
+    override fun showMessageRequest(requestParams: ShowMessageRequestParams): CompletableFuture<MessageActionItem?>? {
+        println(requestParams)
+
+        return CompletableFuture.completedFuture(null)
+    }
+
+    override fun logMessage(message: MessageParams) {
+        showMessage(message)
+    }
+
+    override fun getConnectionMetadata() = CompletableFuture.completedFuture(
+        ConnectionMetadata(
+            SsoProfileData("TODO")
+        )
+    )
+
+    override fun configuration(params: ConfigurationParams): CompletableFuture<List<Any>> {
+        if (params.items.isEmpty()) {
+            return CompletableFuture.completedFuture(null)
+        }
+
+        return CompletableFuture.completedFuture(
+            buildList {
+            }
+        )
+    }
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -14,6 +14,9 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credential
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.SsoProfileData
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Concrete implementation of [AmazonQLanguageClient] to handle messages sent from server
+ */
 class AmazonQLanguageClientImpl : AmazonQLanguageClient {
     override fun telemetryEvent(`object`: Any) {
         println(`object`)

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
@@ -6,6 +6,9 @@ import org.eclipse.lsp4j.services.LanguageServer
 import java.util.concurrent.CompletableFuture
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.UpdateCredentialsPayload
 
+/**
+ * Remote interface exposed by the Amazon Q language server
+ */
 interface AmazonQLanguageServer : LanguageServer {
     @JsonRequest("aws/credentials/token/update")
     fun updateTokenCredentials(payload: UpdateCredentialsPayload): CompletableFuture<ResponseMessage>

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture
 /**
  * Remote interface exposed by the Amazon Q language server
  */
+@Suppress("unused")
 interface AmazonQLanguageServer : LanguageServer {
     @JsonRequest("aws/credentials/token/update")
     fun updateTokenCredentials(payload: UpdateCredentialsPayload): CompletableFuture<ResponseMessage>

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
@@ -1,0 +1,12 @@
+package software.aws.toolkits.jetbrains.services.amazonq.lsp
+
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
+import org.eclipse.lsp4j.services.LanguageServer
+import java.util.concurrent.CompletableFuture
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.UpdateCredentialsPayload
+
+interface AmazonQLanguageServer : LanguageServer {
+    @JsonRequest("aws/credentials/token/update")
+    fun updateTokenCredentials(payload: UpdateCredentialsPayload): CompletableFuture<ResponseMessage>
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
@@ -1,10 +1,13 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package software.aws.toolkits.jetbrains.services.amazonq.lsp
 
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 import org.eclipse.lsp4j.services.LanguageServer
-import java.util.concurrent.CompletableFuture
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.UpdateCredentialsPayload
+import java.util.concurrent.CompletableFuture
 
 /**
  * Remote interface exposed by the Amazon Q language server

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -7,6 +7,7 @@ import com.google.gson.ToNumberPolicy
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.impl.ExecutionManagerImpl
 import com.intellij.execution.process.KillableColoredProcessHandler
+import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutputType
@@ -18,12 +19,13 @@ import com.intellij.openapi.util.Key
 import com.intellij.util.io.await
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InitializedParams
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.launch.LSPLauncher
+import org.slf4j.event.Level
 import software.aws.toolkits.core.utils.getLogger
+import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.isDeveloperMode
 import java.io.IOException
 import java.io.OutputStreamWriter
@@ -32,7 +34,7 @@ import java.io.PipedOutputStream
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.nio.charset.StandardCharsets
-import org.slf4j.event.Level
+import java.util.concurrent.Future
 
 // https://github.com/redhat-developer/lsp4ij/blob/main/src/main/java/com/redhat/devtools/lsp4ij/server/LSPProcessListener.java
 // JB impl and redhat both use a wrapper to handle input buffering issue
@@ -50,7 +52,7 @@ internal class LSPProcessListener : ProcessListener {
                 ExecutionManagerImpl.stopProcess(event.processHandler)
             }
         } else if (ProcessOutputType.isStderr(outputType)) {
-            LOG.warn("LSP process stderr: ${event.text}")
+            LOG.warn { "LSP process stderr: ${event.text}" }
         }
     }
 
@@ -74,13 +76,17 @@ class AmazonQLspService(project: Project, private val cs: CoroutineScope) : Disp
     private val languageServer: AmazonQLanguageServer
         get() = launcher.remoteProxy
 
+    @Suppress("ForbiddenVoid")
+    private val launcherFuture: Future<Void>
+    private val launcherHandler: KillableProcessHandler
+
     init {
         val cmd = GeneralCommandLine("amazon-q-lsp")
 
-        val handler = KillableColoredProcessHandler.Silent(cmd)
+        launcherHandler = KillableColoredProcessHandler.Silent(cmd)
         val inputWrapper = LSPProcessListener()
-        handler.addProcessListener(inputWrapper)
-        handler.startNotify()
+        launcherHandler.addProcessListener(inputWrapper)
+        launcherHandler.startNotify()
 
         launcher = LSPLauncher.Builder<AmazonQLanguageServer>()
             .setLocalService(AmazonQLanguageClientImpl())
@@ -97,17 +103,17 @@ class AmazonQLspService(project: Project, private val cs: CoroutineScope) : Disp
                         private val traceLogger = LOG.atLevel(if (isDeveloperMode()) Level.INFO else Level.DEBUG)
 
                         override fun flush() {
-                            traceLogger.log(buffer.toString())
+                            traceLogger.log { buffer.toString() }
                             buffer.setLength(0)
                         }
                     }
                 )
             )
             .setInput(inputWrapper.inputStream)
-            .setOutput(handler.process.outputStream)
+            .setOutput(launcherHandler.process.outputStream)
             .create()
 
-        launcher.startListening()
+        launcherFuture = launcher.startListening()
 
         cs.launch {
             val initializeResult = languageServer.initialize(
@@ -126,22 +132,29 @@ class AmazonQLspService(project: Project, private val cs: CoroutineScope) : Disp
             // then if this succeeds then we can allow the client to send requests
             languageServer.initialized(InitializedParams())
             if (initializeResult == null) {
-                LOG.warn("LSP initialization failed")
-                handler.destroyProcess()
+                LOG.warn { "LSP initialization failed" }
+                launcherHandler.destroyProcess()
             }
         }
     }
 
     override fun dispose() {
-        languageServer.apply {
-            shutdown().thenRun { exit() }
+        if (!launcherFuture.isDone) {
+            try {
+                languageServer.apply {
+                    shutdown().thenRun { exit() }
+                }
+            } catch (e: Exception) {
+                LOG.warn(e) { "LSP shutdown failed" }
+                launcherHandler.destroyProcess()
+            }
+        } else if (!launcherHandler.isProcessTerminated) {
+            launcherHandler.destroyProcess()
         }
     }
 
     companion object {
         private val LOG = getLogger<AmazonQLspService>()
-        fun getInstance(project: Project): AmazonQLspService {
-            return project.service()
-        }
+        fun getInstance(project: Project) = project.service<AmazonQLspService>()
     }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -1,0 +1,120 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp
+
+import com.google.gson.ToNumberPolicy
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.impl.ExecutionManagerImpl
+import com.intellij.execution.process.KillableColoredProcessHandler
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
+import com.intellij.execution.process.ProcessOutputType
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import org.eclipse.lsp4j.jsonrpc.Launcher
+import org.eclipse.lsp4j.launch.LSPLauncher
+import software.aws.toolkits.core.utils.getLogger
+import software.aws.toolkits.jetbrains.isDeveloperMode
+import java.io.IOException
+import java.io.OutputStreamWriter
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.nio.charset.StandardCharsets
+import org.slf4j.event.Level
+
+// https://github.com/redhat-developer/lsp4ij/blob/main/src/main/java/com/redhat/devtools/lsp4ij/server/LSPProcessListener.java
+// JB impl and redhat both use a wrapper to handle input buffering issue
+internal class LSPProcessListener : ProcessListener {
+    private val outputStream = PipedOutputStream()
+    private val outputStreamWriter = OutputStreamWriter(outputStream, StandardCharsets.UTF_8)
+    val inputStream = PipedInputStream(outputStream)
+
+    override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+        if (ProcessOutputType.isStdout(outputType)) {
+            try {
+                this.outputStreamWriter.write(event.text)
+                this.outputStreamWriter.flush()
+            } catch (_: IOException) {
+                ExecutionManagerImpl.stopProcess(event.processHandler)
+            }
+        } else if (ProcessOutputType.isStderr(outputType)) {
+            LOG.warn("LSP process stderr: ${event.text}")
+        }
+    }
+
+    override fun processTerminated(event: ProcessEvent) {
+        try {
+            this.outputStreamWriter.close()
+            this.outputStream.close()
+        } catch (_: IOException) {
+        }
+    }
+
+    companion object {
+        private val LOG = getLogger<LSPProcessListener>()
+    }
+}
+
+@Service(Service.Level.PROJECT)
+class AmazonQLspService(project: Project) : Disposable {
+    private val launcher: Launcher<AmazonQLanguageServer>
+
+    private val languageServer: AmazonQLanguageServer
+        get() = launcher.remoteProxy
+
+    init {
+        val cmd = GeneralCommandLine("amazon-q-lsp")
+
+        val handler = KillableColoredProcessHandler.Silent(cmd)
+        val inputWrapper = LSPProcessListener()
+        handler.addProcessListener(inputWrapper)
+
+        handler.startNotify()
+
+        launcher = LSPLauncher.Builder<AmazonQLanguageServer>()
+            .setLocalService(AmazonQLanguageClientImpl())
+            .setRemoteInterface(AmazonQLanguageServer::class.java)
+            .configureGson {
+                // TODO: maybe need adapter for initialize:
+                //   https://github.com/aws/amazon-q-eclipse/blob/b9d5bdcd5c38e1dd8ad371d37ab93a16113d7d4b/plugin/src/software/aws/toolkits/eclipse/amazonq/lsp/QLspTypeAdapterFactory.java
+
+                // otherwise Gson treats all numbers as double which causes deser issues
+                it.setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            }.traceMessages(
+                PrintWriter(
+                    object : StringWriter() {
+                        private val traceLogger = LOG.atLevel(if (isDeveloperMode()) Level.INFO else Level.DEBUG)
+
+                        override fun flush() {
+                            traceLogger.log(buffer.toString())
+                            buffer.setLength(0)
+                        }
+                    }
+                )
+            )
+            .setInput(inputWrapper.inputStream)
+            .setOutput(handler.process.outputStream)
+            .create()
+
+        launcher.startListening()
+    }
+
+    override fun dispose() {
+        languageServer.apply {
+            shutdown().thenRun { exit() }
+        }
+    }
+
+    companion object {
+        private val LOG = getLogger<AmazonQLspService>()
+        fun getInstance(project: Project): AmazonQLspService {
+            return project.service()
+        }
+    }
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -130,11 +130,11 @@ class AmazonQLspService(project: Project, private val cs: CoroutineScope) : Disp
             ).await()
 
             // then if this succeeds then we can allow the client to send requests
-            languageServer.initialized(InitializedParams())
             if (initializeResult == null) {
                 LOG.warn { "LSP initialization failed" }
                 launcherHandler.destroyProcess()
             }
+            languageServer.initialized(InitializedParams())
         }
     }
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/ConnectionMetadata.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/ConnectionMetadata.kt
@@ -4,9 +4,9 @@
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials
 
 data class ConnectionMetadata(
-    val sso: SsoProfileData
+    val sso: SsoProfileData,
 )
 
 data class SsoProfileData(
-    val startUrl: String
+    val startUrl: String,
 )

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/ConnectionMetadata.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/ConnectionMetadata.kt
@@ -1,0 +1,12 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials
+
+data class ConnectionMetadata(
+    val sso: SsoProfileData
+)
+
+data class SsoProfileData(
+    val startUrl: String
+)

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/UpdateCredentialsPayload.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/UpdateCredentialsPayload.kt
@@ -1,0 +1,14 @@
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials
+
+data class UpdateCredentialsPayload(
+    val data: String,
+    val encrypted: String,
+)
+
+data class UpdateCredentialsPayloadData(
+    val data: BearerCredentials
+)
+
+data class BearerCredentials(
+    val token: String
+)

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/UpdateCredentialsPayload.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/UpdateCredentialsPayload.kt
@@ -1,3 +1,6 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials
 
 data class UpdateCredentialsPayload(
@@ -6,9 +9,9 @@ data class UpdateCredentialsPayload(
 )
 
 data class UpdateCredentialsPayloadData(
-    val data: BearerCredentials
+    val data: BearerCredentials,
 )
 
 data class BearerCredentials(
-    val token: String
+    val token: String,
 )


### PR DESCRIPTION
This is the initial iteration of the bare minimum of process management to interact with Amazon Q logic vended by Flare.
It is a direct port of the exploratory work done in https://github.com/rli/lsp-exp/tree/master/src/main/kotlin/org/example/lsp4j

Missing are tests and any sort of edge case handling

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
