### PR TITLE
fix(amazonq): set programmingLanguage to Plaintext if language is unknown

### DIFF
--- a/.changes/next-release/bugfix-a9690f2d-611f-45f6-82d1-c3a9e17a6b6b.json
+++ b/.changes/next-release/bugfix-a9690f2d-611f-45f6-82d1-c3a9e17a6b6b.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "/review: set programmingLanguage to Plaintext if language is unknown"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanSession.kt
@@ -264,7 +264,11 @@ class CodeWhispererCodeScanSession(val sessionContext: CodeScanSessionContext) {
             return clientAdaptor.createCodeScan(
                 StartCodeAnalysisRequest.builder()
                     .clientToken(clientToken.toString())
-                    .programmingLanguage { it.languageName(language) }
+                    .programmingLanguage {
+                        it.languageName(
+                            if (language == CodewhispererLanguage.Unknown.toString()) CodewhispererLanguage.Plaintext.toString() else language
+                        )
+                    }
                     .artifacts(artifactsMap)
                     .scope(scope.value)
                     .codeScanName(codeScanName)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Sometimes scans are not triggered due to the scan type being unknown.
The solution is to set programmingLanguage to Plaintext if language is unknown.
The change was tested locally by triggering file scan against plaintext files.
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
