### PR TITLE
test(qdoc): Add ui tests for qdoc create readme flow

### DIFF
--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/ScriptUtils.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/ScriptUtils.kt
@@ -1,9 +1,9 @@
 // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package software.aws.toolkits.jetbrains.uitests.docTests.scripts
+package software.aws.toolkits.jetbrains.uitests
 
-// language=TS
+// language=JS
 val findAndClickButtonScript = """
 const findAndClickButton = async (
   page,

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/Utils.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/Utils.kt
@@ -3,23 +3,25 @@
 
 package software.aws.toolkits.jetbrains.uitests.docTests
 
+import java.io.File
 import java.nio.file.Paths
 
 fun prepTestData(isCreate: Boolean) {
     val process: Process
     if (isCreate) {
         val path = Paths.get("tstData", "qdoc", "createFlow", "README.md").toUri()
-        process = ProcessBuilder("rm", path.path).start()
+        if (File(path).exists()) {
+            File(path).delete()
+        }
     } else {
         val path = Paths.get("tstData", "qdoc", "updateFlow", "README.md").toUri()
         process = ProcessBuilder("git", "restore", path.path).start()
-    }
-
-    val exitCode = process.waitFor()
-    if (exitCode != 0) {
-        println("Warning: git stash command failed with exit code $exitCode")
-        process.errorStream.bufferedReader().use { reader ->
-            println("Error: ${reader.readText()}")
+        val exitCode = process.waitFor()
+        if (exitCode != 0) {
+            println("Warning: git stash command failed with exit code $exitCode")
+            process.errorStream.bufferedReader().use { reader ->
+                println("Error: ${reader.readText()}")
+            }
         }
     }
 }

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
@@ -1,0 +1,273 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.docTests.createReadmeTests
+
+import com.intellij.driver.sdk.waitForProjectOpen
+import com.intellij.ide.starter.ci.CIServer
+import com.intellij.ide.starter.config.ConfigurationStorage
+import com.intellij.ide.starter.di.di
+import com.intellij.ide.starter.driver.engine.runIdeWithDriver
+import com.intellij.ide.starter.ide.IdeProductProvider
+import com.intellij.ide.starter.junit5.hyphenateWithClass
+import com.intellij.ide.starter.models.TestCase
+import com.intellij.ide.starter.project.LocalProjectInfo
+import com.intellij.ide.starter.runner.CurrentTestMethod
+import com.intellij.ide.starter.runner.Starter
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kodein.di.DI
+import org.kodein.di.bindSingleton
+import software.aws.toolkits.jetbrains.uitests.TestCIServer
+import software.aws.toolkits.jetbrains.uitests.clearAwsXmlFile
+import software.aws.toolkits.jetbrains.uitests.docTests.prepTestData
+import software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts.acceptReadmeTestScript
+import software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts.createReadmePromptedToConfirmFolderTestScript
+import software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts.makeChangesFlowTestScript
+import software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts.rejectReadmeTestScript
+import software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts.validateFeatureAvailabilityTestScript
+import software.aws.toolkits.jetbrains.uitests.executePuppeteerScript
+import software.aws.toolkits.jetbrains.uitests.setupTestEnvironment
+import software.aws.toolkits.jetbrains.uitests.useExistingConnectionForTest
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class CreateReadmeTest {
+    init {
+        di = DI {
+            extend(di)
+            bindSingleton<CIServer>(overrides = true) { TestCIServer }
+            val defaults = ConfigurationStorage.instance().defaults.toMutableMap().apply {
+                put("LOG_ENVIRONMENT_VARIABLES", (!System.getenv("CI").toBoolean()).toString())
+            }
+
+            bindSingleton<ConfigurationStorage>(overrides = true) {
+                ConfigurationStorage(this, defaults)
+            }
+        }
+    }
+
+    @BeforeEach
+    fun setUpTest() {
+        // prep test data - remove readme if it exists
+        prepTestData(true)
+    }
+
+    @Test
+    fun `Validate that the qdoc feature can be invoked`() {
+        val testCase = TestCase(
+            IdeProductProvider.IC,
+            LocalProjectInfo(
+                Paths.get("tstData", "qdoc", "createFlow")
+            )
+        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+
+        // inject connection
+        useExistingConnectionForTest()
+
+        Starter.newContext(CurrentTestMethod.hyphenateWithClass(), testCase).apply {
+            System.getProperty("ui.test.plugins").split(File.pathSeparator).forEach { path ->
+                pluginConfigurator.installPluginFromPath(
+                    Path.of(path)
+                )
+            }
+
+            copyExistingConfig(Paths.get("tstData", "configAmazonQTests"))
+            updateGeneralSettings()
+        }.runIdeWithDriver()
+            .useDriverAndCloseIde {
+                waitForProjectOpen()
+                // required wait time for the system to be fully ready
+                Thread.sleep(30000)
+
+                val result = executePuppeteerScript(validateFeatureAvailabilityTestScript)
+                assertTrue(result.contains("Test Successful"))
+                assertFalse(result.contains("Error: Test Failed"))
+                if (result.contains("Error: Test Failed")) {
+                    println("result: $result")
+                }
+            }
+    }
+
+    @Test
+    fun `You are prompted to confirm selected folder, change folder, or cancel back to choosing CREATE or UPDATE`() {
+        val testCase = TestCase(
+            IdeProductProvider.IC,
+            LocalProjectInfo(
+                Paths.get("tstData", "qdoc", "createFlow")
+            )
+        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+
+        // inject connection
+        useExistingConnectionForTest()
+
+        Starter.newContext(CurrentTestMethod.hyphenateWithClass(), testCase).apply {
+            System.getProperty("ui.test.plugins").split(File.pathSeparator).forEach { path ->
+                pluginConfigurator.installPluginFromPath(
+                    Path.of(path)
+                )
+            }
+
+            copyExistingConfig(Paths.get("tstData", "configAmazonQTests"))
+            updateGeneralSettings()
+        }.runIdeWithDriver()
+            .useDriverAndCloseIde {
+                waitForProjectOpen()
+                // required wait time for the system to be fully ready
+                Thread.sleep(30000)
+
+                val result = executePuppeteerScript(createReadmePromptedToConfirmFolderTestScript)
+                assertTrue(result.contains("Test Successful"))
+                assertFalse(result.contains("Error: Test Failed"))
+                if (result.contains("Error: Test Failed")) {
+                    println("result: $result")
+                }
+            }
+    }
+
+    @Test
+    fun `Make changes button brings you to UPDATE with specific changes flow`() {
+        val testCase = TestCase(
+            IdeProductProvider.IC,
+            LocalProjectInfo(
+                Paths.get("tstData", "qdoc", "createFlow")
+            )
+        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+
+        // inject connection
+        useExistingConnectionForTest()
+
+        Starter.newContext(CurrentTestMethod.hyphenateWithClass(), testCase).apply {
+            System.getProperty("ui.test.plugins").split(File.pathSeparator).forEach { path ->
+                pluginConfigurator.installPluginFromPath(
+                    Path.of(path)
+                )
+            }
+
+            copyExistingConfig(Paths.get("tstData", "configAmazonQTests"))
+            updateGeneralSettings()
+        }.runIdeWithDriver()
+            .useDriverAndCloseIde {
+                waitForProjectOpen()
+                // required wait time for the system to be fully ready
+                Thread.sleep(30000)
+
+                val result = executePuppeteerScript(makeChangesFlowTestScript)
+                assertTrue(result.contains("Test Successful"))
+                assertFalse(result.contains("Error: Test Failed"))
+                if (result.contains("Error: Test Failed")) {
+                    println("result: $result")
+                }
+            }
+    }
+
+    @Test
+    fun `Accept button saves the ReadMe in the appropriate folder`() {
+        val testCase = TestCase(
+            IdeProductProvider.IC,
+            LocalProjectInfo(
+                Paths.get("tstData", "qdoc", "createFlow")
+            )
+        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+
+        // inject connection
+        useExistingConnectionForTest()
+
+        Starter.newContext(CurrentTestMethod.hyphenateWithClass(), testCase).apply {
+            System.getProperty("ui.test.plugins").split(File.pathSeparator).forEach { path ->
+                pluginConfigurator.installPluginFromPath(
+                    Path.of(path)
+                )
+            }
+
+            copyExistingConfig(Paths.get("tstData", "configAmazonQTests"))
+            updateGeneralSettings()
+        }.runIdeWithDriver()
+            .useDriverAndCloseIde {
+                waitForProjectOpen()
+                // required wait time for the system to be fully ready
+                Thread.sleep(30000)
+
+                val readmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
+                val readme = File(readmePath.toUri())
+                assertFalse(readme.exists())
+
+                val result = executePuppeteerScript(acceptReadmeTestScript)
+                assertFalse(result.contains("Error: Test Failed"))
+                if (result.contains("Error: Test Failed")) {
+                    println("result: $result")
+                }
+
+                val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
+                val newReadme = File(newReadmePath.toUri())
+                assertTrue(newReadme.exists())
+                assertTrue(newReadme.readText().contains("REST"))
+                assertTrue(newReadme.readText().contains("API"))
+            }
+    }
+
+    @Test
+    fun `Reject button discards the changes`() {
+        val testCase = TestCase(
+            IdeProductProvider.IC,
+            LocalProjectInfo(
+                Paths.get("tstData", "qdoc", "createFlow")
+            )
+        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+
+        // inject connection
+        useExistingConnectionForTest()
+
+        Starter.newContext(CurrentTestMethod.hyphenateWithClass(), testCase).apply {
+            System.getProperty("ui.test.plugins").split(File.pathSeparator).forEach { path ->
+                pluginConfigurator.installPluginFromPath(
+                    Path.of(path)
+                )
+            }
+
+            copyExistingConfig(Paths.get("tstData", "configAmazonQTests"))
+            updateGeneralSettings()
+        }.runIdeWithDriver()
+            .useDriverAndCloseIde {
+                waitForProjectOpen()
+                // required wait time for the system to be fully ready
+                Thread.sleep(30000)
+
+                val readmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
+                val readme = File(readmePath.toUri())
+                assertFalse(readme.exists())
+
+                val result = executePuppeteerScript(rejectReadmeTestScript)
+                assertTrue(result.contains("Test Successful"))
+                assertFalse(result.contains("Error: Test Failed"))
+
+                if (result.contains("Error: Test Failed")) {
+                    println("result: $result")
+                }
+
+                val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
+                val newReadme = File(newReadmePath.toUri())
+                assertFalse(newReadme.exists())
+            }
+    }
+
+    companion object {
+        @JvmStatic
+        @AfterAll
+        fun clearAwsXml() {
+            clearAwsXmlFile()
+        }
+
+        @JvmStatic
+        @BeforeAll
+        fun setUp() {
+            // Setup test environment
+            setupTestEnvironment()
+        }
+    }
+}

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/UpdateReadmeWithLatestChangesScripts.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/UpdateReadmeWithLatestChangesScripts.kt
@@ -3,7 +3,9 @@
 
 package software.aws.toolkits.jetbrains.uitests.docTests.scripts
 
-// language=TS
+import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+
+// language=JS
 val updateReadmeLatestChangesConfirmOptionsScript = """
     const puppeteer = require('puppeteer');
     
@@ -57,7 +59,7 @@ val updateReadmeLatestChangesConfirmOptionsScript = """
     });
 """.trimIndent()
 
-// language=TS
+// language=JS
 val updateReadmeLatestChangesScript = """
 
     const puppeteer = require('puppeteer');
@@ -108,7 +110,7 @@ val updateReadmeLatestChangesScript = """
 
 """.trimIndent()
 
-// language=TS
+// language=JS
 val updateReadmeLatestChangesMakeChangesFlowScript = """
     
     const puppeteer = require('puppeteer');

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/UpdateReadmeWithSpecificChangesScripts.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/UpdateReadmeWithSpecificChangesScripts.kt
@@ -3,7 +3,9 @@
 
 package software.aws.toolkits.jetbrains.uitests.docTests.scripts
 
-// language=TS
+import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+
+// language=JS
 val updateReadmeSpecificChangesMakeChangesFlowScript = """
     
      const puppeteer = require('puppeteer');
@@ -67,7 +69,7 @@ val updateReadmeSpecificChangesMakeChangesFlowScript = """
 
 """.trimIndent()
 
-// language=TS
+// language=JS
 val updateReadmeSpecificChangesScript = """
     
     const puppeteer = require('puppeteer');

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/AcceptReadmeScript.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/AcceptReadmeScript.kt
@@ -1,0 +1,56 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
+
+import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+
+// language=JS
+val acceptReadmeScript = """
+    const puppeteer = require('puppeteer');
+
+    async function testNavigation() {
+        const browser = await puppeteer.connect({
+            browserURL: 'http://localhost:9222'
+        })
+
+        try {
+
+            const pages = await browser.pages()
+
+            for(const page of pages) {
+                const contents = await page.evaluate(el => el.innerHTML, await page.${'$'}(':root'));
+
+                const element = await page.${'$'}('.mynah-chat-prompt-input')
+                if(element) {
+
+                    console.log('Typing /doc in the chat window')
+
+                    await page.type('.mynah-chat-prompt-input', '/doc')
+                    await page.keyboard.press('Enter')
+
+                    console.log('Attempting to find and click Create a README button')
+                    await findAndClickButton(page, 'Create a README', true, 10000)
+                    console.log('Attempting to find and click Yes button to confirm option')
+                    await findAndClickButton(page, 'Yes', true, 10000)
+
+                    console.log('Waiting for README to be generated')
+                    await new Promise(resolve => setTimeout(resolve, 90000));
+
+                    console.log('Attempting to find and click Accept button');
+                    await findAndClickButton(page, 'Accept', true, 10000)
+                }
+          }
+
+        } finally {
+            await browser.close();
+        }
+    }
+
+    testNavigation().catch((error) => {
+      console.log('Error: Test Failed');
+      console.error(error);
+    });
+""".trimIndent()
+
+val acceptReadmeTestScript = acceptReadmeScript.plus(findAndClickButtonScript)

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/MakeChangesFlowScript.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/MakeChangesFlowScript.kt
@@ -1,0 +1,65 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
+
+import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+
+// language=JS
+val makeChangesFlowScript = """
+    const puppeteer = require('puppeteer');
+    
+    async function testNavigation() {
+        const browser = await puppeteer.connect({
+            browserURL: 'http://localhost:9222'
+        })
+    
+        try {
+    
+            const pages = await browser.pages()
+    
+            for(const page of pages) {
+                const contents = await page.evaluate(el => el.innerHTML, await page.${'$'}(':root'));
+    
+                const element = await page.${'$'}('.mynah-chat-prompt-input')
+                if(element) {
+    
+                    console.log('Typing /doc in the chat window')
+    
+                    await page.type('.mynah-chat-prompt-input', '/doc')
+                    await page.keyboard.press('Enter')
+    
+                    console.log('Attempting to find and click Create a README button')
+                    await findAndClickButton(page, 'Create a README', true, 10000)
+                    console.log('Attempting to find and click Yes button to confirm option')
+                    await findAndClickButton(page, 'Yes', true, 10000)
+    
+                    console.log('Waiting for README to be generated')
+                    await new Promise(resolve => setTimeout(resolve, 90000))
+    
+                    console.log('Attempting to find and click Make Changes button');
+                    await findAndClickButton(page, 'Make changes', true, 10000)
+    
+                    const makeChangeText = await page.waitForSelector('[placeholder="Describe documentation changes"]');
+                        if (!makeChangeText) {
+                              console.log('Error: Test Failed');
+                              console.log('Unable to find placeholder description text in Make Changes flow');
+                            } else {
+                                console.log('Found expected placeholder text for Make Changes flow');
+                                console.log('Test Successful');
+                            }
+                }
+          }
+    
+        } finally {
+            await browser.close();
+        }
+    }
+    
+    testNavigation().catch((error) => {
+      console.log('Error: Test Failed');
+      console.error(error);
+    });
+""".trimIndent()
+
+val makeChangesFlowTestScript = makeChangesFlowScript.plus(findAndClickButtonScript)

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/PromptedToConfirmFolderScript.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/PromptedToConfirmFolderScript.kt
@@ -1,0 +1,60 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
+
+import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+
+// language=JS
+val createReadmePromptedToConfirmFolderScript = """
+    const puppeteer = require('puppeteer');
+    
+    async function testNavigation() {
+        const browser = await puppeteer.connect({
+            browserURL: 'http://localhost:9222'
+        })
+
+        try {
+
+            const pages = await browser.pages()
+           
+            for(const page of pages) {
+                const contents = await page.evaluate(el => el.innerHTML, await page.${'$'}(':root'));
+                
+                const element = await page.${'$'}('.mynah-chat-prompt-input')
+                if(element) {
+                    
+                    console.log('Typing /doc in the chat window')
+
+                    await page.type('.mynah-chat-prompt-input', '/doc')
+                    await page.keyboard.press('Enter')
+
+                    console.log('Attempting to find and click Create a README button')
+                    await findAndClickButton(page, 'Create a README', true, 10000)
+                    console.log('Attempting to find all available buttons')
+                    const yesButton = await findAndClickButton(page, 'Yes', false, 10000)
+                    const changeFolderButton = await findAndClickButton(page, 'Change folder', false, 10000)
+                    const cancelButton = await findAndClickButton(page, 'Cancel', false, 10000)
+
+                    if (!yesButton || !changeFolderButton || !cancelButton) {
+                      console.log('Error: Test Failed')
+                      console.log('Unable to find buttons for Yes/ChangeFolder/Cancel')
+                    } else {
+                      console.log('Found all expected buttons')
+                      console.log('Test Successful')
+                    }
+                }
+          }
+
+        } finally {
+            await browser.close();
+        }
+    }
+
+    testNavigation().catch((error) => {
+      console.log('Error: Test Failed');
+      console.error(error);
+    });
+""".trimIndent()
+
+val createReadmePromptedToConfirmFolderTestScript = createReadmePromptedToConfirmFolderScript.plus(findAndClickButtonScript)

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/RejectReadmeScript.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/RejectReadmeScript.kt
@@ -1,0 +1,71 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
+
+import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+
+// language=JS
+val rejectReadmeScript = """
+    const puppeteer = require('puppeteer');
+
+    async function testNavigation() {
+        const browser = await puppeteer.connect({
+            browserURL: 'http://localhost:9222'
+        })
+
+        try {
+
+            const pages = await browser.pages()
+
+            for(const page of pages) {
+                const contents = await page.evaluate(el => el.innerHTML, await page.${'$'}(':root'));
+
+                const element = await page.${'$'}('.mynah-chat-prompt-input')
+                if(element) {
+
+                    console.log('Typing /doc in the chat window')
+
+                    await page.type('.mynah-chat-prompt-input', '/doc')
+                    await page.keyboard.press('Enter')
+
+                    console.log('Attempting to find and click Create a README button')
+                    await findAndClickButton(page, 'Create a README', true, 10000)
+                    console.log('Attempting to find and click Yes button to confirm option')
+                    await findAndClickButton(page, 'Yes', true, 10000)
+
+                    console.log('Waiting for README to be generated')
+                    await new Promise(resolve => setTimeout(resolve, 90000))
+
+                    console.log('Attempting to find and click Reject button');
+                    await findAndClickButton(page, 'Reject', true, 10000)
+
+                    console.log('Attempting to find Your changes have been discarded text')
+                    const discardedMessageElement = await page.evaluate(() => {
+                        const element = Array.from(document.querySelectorAll('p'))
+                            .find(p => p.textContent?.includes('Your changes have been discarded'));
+                        return element ? element : null;
+                    });
+                   
+                    if (!discardedMessageElement) {
+                      console.log('Error: Test Failed');
+                      console.log('Unable to find text indicating changes have been discarded');
+                    } else {
+                        console.log('Found expected text indicating changes have been discarded');
+                        console.log('Test Successful');
+                    }
+                }
+          }
+
+        } finally {
+            await browser.close();
+        }
+    }
+
+    testNavigation().catch((error) => {
+      console.log('Error: Test Failed');
+      console.error(error);
+    });
+""".trimIndent()
+
+val rejectReadmeTestScript = rejectReadmeScript.plus(findAndClickButtonScript)

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/ValidateFeatureAvailabilityScript.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/ValidateFeatureAvailabilityScript.kt
@@ -1,0 +1,57 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
+
+import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+
+// language=JS
+val validateFeatureAvailabilityScript = """
+    const puppeteer = require('puppeteer');
+
+    async function testNavigation() {
+        const browser = await puppeteer.connect({
+            browserURL: 'http://localhost:9222'
+        })
+
+        try {
+
+            const pages = await browser.pages()
+
+            for(const page of pages) {
+                const contents = await page.evaluate(el => el.innerHTML, await page.${'$'}(':root'));
+
+                const element = await page.${'$'}('.mynah-chat-prompt-input')
+                if(element) {
+
+                    console.log('Typing /doc in the chat window')
+
+                    await page.type('.mynah-chat-prompt-input', '/doc')
+                    await page.keyboard.press('Enter')
+
+                    const createReadmeButton = await findAndClickButton(page, 'Create a README', false, 10000)
+                    const updateReadmeButton = await findAndClickButton(page, 'Update an existing README', false, 10000)
+
+                    if (!createReadmeButton || !updateReadmeButton) {
+                      console.log('Error: Test Failed')
+                      console.log('Unable to find buttons for Create/Update Readme buttons')
+                    } else {
+                      console.log('Found all expected buttons')
+                      console.log('Test Successful')
+                    }
+                }
+          }
+
+        } finally {
+            await browser.close();
+        }
+    }
+
+    testNavigation().catch((error) => {
+      console.log('Error: Test Failed');
+      console.error(error);
+    });
+
+""".trimIndent()
+
+val validateFeatureAvailabilityTestScript = validateFeatureAvailabilityScript.plus(findAndClickButtonScript)

--- a/ui-tests-starter/tstData/qdoc/createFlow/build.gradle
+++ b/ui-tests-starter/tstData/qdoc/createFlow/build.gradle
@@ -1,0 +1,26 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+plugins {
+    id 'org.springframework.boot' version '3.2.0'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+}
+
+group = 'com.example'
+version = '1.0-SNAPSHOT'
+sourceCompatibility = '17'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/ui-tests-starter/tstData/qdoc/createFlow/config/application-local.yml
+++ b/ui-tests-starter/tstData/qdoc/createFlow/config/application-local.yml
@@ -1,0 +1,11 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: sample-rest-app
+
+logging:
+  level:
+    root: INFO
+    com.example: DEBUG

--- a/ui-tests-starter/tstData/qdoc/createFlow/src/com/example/App.java
+++ b/ui-tests-starter/tstData/qdoc/createFlow/src/com/example/App.java
@@ -1,0 +1,14 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class App {
+    public static void main(String[] args) {
+        SpringApplication.run(App.class, args);
+    }
+}

--- a/ui-tests-starter/tstData/qdoc/createFlow/src/com/example/controller/SampleController.java
+++ b/ui-tests-starter/tstData/qdoc/createFlow/src/com/example/controller/SampleController.java
@@ -1,0 +1,34 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.controller;
+
+import com.example.model.DataItem;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+public class SampleController {
+
+    private final Map<String, DataItem> dataStore = new HashMap<>();
+
+    @GetMapping("/data/{id}")
+    public ResponseEntity<DataItem> getData(@PathVariable String id) {
+        DataItem item = dataStore.get(id);
+        if (item != null) {
+            return ResponseEntity.ok(item);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @PutMapping("/data/{id}")
+    public ResponseEntity<DataItem> putData(@PathVariable String id, @RequestBody DataItem item) {
+        item.setId(id);
+        dataStore.put(id, item);
+        return ResponseEntity.ok(item);
+    }
+}

--- a/ui-tests-starter/tstData/qdoc/createFlow/src/com/example/model/DataItem.java
+++ b/ui-tests-starter/tstData/qdoc/createFlow/src/com/example/model/DataItem.java
@@ -1,0 +1,26 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.model;
+
+public class DataItem {
+    private String id;
+    private String content;
+
+    // Getters and Setters
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Followups from #5435:
1. Updated Syntax highlighting to JS for all scripts
2. Moved `findAndClickButton` to a common Utils.kt file in the tests directory

Add UI tests to validate the `Create a README` flow 
Created a sample repository from scratch,
There are 5 test cases which validate the following
1. /doc feature can be invoked, and user sees the option to CREATE or UPDATE an existing Readme
3. User is prompted to confirm selected folder, change folder or cancel back to choosing CREATE or UPDATE Readme
4. Make changes button brings the user to UPDATE with specific changes flow
5. Accept button saves the README in the appropriate folder
6. Reject button discards the changes

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
