### PR TITLE
feat(amazonq): add listeners for aws/credentials/token message service 

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -45,6 +45,7 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.isDeveloperMode
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.auth.DefaultAuthCredentialsService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption.JwtEncryptionManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.createExtendedClientMetadata
 import software.aws.toolkits.jetbrains.services.telemetry.ClientMetadata
@@ -303,6 +304,8 @@ private class AmazonQServerInstance(private val project: Project, private val cs
             }
             languageServer.initialized(InitializedParams())
         }
+
+        DefaultAuthCredentialsService(project, encryptionManager, this)
     }
 
     override fun dispose() {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
@@ -3,8 +3,14 @@
 
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.auth
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
+import software.aws.toolkits.core.TokenConnectionSettings
+import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
+import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
+import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProvider
+import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption.JwtEncryptionManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.BearerCredentials
@@ -15,7 +21,31 @@ import java.util.concurrent.CompletableFuture
 class DefaultAuthCredentialsService(
     private val project: Project,
     private val encryptionManager: JwtEncryptionManager,
-) : AuthCredentialsService {
+    serverInstance: Disposable,
+) : AuthCredentialsService,
+    BearerTokenProviderListener {
+    init {
+        project.messageBus.connect(serverInstance).subscribe(BearerTokenProviderListener.TOPIC, this)
+    }
+
+    override fun onChange(providerId: String, newScopes: List<String>?) {
+        val connection = ToolkitConnectionManager.getInstance(project)
+            .activeConnectionForFeature(QConnection.getInstance())
+            ?: return
+
+        val provider = (connection.getConnectionSettings() as? TokenConnectionSettings)
+            ?.tokenProvider
+            ?.delegate as? BearerTokenProvider
+            ?: return
+
+        provider.currentToken()?.accessToken?.let { token ->
+            updateTokenCredentials(token, false)
+        }
+    }
+
+    override fun invalidate(providerId: String) {
+        deleteTokenCredentials()
+    }
 
     override fun updateTokenCredentials(accessToken: String, encrypted: Boolean): CompletableFuture<ResponseMessage> {
         val token = if (encrypted) {

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsServiceTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsServiceTest.kt
@@ -3,10 +3,15 @@
 
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.auth
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.serviceIfCreated
 import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import org.junit.Before
@@ -42,7 +47,14 @@ class DefaultAuthCredentialsServiceTest {
             func.invoke(mockLanguageServer)
         }
 
-        sut = DefaultAuthCredentialsService(project, this.mockEncryptionManager)
+        // Mock message bus
+        val messageBus = mockk<MessageBus>()
+        every { project.messageBus } returns messageBus
+        val mockConnection = mockk<MessageBusConnection>()
+        every { messageBus.connect(any<Disposable>()) } returns mockConnection
+        every { mockConnection.subscribe(any(), any()) } just runs
+
+        sut = DefaultAuthCredentialsService(project, this.mockEncryptionManager, mockk())
     }
 
     @Test


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Hook functions to listeners to send appropriate messages upon event.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Utilize BearerTokenProviderListener to alert the service for onChange and invalidate events.
Token retrieved from ToolkitConnectionManager and sent through to the message service if its the right one. 

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
