### PR TITLE
fix(amazonq): Fix cases where content may be incorrectly excluded from workspace.

### DIFF
--- a/.changes/next-release/bugfix-d13b5621-b191-455b-8918-1a5874216512.json
+++ b/.changes/next-release/bugfix-d13b5621-b191-455b-8918-1a5874216512.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q: Fix cases where content may be incorrectly excluded from workspace."
+}

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
@@ -15,13 +15,9 @@ import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtu
 import software.aws.toolkits.jetbrains.utils.rules.addFileToModule
 import java.util.zip.ZipFile
 
+data class FileCase(val path: String, val content: String = "", val shouldInclude: Boolean = true)
+
 class FeatureDevSessionContextTest : FeatureDevTestBase(HeavyJavaCodeInsightTestFixtureRule()) {
-
-    private fun addFilesToProjectModule(vararg path: String) {
-        val module = projectRule.module
-        path.forEach { projectRule.fixture.addFileToModule(module, it, it) }
-    }
-
     @Rule
     @JvmField
     val ruleChain = RuleChain(projectRule, disposableRule)
@@ -35,90 +31,40 @@ class FeatureDevSessionContextTest : FeatureDevTestBase(HeavyJavaCodeInsightTest
         featureDevSessionContext = FeatureDevSessionContext(featureDevService.project, 1024)
     }
 
-    // FIXME: Add deeper tests, replacing previous shallow tests - BLOCKING
+    private fun fileCases(autoBuildEnabled: Boolean) = listOf(
+        FileCase(path = ".gitignore"),
+        FileCase(path = ".gradle/cached.jar", shouldInclude = false),
+        FileCase(path = "src/MyClass.java"),
+        FileCase(path = "gradlew"),
+        FileCase(path = "gradlew.bat"),
+        FileCase(path = "README.md"),
+        FileCase(path = "settings.gradle"),
+        FileCase(path = "build.gradle"),
+        FileCase(path = "gradle/wrapper/gradle-wrapper.properties"),
+        FileCase(path = "builder/GetTestBuilder.java"),
+        FileCase(path = ".aws-sam/build/function1", shouldInclude = false),
+        FileCase(path = ".gem/specs.rb", shouldInclude = false),
+        FileCase(path = "archive.zip"),
+        FileCase(path = "output.bin"),
+        FileCase(path = "images/logo.png"),
+        FileCase(path = "assets/header.jpg"),
+        FileCase(path = "icons/menu.svg"),
+        FileCase(path = "license.txt"),
+        FileCase(path = "License.md"),
+        FileCase(path = "node_modules/express", shouldInclude = false),
+        FileCase(path = "build/outputs", shouldInclude = false),
+        FileCase(path = "dist/bundle.js", shouldInclude = false),
+        FileCase(path = "gradle/wrapper/gradle-wrapper.jar"),
+        FileCase(path = "big-file.txt", content = "blob".repeat(1024 * 1024), shouldInclude = false),
+        FileCase(path = "devfile.yaml", shouldInclude = autoBuildEnabled),
+    )
 
-    @Test
-    fun testZipProjectWithoutAutoDev() {
-        checkZipProject(
-            false,
-            setOf(
-                "src/MyClass.java",
-                "icons/menu.svg",
-                "assets/header.jpg",
-                "archive.zip",
-                "output.bin",
-                "gradle/wrapper/gradle-wrapper.jar",
-                "gradle/wrapper/gradle-wrapper.properties",
-                "images/logo.png",
-                "builder/GetTestBuilder.java",
-                "gradlew",
-                "README.md",
-                ".gitignore",
-                "License.md",
-                "gradlew.bat",
-                "license.txt",
-                "build.gradle",
-                "settings.gradle"
-            )
-        )
-    }
+    private fun checkZipProject(autoBuildEnabled: Boolean, fileCases: Iterable<FileCase>, onBeforeZip: (() -> Unit)? = null) {
+        fileCases.forEach {
+            projectRule.fixture.addFileToModule(module, it.path, it.content)
+        }
 
-    @Test
-    fun testZipProjectWithAutoDev() {
-        checkZipProject(
-            true,
-            setOf(
-                "src/MyClass.java",
-                "icons/menu.svg",
-                "assets/header.jpg",
-                "archive.zip",
-                "output.bin",
-                "gradle/wrapper/gradle-wrapper.jar",
-                "gradle/wrapper/gradle-wrapper.properties",
-                "images/logo.png",
-                "builder/GetTestBuilder.java",
-                "gradlew",
-                "README.md",
-                ".gitignore",
-                "License.md",
-                "gradlew.bat",
-                "license.txt",
-                "build.gradle",
-                "devfile.yaml",
-                "settings.gradle"
-            )
-        )
-    }
-
-    fun checkZipProject(autoBuildEnabled: Boolean, expectedFiles: Set<String>) {
-        addFilesToProjectModule(
-            ".gitignore",
-            ".gradle/cached.jar",
-            "src/MyClass.java",
-            "gradlew",
-            "gradlew.bat",
-            "README.md",
-            "settings.gradle",
-            "build.gradle",
-            "gradle/wrapper/gradle-wrapper.properties",
-            "builder/GetTestBuilder.java", // check for false positives
-            ".aws-sam/build/function1",
-            ".gem/specs.rb",
-            "archive.zip",
-            "output.bin",
-            "images/logo.png",
-            "assets/header.jpg",
-            "icons/menu.svg",
-            "license.txt",
-            "License.md",
-            "node_modules/express",
-            "build/outputs",
-            "dist/bundle.js",
-            "gradle/wrapper/gradle-wrapper.jar",
-            "devfile.yaml",
-        )
-
-        projectRule.fixture.addFileToModule(module, "large-file.txt", "loblob".repeat(1024 * 1024))
+        onBeforeZip?.invoke()
 
         val zipResult = featureDevSessionContext.getProjectZip(autoBuildEnabled)
         val zipPath = zipResult.payload.path
@@ -132,6 +78,60 @@ class FeatureDevSessionContextTest : FeatureDevTestBase(HeavyJavaCodeInsightTest
             }
         }
 
-        assertEquals(zippedFiles, expectedFiles)
+        // The input file paths are relative to the workspaceRoot, however the zip content is relative to the addressableRoot:
+        val addressableRoot = featureDevSessionContext.addressableRoot.path
+        val workspaceRoot = featureDevSessionContext.workspaceRoot.path
+        val base = addressableRoot.removePrefix(workspaceRoot).removePrefix("/")
+        fun addressablePathOf(path: String) = path.removePrefix(base).removePrefix("/")
+
+        fileCases.forEach {
+            assertEquals(it.shouldInclude, zippedFiles.contains(addressablePathOf(it.path)))
+        }
+    }
+
+    @Test
+    fun `test zip with autoBuild enabled`() {
+        checkZipProject(autoBuildEnabled = true, fileCases(autoBuildEnabled = true))
+    }
+
+    @Test
+    fun `test zip with autoBuild disabled`() {
+        checkZipProject(autoBuildEnabled = false, fileCases(autoBuildEnabled = false))
+    }
+
+    @Test
+    fun `test content is included when selection root is workspace root`() {
+        val fileCases = listOf(
+            FileCase(path = "file.txt", shouldInclude = true),
+            FileCase(path = "project/file.txt", shouldInclude = true),
+            FileCase(path = "deep/nested/file.txt", shouldInclude = true)
+        )
+
+        checkZipProject(autoBuildEnabled = false, fileCases = fileCases, onBeforeZip = {
+            featureDevSessionContext.selectionRoot = featureDevSessionContext.workspaceRoot
+        })
+    }
+
+    @Test
+    fun `test content is included within selection root which is deeper than content root`() {
+        val fileCases = listOf(FileCase(path = "project/module/deep/file.txt", shouldInclude = true))
+
+        checkZipProject(autoBuildEnabled = false, fileCases = fileCases, onBeforeZip = {
+            featureDevSessionContext.selectionRoot = featureDevSessionContext.workspaceRoot.findFileByRelativePath("project/module/deep")
+                ?: error("Failed to find fixture")
+        })
+    }
+
+    @Test
+    fun `test content is excluded outside of selection root`() {
+        val fileCases = listOf(
+            FileCase(path = "project/module/file.txt", shouldInclude = true),
+            FileCase(path = "project/outside/no.txt", shouldInclude = false),
+        )
+
+        checkZipProject(autoBuildEnabled = false, fileCases = fileCases, onBeforeZip = {
+            featureDevSessionContext.selectionRoot = featureDevSessionContext.workspaceRoot.findFileByRelativePath("project/module")
+                ?: error("Failed to find fixture")
+        })
     }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/Workspace.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/Workspace.kt
@@ -79,7 +79,7 @@ val additionalGlobalIgnoreRulesForStrictSources =
         listOf(
             // FIXME: It is incredibly brittle that this source of truth is a "telemetry" component
             // It would be worth considering sniffing text vs arbitrary binary file contents, and making decisions on that basis, rather than file extension.
-            fun (path: VirtualFile) = !ALLOWED_CODE_EXTENSIONS.contains(path.extension),
+            fun (path: VirtualFile) = path.extension != null && !ALLOWED_CODE_EXTENSIONS.contains(path.extension),
         )
 
 /**

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/DevFileUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/DevFileUtils.kt
@@ -5,4 +5,6 @@ package software.aws.toolkits.jetbrains.utils
 
 import com.intellij.openapi.vfs.VirtualFile
 
-fun isDevFile(file: VirtualFile): Boolean = file.name.matches(Regex("devfile\\.ya?ml", RegexOption.IGNORE_CASE))
+fun isWorkspaceDevFile(file: VirtualFile, addressableRoot: VirtualFile): Boolean =
+    file.name.matches(Regex("devfile\\.ya?ml", RegexOption.IGNORE_CASE)) &&
+        file.parent?.path == addressableRoot.path


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

**Problem 1:** Incorrectly filtering out directories in `additionalGlobalIgnoreRulesForStrictSources` due to missing null check on file extension. Fixed and added tests.

**Problem 2:** Because we start traversal at the content roots, but filter out any content not within the selection root, we were incorrectly stopping traversal when the selection root is nested within any content root. In this case, we were exiting without traversing to find the `selectedRoot`. Fixed and added tests.

**Problem 3:** Add support for DevFile (as normally supported, when at workspace root) when workspace root is not a content root. Fixes excluding the DevFile when it's not in a content root.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [N/A] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
