### PR TITLE
feat(amazonQ): LSP -- Implement Initialize message 

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -92,8 +92,8 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
     private val launcherFuture: Future<Void>
     private val launcherHandler: KillableProcessHandler
 
-    private fun createClientCapabilities(): ClientCapabilities {
-        return ClientCapabilities().apply {
+    private fun createClientCapabilities(): ClientCapabilities =
+        ClientCapabilities().apply {
             textDocument = TextDocumentClientCapabilities().apply {
                 // For didSaveTextDocument, other textDocument/ messages always mandatory
                 synchronization = SynchronizationCapabilities().apply {
@@ -114,11 +114,10 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
                 }
             }
         }
-    }
 
     // needs case handling when project's base path is null: default projects/unit tests
-    private fun createWorkspaceFolders(): List<WorkspaceFolder> {
-        return project.basePath?.let { basePath ->
+    private fun createWorkspaceFolders(): List<WorkspaceFolder> =
+        project.basePath?.let { basePath ->
             listOf(
                 WorkspaceFolder(
                     URI("file://$basePath").toString(),
@@ -126,7 +125,6 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
                 )
             )
         } ?: emptyList() // no folders to report or workspace not folder based
-    }
 
     private fun createClientInfo(): ClientInfo {
         val metadata = ClientMetadata.getDefault()
@@ -136,15 +134,14 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
         }
     }
 
-    private fun createInitializeParams(): InitializeParams {
-        return InitializeParams().apply {
+    private fun createInitializeParams(): InitializeParams =
+        InitializeParams().apply {
             processId = ProcessHandle.current().pid().toInt()
             capabilities = createClientCapabilities()
             clientInfo = createClientInfo()
             workspaceFolders = createWorkspaceFolders()
             initializationOptions = createExtendedClientMetadata()
         }
-    }
 
     init {
         val cmd = GeneralCommandLine("amazon-q-lsp")

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -124,7 +124,7 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
                     project.name
                 )
             )
-        } ?: emptyList() // no folders to report or workspace not folder based
+        }.orEmpty() // no folders to report or workspace not folder based
 
     private fun createClientInfo(): ClientInfo {
         val metadata = ClientMetadata.getDefault()

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.time.withTimeout
-import kotlinx.serialization.Serializable
 import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.ClientInfo
 import org.eclipse.lsp4j.FileOperationsWorkspaceCapabilities
@@ -37,6 +36,7 @@ import org.slf4j.event.Level
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.isDeveloperMode
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.createExtendedClientMetadata
 import software.aws.toolkits.jetbrains.services.telemetry.ClientMetadata
 import java.io.IOException
 import java.io.OutputStreamWriter
@@ -48,48 +48,6 @@ import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.Future
-
-@Serializable
-data class ExtendedClientMetadata(
-    val aws: AwsMetadata,
-)
-
-@Serializable
-data class AwsMetadata(
-    val clientInfo: ClientInfoMetadata,
-)
-
-@Serializable
-data class ClientInfoMetadata(
-    val extension: ExtensionMetadata,
-    val clientId: String,
-    val version: String,
-    val name: String,
-)
-
-@Serializable
-data class ExtensionMetadata(
-    val name: String,
-    val version: String,
-)
-
-private fun createExtendedClientMetadata(): ExtendedClientMetadata {
-    val metadata = ClientMetadata.getDefault()
-    return ExtendedClientMetadata(
-        aws = AwsMetadata(
-            clientInfo = ClientInfoMetadata(
-                extension = ExtensionMetadata(
-                    name = metadata.awsProduct.toString(),
-                    version = metadata.awsVersion
-                ),
-                clientId = metadata.clientId,
-                version = metadata.parentProductVersion,
-                name = metadata.parentProduct
-            )
-        )
-    )
-}
-
 // https://github.com/redhat-developer/lsp4ij/blob/main/src/main/java/com/redhat/devtools/lsp4ij/server/LSPProcessListener.java
 // JB impl and redhat both use a wrapper to handle input buffering issue
 internal class LSPProcessListener : ProcessListener {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -167,7 +167,7 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
                     project.name
                 )
             )
-        } ?: emptyList()
+        } ?: emptyList() // no folders to report or workspace not folder based
     }
 
     private fun createClientInfo(): ClientInfo {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -41,6 +41,7 @@ import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.Future
 
@@ -78,7 +79,7 @@ internal class LSPProcessListener : ProcessListener {
 }
 
 @Service(Service.Level.PROJECT)
-class AmazonQLspService(project: Project, private val cs: CoroutineScope) : Disposable {
+class AmazonQLspService(private val project: Project, private val cs: CoroutineScope) : Disposable {
     private val launcher: Launcher<AmazonQLanguageServer>
 
     private val languageServer: AmazonQLanguageServer
@@ -123,7 +124,12 @@ class AmazonQLspService(project: Project, private val cs: CoroutineScope) : Disp
     }
 
     private fun createWorkspaceFolders(): List<WorkspaceFolder> {
-        return emptyList()
+        return project.basePath?.let { basePath ->
+            listOf(WorkspaceFolder(
+                URI("file://$basePath").toString(),
+                project.name
+            ))
+        } ?: emptyList()
     }
 
     private fun createClientInfo(): ClientInfo {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -158,6 +158,7 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
         }
     }
 
+    // needs case handling when project's base path is null: default projects/unit tests
     private fun createWorkspaceFolders(): List<WorkspaceFolder> {
         return project.basePath?.let { basePath ->
             listOf(

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -19,14 +19,22 @@ import com.intellij.openapi.util.Key
 import com.intellij.util.io.await
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.ClientInfo
+import org.eclipse.lsp4j.FileOperationsWorkspaceCapabilities
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InitializedParams
+import org.eclipse.lsp4j.SynchronizationCapabilities
+import org.eclipse.lsp4j.TextDocumentClientCapabilities
+import org.eclipse.lsp4j.WorkspaceClientCapabilities
+import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.launch.LSPLauncher
 import org.slf4j.event.Level
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.isDeveloperMode
+import software.aws.toolkits.jetbrains.services.telemetry.ClientMetadata
 import java.io.IOException
 import java.io.OutputStreamWriter
 import java.io.PipedInputStream
@@ -80,6 +88,69 @@ class AmazonQLspService(project: Project, private val cs: CoroutineScope) : Disp
     private val launcherFuture: Future<Void>
     private val launcherHandler: KillableProcessHandler
 
+    private fun createInitializeParams(): InitializeParams {
+        return InitializeParams().apply {
+            processId = ProcessHandle.current().pid().toInt()
+            capabilities = createClientCapabilities()
+            clientInfo = createClientInfo()
+            workspaceFolders = createWorkspaceFolders()
+            initializationOptions = getExtendedClientMetadata()
+        }
+    }
+
+    private fun createClientCapabilities(): ClientCapabilities {
+        return ClientCapabilities().apply {
+            textDocument = TextDocumentClientCapabilities().apply {
+                // For didSaveTextDocument, other textDocument/ messages always mandatory
+                synchronization = SynchronizationCapabilities().apply {
+                    didSave = true
+                }
+            }
+
+            workspace = WorkspaceClientCapabilities().apply {
+                applyEdit = false
+
+                // For workspace folder changes
+                workspaceFolders = true
+
+                // For file operations (create, delete)
+                fileOperations = FileOperationsWorkspaceCapabilities().apply {
+                    didCreate = true
+                    didDelete = true
+                }
+            }
+        }
+    }
+
+    private fun createWorkspaceFolders(): List<WorkspaceFolder> {
+        return emptyList()
+    }
+
+    private fun createClientInfo(): ClientInfo {
+        val metadata = ClientMetadata.getDefault()
+        return ClientInfo().apply {
+            name = metadata.awsProduct.toString()
+            version = metadata.awsVersion
+        }
+    }
+
+    private fun getExtendedClientMetadata(): Map<String, Any> {
+        val metadata = ClientMetadata.getDefault()
+        return mapOf(
+            "aws" to mapOf(
+                "clientInfo" to mapOf(
+                    "extension" to mapOf(
+                        "name" to metadata.awsProduct.toString(),
+                        "version" to metadata.awsVersion
+                    ),
+                    "clientId" to metadata.clientId,
+                    "version" to metadata.parentProductVersion,
+                    "name" to metadata.parentProduct
+                )
+            )
+        )
+    }
+
     init {
         val cmd = GeneralCommandLine("amazon-q-lsp")
 
@@ -116,18 +187,7 @@ class AmazonQLspService(project: Project, private val cs: CoroutineScope) : Disp
         launcherFuture = launcher.startListening()
 
         cs.launch {
-            val initializeResult = languageServer.initialize(
-                InitializeParams().apply {
-                    // does this work on windows
-                    processId = ProcessHandle.current().pid().toInt()
-                    // capabilities
-                    // client info
-                    // trace?
-                    // workspace folders?
-                    // anything else we need?
-                }
-                // probably need a timeout
-            ).await()
+            val initializeResult = languageServer.initialize(createInitializeParams()).await()
 
             // then if this succeeds then we can allow the client to send requests
             if (initializeResult == null) {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -89,16 +89,6 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
     private val launcherFuture: Future<Void>
     private val launcherHandler: KillableProcessHandler
 
-    private fun createInitializeParams(): InitializeParams {
-        return InitializeParams().apply {
-            processId = ProcessHandle.current().pid().toInt()
-            capabilities = createClientCapabilities()
-            clientInfo = createClientInfo()
-            workspaceFolders = createWorkspaceFolders()
-            initializationOptions = getExtendedClientMetadata()
-        }
-    }
-
     private fun createClientCapabilities(): ClientCapabilities {
         return ClientCapabilities().apply {
             textDocument = TextDocumentClientCapabilities().apply {
@@ -125,10 +115,12 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
 
     private fun createWorkspaceFolders(): List<WorkspaceFolder> {
         return project.basePath?.let { basePath ->
-            listOf(WorkspaceFolder(
-                URI("file://$basePath").toString(),
-                project.name
-            ))
+            listOf(
+                WorkspaceFolder(
+                    URI("file://$basePath").toString(),
+                    project.name
+                )
+            )
         } ?: emptyList()
     }
 
@@ -155,6 +147,16 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
                 )
             )
         )
+    }
+
+    private fun createInitializeParams(): InitializeParams {
+        return InitializeParams().apply {
+            processId = ProcessHandle.current().pid().toInt()
+            capabilities = createClientCapabilities()
+            clientInfo = createClientInfo()
+            workspaceFolders = createWorkspaceFolders()
+            initializationOptions = getExtendedClientMetadata()
+        }
     }
 
     init {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/ExtendedClientMetadata.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/ExtendedClientMetadata.kt
@@ -1,0 +1,43 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.model
+
+import software.aws.toolkits.jetbrains.services.telemetry.ClientMetadata
+
+data class ExtendedClientMetadata(
+    val aws: AwsMetadata,
+)
+
+data class AwsMetadata(
+    val clientInfo: ClientInfoMetadata,
+)
+
+data class ClientInfoMetadata(
+    val extension: ExtensionMetadata,
+    val clientId: String,
+    val version: String,
+    val name: String,
+)
+
+data class ExtensionMetadata(
+    val name: String,
+    val version: String,
+)
+
+fun createExtendedClientMetadata(): ExtendedClientMetadata {
+    val metadata = ClientMetadata.getDefault()
+    return ExtendedClientMetadata(
+        aws = AwsMetadata(
+            clientInfo = ClientInfoMetadata(
+                extension = ExtensionMetadata(
+                    name = metadata.awsProduct.toString(),
+                    version = metadata.awsVersion
+                ),
+                clientId = metadata.clientId,
+                version = metadata.parentProductVersion,
+                name = metadata.parentProduct
+            )
+        )
+    )
+}


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

Creates the initialization parameters for the Amazon Q LSP connection

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Initialize message is the first request sent from the client and sets up the LSP session configuration for subsequent communications. 
Includes:
 *  Process ID for server management
 *  Client capabilities for LSP features
 *  Client information (IDE/product details)
 *  Workspace folders for project context
 *  Extended client metadata specific to Amazon Q
 
 ***needs tests, not currently working

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
