### PR TITLE
ci(windows): manually install jdk21

### DIFF
--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -8,6 +8,15 @@ env:
 phases:
   install:
     commands:
+      # force install java21 while we work throuh path issues
+      - |
+        $url = 'https://corretto.aws/downloads/latest/amazon-corretto-17-x64-windows-jdk.msi';
+        Write-Host ('Downloading from {0}' -f $url);
+        [ Net.ServicePointManager ]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+        Invoke-WebRequest -Uri $url -OutFile 'corretto_jdk_build.msi';
+        Start-Process 'corretto_jdk_build.msi' -PassThru | Wait-Process;
+        Write-Host 'Removing ...';
+        Remove-Item corretto_jdk_build.msi -Force;
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -35,6 +35,8 @@ phases:
         # See https://github.com/NuGet/NuGet.Client/pull/4259
         $Env:NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY = "3,1000"
 
+        $Env:JAVA_HOME = $JAVA_HOME
+
         if ($Env:CODEARTIFACT_DOMAIN_NAME -and $Env:CODEARTIFACT_REPO_NAME) {
           $Env:CODEARTIFACT_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format maven --query repositoryEndpoint --output text
           # $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -10,7 +10,7 @@ phases:
     commands:
       # force install java21 while we work throuh path issues
       - |
-        $url = 'https://corretto.aws/downloads/latest/amazon-corretto-17-x64-windows-jdk.msi';
+        $url = 'https://corretto.aws/downloads/latest/amazon-corretto-21-x64-windows-jdk.msi';
         Write-Host ('Downloading from {0}' -f $url);
         [ Net.ServicePointManager ]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
         Invoke-WebRequest -Uri $url -OutFile 'corretto_jdk_build.msi';

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -10,16 +10,8 @@ phases:
     commands:
       # force install java21 while we work throuh path issues
       - |
-        $url = 'https://corretto.aws/downloads/latest/amazon-corretto-21-x64-windows-jdk.msi';
-        Write-Host ('Downloading from {0}' -f $url);
-        [ Net.ServicePointManager ]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
-        Invoke-WebRequest -Uri $url -OutFile 'corretto_jdk_build.msi';
-        Start-Process 'corretto_jdk_build.msi' -PassThru | Wait-Process;
-        Write-Host 'Removing ...';
-        Remove-Item corretto_jdk_build.msi -Force;
-      - |
         $javaName = "C:\Program Files\Amazon Corretto" | ForEach-Object {
-          ls $_ | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name
+          ls $_ | Where-Object {$_ -Like "jdk*"} | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name
         }
         $JAVA_HOME = "C:\Program Files\Amazon Corretto\$javaName"
       - |

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -18,6 +18,11 @@ phases:
         Write-Host 'Removing ...';
         Remove-Item corretto_jdk_build.msi -Force;
       - |
+        $javaName = "C:\Program Files\Amazon Corretto" | ForEach-Object {
+          ls $_ | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name
+        }
+        $JAVA_HOME = "C:\Program Files\Amazon Corretto\$javaName"
+      - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
             Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/AwsSdkClientTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/AwsSdkClientTest.kt
@@ -122,6 +122,7 @@ class AwsSdkClientTest {
         val selfSignedJks = AwsSdkClientTest::class.java.getResource("/selfSigned.jks")
         return WireMockRule(
             wireMockConfig()
+                .httpDisabled(true)
                 .dynamicHttpsPort()
                 .keystorePath(selfSignedJks.toString())
                 .keystorePassword("changeit")


### PR DESCRIPTION
as of feb 24, 2025, codebuild has java8 first in PATH which causes gradle to fail because we require 21

this is the same hack previously used for 223
https://github.com/aws/aws-toolkit-jetbrains/blob/162acabc3809f737684257903c9b72a4273c4850/buildspec/windowsTests.yml
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
