### PR TITLE
ci(251): disable rider tests due to CI failures

### DIFF
--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -36,7 +36,7 @@ phases:
         }
 
          # Rider is very expensive (spikes our CI jobs to 50% CPU, so let it do the prep work in parallel, but run tests later
-        ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" :plugin-toolkit:intellij-standalone:check :plugin-toolkit:jetbrains-rider:compileTestKotlin --info --console plain --continue
+        ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" :plugin-toolkit:intellij-standalone:check :plugin-toolkit:jetbrains-rider:compileTestKotlin -x :plugin-toolkit:jetbrains-rider:check --info --console plain --continue
         if ($LastExitCode -ne 0) {
           Write-Host "Command failed with exit code $LastExitCode"
           exit -1


### PR DESCRIPTION

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
