### PR TITLE
test(qdoc): add more test cases for createReadme testing

### DIFF
--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/Utils.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/Utils.kt
@@ -13,6 +13,11 @@ fun prepTestData(isCreate: Boolean) {
         if (File(path).exists()) {
             File(path).delete()
         }
+        // check multi-root workspace readme as well
+        val path2 = Paths.get("tstData", "qdoc", "README.md").toUri()
+        if (File(path2).exists()) {
+            File(path2).delete()
+        }
     } else {
         val path = Paths.get("tstData", "qdoc", "updateFlow", "README.md").toUri()
         process = ProcessBuilder("git", "restore", path.path).start()

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
@@ -277,17 +277,17 @@ class CreateReadmeTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val readme = File(readmePath.toUri())
-                assertFalse(readme.exists())
+                assertThat(readme).doesNotExist()
 
                 val result = executePuppeteerScript(newReadmeDiffViewerTestScript)
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result).doesNotContain("Error: Test Failed")
 
                 if (result.contains("Error: Test Failed")) {
                     println("result: $result")
                 }
 
                 val panel = this.ui.x("//div[contains(@class, 'SimpleDiffPanel')]")
-                assertTrue(panel.present())
+                assertThat(panel.present()).isTrue()
             }
     }
 

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
@@ -280,11 +280,8 @@ class CreateReadmeTest {
                 assertThat(readme).doesNotExist()
 
                 val result = executePuppeteerScript(newReadmeDiffViewerTestScript)
-                assertThat(result).doesNotContain("Error: Test Failed")
-
-                if (result.contains("Error: Test Failed")) {
-                    println("result: $result")
-                }
+                assertThat(result)
+                    .doesNotContain("Error: Test Failed")
 
                 val panel = this.ui.x("//div[contains(@class, 'SimpleDiffPanel')]")
                 assertThat(panel.present()).isTrue()

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
@@ -129,7 +129,7 @@ class CreateReadmeWorkspacesTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "createFlow", "src", "README.md")
                 val readme = File(readmePath.toUri())
-                assertThat(readme).exists()
+                assertThat(readme).doesNotExist()
 
                 val result = executePuppeteerScript(createReadmeSubFolderPreFolderChangeTestScript)
                 this.ui.robot.pressAndReleaseKey(KeyEvent.VK_RIGHT)
@@ -180,7 +180,7 @@ class CreateReadmeWorkspacesTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "README.md")
                 val readme = File(readmePath.toUri())
-                assertThat(readme).exists()
+                assertThat(readme).doesNotExist()
 
                 val result = executePuppeteerScript(acceptReadmeTestScript)
                 assertThat(result).doesNotContain("Error: Test Failed")

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
@@ -1,0 +1,217 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.uitests.docTests.createReadmeTests
+
+import com.intellij.driver.sdk.ui.ui
+import com.intellij.driver.sdk.waitForProjectOpen
+import com.intellij.ide.starter.ci.CIServer
+import com.intellij.ide.starter.config.ConfigurationStorage
+import com.intellij.ide.starter.di.di
+import com.intellij.ide.starter.driver.engine.runIdeWithDriver
+import com.intellij.ide.starter.ide.IdeProductProvider
+import com.intellij.ide.starter.junit5.hyphenateWithClass
+import com.intellij.ide.starter.models.TestCase
+import com.intellij.ide.starter.project.LocalProjectInfo
+import com.intellij.ide.starter.runner.CurrentTestMethod
+import com.intellij.ide.starter.runner.Starter
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kodein.di.DI
+import org.kodein.di.bindSingleton
+import software.aws.toolkits.jetbrains.uitests.TestCIServer
+import software.aws.toolkits.jetbrains.uitests.clearAwsXmlFile
+import software.aws.toolkits.jetbrains.uitests.docTests.prepTestData
+import software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts.acceptReadmeTestScript
+import software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts.createReadmeSubFolderPostFolderChangeTestScript
+import software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts.createReadmeSubFolderPreFolderChangeTestScript
+import software.aws.toolkits.jetbrains.uitests.executePuppeteerScript
+import software.aws.toolkits.jetbrains.uitests.setupTestEnvironment
+import software.aws.toolkits.jetbrains.uitests.useExistingConnectionForTest
+import java.awt.event.KeyEvent
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class CreateReadmeWorkspacesTest {
+    init {
+        di = DI {
+            extend(di)
+            bindSingleton<CIServer>(overrides = true) { TestCIServer }
+            val defaults = ConfigurationStorage.instance().defaults.toMutableMap().apply {
+                put("LOG_ENVIRONMENT_VARIABLES", (!System.getenv("CI").toBoolean()).toString())
+            }
+
+            bindSingleton<ConfigurationStorage>(overrides = true) {
+                ConfigurationStorage(this, defaults)
+            }
+        }
+    }
+
+    @BeforeEach
+    fun setUpTest() {
+        // prep test data - remove readme if it exists
+        prepTestData(true)
+    }
+
+    @Test
+    fun `Create readme with single-root workspace, root folder returns a readme` () {
+        val testCase = TestCase(
+            IdeProductProvider.IC,
+            LocalProjectInfo(
+                Paths.get("tstData", "qdoc", "createFlow")
+            )
+        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+
+        // inject connection
+        useExistingConnectionForTest()
+
+        Starter.newContext(CurrentTestMethod.hyphenateWithClass(), testCase).apply {
+            System.getProperty("ui.test.plugins").split(File.pathSeparator).forEach { path ->
+                pluginConfigurator.installPluginFromPath(
+                    Path.of(path)
+                )
+            }
+
+            copyExistingConfig(Paths.get("tstData", "configAmazonQTests"))
+            updateGeneralSettings()
+        }.runIdeWithDriver()
+            .useDriverAndCloseIde {
+                waitForProjectOpen()
+                // required wait time for the system to be fully ready
+                Thread.sleep(30000)
+
+                val readmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
+                val readme = File(readmePath.toUri())
+                assertFalse(readme.exists())
+
+                val result = executePuppeteerScript(acceptReadmeTestScript)
+                assertFalse(result.contains("Error: Test Failed"))
+                if (result.contains("Error: Test Failed")) {
+                    println("result: $result")
+                }
+
+                val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
+                val newReadme = File(newReadmePath.toUri())
+                assertTrue(newReadme.exists())
+                assertTrue(newReadme.readText().contains("REST"))
+                assertTrue(newReadme.readText().contains("API"))
+            }
+    }
+
+    @Test
+    fun `Create readme with single-root workspace, in a subfolder returns a readme`() {
+        val testCase = TestCase(
+            IdeProductProvider.IC,
+            LocalProjectInfo(
+                Paths.get("tstData", "qdoc", "createFlow")
+            )
+        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+
+        // inject connection
+        useExistingConnectionForTest()
+
+        Starter.newContext(CurrentTestMethod.hyphenateWithClass(), testCase).apply {
+            System.getProperty("ui.test.plugins").split(File.pathSeparator).forEach { path ->
+                pluginConfigurator.installPluginFromPath(
+                    Path.of(path)
+                )
+            }
+
+            copyExistingConfig(Paths.get("tstData", "configAmazonQTests"))
+            updateGeneralSettings()
+        }.runIdeWithDriver()
+            .useDriverAndCloseIde {
+                waitForProjectOpen()
+                // required wait time for the system to be fully ready
+                Thread.sleep(30000)
+
+                val readmePath = Paths.get("tstData", "qdoc", "createFlow", "src", "README.md")
+                val readme = File(readmePath.toUri())
+                assertFalse(readme.exists())
+
+                val result = executePuppeteerScript(createReadmeSubFolderPreFolderChangeTestScript)
+                this.ui.robot.pressAndReleaseKey(KeyEvent.VK_RIGHT)
+                this.ui.robot.pressAndReleaseKey(KeyEvent.VK_DOWN)
+                this.ui.robot.pressAndReleaseKey(KeyEvent.VK_ENTER)
+                val result2 = executePuppeteerScript(createReadmeSubFolderPostFolderChangeTestScript)
+
+                assertFalse(result.contains("Error: Test Failed"))
+                assertFalse(result2.contains("Error: Test Failed"))
+
+                if (result.contains("Error: Test Failed") || result2.contains("Error: Test Failed")) {
+                    println("result: $result")
+                    println("result2: $result2")
+                }
+
+                val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "src", "README.md")
+                val newReadme = File(newReadmePath.toUri())
+                assertTrue(newReadme.exists())
+            }
+    }
+
+    @Test
+    fun `Create readme with multi-root workspace returns a readme`() {
+        val testCase = TestCase(
+            IdeProductProvider.IC,
+            LocalProjectInfo(
+                Paths.get("tstData", "qdoc")
+            )
+        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+
+        // inject connection
+        useExistingConnectionForTest()
+
+        Starter.newContext(CurrentTestMethod.hyphenateWithClass(), testCase).apply {
+            System.getProperty("ui.test.plugins").split(File.pathSeparator).forEach { path ->
+                pluginConfigurator.installPluginFromPath(
+                    Path.of(path)
+                )
+            }
+
+            copyExistingConfig(Paths.get("tstData", "configAmazonQTests"))
+            updateGeneralSettings()
+        }.runIdeWithDriver()
+            .useDriverAndCloseIde {
+                waitForProjectOpen()
+                // required wait time for the system to be fully ready
+                Thread.sleep(30000)
+
+                val readmePath = Paths.get("tstData", "qdoc", "README.md")
+                val readme = File(readmePath.toUri())
+                assertFalse(readme.exists())
+
+                val result = executePuppeteerScript(acceptReadmeTestScript)
+                assertFalse(result.contains("Error: Test Failed"))
+                if (result.contains("Error: Test Failed")) {
+                    println("result: $result")
+                }
+
+                val newReadmePath = Paths.get("tstData", "qdoc", "README.md")
+                val newReadme = File(newReadmePath.toUri())
+                assertTrue(newReadme.exists())
+                val readmeContents = newReadme.readText()
+                assertTrue(readmeContents.contains("REST"))
+                assertTrue(readmeContents.contains("API"))
+            }
+    }
+
+    companion object {
+        @JvmStatic
+        @AfterAll
+        fun clearAwsXml() {
+            clearAwsXmlFile()
+        }
+
+        @JvmStatic
+        @BeforeAll
+        fun setUp() {
+            // Setup test environment
+            setupTestEnvironment()
+        }
+    }
+}

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
@@ -16,8 +16,8 @@ import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -59,7 +59,7 @@ class CreateReadmeWorkspacesTest {
     }
 
     @Test
-    fun `Create readme with single-root workspace, root folder returns a readme` () {
+    fun `Create readme with single-root workspace, root folder returns a readme`() {
         val testCase = TestCase(
             IdeProductProvider.IC,
             LocalProjectInfo(

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
@@ -89,14 +89,15 @@ class CreateReadmeWorkspacesTest {
                 assertThat(readme).doesNotExist()
 
                 val result = executePuppeteerScript(acceptReadmeTestScript)
-                assertThat(result).doesNotContain("Error: Test Failed")
-                if (result.contains("Error: Test Failed")) {
-                    println("result: $result")
-                }
+                assertThat(result)
+                    .doesNotContain("Error: Test Failed")
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val newReadme = File(newReadmePath.toUri())
-                assertThat(newReadme).exists().content().contains("REST", "API")
+                assertThat(newReadme)
+                    .exists()
+                    .content()
+                    .contains("REST", "API")
             }
     }
 
@@ -129,7 +130,8 @@ class CreateReadmeWorkspacesTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "createFlow", "src", "README.md")
                 val readme = File(readmePath.toUri())
-                assertThat(readme).doesNotExist()
+                assertThat(readme)
+                    .doesNotExist()
 
                 val result = executePuppeteerScript(createReadmeSubFolderPreFolderChangeTestScript)
                 this.ui.robot.pressAndReleaseKey(KeyEvent.VK_RIGHT)
@@ -137,17 +139,15 @@ class CreateReadmeWorkspacesTest {
                 this.ui.robot.pressAndReleaseKey(KeyEvent.VK_ENTER)
                 val result2 = executePuppeteerScript(createReadmeSubFolderPostFolderChangeTestScript)
 
-                assertThat(result).doesNotContain("Error: Test Failed")
-                assertThat(result2).doesNotContain("Error: Test Failed")
-
-                if (result.contains("Error: Test Failed") || result2.contains("Error: Test Failed")) {
-                    println("result: $result")
-                    println("result2: $result2")
-                }
+                assertThat(result)
+                    .doesNotContain("Error: Test Failed")
+                assertThat(result2)
+                    .doesNotContain("Error: Test Failed")
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "src", "README.md")
                 val newReadme = File(newReadmePath.toUri())
-                assertThat(newReadme).exists()
+                assertThat(newReadme)
+                    .exists()
             }
     }
 
@@ -183,14 +183,13 @@ class CreateReadmeWorkspacesTest {
                 assertThat(readme).doesNotExist()
 
                 val result = executePuppeteerScript(acceptReadmeTestScript)
-                assertThat(result).doesNotContain("Error: Test Failed")
-                if (result.contains("Error: Test Failed")) {
-                    println("result: $result")
-                }
+                assertThat(result)
+                    .doesNotContain("Error: Test Failed")
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "README.md")
                 val newReadme = File(newReadmePath.toUri())
-                assertThat(newReadme).exists()
+                assertThat(newReadme)
+                    .exists()
                     .content()
                     .contains(
                         "REST",

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
@@ -136,7 +136,7 @@ class CreateReadmeWorkspacesTest {
 
                 val result = executePuppeteerScript(createReadmeSubFolderPreFolderChangeTestScript)
                 this.ui.robot.pressAndReleaseKey(KeyEvent.VK_RIGHT)
-                this.ui.robot.pressAndReleaseKey(KeyEvent.VK_DOWN)
+                this.ui.robot.enterText("\\/src")
                 this.ui.robot.pressAndReleaseKey(KeyEvent.VK_ENTER)
                 val result2 = executePuppeteerScript(createReadmeSubFolderPostFolderChangeTestScript)
 

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
@@ -134,6 +134,10 @@ class CreateReadmeWorkspacesTest {
                     .doesNotExist()
 
                 val result = executePuppeteerScript(createReadmeSubFolderPreFolderChangeTestScript)
+                // Using keyboard press to select a subfolder based on a windows/linux folder selector
+                // right to move active cursor to the end
+                // enter src as the subfolder name (subfolder name tstData/qdoc/createFlow/src)
+                // enter to confirm selected subfolder
                 this.ui.robot.pressAndReleaseKey(KeyEvent.VK_RIGHT)
                 this.ui.robot.enterText("\\/src")
                 this.ui.robot.pressAndReleaseKey(KeyEvent.VK_ENTER)

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeWorkspacesTest.kt
@@ -15,9 +15,8 @@ import com.intellij.ide.starter.models.TestCase
 import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -87,19 +86,17 @@ class CreateReadmeWorkspacesTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val readme = File(readmePath.toUri())
-                assertFalse(readme.exists())
+                assertThat(readme).doesNotExist()
 
                 val result = executePuppeteerScript(acceptReadmeTestScript)
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result).doesNotContain("Error: Test Failed")
                 if (result.contains("Error: Test Failed")) {
                     println("result: $result")
                 }
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val newReadme = File(newReadmePath.toUri())
-                assertTrue(newReadme.exists())
-                assertTrue(newReadme.readText().contains("REST"))
-                assertTrue(newReadme.readText().contains("API"))
+                assertThat(newReadme).exists().content().contains("REST", "API")
             }
     }
 
@@ -132,7 +129,7 @@ class CreateReadmeWorkspacesTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "createFlow", "src", "README.md")
                 val readme = File(readmePath.toUri())
-                assertFalse(readme.exists())
+                assertThat(readme).exists()
 
                 val result = executePuppeteerScript(createReadmeSubFolderPreFolderChangeTestScript)
                 this.ui.robot.pressAndReleaseKey(KeyEvent.VK_RIGHT)
@@ -140,8 +137,8 @@ class CreateReadmeWorkspacesTest {
                 this.ui.robot.pressAndReleaseKey(KeyEvent.VK_ENTER)
                 val result2 = executePuppeteerScript(createReadmeSubFolderPostFolderChangeTestScript)
 
-                assertFalse(result.contains("Error: Test Failed"))
-                assertFalse(result2.contains("Error: Test Failed"))
+                assertThat(result).doesNotContain("Error: Test Failed")
+                assertThat(result2).doesNotContain("Error: Test Failed")
 
                 if (result.contains("Error: Test Failed") || result2.contains("Error: Test Failed")) {
                     println("result: $result")
@@ -150,7 +147,7 @@ class CreateReadmeWorkspacesTest {
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "src", "README.md")
                 val newReadme = File(newReadmePath.toUri())
-                assertTrue(newReadme.exists())
+                assertThat(newReadme).exists()
             }
     }
 
@@ -183,20 +180,22 @@ class CreateReadmeWorkspacesTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "README.md")
                 val readme = File(readmePath.toUri())
-                assertFalse(readme.exists())
+                assertThat(readme).exists()
 
                 val result = executePuppeteerScript(acceptReadmeTestScript)
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result).doesNotContain("Error: Test Failed")
                 if (result.contains("Error: Test Failed")) {
                     println("result: $result")
                 }
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "README.md")
                 val newReadme = File(newReadmePath.toUri())
-                assertTrue(newReadme.exists())
-                val readmeContents = newReadme.readText()
-                assertTrue(readmeContents.contains("REST"))
-                assertTrue(readmeContents.contains("API"))
+                assertThat(newReadme).exists()
+                    .content()
+                    .contains(
+                        "REST",
+                        "API"
+                    )
             }
     }
 

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/CreateReadmeSubFolderTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/CreateReadmeSubFolderTest.kt
@@ -1,0 +1,91 @@
+ // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ // SPDX-License-Identifier: Apache-2.0
+
+ package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
+
+ import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+
+ // language=JS
+ val createReadmeSubFolderPreFolderChangeScript = """
+    const puppeteer = require('puppeteer');
+
+    async function testNavigation() {
+        const browser = await puppeteer.connect({
+            browserURL: 'http://localhost:9222'
+        })
+
+        try {
+
+            const pages = await browser.pages()
+
+            for(const page of pages) {
+                const contents = await page.evaluate(el => el.innerHTML, await page.${'$'}(':root'));
+
+                const element = await page.${'$'}('.mynah-chat-prompt-input')
+                if(element) {
+
+                    console.log('Typing /doc in the chat window')
+
+                    await page.type('.mynah-chat-prompt-input', '/doc')
+                    await page.keyboard.press('Enter')
+
+                    console.log('Attempting to find and click Create a README button')
+                    await findAndClickButton(page, 'Create a README', true, 10000)
+                    console.log('Attempting to find and click Change folder button to select subfolder')
+                    await findAndClickButton(page, 'Change folder', true, 10000)
+                }
+          }
+
+        } finally {
+            await browser.close();
+        }
+    }
+
+    testNavigation().catch((error) => {
+      console.log('Error: Test Failed');
+      console.error(error);
+    });
+ """.trimIndent()
+
+ // language=JS
+ val createReadmeSubFolderPostFolderChangeScript = """
+        const puppeteer = require('puppeteer');
+
+        async function testNavigation() {
+            const browser = await puppeteer.connect({
+                browserURL: 'http://localhost:9222'
+            })
+
+            try {
+
+                const pages = await browser.pages()
+
+                for(const page of pages) {
+                    const contents = await page.evaluate(el => el.innerHTML, await page.${'$'}(':root'));
+
+                    const element = await page.${'$'}('.mynah-chat-prompt-input')
+                    if(element) {
+                        console.log('Attempting to find and click Yes button to confirm option')
+                        await findAndClickButton(page, 'Yes', true, 10000)
+
+                        console.log('Waiting for README to be generated')
+                        await new Promise(resolve => setTimeout(resolve, 90000))
+
+                        console.log('Attempting to find and click Accept button');
+                        await findAndClickButton(page, 'Accept', true, 10000)
+                    }
+              }
+
+            } finally {
+                await browser.close();
+            }
+        }
+
+        testNavigation().catch((error) => {
+          console.log('Error: Test Failed');
+          console.error(error);
+        });
+ """.trimIndent()
+
+ val createReadmeSubFolderPreFolderChangeTestScript = createReadmeSubFolderPreFolderChangeScript.plus(findAndClickButtonScript)
+ val createReadmeSubFolderPostFolderChangeTestScript = createReadmeSubFolderPostFolderChangeScript.plus(findAndClickButtonScript)

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/CreateReadmeSubFolderTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/CreateReadmeSubFolderTest.kt
@@ -1,12 +1,12 @@
- // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- // SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
- package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
+package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
 
- import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
 
- // language=JS
- val createReadmeSubFolderPreFolderChangeScript = """
+// language=JS
+val createReadmeSubFolderPreFolderChangeScript = """
     const puppeteer = require('puppeteer');
 
     async function testNavigation() {
@@ -45,10 +45,10 @@
       console.log('Error: Test Failed');
       console.error(error);
     });
- """.trimIndent()
+""".trimIndent()
 
- // language=JS
- val createReadmeSubFolderPostFolderChangeScript = """
+// language=JS
+val createReadmeSubFolderPostFolderChangeScript = """
         const puppeteer = require('puppeteer');
 
         async function testNavigation() {
@@ -85,7 +85,7 @@
           console.log('Error: Test Failed');
           console.error(error);
         });
- """.trimIndent()
+""".trimIndent()
 
- val createReadmeSubFolderPreFolderChangeTestScript = createReadmeSubFolderPreFolderChangeScript.plus(findAndClickButtonScript)
- val createReadmeSubFolderPostFolderChangeTestScript = createReadmeSubFolderPostFolderChangeScript.plus(findAndClickButtonScript)
+val createReadmeSubFolderPreFolderChangeTestScript = createReadmeSubFolderPreFolderChangeScript.plus(findAndClickButtonScript)
+val createReadmeSubFolderPostFolderChangeTestScript = createReadmeSubFolderPostFolderChangeScript.plus(findAndClickButtonScript)

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/NewReadmeDiffViewerScript.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/NewReadmeDiffViewerScript.kt
@@ -1,0 +1,57 @@
+ // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ // SPDX-License-Identifier: Apache-2.0
+
+ package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
+
+ import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+
+ // language=JS
+ val newReadmeDiffViewerScript = """
+    const puppeteer = require('puppeteer');
+
+    async function testNavigation() {
+        const browser = await puppeteer.connect({
+            browserURL: 'http://localhost:9222'
+        })
+
+        try {
+
+            const pages = await browser.pages()
+
+            for(const page of pages) {
+                const contents = await page.evaluate(el => el.innerHTML, await page.${'$'}(':root'));
+
+                const element = await page.${'$'}('.mynah-chat-prompt-input')
+                if(element) {
+
+                    console.log('Typing /doc in the chat window')
+
+                    await page.type('.mynah-chat-prompt-input', '/doc')
+                    await page.keyboard.press('Enter')
+
+                    console.log('Attempting to find and click Create a README button')
+                    await findAndClickButton(page, 'Create a README', true, 10000)
+                    console.log('Attempting to find and click Yes button to confirm option')
+                    await findAndClickButton(page, 'Yes', true, 10000)
+
+                    console.log('Waiting for README to be generated')
+                    await new Promise(resolve => setTimeout(resolve, 75000));
+
+                    console.log('Attempting to find Accept button to confirm Readme has been generated');
+                    await findAndClickButton(page, 'Accept', false, 10000)
+                }
+          }
+
+        } finally {
+            await browser.close();
+        }
+    }
+
+    
+testNavigation().catch((error) => {
+      console.log('Error: Test Failed');
+      console.error(error);
+    });
+ """.trimIndent()
+
+ val newReadmeDiffViewerTestScript = newReadmeDiffViewerScript.plus(findAndClickButtonScript)

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/NewReadmeDiffViewerScript.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/scripts/createReadmeScripts/NewReadmeDiffViewerScript.kt
@@ -1,12 +1,12 @@
- // Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- // SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
- package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
+package software.aws.toolkits.jetbrains.uitests.docTests.scripts.createReadmeScripts
 
- import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
+import software.aws.toolkits.jetbrains.uitests.findAndClickButtonScript
 
- // language=JS
- val newReadmeDiffViewerScript = """
+// language=JS
+val newReadmeDiffViewerScript = """
     const puppeteer = require('puppeteer');
 
     async function testNavigation() {
@@ -52,6 +52,6 @@ testNavigation().catch((error) => {
       console.log('Error: Test Failed');
       console.error(error);
     });
- """.trimIndent()
+""".trimIndent()
 
- val newReadmeDiffViewerTestScript = newReadmeDiffViewerScript.plus(findAndClickButtonScript)
+val newReadmeDiffViewerTestScript = newReadmeDiffViewerScript.plus(findAndClickButtonScript)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Add UI Tests to validate more flows during `Create a Readme`
The tests are using the sample repository that was created for the earlier tests
There are 4 test cases which validate the following
1. New Readme generated opens in a diff viewer panel 
2. New Readme is generated In a single-root workspace, within the root folder 
3. New Readme is generated in a single-root workspace, within a sub folder 
4. New Readme is generated in a multi-root workspace, within the root folder

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
