### PR TITLE
fix(amazonq): didOpen emits for files already open on IDE start

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -52,6 +52,27 @@ class TextDocumentServiceHandler(
             FileDocumentManagerListener.TOPIC,
             this
         )
+
+        // open files on startup
+        val fileEditorManager = FileEditorManager.getInstance(project)
+        fileEditorManager.openFiles.forEach { file ->
+            handleFileOpened(file)
+        }
+    }
+
+    private fun handleFileOpened(file: VirtualFile) {
+        AmazonQLspService.executeIfRunning(project) { languageServer ->
+            toUriString(file)?.let { uri ->
+                languageServer.textDocumentService.didOpen(
+                    DidOpenTextDocumentParams().apply {
+                        textDocument = TextDocumentItem().apply {
+                            this.uri = uri
+                            text = file.inputStream.readAllBytes().decodeToString()
+                        }
+                    }
+                )
+            }
+        }
     }
 
     override fun beforeDocumentSaving(document: Document) {
@@ -99,18 +120,7 @@ class TextDocumentServiceHandler(
         source: FileEditorManager,
         file: VirtualFile,
     ) {
-        AmazonQLspService.executeIfRunning(project) { languageServer ->
-            toUriString(file)?.let { uri ->
-                languageServer.textDocumentService.didOpen(
-                    DidOpenTextDocumentParams().apply {
-                        textDocument = TextDocumentItem().apply {
-                            this.uri = uri
-                            text = file.inputStream.readAllBytes().decodeToString()
-                        }
-                    }
-                )
-            }
-        }
+        handleFileOpened(file)
     }
 
     override fun fileClosed(


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

Previously only emitted for new file open events, and did emit for files that had been opened in previous sessions that were still open on IDE start.

This change is needed for inline completion to work properly, as didOpen events are used to populate server's textDocuments. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
