### PR TITLE
fix(amazonq): always send creds on lsp init if available

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -316,11 +316,18 @@ private class AmazonQServerInstance(private val project: Project, private val cs
             initializeResult
         }
 
-        DefaultAuthCredentialsService(project, encryptionManager, this)
-        TextDocumentServiceHandler(project, this)
-        WorkspaceServiceHandler(project, this)
-        cs.launch {
-            DefaultModuleDependenciesService(project, this@AmazonQServerInstance)
+        // invokeOnCompletion results in weird lock/timeout error
+        initializeResult.asCompletableFuture().handleAsync { r, ex ->
+            if (ex != null) {
+                return@handleAsync
+            }
+
+            this@AmazonQServerInstance.apply {
+                DefaultAuthCredentialsService(project, encryptionManager, this)
+                TextDocumentServiceHandler(project, this)
+                WorkspaceServiceHandler(project, this)
+                DefaultModuleDependenciesService(project, this)
+            }
         }
     }
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
@@ -26,6 +26,8 @@ class DefaultAuthCredentialsService(
     BearerTokenProviderListener {
     init {
         project.messageBus.connect(serverInstance).subscribe(BearerTokenProviderListener.TOPIC, this)
+
+        onChange("init", null)
     }
 
     override fun onChange(providerId: String, newScopes: List<String>?) {


### PR DESCRIPTION
Previously lsp server gets token by luck depending on timing of credential events. Instead, client should explicitly send token after server finishes init
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
