### PR TITLE
fix(amazonq): Q infers source file from active test file for UTG.

### DIFF
--- a/.changes/next-release/bugfix-62042604-3335-445b-90f6-d6f688087c9d.json
+++ b/.changes/next-release/bugfix-62042604-3335-445b-90f6-d6f688087c9d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q /test: Q identify active test file and infer source file for test generation."
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/CodeWhispererUTGChatManager.kt
@@ -59,6 +59,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
+import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Duration
 import java.time.Instant
@@ -249,9 +250,10 @@ class CodeWhispererUTGChatManager(val project: Project, private val cs: Coroutin
                     if (shortAnswer.stopIteration == "true") {
                         throw CodeTestException("TestGenFailedError: ${shortAnswer.planSummary}", "TestGenFailedError", shortAnswer.planSummary)
                     }
+                    val fileName = shortAnswer.sourceFilePath?.let { Path.of(it).fileName.toString() } ?: path.fileName.toString()
                     codeTestChatHelper.updateAnswer(
                         CodeTestChatMessageContent(
-                            message = generateSummaryMessage(path.fileName.toString()) + shortAnswer.planSummary,
+                            message = generateSummaryMessage(fileName) + shortAnswer.planSummary,
                             type = ChatMessageType.Answer
                         ),
                         messageIdOverride = codeTestResponseContext.testSummaryMessageId


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem
-  If user tries to run `/test` on the test file, Q considers test file as source file and starts the test generation on the test file.

### Solution
- If user tries to run `/test` on the test file, Q infers the context from the original source file and generate tests accordingly.
- No change in functionality, minor change in UX filename.
![image](https://github.com/user-attachments/assets/853de1e9-9c9d-4e47-9f53-389adbccb964)



## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
