### PR TITLE
fix(amazonq): increase chat timeout threshold

### DIFF
--- a/.changes/next-release/bugfix-fd9065e5-2661-4250-852c-ec51deedd10f.json
+++ b/.changes/next-release/bugfix-fd9065e5-2661-4250-852c-ec51deedd10f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "fix Q chat request timeout"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/ChatConstants.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/ChatConstants.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkits.jetbrains.services.cwc
 
 object ChatConstants {
-    const val REQUEST_TIMEOUT_MS = 60_000 // 60 seconds
+    const val REQUEST_TIMEOUT_MS = 180_000 // 180 seconds
 
     // API Constraints
     const val FILE_PATH_SIZE_LIMIT = 4_000 // Maximum length of file paths in characters (actual API limit: 4096)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Customer reported issue that chat request timeout in IntelliJ while it works in VSC, so increasing the chat timeout limit to be 3 minutes.

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
