### PR TITLE
fix(amazonq): fix deserialization failure from workspace context chunks

### DIFF
--- a/.changes/next-release/bugfix-00947041-108c-4ef1-bec6-eb749dae7c2f.json
+++ b/.changes/next-release/bugfix-00947041-108c-4ef1-bec6-eb749dae7c2f.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue where Amazon Q cannot process chunks from local `@workspace` context"
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -74,8 +74,8 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
     )
 
     // TODO: move to LspMessage.kt
+    @JsonIgnoreProperties(ignoreUnknown = true)
     data class Usage(
-        @JsonIgnoreProperties(ignoreUnknown = true)
         @JsonProperty("memoryUsage")
         val memoryUsage: Int? = null,
         @JsonProperty("cpuUsage")
@@ -83,8 +83,8 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
     )
 
     // TODO: move to LspMessage.kt
+    @JsonIgnoreProperties(ignoreUnknown = true)
     data class Chunk(
-        @JsonIgnoreProperties(ignoreUnknown = true)
         @JsonProperty("filePath")
         val filePath: String? = null,
         @JsonProperty("content")


### PR DESCRIPTION
`@JsonIgnoreProperties` is a class-level annotation

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
