### PR TITLE
fix(telemetry): fix region warning when initializing telemetry with no user-selected region

### DIFF
--- a/plugins/core/jetbrains-community/src/migration/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
+++ b/plugins/core/jetbrains-community/src/migration/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
@@ -54,9 +54,10 @@ abstract class TelemetryService(private val publisher: TelemetryPublisher, prote
                     awsRegion = DefaultMetricEvent.METADATA_INVALID
                 )
             } else {
+                val connectionSettings = project.getConnectionSettings()
                 MetricEventMetadata(
-                    awsAccount = project.getConnectionSettings()?.activeAwsAccountIfKnown() ?: DefaultMetricEvent.METADATA_NOT_SET,
-                    awsRegion = project.activeRegion().id
+                    awsAccount = connectionSettings?.activeAwsAccountIfKnown() ?: DefaultMetricEvent.METADATA_NOT_SET,
+                    awsRegion = connectionSettings?.region?.id ?: DefaultMetricEvent.METADATA_NOT_SET
                 )
             }
         } else {

--- a/plugins/core/jetbrains-community/src/migration/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
+++ b/plugins/core/jetbrains-community/src/migration/software/aws/toolkits/jetbrains/services/telemetry/TelemetryService.kt
@@ -13,7 +13,6 @@ import software.aws.toolkits.core.telemetry.MetricEvent
 import software.aws.toolkits.core.telemetry.TelemetryBatcher
 import software.aws.toolkits.core.telemetry.TelemetryPublisher
 import software.aws.toolkits.core.utils.tryOrNull
-import software.aws.toolkits.jetbrains.core.credentials.activeRegion
 import software.aws.toolkits.jetbrains.core.credentials.getConnectionSettings
 import software.aws.toolkits.jetbrains.core.getResourceIfPresent
 import software.aws.toolkits.jetbrains.services.sts.StsResources

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/telemetry/TelemetryServiceTest.kt
@@ -152,7 +152,7 @@ class TelemetryServiceTest {
 
         verify(batcher).enqueue(eventCaptor.capture())
 
-        assertMetricEventsContains(eventCaptor.allValues, "Foo", METADATA_NOT_SET, "us-east-1")
+        assertMetricEventsContains(eventCaptor.allValues, "Foo", METADATA_NOT_SET, METADATA_NOT_SET)
     }
 
     @Test


### PR DESCRIPTION
```
WARN - software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager - Using activeRegion when region is null, calling code needs to be migrated to handle null
java.lang.IllegalStateException
	at software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManager.getActiveRegion(AwsConnectionManager.kt:224)
	at software.aws.toolkits.jetbrains.core.credentials.AwsConnectionManagerKt.activeRegion(AwsConnectionManager.kt:370)
	at migration.software.aws.toolkits.jetbrains.services.telemetry.TelemetryService.record(TelemetryService.kt:59)
	at software.aws.toolkits.telemetry.SessionTelemetry.start(SessionTelemetry.kt:287)
	at software.aws.toolkits.telemetry.SessionTelemetry.start$default(SessionTelemetry.kt:271)
	at software.aws.toolkits.jetbrains.services.telemetry.AwsToolkitStartupMetrics.execute$lambda$0(AwsToolkitStartupMetrics.kt:14)
	at com.intellij.ide.util.RunOnceUtilKt.doRunOnce(RunOnceUtil.kt:68)
	at com.intellij.ide.util.RunOnceUtilKt.access$doRunOnce(RunOnceUtil.kt:1)
```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
