### PR TITLE
fix(amazonq): fix didChangeDependencyPathsParams with absolute pathing

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependencyProvider.kt
@@ -19,6 +19,6 @@ interface ModuleDependencyProvider {
 
     fun getWorkspaceFolderPath(module: Module): String {
         val contentRoots: Array<VirtualFile> = ModuleRootManager.getInstance(module).contentRoots
-        return contentRoots.firstOrNull()?.path ?: ""
+        return contentRoots.firstOrNull()?.path.orEmpty()
     }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependencyProvider.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.util.FileUriUtil.toUriString
 
 interface ModuleDependencyProvider {
     companion object {
@@ -19,6 +20,6 @@ interface ModuleDependencyProvider {
 
     fun getWorkspaceFolderPath(module: Module): String {
         val contentRoots: Array<VirtualFile> = ModuleRootManager.getInstance(module).contentRoots
-        return contentRoots.firstOrNull()?.path.orEmpty()
+        return contentRoots.firstOrNull()?.let { toUriString(it) }.orEmpty()
     }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependencyProvider.kt
@@ -5,6 +5,8 @@ package software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies
 
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VirtualFile
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 
 interface ModuleDependencyProvider {
@@ -14,4 +16,9 @@ interface ModuleDependencyProvider {
 
     fun isApplicable(module: Module): Boolean
     fun createParams(module: Module): DidChangeDependencyPathsParams
+
+    fun getWorkspaceFolderPath(module: Module): String {
+        val contentRoots: Array<VirtualFile> = ModuleRootManager.getInstance(module).contentRoots
+        return contentRoots.firstOrNull()?.path ?: ""
+    }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/JavaModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/JavaModuleDependencyProvider.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.projectRoots.JavaSdkType
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.vfs.VfsUtil
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.ModuleDependencyProvider
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 
@@ -16,31 +15,21 @@ internal class JavaModuleDependencyProvider : ModuleDependencyProvider {
         ModuleRootManager.getInstance(module).sdk?.sdkType is JavaSdkType
 
     override fun createParams(module: Module): DidChangeDependencyPathsParams {
-        val sourceRoots = getSourceRoots(module)
         val dependencies = mutableListOf<String>()
 
         ModuleRootManager.getInstance(module).orderEntries().forEachLibrary { library ->
-            library.getUrls(OrderRootType.CLASSES).forEach { url ->
-                dependencies.add(VfsUtil.urlToPath(url))
+            library.getFiles(OrderRootType.CLASSES).forEach { file ->
+                dependencies.add(file.path)
             }
             true
         }
 
         return DidChangeDependencyPathsParams(
-            moduleName = module.name,
-            programmingLanguage = "Java",
-            files = sourceRoots,
-            dirs = dependencies,
+            moduleName = getWorkspaceFolderPath(module),
+            programmingLanguage = "java",
+            paths = dependencies,
             includePatterns = emptyList(),
             excludePatterns = emptyList()
         )
     }
-
-    private fun getSourceRoots(module: Module): List<String> =
-        ModuleRootManager.getInstance(module).contentEntries
-            .flatMap { contentEntry ->
-                contentEntry.sourceFolders
-                    .filter { !it.isTestSource }
-                    .mapNotNull { it.file?.path }
-            }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/JavaModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/JavaModuleDependencyProvider.kt
@@ -19,7 +19,7 @@ internal class JavaModuleDependencyProvider : ModuleDependencyProvider {
 
         ModuleRootManager.getInstance(module).orderEntries().forEachLibrary { library ->
             library.getFiles(OrderRootType.CLASSES).forEach { file ->
-                dependencies.add(file.path)
+                dependencies.add(file.path.removeSuffix("!/"))
             }
             true
         }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/PythonModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/PythonModuleDependencyProvider.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.providers
 
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.roots.ModuleRootManager
 import com.jetbrains.python.packaging.management.PythonPackageManager
 import com.jetbrains.python.sdk.PythonSdkUtil
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.ModuleDependencyProvider
@@ -15,31 +14,26 @@ internal class PythonModuleDependencyProvider : ModuleDependencyProvider {
         PythonSdkUtil.findPythonSdk(module) != null
 
     override fun createParams(module: Module): DidChangeDependencyPathsParams {
-        val sourceRoots = getSourceRoots(module)
         val dependencies = mutableListOf<String>()
 
         PythonSdkUtil.findPythonSdk(module)?.let { sdk ->
-            val packageManager = PythonPackageManager.forSdk(module.project, sdk)
-            packageManager.installedPackages.forEach { pkg ->
-                dependencies.add(pkg.name)
+            PythonSdkUtil.getSitePackagesDirectory(sdk)?.let { sitePackagesDir ->
+                val packageManager = PythonPackageManager.forSdk(module.project, sdk)
+                packageManager.installedPackages.forEach { pkg ->
+                    val packageDir = sitePackagesDir.findChild(pkg.name)
+                    if (packageDir != null) {
+                        dependencies.add(packageDir.path)
+                    }
+                }
             }
         }
 
         return DidChangeDependencyPathsParams(
-            moduleName = module.name,
-            programmingLanguage = "Python",
-            files = sourceRoots,
-            dirs = dependencies,
+            moduleName = getWorkspaceFolderPath(module),
+            programmingLanguage = "python",
+            paths = dependencies,
             includePatterns = emptyList(),
             excludePatterns = emptyList()
         )
     }
-
-    private fun getSourceRoots(module: Module): List<String> =
-        ModuleRootManager.getInstance(module).contentEntries
-            .flatMap { contentEntry ->
-                contentEntry.sourceFolders
-                    .filter { !it.isTestSource }
-                    .mapNotNull { it.file?.path }
-            }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/dependencies/DidChangeDependencyPathsParams.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/dependencies/DidChangeDependencyPathsParams.kt
@@ -6,8 +6,7 @@ package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependenc
 class DidChangeDependencyPathsParams(
     val moduleName: String,
     val programmingLanguage: String,
-    val files: List<String>,
-    val dirs: List<String>,
+    val paths: List<String>,
     val includePatterns: List<String>,
     val excludePatterns: List<String>,
 )

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
@@ -185,7 +185,6 @@ class DefaultModuleDependenciesServiceTest {
         verify(exactly = 2) { mockLanguageServer.didChangeDependencyPaths(params) }
     }
 
-
     private fun prepDependencyProvider(moduleParamPairs: List<Pair<Module, DidChangeDependencyPathsParams>>) {
         every { mockModuleManager.modules } returns moduleParamPairs.map { it.first }.toTypedArray()
 

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
@@ -91,15 +91,13 @@ class DefaultModuleDependenciesServiceTest {
         val module = mockk<Module>()
         val params = DidChangeDependencyPathsParams(
             moduleName = "testModule",
-            programmingLanguage = "Java",
-            files = listOf("src/main"),
-            dirs = listOf("lib"),
+            programmingLanguage = "java",
+            paths = listOf("/path/to/dependency.jar"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()
         )
 
         every { mockModuleManager.modules } returns arrayOf(module)
-
         prepDependencyProvider(listOf(Pair(module, params)))
 
         sut = DefaultModuleDependenciesService(project, mockk())
@@ -114,17 +112,15 @@ class DefaultModuleDependenciesServiceTest {
         val module2 = mockk<Module>()
         val params1 = DidChangeDependencyPathsParams(
             moduleName = "module1",
-            programmingLanguage = "Java",
-            files = listOf("src/main1"),
-            dirs = listOf("lib1"),
+            programmingLanguage = "java",
+            paths = listOf("/path/to/dependency1.jar"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()
         )
         val params2 = DidChangeDependencyPathsParams(
             moduleName = "module2",
-            programmingLanguage = "Java",
-            files = listOf("src/main2"),
-            dirs = listOf("lib2"),
+            programmingLanguage = "python",
+            paths = listOf("/path/to/site-packages/package1"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()
         )
@@ -138,30 +134,8 @@ class DefaultModuleDependenciesServiceTest {
 
         sut = DefaultModuleDependenciesService(project, mockk())
 
-        // Verify both modules were synced
         verify { mockLanguageServer.didChangeDependencyPaths(params1) }
         verify { mockLanguageServer.didChangeDependencyPaths(params2) }
-    }
-
-    @Test
-    fun `test rootsChanged with non-applicable module`() {
-        // Arrange
-        val module = mockk<Module>()
-
-        every { mockModuleManager.modules } returns arrayOf(module)
-
-        every {
-            EP_NAME.forEachExtensionSafe(any<Consumer<ModuleDependencyProvider>>())
-        } answers {
-            val consumer = firstArg<Consumer<ModuleDependencyProvider>>()
-            every { mockDependencyProvider.isApplicable(any()) } returns false
-            consumer.accept(mockDependencyProvider)
-        }
-
-        sut = DefaultModuleDependenciesService(project, mockk())
-
-        // Verify no sync occurred
-        verify(exactly = 0) { mockLanguageServer.didChangeDependencyPaths(any()) }
     }
 
     @Test
@@ -170,9 +144,8 @@ class DefaultModuleDependenciesServiceTest {
         val module = mockk<Module>()
         val params = DidChangeDependencyPathsParams(
             moduleName = "testModule",
-            programmingLanguage = "Java",
-            files = listOf("src/main"),
-            dirs = listOf("lib"),
+            programmingLanguage = "java",
+            paths = listOf("/path/to/dependency.jar"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()
         )
@@ -182,10 +155,8 @@ class DefaultModuleDependenciesServiceTest {
 
         sut = DefaultModuleDependenciesService(project, mockk())
 
-        // Act
         sut.rootsChanged(event)
 
-        // Verify sync occurred once - once on init and rootsChange ignores
         verify(exactly = 1) { mockLanguageServer.didChangeDependencyPaths(params) }
     }
 
@@ -195,9 +166,8 @@ class DefaultModuleDependenciesServiceTest {
         val module = mockk<Module>()
         val params = DidChangeDependencyPathsParams(
             moduleName = "testModule",
-            programmingLanguage = "Java",
-            files = listOf("src/main"),
-            dirs = listOf("lib"),
+            programmingLanguage = "java",
+            paths = listOf("/path/to/dependency.jar"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()
         )
@@ -210,12 +180,11 @@ class DefaultModuleDependenciesServiceTest {
 
         sut = DefaultModuleDependenciesService(project, mockk())
 
-        // Act
         sut.rootsChanged(event)
 
-        // Verify sync occurred twice - once on init and once after rootsChanged
         verify(exactly = 2) { mockLanguageServer.didChangeDependencyPaths(params) }
     }
+
 
     private fun prepDependencyProvider(moduleParamPairs: List<Pair<Module, DidChangeDependencyPathsParams>>) {
         every { mockModuleManager.modules } returns moduleParamPairs.map { it.first }.toTypedArray()


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
module name now returns absolute path of module

files/dirs replaced with paths for dependency path

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
