### PR TITLE
Revert "feat(amazonq): generate scanName from workspace config (#5409)"

### DIFF
--- a/.changes/next-release/feature-0b164167-b04b-4a26-a59b-5ac41a717975.json
+++ b/.changes/next-release/feature-0b164167-b04b-4a26-a59b-5ac41a717975.json
@@ -1,4 +1,0 @@
-{
-  "type" : "feature",
-  "description" : "/review: Code reviews are now created with additional workspace context to enable grouping of related scans in the backend"
-}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
@@ -7,21 +7,16 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.modules
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.vfs.LocalFileSystem
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.time.withTimeout
 import kotlinx.coroutines.withContext
-import migration.software.aws.toolkits.jetbrains.settings.AwsSettings
-import org.apache.commons.codec.digest.DigestUtils
 import software.amazon.awssdk.services.codewhisperer.model.ArtifactType
 import software.amazon.awssdk.services.codewhisperer.model.CodeScanFindingsSchema
 import software.amazon.awssdk.services.codewhisperer.model.CodeScanStatus
@@ -38,14 +33,12 @@ import software.aws.toolkits.core.utils.Waiters.waitUntil
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
-import software.aws.toolkits.core.utils.toHexString
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.CodeScanSessionConfig
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.sessionconfig.PayloadContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWhispererClientAdaptor
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.CodeWhispererExplorerActionManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CodeScanResponseContext
 import software.aws.toolkits.jetbrains.services.codewhisperer.model.CreateUploadUrlServiceInvocationContext
-import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.CODE_SCAN_POLLING_INTERVAL_IN_SECONDS
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.FILE_SCANS_THROTTLING_MESSAGE
@@ -59,14 +52,12 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.getTelemetryErrorMessage
 import software.aws.toolkits.jetbrains.utils.assertIsNonDispatchThread
 import software.aws.toolkits.resources.message
-import software.aws.toolkits.telemetry.CodewhispererCodeScanScope
 import software.aws.toolkits.telemetry.CodewhispererLanguage
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 import kotlin.coroutines.coroutineContext
-import kotlin.io.path.pathString
 
 class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
     private val clientToken: UUID = UUID.randomUUID()
@@ -112,7 +103,7 @@ class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
             // 2 & 3. CreateUploadURL and upload the context.
             currentCoroutineContext.ensureActive()
             val artifactsUploadStartTime = now()
-            val codeScanName = generateScanName()
+            val codeScanName = UUID.randomUUID().toString()
 
             val taskType = if (sessionContext.codeAnalysisScope == CodeWhispererConstants.CodeAnalysisScope.PROJECT) {
                 CodeWhispererConstants.UploadTaskType.SCAN_PROJECT
@@ -374,26 +365,6 @@ class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
 
     private fun isAutoScan(): Boolean =
         sessionContext.codeAnalysisScope == CodeWhispererConstants.CodeAnalysisScope.FILE && !sessionContext.sessionConfig.isInitiatedByChat()
-
-    private fun generateScanName(): String {
-        val clientId = AwsSettings.getInstance().clientId
-        val filePath = sessionContext.sessionConfig.getSelectedFile()?.toNioPath()?.pathString
-        val scope = CodeWhispererTelemetryService.getInstance().mapToTelemetryScope(
-            sessionContext.codeAnalysisScope,
-            sessionContext.sessionConfig.isInitiatedByChat()
-        )
-        val projectId = if (scope != CodewhispererCodeScanScope.PROJECT && filePath != null) {
-            filePath
-        } else {
-            ApplicationManager.getApplication().runReadAction<String> {
-                sessionContext.project.modules.map { module ->
-                    ModuleRootManager.getInstance(module).contentRoots.firstOrNull()?.path
-                }.joinToString(",")
-            }
-        }
-
-        return DigestUtils.sha256("$clientId::$projectId::$scope").toHexString()
-    }
 
     companion object {
         private val LOG = getLogger<CodeWhispererCodeScanSession>()

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/telemetry/CodeWhispererTelemetryService.kt
@@ -285,7 +285,7 @@ class CodeWhispererTelemetryService {
         )
     }
 
-    fun mapToTelemetryScope(codeAnalysisScope: CodeWhispererConstants.CodeAnalysisScope, initiatedByChat: Boolean): CodewhispererCodeScanScope =
+    private fun mapToTelemetryScope(codeAnalysisScope: CodeWhispererConstants.CodeAnalysisScope, initiatedByChat: Boolean): CodewhispererCodeScanScope =
         when (codeAnalysisScope) {
             CodeWhispererConstants.CodeAnalysisScope.FILE -> {
                 if (initiatedByChat) {


### PR DESCRIPTION
This reverts commit b74ba3177a6f3c3df6b59a937c4a2eab996866a2.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Scan name change is causing unexpected behavior from the service.

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
