### PR TITLE
fix(amazonq): rename didChangeDependenciesPath param value to match lsp

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/JavaModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/JavaModuleDependencyProvider.kt
@@ -26,7 +26,7 @@ internal class JavaModuleDependencyProvider : ModuleDependencyProvider {
 
         return DidChangeDependencyPathsParams(
             moduleName = getWorkspaceFolderPath(module),
-            programmingLanguage = "java",
+            runtimeLanguage = "java",
             paths = dependencies,
             includePatterns = emptyList(),
             excludePatterns = emptyList()

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/PythonModuleDependencyProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/providers/PythonModuleDependencyProvider.kt
@@ -30,7 +30,7 @@ internal class PythonModuleDependencyProvider : ModuleDependencyProvider {
 
         return DidChangeDependencyPathsParams(
             moduleName = getWorkspaceFolderPath(module),
-            programmingLanguage = "python",
+            runtimeLanguage = "python",
             paths = dependencies,
             includePatterns = emptyList(),
             excludePatterns = emptyList()

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/dependencies/DidChangeDependencyPathsParams.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/dependencies/DidChangeDependencyPathsParams.kt
@@ -5,7 +5,7 @@ package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependenc
 
 class DidChangeDependencyPathsParams(
     val moduleName: String,
-    val programmingLanguage: String,
+    val runtimeLanguage: String,
     val paths: List<String>,
     val includePatterns: List<String>,
     val excludePatterns: List<String>,

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
@@ -91,7 +91,7 @@ class DefaultModuleDependenciesServiceTest {
         val module = mockk<Module>()
         val params = DidChangeDependencyPathsParams(
             moduleName = "testModule",
-            programmingLanguage = "java",
+            runtimeLanguage = "java",
             paths = listOf("/path/to/dependency.jar"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()
@@ -112,14 +112,14 @@ class DefaultModuleDependenciesServiceTest {
         val module2 = mockk<Module>()
         val params1 = DidChangeDependencyPathsParams(
             moduleName = "module1",
-            programmingLanguage = "java",
+            runtimeLanguage = "java",
             paths = listOf("/path/to/dependency1.jar"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()
         )
         val params2 = DidChangeDependencyPathsParams(
             moduleName = "module2",
-            programmingLanguage = "python",
+            runtimeLanguage = "python",
             paths = listOf("/path/to/site-packages/package1"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()
@@ -144,7 +144,7 @@ class DefaultModuleDependenciesServiceTest {
         val module = mockk<Module>()
         val params = DidChangeDependencyPathsParams(
             moduleName = "testModule",
-            programmingLanguage = "java",
+            runtimeLanguage = "java",
             paths = listOf("/path/to/dependency.jar"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()
@@ -166,7 +166,7 @@ class DefaultModuleDependenciesServiceTest {
         val module = mockk<Module>()
         val params = DidChangeDependencyPathsParams(
             moduleName = "testModule",
-            programmingLanguage = "java",
+            runtimeLanguage = "java",
             paths = listOf("/path/to/dependency.jar"),
             includePatterns = emptyList(),
             excludePatterns = emptyList()


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Change to match interface
https://github.com/aws/language-server-runtimes/blob/main/types/didChangeDependencyPaths.ts#L6

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
