### PR TITLE
fix(amazonq): update logic for converting gitignore pattern to regex

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
@@ -161,4 +161,37 @@ class FeatureDevSessionContextTest : FeatureDevTestBase(HeavyJavaCodeInsightTest
 
         assertEquals(zippedFiles, expectedFiles)
     }
+
+    @Test
+    fun testConvertGitIgnorePatternToRegex() {
+        val sampleGitIgnorePatterns = listOf(".*", "build/", "*.txt", "*.png")
+        val sampleFileNames = listOf(
+            ".gitignore/",
+            ".env/",
+            "file.txt/",
+            ".git/config/",
+            "src/file.txt/",
+            "build/",
+            "build/output.jar/",
+            "builds/",
+            "mybuild/",
+            "build.json/",
+            "log.txt/",
+            "file.txt.json/",
+            "file.png/",
+            "src/file.png/"
+        )
+
+        val patterns = sampleGitIgnorePatterns.map { pattern -> featureDevSessionContext.convertGitIgnorePatternToRegex(pattern).toRegex() }
+
+        val matchedFiles = sampleFileNames.filter { fileName ->
+            patterns.any { pattern ->
+                pattern.matches(fileName)
+            }
+        }
+
+        val expectedFilesToMatch = listOf(".gitignore/", ".env/", "file.txt/", ".git/config/", "src/file.txt/", "build/", "build/output.jar/", "log.txt/", "file.png/", "src/file.png/")
+
+        assertEquals(expectedFilesToMatch, matchedFiles)
+    }
 }

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
@@ -190,7 +190,19 @@ class FeatureDevSessionContextTest : FeatureDevTestBase(HeavyJavaCodeInsightTest
             }
         }
 
-        val expectedFilesToMatch = listOf(".gitignore/", ".env/", "file.txt/", ".git/config/", "src/file.txt/", "build/", "build/output.jar/", "log.txt/", "file.png/", "src/file.png/")
+        val expectedFilesToMatch =
+            listOf(
+                ".gitignore/",
+                ".env/",
+                "file.txt/",
+                ".git/config/",
+                "src/file.txt/",
+                "build/",
+                "build/output.jar/",
+                "log.txt/",
+                "file.png/",
+                "src/file.png/"
+            )
 
         assertEquals(expectedFilesToMatch, matchedFiles)
     }

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/FeatureDevSessionContext.kt
@@ -279,10 +279,17 @@ class FeatureDevSessionContext(val project: Project, val maxProjectSizeBytes: Lo
     }
 
     // gitignore patterns are not regex, method update needed.
-    private fun convertGitIgnorePatternToRegex(pattern: String): String = pattern
-        .replace(".", "\\.")
-        .replace("*", ".*")
-        .let { if (it.endsWith("/")) "$it.*" else "$it/.*" } // Add a trailing /* to all patterns. (we add a trailing / to all files when matching)
+    fun convertGitIgnorePatternToRegex(pattern: String): String {
+        // Special case for ".*" to match only dotfiles
+        if (pattern == ".*") {
+            return "^\\..*/.*"
+        }
+
+        return pattern
+            .replace(".", "\\.")
+            .replace("*", ".*")
+            .let { if (it.endsWith("/")) "$it.*" else "$it/.*" } // Add a trailing /* to all patterns. (we add a trailing / to all files when matching)
+    }
     var selectedSourceFolder: VirtualFile
         set(newRoot) {
             _selectedSourceFolder = newRoot


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Updating .gitignore pattern to regex conversion to factor for following edge cases:
* `.*` should be matching only files starting with `.` now, instead of all files previously

As part of the changes, added a unit test to verify the correct regex pattern is being created and files are being matched. 
Existing tests which check the file zipping logic are passing as well so no regression should be expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
The current implementation to convert `.gitignore` patterns into regex is not following gitignore patterns and resulting in the below issues

* `.*` is converted into `\\..*/.*` which results in all files being selected instead of the intention to only select files that start with a `.`. This is a special case where adding `^` in the front makes sure only files starting with `.` are ignored.


### Changes
* Added special handling for `.*` case
* Added a unit test to check the regex patterns are matching the files as expected from the changes

<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [N/A] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [N/A] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
