### PR TITLE
fix(amazonq): /test will ignore additonal file types from payload

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/GitIgnoreFilteringUtil.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/GitIgnoreFilteringUtil.kt
@@ -56,7 +56,11 @@ class GitIgnoreFilteringUtil(
                     "*.a",
                     "*.map",
                     "*.graph",
-                    "*.so"
+                    "*.so",
+                    "*.csv",
+                    "*.dylib",
+                    "*.parquet",
+                    "*.xlsx"
                 )
             )
         }
@@ -101,6 +105,18 @@ class GitIgnoreFilteringUtil(
 
     suspend fun ignoreFile(file: VirtualFile): Boolean {
         // this method reads like something a JS dev would write and doesn't do what the author thinks
+
+        // ignores no extension files for test generation use case.
+        val allowedNoExtFiles = setOf("Config", "Dockerfile", "README")
+        if (useCase == CodeWhispererConstants.FeatureName.TEST_GENERATION &&
+            !file.isDirectory &&
+            file.extension.isNullOrEmpty() &&
+            !allowedNoExtFiles.any {
+                it.equals(file.name, ignoreCase = true)
+            }
+        ) {
+            return true
+        }
         val deferredResults = ignorePatternsWithGitIgnore.map { pattern ->
             withContext(coroutineContext) {
                 // avoid partial match (pattern.containsMatchIn) since it causes us matching files


### PR DESCRIPTION
…ase ignore list.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
 /test will ignore additonal file types from payload to reduce payload limit errors after data collection leading to these errors including .csv files, .parquet and files with no extension barring config files.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
