### PR TITLE
feat(amazonq): Added changes for override lsp artifacts

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/artifacts/ArtifactManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/artifacts/ArtifactManager.kt
@@ -3,7 +3,10 @@
 
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.artifacts
 
+import com.intellij.openapi.fileChooser.FileChooser
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.util.text.SemVer
 import org.jetbrains.annotations.VisibleForTesting
 import software.aws.toolkits.core.utils.error
@@ -11,6 +14,7 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.jetbrains.services.amazonq.project.manifest.ManifestManager
 import java.nio.file.Path
+import java.nio.file.Paths
 
 class ArtifactManager(
     private val project: Project,
@@ -104,5 +108,19 @@ class ArtifactManager(
         }
         logger.info { "Target found in the current Version: ${versions.first().serverVersion}" }
         return currentTarget
+    }
+
+    fun overrideLspArtifacts(): Path? {
+        val baseDir = VfsUtil.getUserHomeDir()
+
+        val fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFileDescriptor()
+            .withTitle("Select Artifact")
+            .withDescription("Choose a file to upload")
+            .withExtensionFilter("js")
+        fileChooserDescriptor.isForcedToUseIdeaFileChooser = true
+
+        return FileChooser.chooseFile(fileChooserDescriptor, project, baseDir)?.path?.let {
+            Paths.get(it)
+        }
     }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
When user want to override existing LSP artifacts this method will help them to select the corresponding JS file.

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
