### PR TITLE
fix(amazonq): /doc close diff and open readme in preview mode after a…

### DIFF
--- a/.changes/next-release/bugfix-19118cf8-9378-4bd6-bf5e-7e57520181d0.json
+++ b/.changes/next-release/bugfix-19118cf8-9378-4bd6-bf5e-7e57520181d0.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q /doc: close diff tab and open README file in preview mode after user accept changes"
+}


### PR DESCRIPTION
After this change:
After users click `Accept` to accept the README.md file change, `diff` tab will be closed and `README.md` file will be opened.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
