### PR TITLE
fix(amazonq): prompt users to re-auth on invalid grant

### DIFF
--- a/.changes/next-release/bugfix-29d1b3f1-b7e6-489d-b614-49f7d908f221.json
+++ b/.changes/next-release/bugfix-29d1b3f1-b7e6-489d-b614-49f7d908f221.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "/transform: prompt user to re-authenticate if credentials expire during transformation"
+}

--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/panels/managers/CodeModernizerBottomWindowPanelManager.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/panels/managers/CodeModernizerBottomWindowPanelManager.kt
@@ -39,7 +39,7 @@ import javax.swing.BorderFactory
 import javax.swing.JPanel
 
 class CodeModernizerBottomWindowPanelManager(private val project: Project) : JPanel(BorderLayout()) {
-    private var lastShownProgressPanel: Component? = null
+    private var progressPanel: Component? = null
     val toolbar = createToolbar().apply {
         targetComponent = this@CodeModernizerBottomWindowPanelManager
         component.border = BorderFactory.createCompoundBorder(
@@ -64,7 +64,7 @@ class CodeModernizerBottomWindowPanelManager(private val project: Project) : JPa
 
     private fun setUI(function: () -> Unit) {
         runInEdt {
-            lastShownProgressPanel = this.components.firstOrNull { it == fullSizeLoadingPanel || it == buildProgressSplitterPanelManager } ?: lastShownProgressPanel
+            progressPanel = this.components.firstOrNull { it == fullSizeLoadingPanel || it == buildProgressSplitterPanelManager } ?: progressPanel
             removeAll()
             add(BorderLayout.WEST, toolbar.component)
             add(BorderLayout.NORTH, banner)
@@ -176,8 +176,8 @@ class CodeModernizerBottomWindowPanelManager(private val project: Project) : JPa
     }
 
     fun showUnalteredJobUI() = setUI {
-        if (lastShownProgressPanel != null) {
-            add(BorderLayout.CENTER, lastShownProgressPanel)
+        if (progressPanel != null) {
+            add(BorderLayout.CENTER, progressPanel)
         } else {
             add(BorderLayout.CENTER, fullSizeLoadingPanel)
             fullSizeLoadingPanel.progressIndicatorLabel.text = "No jobs active"

--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/panels/managers/CodeModernizerBottomWindowPanelManager.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/panels/managers/CodeModernizerBottomWindowPanelManager.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.JavaSdkVersion
@@ -62,14 +63,16 @@ class CodeModernizerBottomWindowPanelManager(private val project: Project) : JPa
     }
 
     private fun setUI(function: () -> Unit) {
-        lastShownProgressPanel = this.components.firstOrNull { it == fullSizeLoadingPanel || it == buildProgressSplitterPanelManager } ?: lastShownProgressPanel
-        removeAll()
-        add(BorderLayout.WEST, toolbar.component)
-        add(BorderLayout.NORTH, banner)
-        function.invoke()
-        updateRunTime()
-        revalidate()
-        repaint()
+        runInEdt {
+            lastShownProgressPanel = this.components.firstOrNull { it == fullSizeLoadingPanel || it == buildProgressSplitterPanelManager } ?: lastShownProgressPanel
+            removeAll()
+            add(BorderLayout.WEST, toolbar.component)
+            add(BorderLayout.NORTH, banner)
+            function.invoke()
+            updateRunTime()
+            revalidate()
+            repaint()
+        }
     }
 
     private fun updateRunTime(now: Instant? = null) {

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerUtilsTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerUtilsTest.kt
@@ -4,8 +4,6 @@
 package software.aws.toolkits.jetbrains.services.codemodernizer
 import io.mockk.every
 import io.mockk.just
-import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerUtilsTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerUtilsTest.kt
@@ -4,6 +4,8 @@
 package software.aws.toolkits.jetbrains.services.codemodernizer
 import io.mockk.every
 import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
@@ -32,7 +34,6 @@ import software.aws.toolkits.jetbrains.utils.notifyStickyWarn
 import software.aws.toolkits.jetbrains.utils.rules.addFileToModule
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.createTempFile
-import io.mockk.*
 
 class CodeWhispererCodeModernizerUtilsTest : CodeWhispererCodeModernizerTestBase() {
     @Before

--- a/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerUtilsTest.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codemodernizer/CodeWhispererCodeModernizerUtilsTest.kt
@@ -20,7 +20,6 @@ import software.amazon.awssdk.services.codewhispererruntime.model.AccessDeniedEx
 import software.amazon.awssdk.services.codewhispererruntime.model.TransformationProgressUpdate
 import software.amazon.awssdk.services.codewhispererruntime.model.TransformationStatus
 import software.amazon.awssdk.services.ssooidc.model.InvalidGrantException
-import software.aws.toolkits.jetbrains.services.codemodernizer.commands.CodeTransformMessageListener
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.CodeTransformType
 import software.aws.toolkits.jetbrains.services.codemodernizer.utils.getBillingText
 import software.aws.toolkits.jetbrains.services.codemodernizer.utils.getTableMapping

--- a/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -778,6 +778,7 @@ codemodernizer.notification.warn.download_failed_invalid_artifact=Amazon Q was u
 codemodernizer.notification.warn.download_failed_other.content=Amazon Q ran into an issue while trying to download your {0}. Please try again. {1}
 codemodernizer.notification.warn.download_failed_ssl.content=Please make sure all your certificates for your proxy client have been set up correctly for your IDE.
 codemodernizer.notification.warn.download_failed_wildcard.content=Check your IDE proxy settings and remove any wildcard (*) references, and then try viewing the diff again.
+codemodernizer.notification.warn.expired_credentials.content=Unable to check transformation status as your credentials expired. Try signing out of Amazon Q and signing back in again if 'Reauthenticate' below does not work.
 codemodernizer.notification.warn.expired_credentials.title=Your connection to Q has expired
 codemodernizer.notification.warn.invalid_project.description.reason.missing_content_roots=None of your open modules are supported for code transformation with Amazon Q. Amazon Q can upgrade Java 8, Java 11, Java 17, and Java 21 projects built on Maven, with content roots configured.
 codemodernizer.notification.warn.invalid_project.description.reason.not_logged_in=Amazon Q cannot start the transformation as you are not logged in with Identity Center or Builder ID. Also ensure that you are not using IntelliJ version 232.8660.185 and that you are not developing on a remote host (uncommon).


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
When we get an `InvalidGrantException` we should *not* be trying to refresh the token; rather, we should prompt the user to re-authenticate to Q.
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
