### PR TITLE
feat(amazonq): Enable checkbox to accept or block code fix with references

### DIFF
--- a/.changes/next-release/feature-21a9e26b-edbf-4ad3-a5f4-2662420d4f0d.json
+++ b/.changes/next-release/feature-21a9e26b-edbf-4ad3-a5f4-2662420d4f0d.json
@@ -1,4 +1,4 @@
 {
   "type" : "feature",
-  "description" : "/review: passing referenceTrackerConfiguration to StartCodeFixJob"
+  "description" : "/review: Enable checkbox to accept or block code fix with references"
 }

--- a/.changes/next-release/feature-21a9e26b-edbf-4ad3-a5f4-2662420d4f0d.json
+++ b/.changes/next-release/feature-21a9e26b-edbf-4ad3-a5f4-2662420d4f0d.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "/review: passing referenceTrackerConfiguration to StartCodeFixJob"
+}

--- a/.changes/next-release/feature-21a9e26b-edbf-4ad3-a5f4-2662420d4f0d.json
+++ b/.changes/next-release/feature-21a9e26b-edbf-4ad3-a5f4-2662420d4f0d.json
@@ -1,4 +1,4 @@
 {
-  "type" : "feature",
-  "description" : "/review: Enable checkbox to accept or block code fix with references"
+  "type" : "bugfix",
+  "description" : "/review: Respect user option to allow code suggestions with references"
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/AmazonQCodeFixSession.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/AmazonQCodeFixSession.kt
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.codewhispererruntime.model.GetCodeFixJobR
 import software.amazon.awssdk.services.codewhispererruntime.model.GetCodeFixJobResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.Position
 import software.amazon.awssdk.services.codewhispererruntime.model.Range
+import software.amazon.awssdk.services.codewhispererruntime.model.RecommendationsWithReferencesPreference
 import software.amazon.awssdk.services.codewhispererruntime.model.StartCodeFixJobRequest
 import software.amazon.awssdk.services.codewhispererruntime.model.StartCodeFixJobResponse
 import software.amazon.awssdk.services.codewhispererruntime.model.UploadContext
@@ -28,6 +29,7 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.credentials.CodeWh
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererZipUploadManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.getTelemetryErrorMessage
+import software.aws.toolkits.jetbrains.settings.CodeWhispererSettings
 import software.aws.toolkits.resources.message
 import java.io.File
 import java.nio.file.Path
@@ -161,12 +163,19 @@ class AmazonQCodeFixSession(val project: Project) {
         codeFixName: String? = null,
         ruleId: String? = null,
     ): StartCodeFixJobResponse {
+        val includeCodeWithReference = if (CodeWhispererSettings.getInstance().isIncludeCodeWithReference()) {
+            RecommendationsWithReferencesPreference.ALLOW
+        } else {
+            RecommendationsWithReferencesPreference.BLOCK
+        }
+
         val request = StartCodeFixJobRequest.builder()
             .uploadId(uploadId)
             .snippetRange(snippetRange)
             .codeFixName(codeFixName)
             .ruleId(ruleId)
             .description(description)
+            .referenceTrackerConfiguration { it.recommendationsWithReferences(includeCodeWithReference) }
             .build()
 
         return try {

--- a/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
+++ b/plugins/core/sdk-codegen/codegen-resources/codewhispererruntime/service-2.json
@@ -2082,7 +2082,8 @@
                 "uploadId": { "shape": "UploadId" },
                 "description": { "shape": "StartCodeFixJobRequestDescriptionString" },
                 "ruleId": { "shape": "StartCodeFixJobRequestRuleIdString" },
-                "codeFixName": { "shape": "CodeFixName" }
+                "codeFixName": { "shape": "CodeFixName" },
+                "referenceTrackerConfiguration": { "shape": "ReferenceTrackerConfiguration" }
             }
         },
         "StartCodeFixJobRequestDescriptionString": {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
When Q generates code fixes, it some times can get code from external links. For these fixes, it is required to return the reference along with the code fixes. This change gives customer the choice to either accept or block the code fix with references by using the referenceTrackerConfiguration checkbox in Setting.
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
