### PR TITLE
fix(amazonq): Truncating user prompt for unit test generation.

### DIFF
--- a/.changes/next-release/bugfix-47911d01-4571-42a5-b447-d443910e8aee.json
+++ b/.changes/next-release/bugfix-47911d01-4571-42a5-b447-d443910e8aee.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q /test: Truncating user input to 4096 characters for unit test generation."
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqCodeTest/controller/CodeTestChatController.kt
@@ -201,12 +201,11 @@ class CodeTestChatController(
 
             session.isCodeBlockSelected = selectionRange !== null
 
-            // This check is added to remove /test if user accidentally added while doing Regenerate unit tests.
-            val userPrompt = if (message.prompt.startsWith("/test")) {
-                message.prompt.substringAfter("/test ").trim()
-            } else {
-                message.prompt
-            }
+            // This removes /test if user accidentally added while doing Regenerate unit tests and truncates the user response to 4096 characters.
+            val userPrompt = message.prompt
+                .let { if (it.startsWith("/test")) it.substringAfter("/test ").trim() else it }
+                .take(4096)
+
             CodeWhispererUTGChatManager.getInstance(project).generateTests(userPrompt, codeTestChatHelper, null, selectionRange)
         } else {
             // Not adding a progress bar to unsupported language cases


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
### Problem
- If user gives user input prompt more than 4096 characters, this fails at RTS as model supports only 4096 input characters.
`Value at 'userInput' failed to satisfy constraint: Member must have length less than or equal to 4096`
- Ideally we should not get more than 4096 char input from user input but still features like `/test`, `/dev` were able to get the message length more than 4096.

This recording is for VSCode but similar experience for JB too.

https://github.com/user-attachments/assets/93149e8b-f809-4dfa-8a8a-847f026cab51


### Solution
- To resolve this issue, we are adding a truncation logic to continue the test generation workflow instead of failing at RTS.
- No new tests were added as the functionality is not impacted.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
