### PR TITLE
fix(amazonq):fix cross-tab data interference

### DIFF
--- a/.changes/next-release/bugfix-79596dfc-37a0-44c8-adf2-a6c87ba806ac.json
+++ b/.changes/next-release/bugfix-79596dfc-37a0-44c8-adf2-a6c87ba806ac.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q: Fix data isolation between tabs to prevent interference when using /doc in multiple tabs"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Toolkit Version
-toolkitVersion=3.57
+toolkitVersion=3.58-SNAPSHOT
 
 # Publish Settings
 publishToken=

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocControllerExtensions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocControllerExtensions.kt
@@ -31,7 +31,7 @@ suspend fun DocController.onCodeGeneration(session: DocSession, message: String,
         messenger.sendAsyncEventProgress(tabId, inProgress = true)
         messenger.sendUpdatePromptProgress(tabId, inProgress(progress = 10, message("amazonqDoc.progress_message.scanning")))
         messenger.sendAnswer(
-            message = docGenerationProgressMessage(DocGenerationStep.UPLOAD_TO_S3, this.mode),
+            message = docGenerationProgressMessage(DocGenerationStep.UPLOAD_TO_S3, mode),
             messageType = DocMessageType.AnswerPart,
             tabId = tabId,
         )
@@ -108,7 +108,7 @@ suspend fun DocController.onCodeGeneration(session: DocSession, message: String,
             messenger.sendAnswer(
                 tabId = tabId,
                 messageType = DocMessageType.Answer,
-                message = if (this.mode === Mode.CREATE) {
+                message = if (mode === Mode.CREATE) {
                     message("amazonqDoc.answer.readmeCreated")
                 } else {
                     "${message("amazonqDoc.answer.readmeUpdated")} ${message("amazonqDoc.answer.codeResult")}"

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocGenerationTask.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocGenerationTask.kt
@@ -11,7 +11,19 @@ import software.amazon.awssdk.services.codewhispererruntime.model.DocV2Generatio
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 
+class DocGenerationTasks {
+    private val tasks: MutableMap<String, DocGenerationTask> = mutableMapOf()
+
+    fun getTask(tabId: String): DocGenerationTask = tasks.getOrPut(tabId) { DocGenerationTask() }
+
+    fun deleteTask(tabId: String) {
+        tasks.remove(tabId)
+    }
+}
+
 class DocGenerationTask {
+    var mode: Mode = Mode.NONE
+
     // Telemetry fields
     var conversationId: String? = null
     var numberOfAddedChars: Int? = null
@@ -22,8 +34,8 @@ class DocGenerationTask {
     var numberOfGeneratedFiles: Int? = null
     var userDecision: DocUserDecision? = null
     var interactionType: DocInteractionType? = null
-    var numberOfNavigations = 0
-    var folderLevel: DocFolderLevel? = DocFolderLevel.ENTIRE_WORKSPACE
+    var numberOfNavigations: Int = 0
+    var folderLevel: DocFolderLevel = DocFolderLevel.ENTIRE_WORKSPACE
     fun docGenerationEventBase(): DocV2GenerationEvent {
         val undefinedProps = this::class.java.declaredFields
             .filter { it.get(this) == null }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Context
When users open multiple tabs while using /doc command, tab data interferes with each other
This causes incorrect user flow and inaccurate telemetry tracking
- Solution:
Implemented proper tab isolation mechanism
Ensured each tab maintains its own independent state

<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
