### PR TITLE
feat(amazonq): automatically generate fix without clicking Generate Fix button

### DIFF
--- a/.changes/next-release/feature-4e0e76eb-a634-47e2-9e73-4e7dfde76160.json
+++ b/.changes/next-release/feature-4e0e76eb-a634-47e2-9e73-4e7dfde76160.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "/review: automatically generate fix without clicking Generate Fix button"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanIssueDetailsPanel.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanIssueDetailsPanel.kt
@@ -333,5 +333,10 @@ internal class CodeWhispererCodeScanIssueDetailsPanel(
         add(BorderLayout.SOUTH, buttonPane)
         isVisible = true
         revalidate()
+        if (issue.suggestedFixes.isEmpty()) {
+            defaultScope.launch {
+                handleGenerateFix(issue)
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Automatically generate fix without clicking Generate Fix button
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
