### PR TITLE
fix(amazonq): rename syncModuleDependencies to getModuleDependencyPaths

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
@@ -8,7 +8,7 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 import org.eclipse.lsp4j.services.LanguageServer
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.UpdateCredentialsPayload
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.SyncModuleDependenciesParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -16,8 +16,8 @@ import java.util.concurrent.CompletableFuture
  */
 @Suppress("unused")
 interface AmazonQLanguageServer : LanguageServer {
-    @JsonNotification("aws/syncModuleDependencies")
-    fun syncModuleDependencies(params: SyncModuleDependenciesParams): CompletableFuture<Unit>
+    @JsonNotification("aws/didChangeDependencyPaths")
+    fun didChangeDependencyPaths(params: DidChangeDependencyPathsParams): CompletableFuture<Unit>
 
     @JsonRequest("aws/credentials/token/update")
     fun updateTokenCredentials(payload: UpdateCredentialsPayload): CompletableFuture<ResponseMessage>

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesService.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.roots.ModuleRootEvent
 import com.intellij.openapi.roots.ModuleRootListener
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.ModuleDependencyProvider.Companion.EP_NAME
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.SyncModuleDependenciesParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 import java.util.concurrent.CompletableFuture
 
 class DefaultModuleDependenciesService(
@@ -34,16 +34,16 @@ class DefaultModuleDependenciesService(
         syncAllModules()
     }
 
-    override fun syncModuleDependencies(params: SyncModuleDependenciesParams): CompletableFuture<Unit> =
+    override fun didChangeDependencyPaths(params: DidChangeDependencyPathsParams): CompletableFuture<Unit> =
         AmazonQLspService.executeIfRunning(project) { languageServer ->
-            languageServer.syncModuleDependencies(params)
+            languageServer.didChangeDependencyPaths(params)
         }?.toCompletableFuture() ?: CompletableFuture.failedFuture(IllegalStateException("LSP Server not running"))
 
     private fun syncAllModules() {
         ModuleManager.getInstance(project).modules.forEach { module ->
             EP_NAME.forEachExtensionSafe {
                 if (it.isApplicable(module)) {
-                    syncModuleDependencies(it.createParams(module))
+                    didChangeDependencyPaths(it.createParams(module))
                     return@forEachExtensionSafe
                 }
             }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependenciesService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependenciesService.kt
@@ -3,9 +3,9 @@
 
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies
 
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.SyncModuleDependenciesParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 import java.util.concurrent.CompletableFuture
 
 interface ModuleDependenciesService {
-    fun syncModuleDependencies(params: SyncModuleDependenciesParams): CompletableFuture<Unit>
+    fun didChangeDependencyPaths(params: DidChangeDependencyPathsParams): CompletableFuture<Unit>
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependencyProvider.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies
 
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.module.Module
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.SyncModuleDependenciesParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 
 interface ModuleDependencyProvider {
     companion object {
@@ -13,5 +13,5 @@ interface ModuleDependencyProvider {
     }
 
     fun isApplicable(module: Module): Boolean
-    fun createParams(module: Module): SyncModuleDependenciesParams
+    fun createParams(module: Module): DidChangeDependencyPathsParams
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/JavaModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/JavaModuleDependencyProvider.kt
@@ -9,13 +9,13 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.vfs.VfsUtil
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.ModuleDependencyProvider
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.SyncModuleDependenciesParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 
 internal class JavaModuleDependencyProvider : ModuleDependencyProvider {
     override fun isApplicable(module: Module): Boolean =
         ModuleRootManager.getInstance(module).sdk?.sdkType is JavaSdkType
 
-    override fun createParams(module: Module): SyncModuleDependenciesParams {
+    override fun createParams(module: Module): DidChangeDependencyPathsParams {
         val sourceRoots = getSourceRoots(module)
         val dependencies = mutableListOf<String>()
 
@@ -26,7 +26,7 @@ internal class JavaModuleDependencyProvider : ModuleDependencyProvider {
             true
         }
 
-        return SyncModuleDependenciesParams(
+        return DidChangeDependencyPathsParams(
             moduleName = module.name,
             programmingLanguage = "Java",
             files = sourceRoots,

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/PythonModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/PythonModuleDependencyProvider.kt
@@ -8,13 +8,13 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.jetbrains.python.packaging.management.PythonPackageManager
 import com.jetbrains.python.sdk.PythonSdkUtil
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.ModuleDependencyProvider
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.SyncModuleDependenciesParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 
 internal class PythonModuleDependencyProvider : ModuleDependencyProvider {
     override fun isApplicable(module: Module): Boolean =
         PythonSdkUtil.findPythonSdk(module) != null
 
-    override fun createParams(module: Module): SyncModuleDependenciesParams {
+    override fun createParams(module: Module): DidChangeDependencyPathsParams {
         val sourceRoots = getSourceRoots(module)
         val dependencies = mutableListOf<String>()
 
@@ -25,7 +25,7 @@ internal class PythonModuleDependencyProvider : ModuleDependencyProvider {
             }
         }
 
-        return SyncModuleDependenciesParams(
+        return DidChangeDependencyPathsParams(
             moduleName = module.name,
             programmingLanguage = "Python",
             files = sourceRoots,

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/dependencies/DidChangeDependencyPathsParams.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/dependencies/DidChangeDependencyPathsParams.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies
 
-class SyncModuleDependenciesParams(
+class DidChangeDependencyPathsParams(
     val moduleName: String,
     val programmingLanguage: String,
     val files: List<String>,

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLanguageServer
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.ModuleDependencyProvider.Companion.EP_NAME
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.SyncModuleDependenciesParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 
@@ -45,7 +45,7 @@ class DefaultModuleDependenciesServiceTest {
         mockDependencyProvider = mockk<ModuleDependencyProvider>()
         mockLanguageServer = mockk()
 
-        every { mockLanguageServer.syncModuleDependencies(any()) } returns CompletableFuture<Unit>()
+        every { mockLanguageServer.didChangeDependencyPaths(any()) } returns CompletableFuture<Unit>()
 
         // Mock Application
         mockApplication = mockk()
@@ -89,7 +89,7 @@ class DefaultModuleDependenciesServiceTest {
     fun `test initial sync on construction`() {
         // Arrange
         val module = mockk<Module>()
-        val params = SyncModuleDependenciesParams(
+        val params = DidChangeDependencyPathsParams(
             moduleName = "testModule",
             programmingLanguage = "Java",
             files = listOf("src/main"),
@@ -104,7 +104,7 @@ class DefaultModuleDependenciesServiceTest {
 
         sut = DefaultModuleDependenciesService(project, mockk())
 
-        verify { mockLanguageServer.syncModuleDependencies(params) }
+        verify { mockLanguageServer.didChangeDependencyPaths(params) }
     }
 
     @Test
@@ -112,7 +112,7 @@ class DefaultModuleDependenciesServiceTest {
         // Arrange
         val module1 = mockk<Module>()
         val module2 = mockk<Module>()
-        val params1 = SyncModuleDependenciesParams(
+        val params1 = DidChangeDependencyPathsParams(
             moduleName = "module1",
             programmingLanguage = "Java",
             files = listOf("src/main1"),
@@ -120,7 +120,7 @@ class DefaultModuleDependenciesServiceTest {
             includePatterns = emptyList(),
             excludePatterns = emptyList()
         )
-        val params2 = SyncModuleDependenciesParams(
+        val params2 = DidChangeDependencyPathsParams(
             moduleName = "module2",
             programmingLanguage = "Java",
             files = listOf("src/main2"),
@@ -139,8 +139,8 @@ class DefaultModuleDependenciesServiceTest {
         sut = DefaultModuleDependenciesService(project, mockk())
 
         // Verify both modules were synced
-        verify { mockLanguageServer.syncModuleDependencies(params1) }
-        verify { mockLanguageServer.syncModuleDependencies(params2) }
+        verify { mockLanguageServer.didChangeDependencyPaths(params1) }
+        verify { mockLanguageServer.didChangeDependencyPaths(params2) }
     }
 
     @Test
@@ -161,14 +161,14 @@ class DefaultModuleDependenciesServiceTest {
         sut = DefaultModuleDependenciesService(project, mockk())
 
         // Verify no sync occurred
-        verify(exactly = 0) { mockLanguageServer.syncModuleDependencies(any()) }
+        verify(exactly = 0) { mockLanguageServer.didChangeDependencyPaths(any()) }
     }
 
     @Test
     fun `test rootsChanged withFileTypesChange`() {
         // Arrange
         val module = mockk<Module>()
-        val params = SyncModuleDependenciesParams(
+        val params = DidChangeDependencyPathsParams(
             moduleName = "testModule",
             programmingLanguage = "Java",
             files = listOf("src/main"),
@@ -186,14 +186,14 @@ class DefaultModuleDependenciesServiceTest {
         sut.rootsChanged(event)
 
         // Verify sync occurred once - once on init and rootsChange ignores
-        verify(exactly = 1) { mockLanguageServer.syncModuleDependencies(params) }
+        verify(exactly = 1) { mockLanguageServer.didChangeDependencyPaths(params) }
     }
 
     @Test
     fun `test rootsChanged after module changes`() {
         // Arrange
         val module = mockk<Module>()
-        val params = SyncModuleDependenciesParams(
+        val params = DidChangeDependencyPathsParams(
             moduleName = "testModule",
             programmingLanguage = "Java",
             files = listOf("src/main"),
@@ -214,10 +214,10 @@ class DefaultModuleDependenciesServiceTest {
         sut.rootsChanged(event)
 
         // Verify sync occurred twice - once on init and once after rootsChanged
-        verify(exactly = 2) { mockLanguageServer.syncModuleDependencies(params) }
+        verify(exactly = 2) { mockLanguageServer.didChangeDependencyPaths(params) }
     }
 
-    private fun prepDependencyProvider(moduleParamPairs: List<Pair<Module, SyncModuleDependenciesParams>>) {
+    private fun prepDependencyProvider(moduleParamPairs: List<Pair<Module, DidChangeDependencyPathsParams>>) {
         every { mockModuleManager.modules } returns moduleParamPairs.map { it.first }.toTypedArray()
 
         every {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
