### PR TITLE
feat(amazonq): hook up lsp payload encryption

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManager.kt
@@ -1,0 +1,60 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nimbusds.jose.EncryptionMethod
+import com.nimbusds.jose.JWEAlgorithm
+import com.nimbusds.jose.JWEHeader
+import com.nimbusds.jose.JWEObject
+import com.nimbusds.jose.Payload
+import com.nimbusds.jose.crypto.DirectDecrypter
+import com.nimbusds.jose.crypto.DirectEncrypter
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.EncryptionInitializationRequest
+import java.io.OutputStream
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+
+class JwtEncryptionManager(private val key: SecretKey) {
+    constructor() : this(generateHmacKey())
+
+    private val mapper = jacksonObjectMapper()
+
+    fun writeInitializationPayload(os: OutputStream) {
+        val payload = EncryptionInitializationRequest(
+            EncryptionInitializationRequest.Version.V1_0,
+            EncryptionInitializationRequest.Mode.JWT,
+            Base64.getUrlEncoder().withoutPadding().encodeToString(key.encoded)
+        )
+
+        // write directly to stream because utils are closing the underlying stream
+        os.write("${mapper.writeValueAsString(payload)}\n".toByteArray())
+    }
+
+    fun encrypt(data: Any): String {
+        val header = JWEHeader(JWEAlgorithm.DIR, EncryptionMethod.A256GCM)
+        val payload = Payload(mapper.writeValueAsBytes(data))
+        val jweObject = JWEObject(header, payload)
+        jweObject.encrypt(DirectEncrypter(key))
+
+        return jweObject.serialize()
+    }
+
+    fun decrypt(jwt: String): String {
+        val jweObject = JWEObject.parse(jwt)
+        jweObject.decrypt(DirectDecrypter(key))
+
+        return jweObject.payload.toString()
+    }
+
+    private companion object {
+        private fun generateHmacKey(): SecretKey {
+            val keyBytes = ByteArray(32)
+            SecureRandom().nextBytes(keyBytes)
+            return SecretKeySpec(keyBytes, "HmacSHA256")
+        }
+    }
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManager.kt
@@ -36,7 +36,12 @@ class JwtEncryptionManager(private val key: SecretKey) {
 
     fun encrypt(data: Any): String {
         val header = JWEHeader(JWEAlgorithm.DIR, EncryptionMethod.A256GCM)
-        val payload = Payload(mapper.writeValueAsBytes(data))
+        val payload = if (data is String) {
+            Payload(data)
+        } else {
+            Payload(mapper.writeValueAsBytes(data))
+        }
+
         val jweObject = JWEObject(header, payload)
         jweObject.encrypt(DirectEncrypter(key))
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/EncryptionInitializationRequest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/EncryptionInitializationRequest.kt
@@ -1,0 +1,20 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.model
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+data class EncryptionInitializationRequest(
+    val version: Version,
+    val mode: Mode,
+    val key: String,
+) {
+    enum class Version(@JsonValue val value: String) {
+        V1_0("1.0"),
+    }
+
+    enum class Mode(@JsonValue val value: String) {
+        JWT("JWT"),
+    }
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/UpdateCredentialsPayload.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/credentials/UpdateCredentialsPayload.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentia
 
 data class UpdateCredentialsPayload(
     val data: String,
-    val encrypted: String,
+    val encrypted: Boolean,
 )
 
 data class UpdateCredentialsPayloadData(

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManagerTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManagerTest.kt
@@ -6,6 +6,7 @@ package software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.crypto.spec.SecretKeySpec
 import kotlin.random.Random
 
@@ -40,18 +41,26 @@ class JwtEncryptionManagerTest {
         val bytes = "DEADBEEF".repeat(8).hexToByteArray() // 32 bytes
         val key = SecretKeySpec(bytes, "HmacSHA256")
 
-        val os = ByteArrayOutputStream()
+        val closed = AtomicBoolean(false)
+        val os = object : ByteArrayOutputStream() {
+            override fun close() {
+                closed.set(true)
+            }
+        }
         JwtEncryptionManager(key).writeInitializationPayload(os)
         assertThat(os.toString())
             // Flare requires encryption ends with new line
             // https://github.com/aws/language-server-runtimes/blob/4d7f81295dc12b59ed2e1c0ebaedb85ccb86cf76/runtimes/README.md#encryption
             .endsWith("\n")
-            // language=JSON
             .isEqualTo(
+                // language=JSON
                 """
             |{"version":"1.0","mode":"JWT","key":"3q2-796tvu_erb7v3q2-796tvu_erb7v3q2-796tvu8"}
             |
                 """.trimMargin()
             )
+
+        // writeInitializationPayload should not close the stream
+        assertThat(closed.get()).isFalse
     }
 }

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManagerTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManagerTest.kt
@@ -1,0 +1,56 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import javax.crypto.spec.SecretKeySpec
+import kotlin.random.Random
+
+class JwtEncryptionManagerTest {
+    @Test
+    fun `uses a different encryption key for each instance`() {
+        val blob = Random.Default.nextBytes(256)
+        assertThat(JwtEncryptionManager().encrypt(blob))
+            .isNotEqualTo(JwtEncryptionManager().encrypt(blob))
+    }
+
+    @Test
+    @OptIn(ExperimentalStdlibApi::class)
+    fun `encryption is stable with static key`() {
+        val blob = Random.Default.nextBytes(256)
+        val bytes = "DEADBEEF".repeat(8).hexToByteArray() // 32 bytes
+        val key = SecretKeySpec(bytes, "HmacSHA256")
+        assertThat(JwtEncryptionManager(key).encrypt(blob))
+            .isNotEqualTo(JwtEncryptionManager(key).encrypt(blob))
+    }
+
+    @Test
+    fun `encryption can be round-tripped`() {
+        val sut = JwtEncryptionManager()
+        val blob = "DEADBEEF".repeat(8)
+        assertThat(sut.decrypt(sut.encrypt(blob))).isEqualTo(blob)
+    }
+
+    @Test
+    @OptIn(ExperimentalStdlibApi::class)
+    fun writeInitializationPayload() {
+        val bytes = "DEADBEEF".repeat(8).hexToByteArray() // 32 bytes
+        val key = SecretKeySpec(bytes, "HmacSHA256")
+
+        val os = ByteArrayOutputStream()
+        JwtEncryptionManager(key).writeInitializationPayload(os)
+        assertThat(os.toString())
+            // Flare requires encryption ends with new line
+            // https://github.com/aws/language-server-runtimes/blob/4d7f81295dc12b59ed2e1c0ebaedb85ccb86cf76/runtimes/README.md#encryption
+            .endsWith("\n")
+            // language=JSON
+            .isEqualTo("""
+            |{"version":"1.0","mode":"JWT","key":"3q2-796tvu_erb7v3q2-796tvu_erb7v3q2-796tvu8"}
+            |
+            """.trimMargin()
+            )
+    }
+}

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManagerTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/encryption/JwtEncryptionManagerTest.kt
@@ -47,10 +47,11 @@ class JwtEncryptionManagerTest {
             // https://github.com/aws/language-server-runtimes/blob/4d7f81295dc12b59ed2e1c0ebaedb85ccb86cf76/runtimes/README.md#encryption
             .endsWith("\n")
             // language=JSON
-            .isEqualTo("""
+            .isEqualTo(
+                """
             |{"version":"1.0","mode":"JWT","key":"3q2-796tvu_erb7v3q2-796tvu_erb7v3q2-796tvu8"}
             |
-            """.trimMargin()
+                """.trimMargin()
             )
     }
 }


### PR DESCRIPTION
Certain LSP messages require AES-256-GCM encryption packaged as JWE


 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
