### PR TITLE
ci: stop using dockerhub token

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -15,10 +15,6 @@ phases:
   install:
     commands:
       - startDocker.sh
-      # login to DockerHub so we don't get throttled
-      - export DOCKER_USERNAME=`echo $DOCKER_HUB_TOKEN | jq -r '.username'`
-      - export DOCKER_PASSWORD=`echo $DOCKER_HUB_TOKEN | jq -r '.password'`
-      - docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD || true
       # should probably be managed as an extension/rule in any tests that need a screen available
       - /usr/bin/Xvfb :22 -screen 0 1920x1080x24 &
 

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -21,11 +21,6 @@ phases:
     commands:
       - dnf install -y marco mate-media e2fsprogs
       - startDesktop.sh
-
-      # login to DockerHub so we don't get throttled
-      - export DOCKER_USERNAME=`echo $DOCKER_HUB_TOKEN | jq -r '.username'`
-      - export DOCKER_PASSWORD=`echo $DOCKER_HUB_TOKEN | jq -r '.password'`
-      - docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD || true
       - export PATH="$PATH:$HOME/.dotnet/tools"
       - dotnet codeartifact-creds install
 


### PR DESCRIPTION
no longer needed now that public ecr exists
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
