### PR TITLE
ci: fix 241 integ / 251 ui classpath issues

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-integration-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-integration-testing.gradle.kts
@@ -79,6 +79,11 @@ extensions.findByType<IntelliJPlatformTestingExtension>()?.let {
         task {
             integrationTestConfiguration(this)
         }
+
+        // https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1844
+        prepareSandboxTask {
+            disabledPlugins.add("com.intellij.swagger")
+        }
     }
 } ?: run {
     val integrationTest by tasks.registering(Test::class, integrationTestConfiguration)

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -3,6 +3,7 @@
 
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 import software.aws.toolkits.gradle.findFolders
 import software.aws.toolkits.gradle.intellij.IdeVersions
 import software.aws.toolkits.gradle.intellij.toolkitIntelliJ
@@ -103,7 +104,8 @@ dependencies {
     }
 }
 
-tasks.prepareTestSandbox {
+// https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1844
+tasks.withType<PrepareSandboxTask>() {
     disabledPlugins.addAll(
         "com.intellij.swagger",
         "org.jetbrains.plugins.kotlin.jupyter",

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -105,7 +105,7 @@ dependencies {
 }
 
 // https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1844
-tasks.withType<PrepareSandboxTask>() {
+tasks.withType<PrepareSandboxTask>().configureEach {
     disabledPlugins.addAll(
         "com.intellij.swagger",
         "org.jetbrains.plugins.kotlin.jupyter",

--- a/ui-tests-starter/.gitignore
+++ b/ui-tests-starter/.gitignore
@@ -1,1 +1,3 @@
 allure-results/
+package.json
+package-lock.json

--- a/ui-tests-starter/build.gradle.kts
+++ b/ui-tests-starter/build.gradle.kts
@@ -38,6 +38,7 @@ intellijPlatform {
 }
 
 val uiTestImplementation by configurations.getting
+val uiTestRuntimeOnly by configurations.getting
 
 configurations.getByName(uiTestSource.compileClasspathConfigurationName) {
     extendsFrom(uiTestImplementation)
@@ -52,6 +53,9 @@ dependencies {
     uiTestImplementation("org.kodein.di:kodein-di-jvm:7.20.2")
     uiTestImplementation(platform(libs.junit5.bom))
     uiTestImplementation(libs.junit5.jupiter)
+
+    // not sure why not coming in transitively for starter
+    uiTestRuntimeOnly(libs.kotlin.coroutines)
 
     intellijPlatform {
         val version = ideProfile.community.sdkVersion

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/OfflineAmazonQInlineCompletionTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/OfflineAmazonQInlineCompletionTest.kt
@@ -46,7 +46,7 @@ class OfflineAmazonQInlineCompletionTest {
             LocalProjectInfo(
                 Paths.get("tstData", "Hello")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
         Paths.get(System.getProperty("user.home"), ".aws", "sso", "cache", "ee1d2538cb8d358377d7661466c866af747a8a3f.json")
             .createParentDirectories()
             .writeText(

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/chatTests/AmazonQChatTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/chatTests/AmazonQChatTest.kt
@@ -58,7 +58,7 @@ class AmazonQChatTest {
             LocalProjectInfo(
                 Paths.get("tstData", "Hello")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
@@ -65,7 +65,7 @@ class CreateReadmeTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "createFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -101,7 +101,7 @@ class CreateReadmeTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "createFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -137,7 +137,7 @@ class CreateReadmeTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "createFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -173,7 +173,7 @@ class CreateReadmeTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "createFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -218,7 +218,7 @@ class CreateReadmeTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "createFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/updateReadmeTests/UpdateReadmeLatestChangesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/updateReadmeTests/UpdateReadmeLatestChangesTest.kt
@@ -63,7 +63,7 @@ class UpdateReadmeLatestChangesTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "updateFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -101,7 +101,7 @@ class UpdateReadmeLatestChangesTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "updateFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -139,7 +139,7 @@ class UpdateReadmeLatestChangesTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "updateFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/updateReadmeTests/UpdateReadmeSpecificChangesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/updateReadmeTests/UpdateReadmeSpecificChangesTest.kt
@@ -62,7 +62,7 @@ class UpdateReadmeSpecificChangesTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "updateFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -100,7 +100,7 @@ class UpdateReadmeSpecificChangesTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qdoc", "updateFlow")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/featureDevTests/FeatureDevTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/featureDevTests/FeatureDevTest.kt
@@ -68,7 +68,7 @@ class FeatureDevTest {
             LocalProjectInfo(
                 Paths.get("tstData", "FeatureDevE2ETestFolder")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -100,7 +100,7 @@ class FeatureDevTest {
             LocalProjectInfo(
                 Paths.get("tstData", "FeatureDevE2ETestFolder")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -132,7 +132,7 @@ class FeatureDevTest {
             LocalProjectInfo(
                 Paths.get("tstData", "FeatureDevE2ETestFolder")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -164,7 +164,7 @@ class FeatureDevTest {
             LocalProjectInfo(
                 Paths.get("tstData", "FeatureDevE2ETestFolder")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -196,7 +196,7 @@ class FeatureDevTest {
             LocalProjectInfo(
                 Paths.get("tstData", "FeatureDevE2ETestFolder")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/testTests/QTestGenerationChatTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/testTests/QTestGenerationChatTest.kt
@@ -57,7 +57,7 @@ class QTestGenerationChatTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qTestGenerationTestProject")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -89,7 +89,7 @@ class QTestGenerationChatTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qTestGenerationTestProject/")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -123,7 +123,7 @@ class QTestGenerationChatTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qTestGenerationTestProject/")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()
@@ -155,7 +155,7 @@ class QTestGenerationChatTest {
             LocalProjectInfo(
                 Paths.get("tstData", "qTestGenerationTestProject/")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/transformTests/TransformChatTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/transformTests/TransformChatTest.kt
@@ -123,7 +123,7 @@ class TransformChatTest {
             LocalProjectInfo(
                 Paths.get("tstData", "Hello")
             )
-        ).useRelease(System.getProperty("org.gradle.project.ideProfileName"))
+        ).withVersion(System.getProperty("org.gradle.project.ideProfileName"))
 
         // inject connection
         useExistingConnectionForTest()


### PR DESCRIPTION
* integ / ui failing due to missing / conflicting classpath issues
* 251 ui failing since `useRelease` filters out non-release builds

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
