### PR TITLE
style: ban org.junit.Assert and org.junit.jupiter.api.Assertions

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-integration-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-integration-testing.gradle.kts
@@ -79,11 +79,6 @@ extensions.findByType<IntelliJPlatformTestingExtension>()?.let {
         task {
             integrationTestConfiguration(this)
         }
-
-        // https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1844
-        prepareSandboxTask {
-            disabledPlugins.add("com.intellij.swagger")
-        }
     }
 } ?: run {
     val integrationTest by tasks.registering(Test::class, integrationTestConfiguration)

--- a/buildSrc/src/main/kotlin/toolkit-integration-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-integration-testing.gradle.kts
@@ -79,6 +79,11 @@ extensions.findByType<IntelliJPlatformTestingExtension>()?.let {
         task {
             integrationTestConfiguration(this)
         }
+
+        // https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1844
+        prepareSandboxTask {
+            disabledPlugins.add("com.intellij.swagger")
+        }
     }
 } ?: run {
     val integrationTest by tasks.registering(Test::class, integrationTestConfiguration)

--- a/detekt-rules/src/software/aws/toolkits/gradle/detekt/rules/BannedImportsRule.kt
+++ b/detekt-rules/src/software/aws/toolkits/gradle/detekt/rules/BannedImportsRule.kt
@@ -17,7 +17,7 @@ class BannedImportsRule : Rule() {
     override fun visitImportList(importList: KtImportList) {
         super.visitImportList(importList)
         importList.imports.forEach { element ->
-            val importedFqName = element.importedFqName?.asString()
+            val importedFqName = element.importedFqName?.asString() ?: return
             if (importedFqName == "org.assertj.core.api.Assertions") {
                 report(
                     CodeSmell(
@@ -28,7 +28,7 @@ class BannedImportsRule : Rule() {
                 )
             }
 
-            if (importedFqName?.startsWith("org.hamcrest") == true) {
+            if (importedFqName.startsWith("org.hamcrest")) {
                 report(
                     CodeSmell(
                         issue,
@@ -38,9 +38,7 @@ class BannedImportsRule : Rule() {
                 )
             }
 
-            if (importedFqName?.startsWith("kotlin.test.assert") == true &&
-                importedFqName.startsWith("kotlin.test.assertNotNull") == false
-            ) {
+            if (importedFqName.startsWith("kotlin.test.assert") && !importedFqName.startsWith("kotlin.test.assertNotNull")) {
                 report(
                     CodeSmell(
                         issue,
@@ -50,7 +48,17 @@ class BannedImportsRule : Rule() {
                 )
             }
 
-            if (importedFqName?.startsWith("org.gradle.internal.impldep") == true) {
+            if (importedFqName.startsWith("org.junit.jupiter.api.Assertions") || importedFqName.startsWith("org.junit.Assert")) {
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.from(element),
+                        message = "Use AssertJ instead of JUnit assertions"
+                    )
+                )
+            }
+
+            if (importedFqName.startsWith("org.gradle.internal.impldep")) {
                 report(
                     CodeSmell(
                         issue,
@@ -60,7 +68,7 @@ class BannedImportsRule : Rule() {
                 )
             }
 
-            if (importedFqName?.contains("kotlinx.coroutines.Dispatchers") == true) {
+            if (importedFqName.contains("kotlinx.coroutines.Dispatchers")) {
                 report(
                     CodeSmell(
                         issue,

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevSessionContextTest.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import com.intellij.testFramework.RuleChain
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -85,7 +85,11 @@ class FeatureDevSessionContextTest : FeatureDevTestBase(HeavyJavaCodeInsightTest
         fun addressablePathOf(path: String) = path.removePrefix(base).removePrefix("/")
 
         fileCases.forEach {
-            assertEquals(it.shouldInclude, zippedFiles.contains(addressablePathOf(it.path)))
+            if (it.shouldInclude) {
+                assertThat(zippedFiles).contains(addressablePathOf(it.path))
+            } else {
+                assertThat(zippedFiles).doesNotContain(addressablePathOf(it.path))
+            }
         }
     }
 

--- a/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/storage/ChatSessionStorageTest.kt
+++ b/plugins/amazonq/chat/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/storage/ChatSessionStorageTest.kt
@@ -3,14 +3,13 @@
 
 package software.aws.toolkits.jetbrains.services.amazonqFeatureDev.storage
 
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevTestBase
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.session.Session
-import kotlin.test.assertNotNull
 
 class ChatSessionStorageTest : FeatureDevTestBase() {
 
@@ -27,9 +26,9 @@ class ChatSessionStorageTest : FeatureDevTestBase() {
     @Test
     fun `check getSession for NewSession`() {
         val testSession = chatSessionStorage.getSession("tabId", project)
-        assertNotNull(testSession)
-        assertEquals(testSession.tabID, "tabId")
-        assertEquals(testSession.project, project)
+        assertThat(testSession).isNotNull()
+        assertThat(testSession.tabID).isEqualTo("tabId")
+        assertThat(testSession.project).isEqualTo(project)
     }
 
     @Test
@@ -39,7 +38,7 @@ class ChatSessionStorageTest : FeatureDevTestBase() {
 
         val expectedSession = chatSessionStorage.getSession(mockSession.tabID, mockSession.project)
         val actualSession = chatSessionStorage.getSession("tab1", project)
-        assertNotNull(actualSession)
-        assertEquals(expectedSession, actualSession)
+        assertThat(actualSession).isNotNull()
+        assertThat(actualSession).isEqualTo(expectedSession)
     }
 }

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformChatTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformChatTest.kt
@@ -37,7 +37,7 @@ class CodeTransformChatTest {
                 assertThat(buttons[0].id).isEqualTo(CodeTransformButtonId.ViewDiff.id)
                 assertThat(buttons[0].text).isEqualTo("View diff 1/5")
                 assertThat(buttons[1].id).isEqualTo(CodeTransformButtonId.ViewSummary.id)
-        }
+            }
     }
 
     @Test

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformChatTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformChatTest.kt
@@ -3,15 +3,13 @@
 
 package software.aws.toolkits.jetbrains.services.codemodernizer
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.fail
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import software.aws.toolkits.jetbrains.services.codemodernizer.constants.buildTransformResultChatContent
 import software.aws.toolkits.jetbrains.services.codemodernizer.messages.CodeTransformButtonId
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.CodeModernizerJobCompletedResult
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.JobId
+import software.aws.toolkits.jetbrains.utils.satisfiesKt
 import software.aws.toolkits.resources.message
 
 class CodeTransformChatTest {
@@ -20,41 +18,49 @@ class CodeTransformChatTest {
     fun `test that transform result chat item includes view build log button and message when pre-build fails`() {
         val result = CodeModernizerJobCompletedResult.JobFailedInitialBuild(JobId("dummy-job-id-123"), "Build failed in Java 8 sandbox", true)
         val chatItem = buildTransformResultChatContent(result)
-        assertEquals(chatItem.message, message("codemodernizer.chat.message.result.fail_initial_build"))
-        assertNotNull(chatItem.buttons)
-        assertEquals(chatItem.buttons?.size ?: fail("buttons is null"), 1)
-        assertEquals(chatItem.buttons?.get(0)?.id ?: fail("buttons is null"), CodeTransformButtonId.ViewBuildLog.id)
+        assertThat(chatItem.message).isEqualTo(message("codemodernizer.chat.message.result.fail_initial_build"))
+        assertThat(chatItem.buttons)
+            .singleElement()
+            .satisfiesKt {
+                assertThat(it.id).isEqualTo(CodeTransformButtonId.ViewBuildLog.id)
+            }
     }
 
     @Test
     fun `test that transform result chat item includes view summary button and view diff button with correct label when job fully succeeded with 5 patch files`() {
         val result = CodeModernizerJobCompletedResult.JobCompletedSuccessfully(JobId("dummy-job-id-123"))
         val chatItem = buildTransformResultChatContent(result, 5)
-        assertEquals(chatItem.message, message("codemodernizer.chat.message.result.success.multiple_diffs"))
-        assertNotNull(chatItem.buttons)
-        assertEquals(chatItem.buttons?.size ?: fail("buttons is null"), 2)
-        assertEquals(chatItem.buttons?.get(0)?.id ?: fail("buttons is null"), CodeTransformButtonId.ViewDiff.id)
-        assertEquals(chatItem.buttons?.get(0)?.text ?: fail("buttons is null"), "View diff 1/5")
-        assertEquals(chatItem.buttons?.get(1)?.id ?: fail("buttons is null"), CodeTransformButtonId.ViewSummary.id)
+        assertThat(chatItem.message).isEqualTo(message("codemodernizer.chat.message.result.success.multiple_diffs"))
+        assertThat(chatItem.buttons)
+            .hasSize(2)
+            .satisfiesKt { buttons ->
+                assertThat(buttons[0].id).isEqualTo(CodeTransformButtonId.ViewDiff.id)
+                assertThat(buttons[0].text).isEqualTo("View diff 1/5")
+                assertThat(buttons[1].id).isEqualTo(CodeTransformButtonId.ViewSummary.id)
+        }
     }
 
     @Test
     fun `test that transform result chat item includes view summary button and view diff button with correct label when job partially succeeded with 1 patch file`() {
         val result = CodeModernizerJobCompletedResult.JobPartiallySucceeded(JobId("dummy-job-id-123"))
         val chatItem = buildTransformResultChatContent(result, 1)
-        assertEquals(chatItem.message, message("codemodernizer.chat.message.result.partially_success"))
-        assertNotNull(chatItem.buttons)
-        assertEquals(chatItem.buttons?.size ?: fail("buttons is null"), 2)
-        assertEquals(chatItem.buttons?.get(0)?.id ?: fail("buttons is null"), CodeTransformButtonId.ViewDiff.id)
-        assertEquals(chatItem.buttons?.get(0)?.text ?: fail("buttons is null"), "View diff")
-        assertEquals(chatItem.buttons?.get(1)?.id ?: fail("buttons is null"), CodeTransformButtonId.ViewSummary.id)
+        assertThat(chatItem.message).isEqualTo(message("codemodernizer.chat.message.result.partially_success"))
+
+        assertThat(chatItem.buttons)
+            .hasSize(2)
+            .satisfiesKt { buttons ->
+                assertThat(buttons[0].id).isEqualTo(CodeTransformButtonId.ViewDiff.id)
+                assertThat(buttons[0].text).isEqualTo("View diff")
+                assertThat(buttons[1].id).isEqualTo(CodeTransformButtonId.ViewSummary.id)
+            }
     }
 
     @Test
     fun `test that transform result chat item does not include any buttons when job failed with known reason`() {
         val result = CodeModernizerJobCompletedResult.JobFailed(JobId("dummy-job-id-123"), message("codemodernizer.file.invalid_pom_version"))
         val chatItem = buildTransformResultChatContent(result)
-        assertEquals(chatItem.message, message("codemodernizer.chat.message.result.fail_with_known_reason", result.failureReason))
-        assertNull(chatItem.buttons)
+
+        assertThat(chatItem.message).isEqualTo(message("codemodernizer.chat.message.result.fail_with_known_reason", result.failureReason))
+        assertThat(chatItem.buttons).isNull()
     }
 }

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformHilDownloadArtifactTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformHilDownloadArtifactTest.kt
@@ -5,11 +5,12 @@ package software.aws.toolkits.jetbrains.services.codemodernizer
 
 import com.intellij.testFramework.assertEqualsToFile
 import com.intellij.util.io.delete
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.CodeTransformHilDownloadArtifact
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
+import software.aws.toolkits.jetbrains.utils.satisfiesKt
 import kotlin.io.path.createTempDirectory
 
 class CodeTransformHilDownloadArtifactTest : CodeWhispererCodeModernizerTestBase(HeavyJavaCodeInsightTestFixtureRule()) {
@@ -25,10 +26,12 @@ class CodeTransformHilDownloadArtifactTest : CodeWhispererCodeModernizerTestBase
         val hilDownloadArtifact = CodeTransformHilDownloadArtifact.create(testZipFilePath, outputFolder)
 
         // verify manifest file values
-        assertEquals(hilDownloadArtifact.manifest.pomArtifactId, "lombok")
-        assertEquals(hilDownloadArtifact.manifest.pomGroupId, "org.projectlombok")
-        assertEquals(hilDownloadArtifact.manifest.sourcePomVersion, "0.11.4")
-        assertEquals(hilDownloadArtifact.manifest.pomArtifactId, "lombok")
+        assertThat(hilDownloadArtifact.manifest).satisfiesKt {
+            assertThat(it.pomArtifactId).isEqualTo("lombok")
+            assertThat(it.pomGroupId).isEqualTo("org.projectlombok")
+            assertThat(it.sourcePomVersion).isEqualTo("0.11.4")
+            assertThat(it.pomArtifactId).isEqualTo("lombok")
+        }
 
         // verify pom file
         val testDownloadPomFile = "humanInTheLoop/pom.xml".toResourceFile().toPath()

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformTelemetryTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformTelemetryTest.kt
@@ -4,8 +4,7 @@
 package software.aws.toolkits.jetbrains.services.codemodernizer
 
 import com.intellij.testFramework.LightVirtualFile
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doReturn
@@ -25,14 +24,16 @@ class CodeTransformTelemetryTest : CodeWhispererCodeModernizerTestBase(HeavyJava
     fun `SessionId updated on prepareForNewJobSubmission invoked`() {
         val originalSessionId = CodeTransformTelemetryState.instance.getSessionId()
         telemetryManagerSpy.prepareForNewJobSubmission()
-        assertNotEquals(originalSessionId, CodeTransformTelemetryState.instance.getSessionId())
+
+        assertThat(originalSessionId).isEqualTo(CodeTransformTelemetryState.instance.getSessionId())
     }
 
     @Test
     fun `ProjectId is reproducible`() {
         val projectId1 = telemetryManagerSpy.getProjectHash(validJDK8CustomerSelection)
         val projectId2 = telemetryManagerSpy.getProjectHash(validJDK8CustomerSelection)
-        assertEquals(projectId1, projectId2)
+
+        assertThat(projectId1).isEqualTo(projectId2)
     }
 
     @Test
@@ -42,6 +43,7 @@ class CodeTransformTelemetryTest : CodeWhispererCodeModernizerTestBase(HeavyJava
         doReturn(Path("/anotherpath/pom.xml")).whenever(emptyPomFileSpy2).toNioPath()
         val newCustomerSelection = validJDK8CustomerSelection.copy(configurationFile = emptyPomFileSpy2)
         val projectId2 = telemetryManagerSpy.getProjectHash(newCustomerSelection)
-        assertNotEquals(projectId1, projectId2)
+
+        assertThat(projectId1).isNotEqualTo(projectId2)
     }
 }

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformTelemetryTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeTransformTelemetryTest.kt
@@ -25,7 +25,7 @@ class CodeTransformTelemetryTest : CodeWhispererCodeModernizerTestBase(HeavyJava
         val originalSessionId = CodeTransformTelemetryState.instance.getSessionId()
         telemetryManagerSpy.prepareForNewJobSubmission()
 
-        assertThat(originalSessionId).isEqualTo(CodeTransformTelemetryState.instance.getSessionId())
+        assertThat(originalSessionId).isNotEqualTo(CodeTransformTelemetryState.instance.getSessionId())
     }
 
     @Test

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
@@ -22,11 +22,6 @@ import kotlinx.coroutines.test.runTest
 import org.apache.commons.codec.digest.DigestUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -51,7 +46,6 @@ import software.amazon.awssdk.http.SdkHttpResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.CreateUploadUrlResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.TransformationStatus
 import software.amazon.awssdk.services.ssooidc.model.SsoOidcException
-import software.aws.toolkits.core.utils.exists
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenAuthState
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.CodeModernizerJobCompletedResult
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.CodeModernizerSessionContext
@@ -141,8 +135,9 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         // get project.projectFile because project.projectFile can not be null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
-        assertFalse(roots.isEmpty() || roots.size > 1)
-        assert(rootManager.dependencies.isEmpty())
+        assertThat(roots).hasSize(1)
+        assertThat(rootManager.dependencies).isEmpty()
+
         val root = roots[0]
         val context = CodeModernizerSessionContext(
             project,
@@ -165,11 +160,11 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
                 val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
                 when (Path(entry.name)) {
                     Path("manifest.json") -> {
-                        assertNotNull(fileContent)
-                        assertTrue(fileContent.contains(MAVEN_BUILD_SKIP_UNIT_TESTS))
+                        assertThat(fileContent).isNotNull()
+                        assertThat(fileContent).contains(MAVEN_BUILD_SKIP_UNIT_TESTS)
                     }
-                    Path("sources/src/tmp.txt") -> assertEquals(fileText, fileContent)
-                    Path("build-logs.txt") -> assertNotNull(fileContent)
+                    Path("sources/src/tmp.txt") -> assertThat(fileContent).isEqualTo(fileText)
+                    Path("build-logs.txt") -> assertThat(fileContent).isNotNull()
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
@@ -190,8 +185,9 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         // get project.projectFile because project.projectFile can not be null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
-        assertFalse(roots.isEmpty() || roots.size > 1)
-        assert(rootManager.dependencies.isEmpty())
+        assertThat(roots).hasSize(1)
+        assertThat(rootManager.dependencies).isEmpty()
+
         val pom = roots[0].children.first { it.name == "pom.xml" }
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
         val mockFile = mock(File::class.java)
@@ -204,10 +200,10 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
             assertThat(zipFile.entries().toList()).allSatisfy { entry ->
                 val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
                 when (Path(entry.name)) {
-                    Path("manifest.json") -> assertNotNull(fileContent)
-                    Path("sources/src/tmp.java") -> assertEquals(fileText, fileContent)
-                    Path("sources/pom.xml") -> assertEquals(fileText, fileContent)
-                    Path("build-logs.txt") -> assertNotNull(fileContent)
+                    Path("manifest.json") -> assertThat(fileContent).isNotNull()
+                    Path("sources/src/tmp.java") -> assertThat(fileContent).isEqualTo(fileText)
+                    Path("sources/pom.xml") -> assertThat(fileContent).isEqualTo(fileText)
+                    Path("build-logs.txt") -> assertThat(fileContent).isNotNull()
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
@@ -227,7 +223,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         // get project.projectFile because project.projectFile can not be null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
-        assertFalse(roots.isEmpty() || roots.size > 1)
+        assertThat(roots).hasSize(1)
 
         val pom = roots[0].children.first { it.name == "pom.xml" }
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
@@ -241,10 +237,10 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
             assertThat(zipFile.entries().toList()).allSatisfy { entry ->
                 val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
                 when (Path(entry.name)) {
-                    Path("manifest.json") -> assertNotNull(fileContent)
-                    Path("sources/src/tmp.java") -> assertEquals(fileText, fileContent)
-                    Path("sources/pom.xml") -> assertEquals(fileText, fileContent)
-                    Path("build-logs.txt") -> assertNotNull(fileContent)
+                    Path("manifest.json") -> assertThat(fileContent).isNotNull()
+                    Path("sources/src/tmp.java") -> assertThat(fileContent).isEqualTo(fileText)
+                    Path("sources/pom.xml") -> assertThat(fileContent).isEqualTo(fileText)
+                    Path("build-logs.txt") -> assertThat(fileContent).isNotNull()
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
@@ -265,7 +261,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         )
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
-        assertFalse(roots.isEmpty() || roots.size > 1)
+        assertThat(roots).hasSize(1)
 
         val pom = roots[0].children.first { it.name == "pom.xml" }
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
@@ -279,12 +275,12 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
             assertThat(zipFile.entries().toList()).allSatisfy { entry ->
                 val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
                 when (Path(entry.name)) {
-                    Path("manifest.json") -> assertNotNull(fileContent)
-                    Path("sources/src/tmp.java") -> assertEquals("src/tmp.java", fileContent)
-                    Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
-                    Path("sources/someModule/src/helloworld.java") -> assertEquals("someModule/src/helloworld.java", fileContent)
-                    Path("sources/someModule/pom.xml") -> assertEquals("someModule/pom.xml", fileContent)
-                    Path("build-logs.txt") -> assertNotNull(fileContent)
+                    Path("manifest.json") -> assertThat(fileContent).isNotNull()
+                    Path("sources/src/tmp.java") -> assertThat(fileContent).isEqualTo("src/tmp.java")
+                    Path("sources/pom.xml") -> assertThat(fileContent).isEqualTo("pom.xml")
+                    Path("sources/someModule/src/helloworld.java") -> assertThat(fileContent).isEqualTo("someModule/src/helloworld.java")
+                    Path("sources/someModule/pom.xml") -> assertThat(fileContent).isEqualTo("someModule/pom.xml")
+                    Path("build-logs.txt") -> assertThat(fileContent).isNotNull()
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
@@ -305,7 +301,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         )
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
-        assertFalse(roots.isEmpty() || roots.size > 1)
+        assertThat(roots).hasSize(1)
 
         val pom = roots[0].children.first { it.name == "pom.xml" }
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
@@ -319,12 +315,12 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
             assertThat(zipFile.entries().toList()).allSatisfy { entry ->
                 val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
                 when (Path(entry.name)) {
-                    Path("manifest.json") -> assertNotNull(fileContent)
-                    Path("sources/src/tmp.java") -> assertEquals("src\\tmp.java", fileContent)
-                    Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
-                    Path("sources/someModule/src/helloworld.java") -> assertEquals("someModule\\src\\helloworld.java", fileContent)
-                    Path("sources/someModule/pom.xml") -> assertEquals("someModule\\pom.xml", fileContent)
-                    Path("build-logs.txt") -> assertNotNull(fileContent)
+                    Path("manifest.json") -> assertThat(fileContent).isNotNull()
+                    Path("sources/src/tmp.java") -> assertThat(fileContent).isEqualTo("src\\tmp.java")
+                    Path("sources/pom.xml") -> assertThat(fileContent).isEqualTo("pom.xml")
+                    Path("sources/someModule/src/helloworld.java") -> assertThat(fileContent).isEqualTo("someModule\\src\\helloworld.java")
+                    Path("sources/someModule/pom.xml") -> assertThat(fileContent).isEqualTo("someModule\\pom.xml")
+                    Path("build-logs.txt") -> assertThat(fileContent).isNotNull()
                     else -> fail("Unexpected entry in zip file: $entry")
                 }
             }
@@ -344,7 +340,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         // get project.projectFile because project.projectFile can not be null
         val rootManager = ModuleRootManager.getInstance(module)
         val roots = rootManager.contentRoots
-        assertFalse(roots.isEmpty() || roots.size > 1)
+        assertThat(roots).hasSize(1)
 
         val pom = roots[0].children.first { it.name == "pom.xml" }
         val context = CodeModernizerSessionContext(project, pom, JavaSdkVersion.JDK_1_8, JavaSdkVersion.JDK_11)
@@ -358,11 +354,11 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
             assertThat(zipFile.entries().toList()).allSatisfy { entry ->
                 val fileContent = zipFile.getInputStream(entry).bufferedReader().readLine()
                 when (Path(entry.name)) {
-                    Path("manifest.json") -> assertNotNull(fileContent)
-                    Path("sources/pom.xml") -> assertEquals("pom.xml", fileContent)
-                    Path("sources/src/tmp.java") -> assertEquals("src/tmp.java", fileContent)
-                    Path("sources/someModule/pom.xml") -> assertEquals("someModule/pom.xml", fileContent)
-                    Path("build-logs.txt") -> assertNotNull(fileContent)
+                    Path("manifest.json") -> assertThat(fileContent).isNotNull()
+                    Path("sources/pom.xml") -> assertThat(fileContent).isEqualTo("pom.xml")
+                    Path("sources/src/tmp.java") -> assertThat(fileContent).isEqualTo("src/tmp.java")
+                    Path("sources/someModule/pom.xml") -> assertThat(fileContent).isEqualTo("someModule/pom.xml")
+                    Path("build-logs.txt") ->assertThat(fileContent).isNotNull()
                     else -> throw AssertionError("Unexpected entry in zip file: $entry")
                 }
             }
@@ -404,8 +400,10 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         }
 
         val dependenciesToUpload = context.iterateThroughDependencies(tempFolder.root)
-        assertEquals(m2Folders.size * expectedFilesAfterClean.size, dependenciesToUpload.size)
-        assertTrue(dependenciesToUpload.all { it.name in expectedFilesAfterClean })
+        assertThat(dependenciesToUpload).hasSize(m2Folders.size * expectedFilesAfterClean.size)
+        assertThat(dependenciesToUpload).allSatisfy {
+            assertThat(it.name).isIn(expectedFilesAfterClean)
+        }
     }
 
     @Test
@@ -416,7 +414,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         doNothing().whenever(clientAdaptorSpy).uploadArtifactToS3(any(), any(), any(), any(), any())
         doReturn(exampleStartCodeMigrationResponse).whenever(clientAdaptorSpy).startCodeModernization(any(), any(), any())
         val result = testSessionSpy.createModernizationJob(MavenCopyCommandsResult.Success(File("./mock/path/")))
-        assertEquals(result, CodeModernizerStartJobResult.Started(jobId))
+        assertThat(result).isEqualTo(CodeModernizerStartJobResult.Started(jobId))
         verify(clientAdaptorSpy, times(1)).createGumbyUploadUrl(any())
         verify(clientAdaptorSpy, times(1)).startCodeModernization(any(), any(), any())
         verify(clientAdaptorSpy, times(1)).uploadArtifactToS3(any(), any(), any(), any(), any())
@@ -430,7 +428,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         doReturn(exampleCreateUploadUrlResponse).whenever(clientAdaptorSpy).createGumbyUploadUrl(any())
         doAnswer { throw AlreadyDisposedException("mock exception") }.whenever(clientAdaptorSpy).uploadArtifactToS3(any(), any(), any(), any(), any())
         val result = testSessionSpy.createModernizationJob(MavenCopyCommandsResult.Success(File("./mock/path/")))
-        assertEquals(CodeModernizerStartJobResult.Disposed, result)
+        assertThat(result).isEqualTo(CodeModernizerStartJobResult.Disposed)
     }
 
     @Test
@@ -440,7 +438,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
             .whenever(testSessionContextSpy).createZipWithModuleFiles(any())
         doAnswer { throw SsoOidcException.builder().build() }.whenever(clientAdaptorSpy).createGumbyUploadUrl(any())
         val result = testSessionSpy.createModernizationJob(MavenCopyCommandsResult.Success(File("./mock/path/")))
-        assertEquals(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.CREDENTIALS_EXPIRED), result)
+        assertThat(result).isEqualTo(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.CREDENTIALS_EXPIRED))
     }
 
     @Test
@@ -448,7 +446,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         listOf(BearerTokenAuthState.NEEDS_REFRESH, BearerTokenAuthState.NOT_AUTHENTICATED).forEach {
             setupConnection(it)
             val result = testSessionSpy.createModernizationJob(MavenCopyCommandsResult.Success(File("./mock/path/")))
-            assertEquals(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.CREDENTIALS_EXPIRED), result)
+            assertThat(result).isEqualTo(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.CREDENTIALS_EXPIRED))
         }
     }
 
@@ -459,9 +457,9 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         doReturn(exampleCreateUploadUrlResponse).whenever(clientAdaptorSpy).createGumbyUploadUrl(any())
         doAnswer { throw HttpRequests.HttpStatusException("mock error", 403, "mock url") }.whenever(testSessionSpy).uploadPayload(any())
         val result = testSessionSpy.createModernizationJob(MavenCopyCommandsResult.Success(File("./mock/path/")))
-        assertEquals(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.PRESIGNED_URL_EXPIRED), result)
+        assertThat(result).isEqualTo(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.PRESIGNED_URL_EXPIRED))
         verify(testSessionStateSpy, times(1)).putJobHistory(any(), eq(TransformationStatus.FAILED), any(), any())
-        assertEquals(testSessionStateSpy.currentJobStatus, TransformationStatus.FAILED)
+        assertThat(testSessionStateSpy.currentJobStatus).isEqualTo(TransformationStatus.FAILED)
     }
 
     @Test
@@ -471,9 +469,9 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         doReturn(exampleCreateUploadUrlResponse).whenever(clientAdaptorSpy).createGumbyUploadUrl(any())
         doAnswer { throw HttpRequests.HttpStatusException("mock error", 407, "mock url") }.whenever(testSessionSpy).uploadPayload(any())
         val result = testSessionSpy.createModernizationJob(MavenCopyCommandsResult.Success(File("./mock/path/")))
-        assertEquals(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.HTTP_ERROR(407)), result)
+        assertThat(result).isEqualTo(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.HTTP_ERROR(407)))
         verify(testSessionStateSpy, times(1)).putJobHistory(any(), eq(TransformationStatus.FAILED), any(), any())
-        assertEquals(testSessionStateSpy.currentJobStatus, TransformationStatus.FAILED)
+        assertThat(testSessionStateSpy.currentJobStatus).isEqualTo(TransformationStatus.FAILED)
     }
 
     @Test
@@ -483,9 +481,9 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         doReturn(exampleCreateUploadUrlResponse).whenever(clientAdaptorSpy).createGumbyUploadUrl(any())
         doAnswer { throw Exception("mock client-side exception") }.whenever(clientAdaptorSpy).uploadArtifactToS3(any(), any(), any(), any(), any())
         val result = testSessionSpy.createModernizationJob(MavenCopyCommandsResult.Success(File("./mock/path/")))
-        assertEquals(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.OTHER("mock client-side exception")), result)
+        assertThat(result).isEqualTo(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.OTHER("mock client-side exception")))
         verify(testSessionStateSpy, times(1)).putJobHistory(any(), eq(TransformationStatus.FAILED), any(), any())
-        assertEquals(testSessionStateSpy.currentJobStatus, TransformationStatus.FAILED)
+        assertThat(testSessionStateSpy.currentJobStatus).isEqualTo(TransformationStatus.FAILED)
     }
 
     @Test
@@ -495,9 +493,9 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         doReturn(exampleCreateUploadUrlResponse).whenever(clientAdaptorSpy).createGumbyUploadUrl(any())
         doAnswer { throw ConnectException("mock exception") }.whenever(testSessionSpy).uploadPayload(any())
         val result = testSessionSpy.createModernizationJob(MavenCopyCommandsResult.Success(File("./mock/path/")))
-        assertEquals(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.CONNECTION_REFUSED), result)
+        assertThat(result).isEqualTo(CodeModernizerStartJobResult.ZipUploadFailed(UploadFailureReason.CONNECTION_REFUSED))
         verify(testSessionStateSpy, times(1)).putJobHistory(any(), eq(TransformationStatus.FAILED), any(), any())
-        assertEquals(testSessionStateSpy.currentJobStatus, TransformationStatus.FAILED)
+        assertThat(testSessionStateSpy.currentJobStatus).isEqualTo(TransformationStatus.FAILED)
     }
 
     @Test
@@ -508,7 +506,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
 
         doNothing().whenever(testSessionStateSpy).updateJobHistory(any(), any(), any())
         val result = testSessionSpy.pollUntilJobCompletion(CodeTransformType.LANGUAGE_UPGRADE, jobId) { _, _ -> }
-        assertEquals(CodeModernizerJobCompletedResult.JobCompletedSuccessfully(jobId), result)
+        assertThat(result).isEqualTo(CodeModernizerJobCompletedResult.JobPartiallySucceeded(jobId))
 
         // two polls to check status as we 1. check for plan existing and 2. check if job completed
         // since the transformationStatus is dynamic by the happyPathMigrationResponses so there will be 10 times to call getCodeModernizationJob
@@ -529,7 +527,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
 
         doNothing().whenever(testSessionStateSpy).updateJobHistory(any(), any(), any())
         val result = testSessionSpy.pollUntilJobCompletion(CodeTransformType.LANGUAGE_UPGRADE, jobId) { _, _ -> }
-        assertEquals(CodeModernizerJobCompletedResult.JobPartiallySucceeded(jobId), result)
+        assertThat(result).isEqualTo(CodeModernizerJobCompletedResult.JobPartiallySucceeded(jobId))
         verify(clientAdaptorSpy, times(4)).getCodeModernizationJob(any())
         verify(clientAdaptorSpy, atLeastOnce()).getCodeModernizationPlan(any())
     }
@@ -584,9 +582,9 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         val hilDownloadArtifact = CodeTransformHilDownloadArtifact.create(testZipFilePath, outputFolder)
 
         // assert null before setting
-        assertNull(testSessionSpy.getHilDownloadArtifact())
+        assertThat(testSessionSpy.getHilDownloadArtifact()).isNull()
         testSessionSpy.setHilDownloadArtifact(hilDownloadArtifact)
-        assertEquals(testSessionSpy.getHilDownloadArtifact(), hilDownloadArtifact)
+        assertThat(testSessionSpy.getHilDownloadArtifact()).isEqualTo(hilDownloadArtifact)
 
         // cleanup
         outputFolder.delete()
@@ -599,8 +597,8 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
         val hilDownloadArtifact = CodeTransformHilDownloadArtifact.create(testZipFilePath, outputFolder)
         testSessionSpy.setHilDownloadArtifact(hilDownloadArtifact)
         testSessionSpy.setHilTempDirectoryPath(outputFolder)
-        assertTrue(outputFolder.exists())
+        assertThat(outputFolder).exists()
         testSessionSpy.hilCleanup()
-        assertFalse(outputFolder.exists())
+        assertThat(outputFolder).doesNotExist()
     }
 }

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
@@ -506,7 +506,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
 
         doNothing().whenever(testSessionStateSpy).updateJobHistory(any(), any(), any())
         val result = testSessionSpy.pollUntilJobCompletion(CodeTransformType.LANGUAGE_UPGRADE, jobId) { _, _ -> }
-        assertThat(result).isEqualTo(CodeModernizerJobCompletedResult.JobPartiallySucceeded(jobId))
+        assertThat(result).isEqualTo(CodeModernizerJobCompletedResult.JobCompletedSuccessfully(jobId))
 
         // two polls to check status as we 1. check for plan existing and 2. check if job completed
         // since the transformationStatus is dynamic by the happyPathMigrationResponses so there will be 10 times to call getCodeModernizationJob

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerSessionTest.kt
@@ -358,7 +358,7 @@ class CodeWhispererCodeModernizerSessionTest : CodeWhispererCodeModernizerTestBa
                     Path("sources/pom.xml") -> assertThat(fileContent).isEqualTo("pom.xml")
                     Path("sources/src/tmp.java") -> assertThat(fileContent).isEqualTo("src/tmp.java")
                     Path("sources/someModule/pom.xml") -> assertThat(fileContent).isEqualTo("someModule/pom.xml")
-                    Path("build-logs.txt") ->assertThat(fileContent).isNotNull()
+                    Path("build-logs.txt") -> assertThat(fileContent).isNotNull()
                     else -> throw AssertionError("Unexpected entry in zip file: $entry")
                 }
             }

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/utils/CodeTransformModuleUtilsTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/utils/CodeTransformModuleUtilsTest.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.roots.LanguageLevelModuleExtensionImpl
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.pom.java.LanguageLevel
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mockStatic
@@ -55,7 +55,7 @@ class CodeTransformModuleUtilsTest : CodeWhispererCodeModernizerTestBase(HeavyJa
         whenever(languageLevelModuleExtensionMock.languageLevel).doReturn(LanguageLevel.JDK_1_8)
         whenever(javaSdkMock.getVersion(any())).doReturn(JavaSdkVersion.JDK_1_8)
         val result = module.tryGetJdk(project)
-        assertEquals(JavaSdkVersion.JDK_1_8, result)
+        assertThat(result).isEqualTo(JavaSdkVersion.JDK_1_8)
     }
 
     @Test
@@ -63,7 +63,7 @@ class CodeTransformModuleUtilsTest : CodeWhispererCodeModernizerTestBase(HeavyJa
         whenever(languageLevelModuleExtensionMock.languageLevel).doReturn(null)
         whenever(javaSdkMock.getVersion(sdkMock)).doReturn(null)
         val result = module.tryGetJdk(project)
-        assertEquals(null, result)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -71,7 +71,7 @@ class CodeTransformModuleUtilsTest : CodeWhispererCodeModernizerTestBase(HeavyJa
         whenever(languageLevelModuleExtensionMock.languageLevel).doReturn(null)
         whenever(javaSdkMock.getVersion(any())).doReturn(JavaSdkVersion.JDK_17)
         val result = module.tryGetJdkLanguageLevelJdk()
-        assertEquals(null, result)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -79,6 +79,6 @@ class CodeTransformModuleUtilsTest : CodeWhispererCodeModernizerTestBase(HeavyJa
         whenever(languageLevelModuleExtensionMock.languageLevel).doReturn(LanguageLevel.JDK_1_8)
         whenever(javaSdkMock.getVersion(any())).doReturn(JavaSdkVersion.JDK_1_8)
         val result = module.tryGetJdkLanguageLevelJdk()
-        assertEquals(JavaSdkVersion.JDK_1_8, result)
+        assertThat(result).isEqualTo(JavaSdkVersion.JDK_1_8)
     }
 }

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/utils/CodeTransformProjectUtilsTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/utils/CodeTransformProjectUtilsTest.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.roots.LanguageLevelProjectExtension
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.pom.java.LanguageLevel
 import com.intellij.testFramework.IdeaTestUtil.getMockJdk21
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.doReturn
@@ -42,7 +42,7 @@ class CodeTransformProjectUtilsTest : CodeWhispererCodeModernizerTestBase() {
         whenever(projectRootManagerMock.projectSdk).doReturn(sdkMock)
         whenever(LanguageLevelProjectExtension.getInstance(project)).doReturn(null)
         val result = project.tryGetJdk()
-        assertEquals(JavaSdkVersion.JDK_21, result)
+        assertThat(result).isEqualTo(JavaSdkVersion.JDK_21)
     }
 
     @Test
@@ -53,20 +53,20 @@ class CodeTransformProjectUtilsTest : CodeWhispererCodeModernizerTestBase() {
         whenever(projectRootManagerMock.projectSdk).doReturn(sdkMock)
         whenever(languageLevelProjectExtensionMock.languageLevel).doReturn(LanguageLevel.JDK_1_8)
         val result = project.tryGetJdk()
-        assertEquals(JavaSdkVersion.JDK_1_8, result)
+        assertThat(result).isEqualTo(JavaSdkVersion.JDK_1_8)
     }
 
     @Test
     fun `CodeTransformProjectUtils tryGetJdkLanguageLevelJdk() function returns null when language level is null`() {
         whenever(LanguageLevelProjectExtension.getInstance(project)).doReturn(null)
         val result = project.tryGetJdkLanguageLevelJdk()
-        assertEquals(null, result)
+        assertThat(result).isEqualTo(null)
     }
 
     @Test
     fun `CodeTransformProjectUtils tryGetJdkLanguageLevelJdk() function returns language level version`() {
         whenever(languageLevelProjectExtensionMock.languageLevel).doReturn(LanguageLevel.JDK_1_8)
         val result = project.tryGetJdkLanguageLevelJdk()
-        assertEquals(JavaSdkVersion.JDK_1_8, result)
+        assertThat(result).isEqualTo(JavaSdkVersion.JDK_1_8)
     }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codetest/CodeTestSessionConfigTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/codetest/CodeTestSessionConfigTest.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.modules
 import com.intellij.openapi.vfs.VirtualFile
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -65,7 +64,7 @@ class CodeTestSessionConfigTest {
 
         assertThat(payload.context.srcPayloadSize).isEqualTo(totalSize)
         assertThat(payload.context.totalLines).isEqualTo(totalLines)
-        assertNotNull(payload.srcZip)
+        assertThat(payload.srcZip).isNotNull()
 
         val bufferedInputStream = BufferedInputStream(payload.srcZip.inputStream())
         val zis = ZipInputStream(bufferedInputStream)
@@ -80,7 +79,7 @@ class CodeTestSessionConfigTest {
     @Test
     fun `getProjectPayloadMetadata()`() {
         val payloadMetadata = codeTestSessionConfig.getProjectPayloadMetadata()
-        assertNotNull(payloadMetadata)
+        assertThat(payloadMetadata).isNotNull()
         val includedSourceFiles = payloadMetadata.sourceFiles
         val srcPayloadSize = payloadMetadata.payloadSize
         val totalLines = payloadMetadata.linesScanned

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/otel/OTelService.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/otel/OTelService.kt
@@ -27,7 +27,6 @@ import io.opentelemetry.sdk.trace.SpanProcessor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.apache.http.impl.conn.SystemDefaultRoutePlanner
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.http.ContentStreamProvider
 import software.amazon.awssdk.http.HttpExecuteRequest
@@ -63,19 +62,6 @@ private class BasicOtlpSpanProcessor(
                 thisLogger().error("Cannot export (url=$traceUrl)", e)
             }
         }
-//
-//        val client = ApacheHttpClient.builder()
-//            .proxyConfiguration(
-//                ProxyConfiguration.builder()
-//                    .useSystemPropertyValues(false)
-//                    .useEnvironmentVariableValues(false)
-//                    .build()
-//            )
-//            .httpRoutePlanner(SystemDefaultRoutePlanner(CommonProxy.getInstance()))
-//            .build()
-//
-//        IdeHttpClientHelpers.ApacheHttpClient4
-
     }
 }
 

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/otel/OTelService.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/services/telemetry/otel/OTelService.kt
@@ -27,6 +27,7 @@ import io.opentelemetry.sdk.trace.SpanProcessor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.http.ContentStreamProvider
 import software.amazon.awssdk.http.HttpExecuteRequest
@@ -62,6 +63,19 @@ private class BasicOtlpSpanProcessor(
                 thisLogger().error("Cannot export (url=$traceUrl)", e)
             }
         }
+//
+//        val client = ApacheHttpClient.builder()
+//            .proxyConfiguration(
+//                ProxyConfiguration.builder()
+//                    .useSystemPropertyValues(false)
+//                    .useEnvironmentVariableValues(false)
+//                    .build()
+//            )
+//            .httpRoutePlanner(SystemDefaultRoutePlanner(CommonProxy.getInstance()))
+//            .build()
+//
+//        IdeHttpClientHelpers.ApacheHttpClient4
+
     }
 }
 

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/notifications/NotificationDismissalStateTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/notifications/NotificationDismissalStateTest.kt
@@ -3,9 +3,7 @@
 
 package software.aws.toolkits.jetbrains.core.notifications
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -30,9 +28,12 @@ class NotificationDismissalStateTest {
 
         val persistedState = state.getState()
 
-        assertEquals(1, persistedState.dismissedNotifications.size)
-        assertTrue(persistedState.dismissedNotifications.any { it.id == "recent-notification" })
-        assertTrue(state.isDismissed("recent-notification"))
+        assertThat(persistedState.dismissedNotifications)
+            .singleElement()
+            .extracting(DismissedNotification::id)
+            .isEqualTo("recent-notification")
+
+        assertThat(state.isDismissed("recent-notification")).isTrue()
     }
 
     @Test
@@ -46,8 +47,8 @@ class NotificationDismissalStateTest {
 
         val persistedState = state.getState()
 
-        assertEquals(0, persistedState.dismissedNotifications.size)
-        assertFalse(state.isDismissed("old-notification"))
+        assertThat(persistedState.dismissedNotifications).isEmpty()
+        assertThat(state.isDismissed("old-notification")).isFalse()
     }
 
     @Test
@@ -69,15 +70,15 @@ class NotificationDismissalStateTest {
 
         val persistedState = state.getState()
 
-        assertEquals(1, persistedState.dismissedNotifications.size)
-        assertTrue(state.isDismissed("recent-notification"))
-        assertFalse(state.isDismissed("old-notification"))
+        assertThat(persistedState.dismissedNotifications).hasSize(1)
+        assertThat(state.isDismissed("recent-notification")).isTrue()
+        assertThat(state.isDismissed("old-notification")).isFalse()
     }
 
     @Test
     fun `dismissing new notification retains it`() {
         state.dismissNotification("new-notification")
 
-        assertTrue(state.isDismissed("new-notification"))
+        assertThat(state.isDismissed("new-notification")).isTrue()
     }
 }

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/utils/ThreadingUtilsKtTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/utils/ThreadingUtilsKtTest.kt
@@ -12,8 +12,8 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.toolkittelemetry.model.AWSProduct
@@ -89,7 +89,7 @@ class ThreadingUtilsKtTest {
         PluginResolver.setThreadLocal(pluginResolver)
 
         pluginAwareExecuteOnPooledThread {
-            assertEquals(PluginResolver.fromCurrentThread().product, AWSProduct.AMAZON_Q_FOR_JET_BRAINS)
+            assertThat(PluginResolver.fromCurrentThread().product).isEqualTo(AWSProduct.AMAZON_Q_FOR_JET_BRAINS)
         }.get()
 
         PluginResolver.setThreadLocal(PluginResolver.fromStackTrace(Thread.currentThread().stackTrace))

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsFetcherTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsFetcherTest.kt
@@ -3,16 +3,16 @@
 package software.aws.toolkits.jetbrains.services.cloudformation.stack
 
 import com.intellij.testFramework.ProjectRule
-import org.junit.Assert
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.amazon.awssdk.services.cloudformation.model.StackEvent
 import software.aws.toolkits.jetbrains.core.MockClientManagerRule
 
 private fun expectRange(from: String, to: String, events: List<StackEvent>, expectedSize: Int = 1024) {
-    Assert.assertEquals("Wrong number of items", expectedSize, events.size)
-    Assert.assertEquals("Wrong page start", from, events.first().eventId())
-    Assert.assertEquals("Wrong page end", to, events.last().eventId())
+    assertThat(events).withFailMessage("Wrong number of items").hasSize(expectedSize)
+    assertThat(events.first().eventId()).withFailMessage("Wrong page start").isEqualTo(from)
+    assertThat(events.last().eventId()).withFailMessage("Wrong page end").isEqualTo(to)
 }
 
 private const val nonEmptyMessage = "Second call on the same page must not return anything"
@@ -37,14 +37,14 @@ class EventsFetcherTest {
             expectRange("4096", "3073", first)
         }
         fetcher.fetchEvents(client, null).apply {
-            Assert.assertTrue(nonEmptyMessage, first.isEmpty())
+            assertThat(first).withFailMessage(nonEmptyMessage).isEmpty()
         }
         generator.addEvent() // New event arrived
         fetcher.fetchEvents(client, null).apply {
             expectRange("4097", "4097", first, expectedSize = 1)
         }
         fetcher.fetchEvents(client, null).apply {
-            Assert.assertTrue(nonEmptyMessage, first.isEmpty())
+            assertThat(first).withFailMessage(nonEmptyMessage).isEmpty()
         }
     }
 
@@ -54,28 +54,28 @@ class EventsFetcherTest {
         val fetcher = EventsFetcher("myStack")
         fetcher.fetchEvents(client, null).apply {
             expectRange("4096", "3073", first)
-            Assert.assertEquals(wrongPageMessage, setOf(Page.NEXT), second)
+            assertThat(second).withFailMessage(wrongPageMessage).isEqualTo(setOf(Page.NEXT))
         }
         fetcher.fetchEvents(client, null).apply {
-            Assert.assertTrue(nonEmptyMessage, first.isEmpty())
-            Assert.assertEquals(wrongPageMessage, setOf(Page.NEXT), second)
+            assertThat(first).withFailMessage(nonEmptyMessage).isEmpty()
+            assertThat(second).withFailMessage(wrongPageMessage).isEqualTo(setOf(Page.NEXT))
         }
         fetcher.fetchEvents(client, Page.NEXT).apply {
             expectRange("3072", "2049", first)
-            Assert.assertEquals(wrongPageMessage, setOf(Page.PREVIOUS, Page.NEXT), second)
+            assertThat(second).withFailMessage(wrongPageMessage).isEqualTo(setOf(Page.PREVIOUS, Page.NEXT))
         }
         fetcher.fetchEvents(client, null).apply {
-            Assert.assertTrue(nonEmptyMessage, first.isEmpty())
-            Assert.assertEquals(wrongPageMessage, setOf(Page.PREVIOUS, Page.NEXT), second)
+            assertThat(first).withFailMessage(nonEmptyMessage).isEmpty()
+            assertThat(second).withFailMessage(wrongPageMessage).isEqualTo(setOf(Page.PREVIOUS, Page.NEXT))
         }
         fetcher.fetchEvents(client, Page.NEXT) // Scroll to the end
         fetcher.fetchEvents(client, Page.NEXT).apply {
             expectRange("1024", "1", first)
-            Assert.assertEquals(wrongPageMessage, setOf(Page.PREVIOUS), second)
+            assertThat(second).withFailMessage(wrongPageMessage).isEqualTo(setOf(Page.PREVIOUS))
         }
         fetcher.fetchEvents(client, Page.PREVIOUS).apply {
             expectRange("2048", "1025", first)
-            Assert.assertEquals(wrongPageMessage, setOf(Page.PREVIOUS, Page.NEXT), second)
+            assertThat(second).withFailMessage(wrongPageMessage).isEqualTo(setOf(Page.PREVIOUS, Page.NEXT))
         }
     }
 }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsFetcherTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/EventsFetcherTest.kt
@@ -18,6 +18,7 @@ private fun expectRange(from: String, to: String, events: List<StackEvent>, expe
 private const val nonEmptyMessage = "Second call on the same page must not return anything"
 private const val wrongPageMessage = "Wrong list of available pages"
 
+@Suppress("UnnecessaryApply")
 class EventsFetcherTest {
     @JvmField
     @Rule

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/Mocks.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/Mocks.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.aws.toolkits.jetbrains.services.cloudformation.stack
 
-import org.junit.Assert
+import org.assertj.core.api.Assertions.assertThat
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient
@@ -40,7 +40,7 @@ internal class MockEventsGenerator {
     val currentPage: List<StackEvent> get() = getEvents(DescribeStackEventsRequest.builder().stackName("foo").build()).stackEvents()
 
     fun getEvents(request: DescribeStackEventsRequest): DescribeStackEventsResponse {
-        Assert.assertNotNull("No stack name provided", request.stackName())
+        assertThat(request.stackName()).withFailMessage("No stack name provided").isNotNull()
         val page = request.nextToken()
         assert(!SwingUtilities.isEventDispatchThread())
         Thread.sleep(600)

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/UpdaterTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/UpdaterTest.kt
@@ -4,7 +4,6 @@ package software.aws.toolkits.jetbrains.services.cloudformation.stack
 
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -120,7 +119,7 @@ class UpdaterTest {
         verify(treeView, atLeast(1)).fillResources(resources)
         verify(outputTable, atLeast(1)).updatedOutputs(outputs)
         verify(eventsTable, atLeast(1)).insertEvents(mockEventsGenerator.currentPage, false)
-        Assert.assertEquals("Wrong button for first page", availablePages, setOf(Page.NEXT))
+        assertThat(availablePages).withFailMessage("Wrong button for first page").isEqualTo(setOf(Page.NEXT))
     }
 
     @Test

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaHandlerCompletionProviderTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/java/JavaHandlerCompletionProviderTest.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.java
 
-import org.junit.Assert.assertFalse
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.lambda.LambdaRuntime
@@ -19,18 +19,18 @@ class JavaHandlerCompletionProviderTest {
     @Test
     fun completionIsNotSupportedJava8() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.JAVA8_AL2)
-        assertFalse(provider.isCompletionSupported)
+        assertThat(provider.isCompletionSupported).isFalse()
     }
 
     @Test
     fun completionIsNotSupportedJava11() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.JAVA11)
-        assertFalse(provider.isCompletionSupported)
+        assertThat(provider.isCompletionSupported).isFalse()
     }
 
     @Test
     fun completionIsNotSupportedJava17() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.JAVA17)
-        assertFalse(provider.isCompletionSupported)
+        assertThat(provider.isCompletionSupported).isFalse()
     }
 }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonHandlerCompletionProviderTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonHandlerCompletionProviderTest.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.python
 
-import org.junit.Assert.assertFalse
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.lambda.LambdaRuntime
@@ -19,24 +19,24 @@ class PythonHandlerCompletionProviderTest {
     @Test
     fun completionIsNotSupportedPython38() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.PYTHON3_8)
-        assertFalse(provider.isCompletionSupported)
+        assertThat(provider.isCompletionSupported).isFalse()
     }
 
     @Test
     fun completionIsNotSupportedPython39() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.PYTHON3_9)
-        assertFalse(provider.isCompletionSupported)
+        assertThat(provider.isCompletionSupported).isFalse()
     }
 
     @Test
     fun completionIsNotSupportedPython310() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.PYTHON3_10)
-        assertFalse(provider.isCompletionSupported)
+        assertThat(provider.isCompletionSupported).isFalse()
     }
 
     @Test
     fun completionIsNotSupportedPython311() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.PYTHON3_11)
-        assertFalse(provider.isCompletionSupported)
+        assertThat(provider.isCompletionSupported).isFalse()
     }
 }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommonTest.kt
@@ -9,14 +9,13 @@ import com.intellij.psi.PsiFile
 import com.intellij.testFramework.runInEdtAndGet
 import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.utils.exists
 import software.aws.toolkits.jetbrains.core.executables.ExecutableManager
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommonTestUtils.makeATestSam
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
+import software.aws.toolkits.jetbrains.utils.satisfiesKt
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
@@ -102,7 +101,7 @@ Resources:
             val templateFile = SamCommon.getTemplateFromDirectory(dir)
             assertNotNull(templateFile)
             val codeUris = SamCommon.getCodeUrisFromTemplate(projectRule.project, templateFile)
-            assertEquals(0, codeUris.size)
+            assertThat(codeUris).isEmpty()
         }
     }
 
@@ -129,8 +128,9 @@ Resources:
             val templateFile = SamCommon.getTemplateFromDirectory(dir)
             assertNotNull(templateFile)
             val codeUris = SamCommon.getCodeUrisFromTemplate(projectRule.project, templateFile)
-            assertEquals(1, codeUris.size)
-            assertEquals("hello_world", codeUris[0].name)
+            assertThat(codeUris).singleElement().satisfiesKt {
+                assertThat(it.name).isEqualTo("hello_world")
+            }
         }
     }
 
@@ -170,8 +170,9 @@ Resources:
             val templateFile = SamCommon.getTemplateFromDirectory(dir)
             assertNotNull(templateFile)
             val codeUris = SamCommon.getCodeUrisFromTemplate(projectRule.project, templateFile)
-            assertEquals(1, codeUris.size)
-            assertEquals("hello_world", codeUris[0].name)
+            assertThat(codeUris).singleElement().satisfiesKt {
+                assertThat(it.name).isEqualTo("hello_world")
+            }
         }
     }
 
@@ -209,9 +210,10 @@ Resources:
             val templateFile = SamCommon.getTemplateFromDirectory(dir)
             assertNotNull(templateFile)
             val codeUris = SamCommon.getCodeUrisFromTemplate(projectRule.project, templateFile)
-            assertEquals(2, codeUris.size)
-            assertTrue(codeUris.any { it.name == "hello_world" })
-            assertTrue(codeUris.any { it.name == "hello_world_42" })
+            assertThat(codeUris).hasSize(2).satisfiesExactlyInAnyOrder(
+                { assertThat(it.name).isEqualTo("hello_world") },
+                { assertThat(it.name).isEqualTo("hello_world_42") }
+            )
         }
     }
 

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCacheTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/sam/SamVersionCacheTest.kt
@@ -3,8 +3,8 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.sam
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
@@ -40,7 +40,7 @@ class SamVersionCacheTest {
     fun samCliMinVersion() {
         val samPath = SamCommonTestUtils.makeATestSam(SamCommonTestUtils.getMinVersionAsJson()).toString()
         val samVersion = SamVersionCache.evaluateBlocking(samPath).result
-        assertEquals("Mismatch SAM executable version", samVersion, SamExecutable.minVersion)
+        assertThat(samVersion).withFailMessage("Mismatch SAM executable version").isEqualTo(SamExecutable.minVersion)
     }
 
     @Test

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
@@ -38,7 +38,6 @@ import org.jetbrains.idea.maven.utils.MavenProgressIndicator.MavenProgressTracke
 import org.jetbrains.plugins.gradle.jvmcompat.GradleJvmSupportMatrix
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
 import org.jetbrains.plugins.gradle.util.GradleConstants
-import org.junit.Assert.fail
 import software.aws.toolkits.core.utils.exists
 import software.aws.toolkits.core.utils.inputStream
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
@@ -146,7 +145,7 @@ fun HeavyJavaCodeInsightTestFixtureRule.setUpGradleProject(compatibility: String
     ExternalSystemUtil.refreshProjects(importSpecBuilder)
 
     if (!error.isNull) {
-        fail("Import failed: " + error.get())
+        error("Import failed: " + error.get())
     }
 
     return lambdaClass

--- a/plugins/toolkit/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsHandlerCompletionProviderTest.kt
+++ b/plugins/toolkit/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/services/lambda/nodejs/NodeJsHandlerCompletionProviderTest.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.lambda.nodejs
 
-import org.junit.Assert.assertFalse
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import software.aws.toolkits.core.lambda.LambdaRuntime
@@ -18,12 +18,12 @@ class NodeJsHandlerCompletionProviderTest {
     @Test
     fun completionIsNotSupportedNodeJs16X() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.NODEJS16_X)
-        assertFalse(provider.isCompletionSupported)
+        assertThat(provider.isCompletionSupported).isFalse()
     }
 
     @Test
     fun completionIsNotSupportedNodeJs18X() {
         val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.NODEJS18_X)
-        assertFalse(provider.isCompletionSupported)
+        assertThat(provider.isCompletionSupported).isFalse()
     }
 }

--- a/ui-tests-starter/build.gradle.kts
+++ b/ui-tests-starter/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     uiTestImplementation("org.kodein.di:kodein-di-jvm:7.20.2")
     uiTestImplementation(platform(libs.junit5.bom))
     uiTestImplementation(libs.junit5.jupiter)
+    uiTestImplementation(libs.assertj)
 
     intellijPlatform {
         val version = ideProfile.community.sdkVersion

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/chatTests/AmazonQChatTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/chatTests/AmazonQChatTest.kt
@@ -14,8 +14,8 @@ import com.intellij.ide.starter.models.TestCase
 import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.kodein.di.DI
@@ -79,14 +79,16 @@ class AmazonQChatTest {
                 Thread.sleep(30000)
 
                 val result = executePuppeteerScript(testFeatureAvailabilityOnSlash)
-                assertTrue(result.contains("/doc"))
-                assertTrue(result.contains("/dev"))
-                assertTrue(result.contains("/transform"))
-                assertTrue(result.contains("/help"))
-                assertTrue(result.contains("/clear"))
-                assertTrue(result.contains("/review"))
-                assertTrue(result.contains("/test"))
-                println("Assertions done")
+                assertThat(result).contains(
+                    "/doc",
+                    "/dev",
+                    "/transform",
+                    "/help",
+                    "/clear",
+                    "/review",
+                    "/test",
+                    "/help"
+                )
             }
     }
 

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
@@ -15,8 +15,6 @@ import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
@@ -87,11 +87,7 @@ class CreateReadmeTest {
                 val result = executePuppeteerScript(validateFeatureAvailabilityTestScript)
                 assertThat(result)
                     .contains("Test Successful")
-                    .contains("Error: Test Failed")
-
-                if (result.contains("Error: Test Failed")) {
-                    println("result: $result")
-                }
+                    .doesNotContain("Error: Test Failed")
             }
     }
 
@@ -125,11 +121,7 @@ class CreateReadmeTest {
                 val result = executePuppeteerScript(createReadmePromptedToConfirmFolderTestScript)
                 assertThat(result)
                     .contains("Test Successful")
-                    .contains("Error: Test Failed")
-
-                if (result.contains("Error: Test Failed")) {
-                    println("result: $result")
-                }
+                    .doesNotContain("Error: Test Failed")
             }
     }
 
@@ -163,11 +155,7 @@ class CreateReadmeTest {
                 val result = executePuppeteerScript(makeChangesFlowTestScript)
                 assertThat(result)
                     .contains("Test Successful")
-                    .contains("Error: Test Failed")
-
-                if (result.contains("Error: Test Failed")) {
-                    println("result: $result")
-                }
+                    .doesNotContain("Error: Test Failed")
             }
     }
 
@@ -204,9 +192,6 @@ class CreateReadmeTest {
 
                 val result = executePuppeteerScript(acceptReadmeTestScript)
                 assertThat(result).doesNotContain("Error: Test Failed")
-                if (result.contains("Error: Test Failed")) {
-                    println("result: $result")
-                }
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val newReadme = File(newReadmePath.toUri())
@@ -253,11 +238,7 @@ class CreateReadmeTest {
                 val result = executePuppeteerScript(rejectReadmeTestScript)
                 assertThat(result)
                     .contains("Test Successful")
-                    .contains("Error: Test Failed")
-
-                if (result.contains("Error: Test Failed")) {
-                    println("result: $result")
-                }
+                    .doesNotContain("Error: Test Failed")
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val newReadme = File(newReadmePath.toUri())

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/createReadmeTests/CreateReadmeTest.kt
@@ -14,6 +14,7 @@ import com.intellij.ide.starter.models.TestCase
 import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -84,8 +85,10 @@ class CreateReadmeTest {
                 Thread.sleep(30000)
 
                 val result = executePuppeteerScript(validateFeatureAvailabilityTestScript)
-                assertTrue(result.contains("Test Successful"))
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result)
+                    .contains("Test Successful")
+                    .contains("Error: Test Failed")
+
                 if (result.contains("Error: Test Failed")) {
                     println("result: $result")
                 }
@@ -120,8 +123,10 @@ class CreateReadmeTest {
                 Thread.sleep(30000)
 
                 val result = executePuppeteerScript(createReadmePromptedToConfirmFolderTestScript)
-                assertTrue(result.contains("Test Successful"))
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result)
+                    .contains("Test Successful")
+                    .contains("Error: Test Failed")
+
                 if (result.contains("Error: Test Failed")) {
                     println("result: $result")
                 }
@@ -156,8 +161,10 @@ class CreateReadmeTest {
                 Thread.sleep(30000)
 
                 val result = executePuppeteerScript(makeChangesFlowTestScript)
-                assertTrue(result.contains("Test Successful"))
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result)
+                    .contains("Test Successful")
+                    .contains("Error: Test Failed")
+
                 if (result.contains("Error: Test Failed")) {
                     println("result: $result")
                 }
@@ -193,19 +200,22 @@ class CreateReadmeTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val readme = File(readmePath.toUri())
-                assertFalse(readme.exists())
+                assertThat(readme).doesNotExist()
 
                 val result = executePuppeteerScript(acceptReadmeTestScript)
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result).doesNotContain("Error: Test Failed")
                 if (result.contains("Error: Test Failed")) {
                     println("result: $result")
                 }
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val newReadme = File(newReadmePath.toUri())
-                assertTrue(newReadme.exists())
-                assertTrue(newReadme.readText().contains("REST"))
-                assertTrue(newReadme.readText().contains("API"))
+                assertThat(newReadme).exists()
+                    .content()
+                    .contains(
+                        "REST",
+                        "API"
+                    )
             }
     }
 
@@ -238,11 +248,12 @@ class CreateReadmeTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val readme = File(readmePath.toUri())
-                assertFalse(readme.exists())
+                assertThat(readme).doesNotExist()
 
                 val result = executePuppeteerScript(rejectReadmeTestScript)
-                assertTrue(result.contains("Test Successful"))
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result)
+                    .contains("Test Successful")
+                    .contains("Error: Test Failed")
 
                 if (result.contains("Error: Test Failed")) {
                     println("result: $result")
@@ -250,7 +261,7 @@ class CreateReadmeTest {
 
                 val newReadmePath = Paths.get("tstData", "qdoc", "createFlow", "README.md")
                 val newReadme = File(newReadmePath.toUri())
-                assertFalse(newReadme.exists())
+                assertThat(newReadme).doesNotExist()
             }
     }
 

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/updateReadmeTests/UpdateReadmeLatestChangesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/updateReadmeTests/UpdateReadmeLatestChangesTest.kt
@@ -14,9 +14,8 @@ import com.intellij.ide.starter.models.TestCase
 import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -89,8 +88,9 @@ class UpdateReadmeLatestChangesTest {
                     println("result: $result")
                 }
 
-                assertTrue(result.contains("Test Successful"))
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result)
+                    .contains("Test Successful")
+                    .doesNotContain("Error: Test Failed")
             }
     }
 
@@ -127,8 +127,9 @@ class UpdateReadmeLatestChangesTest {
                     println("result: $result")
                 }
 
-                assertTrue(result.contains("Test Successful"))
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result)
+                    .contains("Test Successful")
+                    .doesNotContain("Error: Test Failed")
             }
     }
 
@@ -167,9 +168,10 @@ class UpdateReadmeLatestChangesTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "updateFlow", "README.md")
                 val readme = File(readmePath.toUri())
-                assertTrue(readme.exists())
-                assertTrue(readme.readText().contains("sample/qdoc", ignoreCase = true))
-                assertTrue(readme.readText().contains("healthcontroller.java", ignoreCase = true))
+                assertThat(readme).exists()
+                assertThat(readme).content()
+                    .containsIgnoringCase("sample/qdoc")
+                    .containsIgnoringCase("healthcontroller.java")
             }
     }
 

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/updateReadmeTests/UpdateReadmeSpecificChangesTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/docTests/updateReadmeTests/UpdateReadmeSpecificChangesTest.kt
@@ -14,9 +14,8 @@ import com.intellij.ide.starter.models.TestCase
 import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -88,8 +87,9 @@ class UpdateReadmeSpecificChangesTest {
                     println("result: $result")
                 }
 
-                assertTrue(result.contains("Test Successful"))
-                assertFalse(result.contains("Error: Test Failed"))
+                assertThat(result)
+                    .contains("Test Successful")
+                    .doesNotContain("Error: Test Failed")
             }
     }
 
@@ -128,8 +128,10 @@ class UpdateReadmeSpecificChangesTest {
 
                 val readmePath = Paths.get("tstData", "qdoc", "updateFlow", "README.md")
                 val readme = File(readmePath.toUri())
-                assertTrue(readme.exists())
-                assertTrue(readme.readText().contains("Installation", ignoreCase = true))
+                assertThat(readme).exists()
+                assertThat(readme)
+                    .content()
+                    .containsIgnoringCase("Installation")
             }
     }
 

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/featureDevTests/FeatureDevTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/featureDevTests/FeatureDevTest.kt
@@ -14,9 +14,9 @@ import com.intellij.ide.starter.models.TestCase
 import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.kodein.di.DI
@@ -89,7 +89,7 @@ class FeatureDevTest {
                 Thread.sleep(30000)
 
                 val result = executePuppeteerScript(testAcceptInitalCode)
-                assertTrue(result.contains("Success: /dev ends the conversation successfully."))
+                assertThat(result).contains("Success: /dev ends the conversation successfully.")
             }
     }
 
@@ -121,7 +121,7 @@ class FeatureDevTest {
                 Thread.sleep(30000)
 
                 val result = executePuppeteerScript(testIterateCodeGen)
-                assertTrue(result.contains("Success: /dev ends the conversation successfully."))
+                assertThat(result).contains("Success: /dev ends the conversation successfully.")
             }
     }
 
@@ -153,7 +153,7 @@ class FeatureDevTest {
                 Thread.sleep(30000)
 
                 val result = executePuppeteerScript(testNewCodeGen)
-                assertTrue(result.contains("Success: /dev ends the conversation successfully."))
+                assertThat(result).contains("Success: /dev ends the conversation successfully.")
             }
     }
 
@@ -185,7 +185,7 @@ class FeatureDevTest {
                 Thread.sleep(30000)
 
                 val result = executePuppeteerScript(testPartialCodeGen)
-                assertTrue(result.contains("Success: /dev ends the conversation successfully."))
+                assertThat(result).contains("Success: /dev ends the conversation successfully.")
             }
     }
 
@@ -217,7 +217,7 @@ class FeatureDevTest {
                 Thread.sleep(30000)
 
                 val result = executePuppeteerScript(testStopAndRestartCodeGen)
-                assertTrue(result.contains("Success: /dev ends the conversation successfully."))
+                assertThat(result).contains("Success: /dev ends the conversation successfully.")
             }
     }
 

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/testTests/QTestGenerationChatTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/testTests/QTestGenerationChatTest.kt
@@ -15,8 +15,8 @@ import com.intellij.ide.starter.models.TestCase
 import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.kodein.di.DI
@@ -77,8 +77,9 @@ class QTestGenerationChatTest {
                 // required wait time for the system to be fully ready
                 Thread.sleep(30000)
                 val result = executePuppeteerScript(testNoFilePathScript)
-                assertTrue(result.contains("new tab opened"))
-                assertTrue(result.contains("a source file open right now that I can generate a test for"))
+                assertThat(result)
+                    .contains("new tab opened")
+                    .contains("a source file open right now that I can generate a test for")
             }
     }
 
@@ -109,10 +110,14 @@ class QTestGenerationChatTest {
                 openFile(Paths.get("testModule1", "HappyPath.java").toString())
                 Thread.sleep(30000)
                 val result = executePuppeteerScript(testHappyPathScript)
-                assertTrue(result.contains("new tab opened"))
-                assertTrue(result.contains("View Diff opened"))
-                assertTrue(result.contains("Result Accepted"))
-                assertTrue(result.contains("Unit test generation completed."))
+
+                assertThat(result)
+                    .contains(
+                        "new tab opened",
+                        "View Diff opened",
+                        "Result Accepted",
+                        "Unit test generation completed."
+                    )
             }
     }
 
@@ -143,8 +148,12 @@ class QTestGenerationChatTest {
                 openFile(Paths.get("testModule1", "ErrorPath.java").toString())
                 Thread.sleep(30000)
                 val result = executePuppeteerScript(expectedErrorPath)
-                assertTrue(result.contains("new tab opened"))
-                assertTrue(result.contains("Test generation complete with expected error"))
+
+                assertThat(result)
+                    .contains(
+                        "new tab opened",
+                        "Test generation complete with expected error"
+                    )
             }
     }
 
@@ -175,8 +184,12 @@ class QTestGenerationChatTest {
                 openFile(Paths.get("testModule2", "UnSupportedLanguage.kt").toString())
                 Thread.sleep(30000)
                 val result = executePuppeteerScript(unsupportedLanguagePath)
-                assertTrue(result.contains("new tab opened"))
-                assertTrue(result.contains("Test generation complete with expected error"))
+
+                assertThat(result)
+                    .contains(
+                        "new tab opened",
+                        "Test generation complete with expected error"
+                    )
             }
     }
 

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/testTests/QTestGenerationChatTestScripts.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/testTests/QTestGenerationChatTestScripts.kt
@@ -3,6 +3,8 @@
 
 package software.aws.toolkits.jetbrains.uitests.testTests
 
+import org.intellij.lang.annotations.Language
+
 val testHappyPathScript = """
         const puppeteer = require('puppeteer');
         async function testNavigation() {

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/testTests/QTestGenerationChatTestScripts.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/testTests/QTestGenerationChatTestScripts.kt
@@ -3,8 +3,6 @@
 
 package software.aws.toolkits.jetbrains.uitests.testTests
 
-import org.intellij.lang.annotations.Language
-
 val testHappyPathScript = """
         const puppeteer = require('puppeteer');
         async function testNavigation() {

--- a/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/transformTests/TransformChatTest.kt
+++ b/ui-tests-starter/tst-243+/software/aws/toolkits/jetbrains/uitests/transformTests/TransformChatTest.kt
@@ -14,8 +14,8 @@ import com.intellij.ide.starter.models.TestCase
 import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.Starter
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.kodein.di.DI
@@ -143,11 +143,13 @@ class TransformChatTest {
                 // required wait time for the system to be fully ready
                 Thread.sleep(30000)
                 val result = executePuppeteerScript(transformHappyPathScript)
-                assertTrue(result.contains("Choose a module to transform"))
-                assertTrue(result.contains("Choose the target code version"))
-                assertTrue(result.contains("Skip tests form appeared: true"))
-                assertTrue(result.contains("One or multiple diffs form appeared: true"))
-                assertTrue(result.contains("couldn't run the Maven clean install command"))
+                assertThat(result).contains(
+                    "Choose a module to transform",
+                    "Choose the target code version",
+                    "Skip tests form appeared: true",
+                    "One or multiple diffs form appeared: true",
+                    "couldn't run the Maven clean install command"
+                )
             }
     }
 

--- a/ui-tests-starter/tst/software/aws/toolkits/jetbrains/uitests/TestUtils.kt
+++ b/ui-tests-starter/tst/software/aws/toolkits/jetbrains/uitests/TestUtils.kt
@@ -3,14 +3,15 @@
 
 package software.aws.toolkits.jetbrains.uitests
 
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 
 private const val TEST_RESOURCES_PATH = "src/test/tstData"
-fun executePuppeteerScript(scriptContent: String): String {
+fun executePuppeteerScript(@Language("JS") scriptContent: String): String {
     val scriptFile = File("$TEST_RESOURCES_PATH/temp-script.js")
     scriptFile.parentFile.mkdirs()
     scriptFile.writeText(scriptContent)
@@ -25,7 +26,7 @@ fun executePuppeteerScript(scriptContent: String): String {
 
     scriptFile.delete()
 
-    assertEquals(0, exitCode, "Script execution failed with output: $output")
+    assertThat(exitCode).withFailMessage("Script execution failed with output: $output").isEqualTo(0)
     return output
 }
 
@@ -88,10 +89,10 @@ fun setupTestEnvironment() {
         .start()
         .waitFor()
 
-    assertEquals(0, npmInstall, "Failed to install Puppeteer")
+    assertThat(npmInstall).withFailMessage("Failed to install Puppeteer").isEqualTo(0)
 }
 
-fun writeToAwsXml(configContent: String) {
+fun writeToAwsXml(@Language("XML") configContent: String) {
     val path = Paths.get("tstData", "configAmazonQTests", "options", "aws.xml")
 
     Files.createDirectories(path.parent)
@@ -103,6 +104,7 @@ fun writeToAwsXml(configContent: String) {
     )
 }
 
+// language=JS
 val testScriptPrefix = """
 const puppeteer = require('puppeteer');
 


### PR DESCRIPTION
Fluent assertions through AssertJ result in more useful test output
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
