### PR TITLE
fix(amazonq): /doc add suppoort for uploading infrastructure diagrams

### DIFF
--- a/.changes/next-release/feature-bfb6687a-a302-4968-8e7e-8fa0d4ef6c53.json
+++ b/.changes/next-release/feature-bfb6687a-a302-4968-8e7e-8fa0d4ef6c53.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Amazon Q /doc: support making changes to architecture diagrams"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocConstants.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocConstants.kt
@@ -3,11 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.amazonqDoc
 
-import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.FollowUp
-import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.FollowUpStatusType
-import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.FollowUpTypes
-import software.aws.toolkits.resources.message
-
 const val FEATURE_EVALUATION_PRODUCT_NAME = "DocGeneration"
 
 const val FEATURE_NAME = "Amazon Q Documentation Generation"
@@ -21,25 +16,8 @@ const val DEFAULT_RETRY_LIMIT = 0
 // Max allowed size for a repository in bytes
 const val MAX_PROJECT_SIZE_BYTES: Long = 200 * 1024 * 1024
 
-enum class ModifySourceFolderErrorReason(
-    private val reasonText: String,
-) {
-    ClosedBeforeSelection("ClosedBeforeSelection"),
-    NotInWorkspaceFolder("NotInWorkspaceFolder"),
-    ;
-
-    override fun toString(): String = reasonText
-}
-
-val NEW_SESSION_FOLLOWUPS: List<FollowUp> = listOf(
-    FollowUp(
-        pillText = message("amazonqDoc.prompt.reject.new_task"),
-        type = FollowUpTypes.NEW_TASK,
-        status = FollowUpStatusType.Info
-    ),
-    FollowUp(
-        pillText = message("amazonqDoc.prompt.reject.close_session"),
-        type = FollowUpTypes.CLOSE_SESSION,
-        status = FollowUpStatusType.Info
-    )
-)
+const val INFRA_DIAGRAM_PREFIX = "infra."
+const val DIAGRAM_SVG_EXT = "svg"
+const val DIAGRAM_DOT_EXT = "dot"
+val SUPPORTED_DIAGRAM_EXT_SET: Set<String> = setOf(DIAGRAM_SVG_EXT, DIAGRAM_DOT_EXT)
+val SUPPORTED_DIAGRAM_FILE_NAME_SET: Set<String> = SUPPORTED_DIAGRAM_EXT_SET.map { INFRA_DIAGRAM_PREFIX + it }.toSet()

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/messages/DocMessagePublisherExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/messages/DocMessagePublisherExtensions.kt
@@ -7,7 +7,7 @@ import software.aws.toolkits.jetbrains.services.amazonq.auth.AuthNeededState
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
 import software.aws.toolkits.jetbrains.services.amazonqCodeTest.messages.ProgressField
 import software.aws.toolkits.jetbrains.services.amazonqCodeTest.messages.PromptProgressMessage
-import software.aws.toolkits.jetbrains.services.amazonqDoc.NEW_SESSION_FOLLOWUPS
+import software.aws.toolkits.jetbrains.services.amazonqDoc.ui.NEW_SESSION_FOLLOWUPS
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.CodeReferenceGenerated
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.DeletedFileInfo
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.NewFileZipInfo

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocSession.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocSession.kt
@@ -20,7 +20,6 @@ import software.aws.toolkits.jetbrains.common.session.SessionStateConfigData
 import software.aws.toolkits.jetbrains.common.util.AmazonQCodeGenService
 import software.aws.toolkits.jetbrains.common.util.resolveAndCreateOrUpdateFile
 import software.aws.toolkits.jetbrains.common.util.resolveAndDeleteFile
-import software.aws.toolkits.jetbrains.services.amazonq.FeatureDevSessionContext
 import software.aws.toolkits.jetbrains.services.amazonq.messages.MessagePublisher
 import software.aws.toolkits.jetbrains.services.amazonqDoc.CODE_GENERATION_RETRY_LIMIT
 import software.aws.toolkits.jetbrains.services.amazonqDoc.FEATURE_NAME
@@ -40,7 +39,7 @@ import java.security.MessageDigest
 private val logger = getLogger<AmazonQCodeGenerateClient>()
 
 class DocSession(val tabID: String, val project: Project) {
-    var context: FeatureDevSessionContext
+    var context: DocSessionContext = DocSessionContext(project, MAX_PROJECT_SIZE_BYTES)
     val sessionStartTime = System.currentTimeMillis()
 
     var state: SessionState?
@@ -59,7 +58,6 @@ class DocSession(val tabID: String, val project: Project) {
     var isAuthenticating: Boolean
 
     init {
-        context = FeatureDevSessionContext(project, MAX_PROJECT_SIZE_BYTES)
         proxyClient = AmazonQCodeGenerateClient.getInstance(project)
         amazonQCodeGenService = AmazonQCodeGenService(proxyClient, project)
         state = ConversationNotStartedState("", tabID, token = null)

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocSessionContext.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/session/DocSessionContext.kt
@@ -1,0 +1,33 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonqDoc.session
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import software.aws.toolkits.jetbrains.services.amazonq.FeatureDevSessionContext
+import software.aws.toolkits.jetbrains.services.amazonqDoc.SUPPORTED_DIAGRAM_EXT_SET
+import software.aws.toolkits.jetbrains.services.amazonqDoc.SUPPORTED_DIAGRAM_FILE_NAME_SET
+
+class DocSessionContext(project: Project, maxProjectSizeBytes: Long? = null) : FeatureDevSessionContext(project, maxProjectSizeBytes) {
+
+    /**
+     * Ensure diagram files are not ignored
+     */
+    override fun getAdditionalGitIgnoreBinaryFilesRules(): Set<String> {
+        val ignoreRules = super.getAdditionalGitIgnoreBinaryFilesRules()
+        val diagramExtRulesInGitIgnoreFormatSet = SUPPORTED_DIAGRAM_EXT_SET.map { "*.$it" }.toSet()
+        return ignoreRules - diagramExtRulesInGitIgnoreFormatSet
+    }
+
+    /**
+     * Ensure diagram files are not filtered
+     */
+    override fun isFileExtensionAllowed(file: VirtualFile): Boolean {
+        if (super.isFileExtensionAllowed(file)) {
+            return true
+        }
+
+        return file.extension != null && SUPPORTED_DIAGRAM_FILE_NAME_SET.contains(file.name)
+    }
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/ui/UiContants.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/ui/UiContants.kt
@@ -1,0 +1,22 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonqDoc.ui
+
+import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.FollowUp
+import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.FollowUpStatusType
+import software.aws.toolkits.jetbrains.services.amazonqDoc.messages.FollowUpTypes
+import software.aws.toolkits.resources.message
+
+val NEW_SESSION_FOLLOWUPS: List<FollowUp> = listOf(
+    FollowUp(
+        pillText = message("amazonqDoc.prompt.reject.new_task"),
+        type = FollowUpTypes.NEW_TASK,
+        status = FollowUpStatusType.Info
+    ),
+    FollowUp(
+        pillText = message("amazonqDoc.prompt.reject.close_session"),
+        type = FollowUpTypes.CLOSE_SESSION,
+        status = FollowUpStatusType.Info
+    )
+)

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
@@ -43,7 +43,7 @@ interface RepoSizeError {
 }
 class RepoSizeLimitError(override val message: String) : RuntimeException(), RepoSizeError
 
-class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Long? = null) {
+open class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Long? = null) {
     // TODO: Need to correct this class location in the modules going further to support both amazonq and codescan.
 
     private val additionalGitIgnoreFolderRules = setOf(
@@ -61,7 +61,7 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
         "dist",
     )
 
-    private val additionalGitIgnoreBinaryFilesRules = setOf(
+    private val defaultAdditionalGitIgnoreBinaryFilesRules = setOf(
         "*.zip",
         "*.bin",
         "*.png",
@@ -91,17 +91,17 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
     // selectedSourceFolder: is the directory selected in replacement of the root, this happens when the project is too big to bundle for uploading.
     private var _selectedSourceFolder = projectRoot
     private var ignorePatternsWithGitIgnore = emptyList<Regex>()
-    private var ignorePatternsForBinaryFiles = additionalGitIgnoreBinaryFilesRules
-        .map { convertGitIgnorePatternToRegex(it) }
-        .mapNotNull { pattern ->
-            runCatching { Regex(pattern) }.getOrNull()
-        }
+    private var ignorePatternsForBinaryFiles = buildIgnorePatternsForBinaryFiles()
+
     private val gitIgnoreFile = File(selectedSourceFolder.path, ".gitignore")
 
     init {
         ignorePatternsWithGitIgnore = try {
             buildList {
-                addAll(additionalGitIgnoreFolderRules.map { convertGitIgnorePatternToRegex(it) })
+                addAll(
+                    additionalGitIgnoreFolderRules
+                        .map { convertGitIgnorePatternToRegex(it) }
+                )
                 addAll(parseGitIgnore())
             }.mapNotNull { pattern ->
                 runCatching { Regex(pattern) }.getOrNull()
@@ -110,6 +110,15 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
             emptyList()
         }
     }
+
+    private fun buildIgnorePatternsForBinaryFiles(): List<Regex> =
+        getAdditionalGitIgnoreBinaryFilesRules()
+            .map { convertGitIgnorePatternToRegex(it) }
+            .mapNotNull { pattern ->
+                runCatching { Regex(pattern) }.getOrNull()
+            }
+
+    open fun getAdditionalGitIgnoreBinaryFilesRules(): Set<String> = defaultAdditionalGitIgnoreBinaryFilesRules
 
     // This function checks for existence of `devfile.yaml` in customer's repository, currently only `devfile.yaml` is supported for this feature.
     fun checkForDevFile(): Boolean {
@@ -129,7 +138,7 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
         return ZipCreationResult(zippedProject, checkSum256, zippedProject.length())
     }
 
-    fun isFileExtensionAllowed(file: VirtualFile): Boolean {
+    open fun isFileExtensionAllowed(file: VirtualFile): Boolean {
         // if it is a directory, it is allowed
         if (file.isDirectory) return true
         val extension = file.extension ?: return false


### PR DESCRIPTION
Upload infrastructure diagram image files during documentation generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)

## Description
Upload infrastructure diagram image files during documentation generation

![preview](https://github.com/user-attachments/assets/2cc86abe-619b-4746-81e6-f7dc25f5303b)


## Checklist
- [X  ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ X ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
