### PR TITLE
fix(amazonq): update didRenameFile to call didOpen & didClose for documents

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -105,8 +105,6 @@ class TextDocumentServiceHandler(
                     DidOpenTextDocumentParams().apply {
                         textDocument = TextDocumentItem().apply {
                             this.uri = uri
-                            languageId = file.fileType.name.lowercase()
-                            version = file.modificationStamp.toInt()
                             text = file.inputStream.readAllBytes().decodeToString()
                         }
                     }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -105,6 +105,8 @@ class TextDocumentServiceHandler(
                     DidOpenTextDocumentParams().apply {
                         textDocument = TextDocumentItem().apply {
                             this.uri = uri
+                            languageId = file.fileType.name.lowercase()
+                            version = file.modificationStamp.toInt()
                             text = file.inputStream.readAllBytes().decodeToString()
                         }
                     }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
@@ -139,7 +139,6 @@ class WorkspaceServiceHandler(
                     val oldUri = toUriString(parentFile)?.let { parentUri -> "$parentUri/$oldFileName" }
                     val newUri = toUriString(renamedFile)
 
-                    // First close the old document
                     oldUri?.let { uri ->
                         languageServer.textDocumentService.didClose(
                             DidCloseTextDocumentParams().apply {
@@ -150,14 +149,11 @@ class WorkspaceServiceHandler(
                         )
                     }
 
-                    // Then open the new document
                     newUri?.let { uri ->
                         languageServer.textDocumentService.didOpen(
                             DidOpenTextDocumentParams().apply {
                                 textDocument = TextDocumentItem().apply {
                                     this.uri = uri
-                                    languageId = renamedFile.fileType.name.lowercase()
-                                    version = renamedFile.modificationStamp.toInt()
                                     text = renamedFile.inputStream.readAllBytes().decodeToString()
                                 }
                             }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
@@ -139,25 +139,27 @@ class WorkspaceServiceHandler(
                     val oldUri = toUriString(parentFile)?.let { parentUri -> "$parentUri/$oldFileName" }
                     val newUri = toUriString(renamedFile)
 
-                    oldUri?.let { uri ->
-                        languageServer.textDocumentService.didClose(
-                            DidCloseTextDocumentParams().apply {
-                                textDocument = TextDocumentIdentifier().apply {
-                                    this.uri = uri
+                    if (!renamedFile.isDirectory) {
+                        oldUri?.let { uri ->
+                            languageServer.textDocumentService.didClose(
+                                DidCloseTextDocumentParams().apply {
+                                    textDocument = TextDocumentIdentifier().apply {
+                                        this.uri = uri
+                                    }
                                 }
-                            }
-                        )
-                    }
+                            )
+                        }
 
-                    newUri?.let { uri ->
-                        languageServer.textDocumentService.didOpen(
-                            DidOpenTextDocumentParams().apply {
-                                textDocument = TextDocumentItem().apply {
-                                    this.uri = uri
-                                    text = renamedFile.inputStream.readAllBytes().decodeToString()
+                        newUri?.let { uri ->
+                            languageServer.textDocumentService.didOpen(
+                                DidOpenTextDocumentParams().apply {
+                                    textDocument = TextDocumentItem().apply {
+                                        this.uri = uri
+                                        text = renamedFile.inputStream.readAllBytes().decodeToString()
+                                    }
                                 }
-                            }
-                        )
+                            )
+                        }
                     }
 
                     FileRename().apply {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
@@ -22,14 +22,14 @@ import org.eclipse.lsp4j.DidChangeWatchedFilesParams
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
-import org.eclipse.lsp4j.TextDocumentIdentifier
-import org.eclipse.lsp4j.TextDocumentItem
 import org.eclipse.lsp4j.FileChangeType
 import org.eclipse.lsp4j.FileCreate
 import org.eclipse.lsp4j.FileDelete
 import org.eclipse.lsp4j.FileEvent
 import org.eclipse.lsp4j.FileRename
 import org.eclipse.lsp4j.RenameFilesParams
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentItem
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandlerTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandlerTest.kt
@@ -30,10 +30,13 @@ import org.eclipse.lsp4j.CreateFilesParams
 import org.eclipse.lsp4j.DeleteFilesParams
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams
+import org.eclipse.lsp4j.DidCloseTextDocumentParams
+import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.FileChangeType
 import org.eclipse.lsp4j.RenameFilesParams
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
+import org.eclipse.lsp4j.services.TextDocumentService
 import org.eclipse.lsp4j.services.WorkspaceService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -50,6 +53,7 @@ class WorkspaceServiceHandlerTest {
     private lateinit var project: Project
     private lateinit var mockLanguageServer: AmazonQLanguageServer
     private lateinit var mockWorkspaceService: WorkspaceService
+    private lateinit var mockTextDocumentService: TextDocumentService
     private lateinit var sut: WorkspaceServiceHandler
     private lateinit var mockApplication: Application
 
@@ -57,6 +61,7 @@ class WorkspaceServiceHandlerTest {
     fun setup() {
         project = mockk<Project>()
         mockWorkspaceService = mockk<WorkspaceService>()
+        mockTextDocumentService = mockk<TextDocumentService>()
         mockLanguageServer = mockk<AmazonQLanguageServer>()
 
         mockApplication = mockk<Application>()
@@ -88,6 +93,11 @@ class WorkspaceServiceHandlerTest {
         every { mockWorkspaceService.didRenameFiles(any()) } returns Unit
         every { mockWorkspaceService.didChangeWatchedFiles(any()) } returns Unit
         every { mockWorkspaceService.didChangeWorkspaceFolders(any()) } returns Unit
+
+        // Mock textDocument service (for didRename calls)
+        every { mockLanguageServer.textDocumentService } returns mockTextDocumentService
+        every { mockTextDocumentService.didOpen(any()) } returns Unit
+        every { mockTextDocumentService.didClose(any()) } returns Unit
 
         // Mock message bus
         val messageBus = mockk<MessageBus>()
@@ -389,10 +399,19 @@ class WorkspaceServiceHandlerTest {
         // Act
         sut.after(listOf(propertyEvent))
 
+        val closeParams = slot<DidCloseTextDocumentParams>()
+        verify { mockTextDocumentService.didClose(capture(closeParams)) }
+        assertEquals(normalizeFileUri("file:///testDir/$oldName"), closeParams.captured.textDocument.uri)
+
+        val openParams = slot<DidOpenTextDocumentParams>()
+        verify { mockTextDocumentService.didOpen(capture(openParams)) }
+        assertEquals(normalizeFileUri("file:///testDir/$newName"), openParams.captured.textDocument.uri)
+        assertEquals(normalizeFileUri("content"), openParams.captured.textDocument.text)
+
         // Assert
-        val paramsSlot = slot<RenameFilesParams>()
-        verify { mockWorkspaceService.didRenameFiles(capture(paramsSlot)) }
-        with(paramsSlot.captured.files[0]) {
+        val renameParams = slot<RenameFilesParams>()
+        verify { mockWorkspaceService.didRenameFiles(capture(renameParams)) }
+        with(renameParams.captured.files[0]) {
             assertEquals(normalizeFileUri("file:///testDir/$oldName"), oldUri)
             assertEquals(normalizeFileUri("file:///testDir/$newName"), newUri)
         }
@@ -411,6 +430,8 @@ class WorkspaceServiceHandlerTest {
         sut.after(listOf(propertyEvent))
 
         // Assert
+        verify(exactly = 0) { mockTextDocumentService.didClose(any()) }
+        verify(exactly = 0) { mockTextDocumentService.didOpen(any()) }
         verify(exactly = 0) { mockWorkspaceService.didRenameFiles(any()) }
     }
 
@@ -427,6 +448,8 @@ class WorkspaceServiceHandlerTest {
         sut.after(listOf(propertyEvent))
 
         // Assert
+        verify(exactly = 0) { mockTextDocumentService.didClose(any()) }
+        verify(exactly = 0) { mockTextDocumentService.didOpen(any()) }
         val paramsSlot = slot<RenameFilesParams>()
         verify { mockWorkspaceService.didRenameFiles(capture(paramsSlot)) }
         with(paramsSlot.captured.files[0]) {
@@ -624,6 +647,7 @@ class WorkspaceServiceHandlerTest {
             every { fileSystem } returns mockk {
                 every { protocol } returns "file"
             }
+            every { this@mockk.inputStream } returns "content".byteInputStream()
         }
     }
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Document renames should be signaled to a server sending a document close notification with the document’s old name followed by an open notification using the document’s new name. Major reason is that besides the name other attributes can change as well like the language that is associated with the document. In addition the new document could not be of interest for the server anymore.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

DidRename now calls didClose for the old Uri and didOpen for the new one. Ignores these calls for directory renames/ unsupported filetypes. 

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
