### PR TITLE
fix: Fix idea.log path referenced in plugin run configurations

### DIFF
--- a/.run/Run AWS Toolkit - Community [2024.1].run.xml
+++ b/.run/Run AWS Toolkit - Community [2024.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2024.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2024.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2024.2].run.xml
+++ b/.run/Run AWS Toolkit - Community [2024.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2024.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2024.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2024.3].run.xml
+++ b/.run/Run AWS Toolkit - Community [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Gateway [2024.3].run.xml
+++ b/.run/Run AWS Toolkit - Gateway [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Gateway [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/GW-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Gateway [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Gateway [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Gateway [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/GW-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2024.1].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2024.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2024.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2024.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2024.2].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2024.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2024.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2024.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2024.3].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2024.1].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2024.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2024.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2024.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2024.2].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2024.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2024.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2024.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2024.3].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Community [2024.1].run.xml
+++ b/.run/Run All - Community [2024.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Community [2024.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/IC-2024.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Community [2024.2].run.xml
+++ b/.run/Run All - Community [2024.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Community [2024.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/IC-2024.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Community [2024.3].run.xml
+++ b/.run/Run All - Community [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Community [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/IC-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Community [2025.1].run.xml
+++ b/.run/Run All - Community [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Community [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/IC-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Rider [2024.1].run.xml
+++ b/.run/Run All - Rider [2024.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Rider [2024.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/RD-2024.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Rider [2024.2].run.xml
+++ b/.run/Run All - Rider [2024.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Rider [2024.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/RD-2024.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Rider [2024.3].run.xml
+++ b/.run/Run All - Rider [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Rider [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/RD-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Rider [2025.1].run.xml
+++ b/.run/Run All - Rider [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Rider [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/RD-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Ultimate [2024.1].run.xml
+++ b/.run/Run All - Ultimate [2024.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Ultimate [2024.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/IU-2024.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Ultimate [2024.2].run.xml
+++ b/.run/Run All - Ultimate [2024.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Ultimate [2024.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/IU-2024.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Ultimate [2024.3].run.xml
+++ b/.run/Run All - Ultimate [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Ultimate [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/IU-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run All - Ultimate [2025.1].run.xml
+++ b/.run/Run All - Ultimate [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run All - Ultimate [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/sandbox-all/build/idea-sandbox/IU-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Community [2024.1].run.xml
+++ b/.run/Run Amazon Q - Community [2024.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Community [2024.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/IC-2024.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Community [2024.2].run.xml
+++ b/.run/Run Amazon Q - Community [2024.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Community [2024.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/IC-2024.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Community [2024.3].run.xml
+++ b/.run/Run Amazon Q - Community [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Community [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/IC-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Community [2025.1].run.xml
+++ b/.run/Run Amazon Q - Community [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Community [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/IC-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Rider [2024.1].run.xml
+++ b/.run/Run Amazon Q - Rider [2024.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Rider [2024.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/RD-2024.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Rider [2024.2].run.xml
+++ b/.run/Run Amazon Q - Rider [2024.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Rider [2024.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/RD-2024.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Rider [2024.3].run.xml
+++ b/.run/Run Amazon Q - Rider [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Rider [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/RD-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Rider [2025.1].run.xml
+++ b/.run/Run Amazon Q - Rider [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Rider [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/RD-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Ultimate [2024.1].run.xml
+++ b/.run/Run Amazon Q - Ultimate [2024.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Ultimate [2024.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/IU-2024.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Ultimate [2024.2].run.xml
+++ b/.run/Run Amazon Q - Ultimate [2024.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Ultimate [2024.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/IU-2024.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Ultimate [2024.3].run.xml
+++ b/.run/Run Amazon Q - Ultimate [2024.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Ultimate [2024.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2024.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/IU-2024.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Amazon Q - Ultimate [2025.1].run.xml
+++ b/.run/Run Amazon Q - Ultimate [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Amazon Q - Ultimate [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/amazonq/build/idea-sandbox/IU-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/generateConfigs.py
+++ b/.run/generateConfigs.py
@@ -23,7 +23,7 @@ class IdeVariant:
 
 TEMPLATE = '''<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run {plugin.name} - {variant.pretty} [{major_version}]" type="GradleRunConfiguration" factoryName="Gradle" folderName="{major_version}">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/{plugin.path}/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/{plugin.path}/build/idea-sandbox/{variant.short}-{major_version}/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />


### PR DESCRIPTION
Since 2.0, logs are isolated by platform/version pair

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
