### PR TITLE
fix(amazonq): fix failing lsp artifact tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,6 +106,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlin-stdLibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 mockk = { module = "io.mockk:mockk", version.ref="mockk" }
 nimbus-jose-jwt = {module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus-jose-jwt"}
@@ -121,7 +122,7 @@ zjsonpatch = { module = "com.flipkart.zjsonpatch:zjsonpatch", version.ref = "zjs
 [bundles]
 jackson = ["jackson-datetime", "jackson-kotlin", "jackson-yaml", "jackson-xml"]
 kotlin = ["kotlin-stdLibJdk8", "kotlin-reflect"]
-mockito = ["mockito-core", "mockito-kotlin"]
+mockito = ["mockito-core", "mockito-junit-jupiter", "mockito-kotlin"]
 sshd = ["sshd-core", "sshd-scp", "sshd-sftp"]
 
 [plugins]

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/artifacts/ArtifactHelper.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/artifacts/ArtifactHelper.kt
@@ -112,7 +112,7 @@ class ArtifactHelper(private val lspArtifactsPath: Path = DEFAULT_ARTIFACT_PATH,
             logger.info { "Attempt ${currentAttempt.get()} of $maxDownloadAttempts to download LSP artifacts" }
 
             try {
-                withBackgroundProgress(
+                return withBackgroundProgress(
                     project,
                     AwsCoreBundle.message("amazonqFeatureDev.placeholder.downloading_and_extracting_lsp_artifacts"),
                     cancellable = true
@@ -123,9 +123,12 @@ class ArtifactHelper(private val lspArtifactsPath: Path = DEFAULT_ARTIFACT_PATH,
                             .mapNotNull { it.filename }
                             .forEach { filename -> extractZipFile(downloadPath.resolve(filename), downloadPath) }
                         logger.info { "Successfully downloaded and moved LSP artifacts to $downloadPath" }
+
+                        return@withBackgroundProgress downloadPath
                     }
+
+                    return@withBackgroundProgress null
                 }
-                return downloadPath
             } catch (e: Exception) {
                 when (e) {
                     is CancellationException -> {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/artifacts/ManifestFetcher.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/artifacts/ManifestFetcher.kt
@@ -19,7 +19,7 @@ import java.nio.file.Path
 class ManifestFetcher(
     private val lspManifestUrl: String = DEFAULT_MANIFEST_URL,
     private val manifestManager: ManifestManager = ManifestManager(),
-    private val lspManifestFilePath: Path = DEFAULT_MANIFEST_PATH,
+    private val manifestPath: Path = DEFAULT_MANIFEST_PATH,
 ) {
     companion object {
         private val logger = getLogger<ManifestFetcher>()
@@ -33,6 +33,10 @@ class ManifestFetcher(
             .resolve("language-servers")
             .resolve("jetbrains-lsp-manifest.json")
     }
+
+    @get:VisibleForTesting
+    internal val lspManifestFilePath: Path
+        get() = manifestPath
 
     /**
      * Method which will be used to fetch latest manifest.

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/artifacts/ArtifactHelperTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/artifacts/ArtifactHelperTest.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.artifacts
 
 import com.intellij.openapi.project.Project
+import com.intellij.testFramework.ApplicationExtension
 import com.intellij.util.io.createDirectories
 import com.intellij.util.text.SemVer
 import io.mockk.Runs
@@ -14,16 +15,16 @@ import io.mockk.mockkStatic
 import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.annotations.TestOnly
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import org.mockito.kotlin.mock
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.artifacts.ArtifactManager.SupportedManifestVersionRange
 import software.aws.toolkits.jetbrains.services.amazonq.project.manifest.ManifestManager
 import java.nio.file.Path
 
-@TestOnly
+@ExtendWith(ApplicationExtension::class)
 class ArtifactHelperTest {
     @TempDir
     lateinit var tempDir: Path


### PR DESCRIPTION
Tests were not working correctly due to dependency on application, but tests did not declare usage of ApplicationExtension

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
