### PR TITLE
fix(amazonq): lsp token/update emits for init, logins, and token refresh

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
@@ -7,10 +7,12 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import software.aws.toolkits.core.TokenConnectionSettings
+import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProvider
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
+import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManagerListener
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption.JwtEncryptionManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.BearerCredentials
@@ -23,25 +25,50 @@ class DefaultAuthCredentialsService(
     private val encryptionManager: JwtEncryptionManager,
     serverInstance: Disposable,
 ) : AuthCredentialsService,
-    BearerTokenProviderListener {
-    init {
-        project.messageBus.connect(serverInstance).subscribe(BearerTokenProviderListener.TOPIC, this)
+    BearerTokenProviderListener,
+    ToolkitConnectionManagerListener {
 
-        onChange("init", null)
+        init {
+        project.messageBus.connect(serverInstance).subscribe(BearerTokenProviderListener.TOPIC, this)
+        project.messageBus.connect(serverInstance).subscribe(ToolkitConnectionManagerListener.TOPIC, this)
+
+        val connection = ToolkitConnectionManager.getInstance(project)
+            .activeConnectionForFeature(QConnection.getInstance())
+
+        val provider = (connection?.getConnectionSettings() as? TokenConnectionSettings)
+            ?.tokenProvider
+            ?.delegate as? BearerTokenProvider
+
+        provider?.currentToken()?.accessToken?.let { token ->
+            updateTokenCredentials(token, true)
+        }
     }
 
     override fun onChange(providerId: String, newScopes: List<String>?) {
-        val connection = ToolkitConnectionManager.getInstance(project)
-            .activeConnectionForFeature(QConnection.getInstance())
+        val connection = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())
             ?: return
-
         val provider = (connection.getConnectionSettings() as? TokenConnectionSettings)
             ?.tokenProvider
             ?.delegate as? BearerTokenProvider
             ?: return
 
         provider.currentToken()?.accessToken?.let { token ->
-            // assume encryption is always on
+            updateTokenCredentials(token, true)
+        }
+    }
+
+    override fun activeConnectionChanged(newConnection: ToolkitConnection?) {
+        val qConnection = ToolkitConnectionManager.getInstance(project)
+            .activeConnectionForFeature(QConnection.getInstance())
+            ?: return
+        if (newConnection?.id != qConnection.id) return
+        // Handle new connection
+        val provider = (newConnection.getConnectionSettings() as? TokenConnectionSettings)
+            ?.tokenProvider
+            ?.delegate as? BearerTokenProvider
+            ?: return
+
+        provider.currentToken()?.accessToken?.let { token ->
             updateTokenCredentials(token, true)
         }
     }
@@ -82,4 +109,5 @@ class DefaultAuthCredentialsService(
                 encrypted = false
             )
         }
+
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
@@ -9,10 +9,10 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import software.aws.toolkits.core.TokenConnectionSettings
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
+import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManagerListener
 import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProvider
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
-import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManagerListener
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption.JwtEncryptionManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.BearerCredentials
@@ -36,7 +36,7 @@ class DefaultAuthCredentialsService(
             subscribe(ToolkitConnectionManagerListener.TOPIC, this@DefaultAuthCredentialsService)
         }
 
-        if(isQConnected(project) && !isQExpired(project)) {
+        if (isQConnected(project) && !isQExpired(project)) {
             updateTokenFromActiveConnection()
         }
     }
@@ -108,5 +108,4 @@ class DefaultAuthCredentialsService(
                 encrypted = false
             )
         }
-
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Added a listener and changed some of the init logic to better handle auth events for emitting the token to the LSP

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->



## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
