### PR TITLE
ci(windows): Fix indentation error causing failure

### DIFF
--- a/buildspec/windowsTestsForAmazonQ.yml
+++ b/buildspec/windowsTestsForAmazonQ.yml
@@ -8,12 +8,12 @@ env:
 phases:
   install:
     commands:
-      - # force install java21 while we work throuh path issues
-        - |
-          $javaName = "C:\Program Files\Amazon Corretto" | ForEach-Object {
-            ls $_ | Where-Object {$_ -Like "jdk*"} | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name
-          }
-          $JAVA_HOME = "C:\Program Files\Amazon Corretto\$javaName"
+      # force install java21 while we work through path issues
+      - |
+        $javaName = "C:\Program Files\Amazon Corretto" | ForEach-Object {
+          ls $_ | Where-Object {$_ -Like "jdk*"} | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name
+        }
+        $JAVA_HOME = "C:\Program Files\Amazon Corretto\$javaName"
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;

--- a/buildspec/windowsTestsForCore.yml
+++ b/buildspec/windowsTestsForCore.yml
@@ -8,7 +8,7 @@ env:
 phases:
   install:
     commands:
-      # force install java21 while we work throuh path issues
+      # force install java21 while we work through path issues
       - |
         $javaName = "C:\Program Files\Amazon Corretto" | ForEach-Object {
           ls $_ | Where-Object {$_ -Like "jdk*"} | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -8,7 +8,7 @@ env:
 phases:
   install:
     commands:
-      # force install java21 while we work throuh path issues
+      # force install java21 while we work through path issues
       - |
         $javaName = "C:\Program Files\Amazon Corretto" | ForEach-Object {
           ls $_ | Where-Object {$_ -Like "jdk*"} | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
fix an indent issue that was resulting in:

`[Container] 2025/02/28 00:27:55.498059 Running on CodeBuild On-demand
[Container] 2025/02/28 00:27:55.498059 Waiting for agent ping
[Container] 2025/02/28 00:27:55.600906 Waiting for DOWNLOAD_SOURCE
[Container] 2025/02/28 00:27:59.099279 Phase is DOWNLOAD_SOURCE
[Container] 2025/02/28 00:27:59.329947 CODEBUILD_SRC_DIR=C:\codebuild\tmp\output\src2448846166\src
[Container] 2025/02/28 00:27:59.340879 YAML location is C:\codebuild\tmp\output\src2448846166\src\buildspec\windowsTestsForAmazonQ.yml
[Container] 2025/02/28 00:27:59.342033 Phase complete: DOWNLOAD_SOURCE State: FAILED
[Container] 2025/02/28 00:27:59.342033 Phase context status code: YAML_FILE_ERROR Message: Expected Commands[0] to be of string type: found list instead at line 12

`
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
