### PR TITLE
fix(amazonq): didRename emits full oldUri path

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
@@ -247,22 +247,6 @@ class WorkspaceServiceHandler(
         }
     }
 
-    private fun createFileRename(
-        parentFile: VirtualFile,
-        oldFileName: String,
-        newFile: VirtualFile
-    ): FileRename? {
-        val oldUri = toUriString(parentFile)?.let { parentUri -> "$parentUri/$oldFileName" }
-        val newUri = toUriString(newFile)
-
-        if (oldUri == null || newUri == null) return null
-
-        return FileRename().apply {
-            this.oldUri = oldUri
-            this.newUri = newUri
-        }
-    }
-
     private fun shouldHandleFile(file: VirtualFile): Boolean {
         if (file.isDirectory) {
             return true // Matches "**/*" with matches: "folder"

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandlerTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandlerTest.kt
@@ -393,8 +393,8 @@ class WorkspaceServiceHandlerTest {
         val paramsSlot = slot<RenameFilesParams>()
         verify { mockWorkspaceService.didRenameFiles(capture(paramsSlot)) }
         with(paramsSlot.captured.files[0]) {
-            assertEquals(normalizeFileUri("file:///test/$oldName"), oldUri)
-            assertEquals(normalizeFileUri("file:///test/$newName"), newUri)
+            assertEquals(normalizeFileUri("file:///testDir/$oldName"), oldUri)
+            assertEquals(normalizeFileUri("file:///testDir/$newName"), newUri)
         }
     }
 
@@ -430,8 +430,8 @@ class WorkspaceServiceHandlerTest {
         val paramsSlot = slot<RenameFilesParams>()
         verify { mockWorkspaceService.didRenameFiles(capture(paramsSlot)) }
         with(paramsSlot.captured.files[0]) {
-            assertEquals(normalizeFileUri("file:///test/oldDir"), oldUri)
-            assertEquals(normalizeFileUri("file:///test/newDir"), newUri)
+            assertEquals(normalizeFileUri("file:///testDir/oldDir"), oldUri)
+            assertEquals(normalizeFileUri("file:///testDir/newDir"), newUri)
         }
     }
 
@@ -648,10 +648,10 @@ class WorkspaceServiceHandlerTest {
         newName: String,
         isDirectory: Boolean = false,
     ): VFilePropertyChangeEvent {
-        val oldUri = URI("file:///test/$oldName")
-        val newUri = URI("file:///test/$newName")
+        val parent = createMockVirtualFile(URI("file:///testDir/"), "testDir", true)
+        val newUri = URI("file:///testDir/$newName")
         val file = createMockVirtualFile(newUri, newName, isDirectory)
-        every { file.parent } returns createMockVirtualFile(oldUri, oldName, isDirectory)
+        every { file.parent } returns parent
 
         return mockk<VFilePropertyChangeEvent>().apply {
             every { propertyName } returns VirtualFile.PROP_NAME


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Fixed an issue where didRename was emitting only the parent directory without the filename for the oldUri value. 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
