### PR TITLE
feat(amazonq): Implement aws/credentials/token messages

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
@@ -19,5 +19,5 @@ interface AmazonQLanguageServer : LanguageServer {
     fun updateTokenCredentials(payload: UpdateCredentialsPayload): CompletableFuture<ResponseMessage>
 
     @JsonNotification("aws/credentials/token/delete")
-    fun deleteTokenCredentials()
+    fun deleteTokenCredentials(): CompletableFuture<Unit>
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.amazonq.lsp
 
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 import org.eclipse.lsp4j.services.LanguageServer
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.UpdateCredentialsPayload
@@ -16,4 +17,7 @@ import java.util.concurrent.CompletableFuture
 interface AmazonQLanguageServer : LanguageServer {
     @JsonRequest("aws/credentials/token/update")
     fun updateTokenCredentials(payload: UpdateCredentialsPayload): CompletableFuture<ResponseMessage>
+
+    @JsonNotification("aws/credentials/token/delete")
+    fun deleteTokenCredentials()
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/AuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/AuthCredentialsService.kt
@@ -8,5 +8,5 @@ import java.util.concurrent.CompletableFuture
 
 interface AuthCredentialsService {
     fun updateTokenCredentials(accessToken: String, encrypted: Boolean): CompletableFuture<ResponseMessage>
-    fun deleteTokenCredentials(): CompletableFuture<Void>
+    fun deleteTokenCredentials(): CompletableFuture<Unit>
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/AuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/AuthCredentialsService.kt
@@ -1,0 +1,12 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.auth
+
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
+import java.util.concurrent.CompletableFuture
+
+interface AuthCredentialsService {
+    fun updateTokenCredentials(accessToken: String, encrypted: Boolean): CompletableFuture<ResponseMessage>
+    fun deleteTokenCredentials(): CompletableFuture<Void>
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
@@ -26,28 +26,18 @@ class DefaultAuthCredentialsService(
 
         val payload = createUpdateCredentialsPayload(token)
 
-        return CompletableFuture<ResponseMessage>().also { completableFuture ->
-            AmazonQLspService.executeIfRunning(project) { server ->
-                server.updateTokenCredentials(payload)
-                    .whenComplete { response, throwable ->
-                        if (throwable != null) {
-                            completableFuture.completeExceptionally(throwable)
-                        } else {
-                            completableFuture.complete(response)
-                        }
-                    }
-            } ?: completableFuture.completeExceptionally(IllegalStateException("LSP Server not running"))
-        }
+        return AmazonQLspService.executeIfRunning(project) { server ->
+            server.updateTokenCredentials(payload)
+        } ?: (CompletableFuture.failedFuture(IllegalStateException("LSP Server not running")))
     }
 
-    override fun deleteTokenCredentials(): CompletableFuture<Unit> {
-        return CompletableFuture<Unit>().also { completableFuture ->
+    override fun deleteTokenCredentials(): CompletableFuture<Unit> =
+        CompletableFuture<Unit>().also { completableFuture ->
             AmazonQLspService.executeIfRunning(project) { server ->
                 server.deleteTokenCredentials()
                 completableFuture.complete(null)
             } ?: completableFuture.completeExceptionally(IllegalStateException("LSP Server not running"))
         }
-    }
 
     private fun createUpdateCredentialsPayload(token: String): UpdateCredentialsPayload =
         UpdateCredentialsPayload(

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
@@ -40,8 +40,8 @@ class DefaultAuthCredentialsService(
         }
     }
 
-    override fun deleteTokenCredentials(): CompletableFuture<Void> {
-        return CompletableFuture<Void>().also { completableFuture ->
+    override fun deleteTokenCredentials(): CompletableFuture<Unit> {
+        return CompletableFuture<Unit>().also { completableFuture ->
             AmazonQLspService.executeIfRunning(project) { server ->
                 server.deleteTokenCredentials()
                 completableFuture.complete(null)
@@ -49,8 +49,8 @@ class DefaultAuthCredentialsService(
         }
     }
 
-    private fun createUpdateCredentialsPayload(token: String): UpdateCredentialsPayload {
-        return UpdateCredentialsPayload(
+    private fun createUpdateCredentialsPayload(token: String): UpdateCredentialsPayload =
+        UpdateCredentialsPayload(
             data = encryptionManager.encrypt(
                 UpdateCredentialsPayloadData(
                     BearerCredentials(token)
@@ -58,5 +58,4 @@ class DefaultAuthCredentialsService(
             ),
             encrypted = true
         )
-    }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
@@ -1,0 +1,62 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.auth
+
+import com.intellij.openapi.project.Project
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption.JwtEncryptionManager
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.BearerCredentials
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.UpdateCredentialsPayload
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.UpdateCredentialsPayloadData
+import java.util.concurrent.CompletableFuture
+
+class DefaultAuthCredentialsService(
+    private val project: Project,
+    private val encryptionManager: JwtEncryptionManager,
+) : AuthCredentialsService {
+
+    override fun updateTokenCredentials(accessToken: String, encrypted: Boolean): CompletableFuture<ResponseMessage> {
+        val token = if (encrypted) {
+            encryptionManager.decrypt(accessToken)
+        } else {
+            accessToken
+        }
+
+        val payload = createUpdateCredentialsPayload(token)
+
+        return CompletableFuture<ResponseMessage>().also { completableFuture ->
+            AmazonQLspService.executeIfRunning(project) { server ->
+                server.updateTokenCredentials(payload)
+                    .whenComplete { response, throwable ->
+                        if (throwable != null) {
+                            completableFuture.completeExceptionally(throwable)
+                        } else {
+                            completableFuture.complete(response)
+                        }
+                    }
+            } ?: completableFuture.completeExceptionally(IllegalStateException("LSP Server not running"))
+        }
+    }
+
+    override fun deleteTokenCredentials(): CompletableFuture<Void> {
+        return CompletableFuture<Void>().also { completableFuture ->
+            AmazonQLspService.executeIfRunning(project) { server ->
+                server.deleteTokenCredentials()
+                completableFuture.complete(null)
+            } ?: completableFuture.completeExceptionally(IllegalStateException("LSP Server not running"))
+        }
+    }
+
+    private fun createUpdateCredentialsPayload(token: String): UpdateCredentialsPayload {
+        return UpdateCredentialsPayload(
+            data = encryptionManager.encrypt(
+                UpdateCredentialsPayloadData(
+                    BearerCredentials(token)
+                )
+            ),
+            encrypted = true
+        )
+    }
+}

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsServiceTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsServiceTest.kt
@@ -5,11 +5,8 @@ package software.aws.toolkits.jetbrains.services.amazonq.lsp.auth
 
 import com.intellij.openapi.components.serviceIfCreated
 import com.intellij.openapi.project.Project
-import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.verify
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import org.junit.Before
@@ -38,10 +35,10 @@ class DefaultAuthCredentialsServiceTest {
         every { project.serviceIfCreated<AmazonQLspService>() } returns mockLspService
 
         // Mock the LSP service's executeSync method as a suspend function
-        coEvery {
-            mockLspService.executeSync(any())
+        every {
+            mockLspService.executeSync<CompletableFuture<ResponseMessage>>(any())
         } coAnswers {
-            val func = firstArg<suspend (AmazonQLanguageServer) -> Unit>()
+            val func = firstArg<suspend (AmazonQLanguageServer) -> CompletableFuture<ResponseMessage>>()
             func.invoke(mockLanguageServer)
         }
 
@@ -87,7 +84,7 @@ class DefaultAuthCredentialsServiceTest {
 
     @Test
     fun `test deleteTokenCredentials success`() {
-        every { mockLanguageServer.deleteTokenCredentials() } just runs
+        every { mockLanguageServer.deleteTokenCredentials() } returns CompletableFuture.completedFuture(Unit)
 
         sut.deleteTokenCredentials()
 

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsServiceTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsServiceTest.kt
@@ -1,0 +1,96 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.auth
+
+import com.intellij.openapi.components.serviceIfCreated
+import com.intellij.openapi.project.Project
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
+import org.junit.Before
+import org.junit.Test
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLanguageServer
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption.JwtEncryptionManager
+import java.util.concurrent.CompletableFuture
+
+class DefaultAuthCredentialsServiceTest {
+    private lateinit var project: Project
+    private lateinit var mockLanguageServer: AmazonQLanguageServer
+    private lateinit var mockEncryptionManager: JwtEncryptionManager
+    private lateinit var sut: DefaultAuthCredentialsService
+
+    @Before
+    fun setUp() {
+        project = mockk<Project>()
+        mockLanguageServer = mockk<AmazonQLanguageServer>()
+        mockEncryptionManager = mockk<JwtEncryptionManager>()
+        every { mockEncryptionManager.encrypt(any()) } returns "mock-encrypted-data"
+
+        // Mock the service methods on Project
+        val mockLspService = mockk<AmazonQLspService>()
+        every { project.getService(AmazonQLspService::class.java) } returns mockLspService
+        every { project.serviceIfCreated<AmazonQLspService>() } returns mockLspService
+
+        // Mock the LSP service's executeSync method as a suspend function
+        coEvery {
+            mockLspService.executeSync(any())
+        } coAnswers {
+            val func = firstArg<suspend (AmazonQLanguageServer) -> Unit>()
+            func.invoke(mockLanguageServer)
+        }
+
+        sut = DefaultAuthCredentialsService(project, this.mockEncryptionManager)
+    }
+
+    @Test
+    fun `test updateTokenCredentials unencrypted success`() {
+        val token = "unencryptedToken"
+        val isEncrypted = false
+
+        every {
+            mockLanguageServer.updateTokenCredentials(any())
+        } returns CompletableFuture.completedFuture(ResponseMessage())
+
+        sut.updateTokenCredentials(token, isEncrypted)
+
+        verify(exactly = 0) {
+            mockEncryptionManager.decrypt(any())
+        }
+        verify(exactly = 1) {
+            mockLanguageServer.updateTokenCredentials(any())
+        }
+    }
+
+    @Test
+    fun `test updateTokenCredentials encrypted success`() {
+        val encryptedToken = "encryptedToken"
+        val decryptedToken = "decryptedToken"
+        val isEncrypted = true
+
+        every { mockEncryptionManager.decrypt(encryptedToken) } returns decryptedToken
+        every { mockEncryptionManager.encrypt(any()) } returns "mock-encrypted-data"
+        every {
+            mockLanguageServer.updateTokenCredentials(any())
+        } returns CompletableFuture.completedFuture(ResponseMessage())
+
+        sut.updateTokenCredentials(encryptedToken, isEncrypted)
+
+        verify(exactly = 1) { mockEncryptionManager.decrypt(encryptedToken) }
+        verify(exactly = 1) { mockLanguageServer.updateTokenCredentials(any()) }
+    }
+
+    @Test
+    fun `test deleteTokenCredentials success`() {
+        every { mockLanguageServer.deleteTokenCredentials() } just runs
+
+        sut.deleteTokenCredentials()
+
+        verify(exactly = 1) { mockLanguageServer.deleteTokenCredentials() }
+    }
+}


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Added service handlers for aws/credential messages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Implemented credential service class to invoke messaging the LSP server for token updates and token deletion.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
