### PR TITLE
fix(amazonq): /doc close diff and open readme in preview mode after accept change

### DIFF
--- a/.changes/next-release/bugfix-19118cf8-9378-4bd6-bf5e-7e57520181d0.json
+++ b/.changes/next-release/bugfix-19118cf8-9378-4bd6-bf5e-7e57520181d0.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q /doc: close diff tab and open README file in preview mode after user accept changes"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqDoc/controller/DocController.kt
@@ -13,6 +13,8 @@ import com.intellij.diff.util.DiffUserDataKeys
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.TextEditorWithPreview
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.testFramework.LightVirtualFile
@@ -298,8 +300,11 @@ class DocController(
         messenger.sendChatInputEnabledMessage(message.tabId, false)
     }
 
+    private val diffVirtualFiles = mutableMapOf<String, ChainDiffVirtualFile>()
+
     private suspend fun acceptChanges(message: IncomingDocMessage.FollowupClicked) {
         insertCode(message.tabId)
+        previewReadmeFile(message.tabId)
     }
 
     private suspend fun promptForDocTarget(tabId: String) {
@@ -420,6 +425,8 @@ class DocController(
                 request.putUserData(DiffUserDataKeys.FORCE_READ_ONLY, true)
 
                 val newDiff = ChainDiffVirtualFile(SimpleDiffRequestChain(request), message.filePath)
+
+                diffVirtualFiles[message.filePath] = newDiff
                 DiffEditorTabFilesManager.getInstance(context.project).showDiffFile(newDiff, true)
             }
         }
@@ -1045,6 +1052,34 @@ class DocController(
 
         val docAcceptanceEvent = docGenerationTask.docAcceptanceEventBase()
         session.sendDocTelemetryEvent(null, docAcceptanceEvent)
+    }
+
+    private fun previewReadmeFile(tabId: String) {
+        val session = getSessionInfo(tabId)
+        var filePaths: List<NewFileZipInfo> = emptyList()
+
+        when (val state = session.sessionState) {
+            is PrepareDocGenerationState -> {
+                filePaths = state.filePaths
+            }
+        }
+
+        if (filePaths.isNotEmpty()) {
+            val filePath = filePaths[0].zipFilePath
+            val existingDiff = diffVirtualFiles[filePath]
+
+            val newFilePath = session.context.addressableRoot.toNioPath().resolve(filePath)
+            val readmeVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(newFilePath.toString())
+
+            runInEdt {
+                if (existingDiff != null) {
+                    FileEditorManager.getInstance(getProject()).closeFile(existingDiff)
+                }
+                if (readmeVirtualFile != null) {
+                    TextEditorWithPreview.openPreviewForFile(getProject(), readmeVirtualFile)
+                }
+            }
+        }
     }
 
     fun getProject() = context.project


### PR DESCRIPTION
After this change:
After users click `Accept` to accept the README.md file change, `diff` tab will be closed and `README.md` file will be opened.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
