### PR TITLE
feat(amazonq): skip registering run command log file

### DIFF
--- a/.changes/next-release/feature-5391ea41-f418-4154-9f0c-5de8bacf1aeb.json
+++ b/.changes/next-release/feature-5391ea41-f418-4154-9f0c-5de8bacf1aeb.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "The logs emitted by the Agent during user command execution will be accepted and written to `.amazonq/dev/run_command.log` file in the user's local repository."
+}

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevTestBase.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevTestBase.kt
@@ -65,6 +65,8 @@ open class FeatureDevTestBase(
     internal val otherStatus = "Other"
     internal val testTabId = "test-tab-id"
     internal val testFilePaths = mapOf(Pair("test.ts", "This is a comment"))
+    internal val testRunCommandLogPath = ".amazonq/dev/run_command.log"
+    internal val testLogPath = mapOf(Pair(testRunCommandLogPath, "This is a log"))
     internal val testDeletedFiles = listOf("deleted.ts")
     internal val testReferences = listOf(CodeReferenceGenerated())
     internal val testChecksumSha = "test-sha"


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
**Problem:**  
Users currently cannot access logs generated by the Agent when it executes user commands during code generation.

**Solution:**  
The logs emitted by the Agent during user command execution will be accepted and written to the `logs` in the user's local repository. This ensures that:

- Command execution logs are persisted locally
- Users can access the logs directly from their repository

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
