### PR TITLE
build(251): fix rider project classes not found

### DIFF
--- a/plugins/toolkit/jetbrains-rider/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-rider/build.gradle.kts
@@ -75,7 +75,7 @@ dependencies {
         // FIX_WHEN_MIN_IS_251: https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1774
         when (providers.gradleProperty("ideProfileName").get()) {
             "2023.3", "2024.1" -> {}
-            "2024.2", "2024.3" -> {
+            "2024.2", "2024.3", "2025.1" -> {
                 bundledModule("intellij.rider")
             }
         }


### PR DESCRIPTION
Missing classes come from rider bundled library
```
> Task :plugin-toolkit:jetbrains-rider:compileKotlin FAILED
w: Language version 2.1 is experimental, there are no backwards compatibility guarantees for new language and library features
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:13:50 Unresolved reference 'msbuild'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:14:40 Unresolved reference 'SolutionManager'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:15:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:16:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:17:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:25:26 Unresolved reference 'NewProjectDialogContext'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:26:18 Unresolved reference 'ProjectTemplatesSharedModel'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:28:5 'expandTemplate' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:33:33 Unresolved reference 'getSolutionDirectory'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:48:21 Unresolved reference 'project'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:49:13 Unresolved reference 'projectNameProperty'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:49:13 Argument type mismatch: actual type is 'kotlin.text.MatchGroup?', but 'kotlin.String' was expected.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:57:13 Overload resolution ambiguity between candidates:
constructor(p0: String!, p1: String!): File
constructor(p0: File!, p1: String!): File
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:57:76 Unresolved reference 'CsprojFileType'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:58:17 Overload resolution ambiguity between candidates:
constructor(p0: String!, p1: String!): File
constructor(p0: File!, p1: String!): File
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:58:81 Unresolved reference 'CsprojFileType'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:61:72 Unresolved reference 'isFile'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:61:82 Overload resolution ambiguity between candidates:
fun <T> Pair<T, T>.toList(): List<T>
fun <T> Triple<T, T, T>.toList(): List<T>
fun <T> Array<out T>.toList(): List<T>
fun BooleanArray.toList(): List<Boolean>
fun ByteArray.toList(): List<Byte>
fun CharArray.toList(): List<Char>
fun DoubleArray.toList(): List<Double>
fun FloatArray.toList(): List<Float>
fun IntArray.toList(): List<Int>
fun LongArray.toList(): List<Long>
fun ShortArray.toList(): List<Short>
@InlineOnly() fun <T> Enumeration<T>.toList(): List<T>
fun <T> Iterable<T>.toList(): List<T>
fun <K, V> Map<out K, V>.toList(): List<Pair<K, V>>
fun <T> Sequence<T>.toList(): List<T>
fun CharSequence.toList(): List<Char>
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:63:28 Unresolved reference 'ProjectTemplatesExpanderUtils'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:64:20 Unresolved reference 'solutionNameProperty'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:67:36 Unresolved reference 'protocolHost'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:73:17 Unresolved reference 'SolutionManager'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:79:17 Unresolved reference 'createGitRepositoryProperty'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:79:17 Condition type mismatch: inferred type is 'kotlin.text.MatchGroup?' but 'Boolean' was expected.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:79:54 Unresolved reference 'repositoryInitializer'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGenerator.kt:80:17 Unresolved reference 'repositoryInitializer'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:12:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:13:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:14:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:15:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:16:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:26:26 Unresolved reference 'NewProjectDialogContext'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:27:18 Unresolved reference 'ProjectTemplatesSharedModel'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:28:5 Unresolved reference 'ProjectTemplateGeneratorBase'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:38:5 'defaultName' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:59:9 Unresolved reference 'projectNameProperty'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:60:9 Unresolved reference 'sameDirectoryProperty'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:65:5 'getComponent' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:66:25 Unresolved reference 'ProjectTemplateGeneratorBase'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:66:31 Unresolved reference 'getComponent'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:67:9 Unresolved reference 'projectNameTextField'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:68:9 Unresolved reference 'sameDirectoryCheckbox'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:72:5 'createTemplateSpecificPanel' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:78:5 'checkIsAbleToExpand' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:80:9 Unresolved reference 'canExpand'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:87:21 Unresolved reference 'statusMessages'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:87:40 Unresolved reference 'StatusMessages'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:90:17 Unresolved reference 'statusMessages'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:90:46 Unresolved reference 'type'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectGeneratorRoot.kt:90:54 Unresolved reference 'StatusMessageType'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:9:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:10:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:11:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:12:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:13:40 Unresolved reference 'projectTemplates'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:17:34 Unresolved reference 'ProjectTemplateProvider'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:19:5 'isReady' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:21:5 'load' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:21:52 Unresolved reference 'NewProjectDialogContext'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:21:92 Unresolved reference 'ProjectTemplateType'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:24:37 Unresolved reference 'ProjectTemplateType'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:25:9 'group' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:26:9 'icon' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:27:9 'name' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:28:9 'order' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:30:9 'createGenerator' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:30:67 Unresolved reference 'NewProjectDialogContext'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:30:105 Unresolved reference 'ProjectTemplatesSharedModel'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:30:135 Unresolved reference 'ProjectTemplateGenerator'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src-241+/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamProjectProvider.kt:33:9 'getKeywords' overrides nothing.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt:8:50 Unresolved reference 'vb'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetRuntimeGroup.kt:21:9 Unresolved reference 'VbLanguage'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:25:37 Unresolved reference 'DebuggerWorkerProcessHandler'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:26:37 Unresolved reference 'RiderDebuggerWorkerModelManager'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:31:28 Unresolved reference 'run'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:32:28 Unresolved reference 'run'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:92:13 Unresolved reference 'RiderDebuggerWorkerModelManager'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:123:37 Unresolved reference 'initialized'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:123:93 Cannot infer type for this parameter. Please specify it explicitly.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:124:33 Unresolved reference 'not' for operator '!'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:140:60 Unresolved reference 'bindToSettings'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:140:120 Cannot infer type for this parameter. Please specify it explicitly.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:141:33 Unresolved reference 'enableHeuristicPathResolve'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:144:41 Unresolved reference 'activeSession'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:153:54 Unresolved reference 'DebuggerWorkerProcessHandler'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotnetDebugUtils.kt:162:69 Unresolved reference 'IDebuggerOutputListener'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetDebuggerUtils.kt:15:37 Unresolved reference 'DotNetDebugProcess'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetDebuggerUtils.kt:16:37 Unresolved reference 'DotNetDebugRunner'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetDebuggerUtils.kt:17:37 Unresolved reference 'actions'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetDebuggerUtils.kt:19:28 Unresolved reference 'run'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetDebuggerUtils.kt:36:31 Unresolved reference 'IDebuggerOutputListener'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetDebuggerUtils.kt:38:55 Unresolved reference 'DotNetDebugRunner'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetDebuggerUtils.kt:41:73 Unresolved reference 'DotNetDebugProcess'.
e: file:///aws-toolkit-jetbrains/plugins/toolkit/jetbrains-rider/src/software/aws/toolkits/jetbrains/utils/DotNetDebuggerUtils.kt:50:17 Unresolved reference 'OptionsUtil'.
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
