### PR TITLE
telemetry(amazonq): Added metric data for /doc and improved error cla…

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocConstants.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocConstants.kt
@@ -21,3 +21,21 @@ const val DIAGRAM_SVG_EXT = "svg"
 const val DIAGRAM_DOT_EXT = "dot"
 val SUPPORTED_DIAGRAM_EXT_SET: Set<String> = setOf(DIAGRAM_SVG_EXT, DIAGRAM_DOT_EXT)
 val SUPPORTED_DIAGRAM_FILE_NAME_SET: Set<String> = SUPPORTED_DIAGRAM_EXT_SET.map { INFRA_DIAGRAM_PREFIX + it }.toSet()
+
+enum class MetricDataOperationName(private val operationName: String) {
+    StartDocGeneration("StartDocGeneration"),
+    EndDocGeneration("EndDocGeneration"),
+    ;
+
+    override fun toString(): String = operationName
+}
+
+enum class MetricDataResult(private val resultName: String) {
+    Success("Success"),
+    Fault("Fault"),
+    Error("Error"),
+    LlmFailure("LLMFailure"),
+    ;
+
+    override fun toString(): String = resultName
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocExceptions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/DocExceptions.kt
@@ -3,24 +3,93 @@
 
 package software.aws.toolkits.jetbrains.services.amazonqDoc
 
+import software.aws.toolkits.jetbrains.services.amazonq.project.RepoSizeError
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ClientException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.LlmException
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.ServiceException
 import software.aws.toolkits.resources.message
 
-open class DocException(
-    override val message: String?,
-    override val cause: Throwable? = null,
+open class DocClientException(
+    message: String,
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
     val remainingIterations: Int? = null,
-) : RuntimeException()
-
-class ZipFileError(override val message: String, override val cause: Throwable?) : RuntimeException()
-
-class CodeIterationLimitError(override val message: String, override val cause: Throwable?) : RuntimeException()
-
-internal fun docServiceError(message: String?, cause: Throwable? = null, remainingIterations: Int? = null): Nothing =
-    throw DocException(message, cause, remainingIterations)
-
-internal fun conversationIdNotFound(): Nothing =
-    throw DocException(message("amazonqFeatureDev.exception.conversation_not_found"))
+) : ClientException(message, operation, desc, cause)
 
 val denyListedErrors = arrayOf("Deserialization error", "Inaccessible host", "UnknownHost")
 fun createUserFacingErrorMessage(message: String?): String? =
     if (message != null && denyListedErrors.any { message.contains(it) }) "$FEATURE_NAME API request failed" else message
+
+class ReadmeTooLargeException(
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+    remainingIterations: Int? = null,
+) : DocClientException(message("amazonqDoc.exception.readme_too_large"), operation, desc, cause, remainingIterations)
+
+class ReadmeUpdateTooLargeException(
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+    remainingIterations: Int? = null,
+) : DocClientException(message("amazonqDoc.exception.readme_update_too_large"), operation, desc, cause, remainingIterations)
+
+class ContentLengthException(
+    override val message: String = message("amazonqDoc.exception.content_length_error"),
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+) :
+    RepoSizeError, ClientException(message, operation, desc, cause)
+
+class WorkspaceEmptyException(
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+) : DocClientException(message("amazonqDoc.exception.workspace_empty"), operation, desc, cause)
+
+class PromptUnrelatedException(
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+    remainingIterations: Int? = null,
+) : DocClientException(message("amazonqDoc.exception.prompt_unrelated"), operation, desc, cause, remainingIterations)
+
+class PromptTooVagueException(
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+    remainingIterations: Int? = null,
+) : DocClientException(message("amazonqDoc.exception.prompt_too_vague"), operation, desc, cause, remainingIterations)
+
+class PromptRefusalException(
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+    remainingIterations: Int? = null,
+) : DocClientException(message("amazonqFeatureDev.exception.prompt_refusal"), operation, desc, cause, remainingIterations)
+
+class GuardrailsException(
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+) : DocClientException(message("amazonqDoc.error_text"), operation, desc, cause)
+
+class NoChangeRequiredException(
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+) : DocClientException(message("amazonqDoc.exception.no_change_required"), operation, desc, cause)
+
+class EmptyPatchException(operation: String, desc: String?, cause: Throwable? = null) :
+    LlmException(message("amazonqDoc.error_text"), operation, desc, cause)
+
+class ThrottlingException(
+    operation: String,
+    desc: String?,
+    cause: Throwable? = null,
+) : DocClientException(message("amazonqFeatureDev.exception.throttling"), operation, desc, cause)
+
+class DocGenerationException(operation: String, desc: String?, cause: Throwable? = null) :
+    ServiceException(message("amazonqDoc.error_text"), operation, desc, cause)


### PR DESCRIPTION
…ssification

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- This commit introduces metric telemetry for the /doc, which will be triggered during the code generation process. The new telemetry will:
  1. Record successful and failure generation requests
  2. Track failed requests with specific error types
  3. Enable the setup of client monitoring alarms base on the metric data
- Improve the error classification for /doc base on /dev's change: https://github.com/aws/aws-toolkit-jetbrains/pull/5469

These enhancements will provide better insights into client performance
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
