### PR TITLE
fix(amazonq): make amazon.q.endpoints.json more maintainable

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererEndpointCustomizer.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererEndpointCustomizer.kt
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.codewhispererruntime.CodeWhispererRuntime
 import software.amazon.awssdk.services.codewhispererstreaming.CodeWhispererStreamingAsyncClientBuilder
 import software.aws.toolkits.core.ToolkitClientCustomizer
 import software.aws.toolkits.core.utils.tryOrNull
+import software.aws.toolkits.jetbrains.services.amazonq.profile.QDefaultServiceConfig
 import software.aws.toolkits.jetbrains.services.amazonq.profile.QEndpoints
 import software.aws.toolkits.jetbrains.settings.CodeWhispererSettings
 import java.net.Proxy
@@ -42,7 +43,7 @@ class CodeWhispererEndpointCustomizer : ToolkitClientCustomizer {
         if (builder is CodeWhispererRuntimeClientBuilder || builder is CodeWhispererStreamingAsyncClientBuilder) {
             val endpoint = tryOrNull { QEndpoints.getQEndpointWithRegion(regionId) }
                 ?.let { URI.create(it) }
-                ?: URI.create(QEndpoints.Q_DEFAULT_SERVICE_CONFIG.ENDPOINT)
+                ?: URI.create(QDefaultServiceConfig.ENDPOINT)
             builder
                 .endpointOverride(endpoint)
                 .region(Region.of(regionId))

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/QEndpointsTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/QEndpointsTest.kt
@@ -49,7 +49,6 @@ class QEndpointsTest {
         assertThat(QEndpoints.listRegionEndpoints()).isEqualTo(QDefaultServiceConfig.ENDPOINT_MAP.toEndpointList())
     }
 
-
     @Test
     fun `uses default entries if invalid`() {
         registryExtension.setValue("amazon.q.endpoints.json", "asdfadfkajdklf32.4;'2l4;234l23.424';1l1!!@#!")

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
@@ -157,7 +157,7 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
         }
 
         val settings = conn.getConnectionSettings()
-        val awsRegion = AwsRegionProvider.getInstance()[QEndpoints.Q_DEFAULT_SERVICE_CONFIG.REGION] ?: error("unknown region from Q default service config")
+        val awsRegion = AwsRegionProvider.getInstance()[QDefaultServiceConfig.REGION] ?: error("unknown region from Q default service config")
 
         // TODO: different window should be able to select different profile
         return activeProfile(project)?.let { profile ->

--- a/plugins/amazonq/src/main/resources/META-INF/plugin.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/plugin.xml
@@ -87,8 +87,7 @@
         <registryKey key="amazon.q.endpoint" description="Endpoint to use for Amazon Q"
                      defaultValue="" restartRequired="true"/>
         <registryKey key="amazon.q.endpoints.json" description="List of region-endpoint pairs in JSON array form"
-                     defaultValue="[{&quot;region&quot;:&quot;us-east-1&quot;,&quot;endpoint&quot;:&quot;https://q.us-east-1.amazonaws.com/&quot;},
-                   {&quot;region&quot;:&quot;eu-central-1&quot;,&quot;endpoint&quot;:&quot;https://q.eu-central-1.amazonaws.com/&quot;}]"
+                     defaultValue=""
                      restartRequired="true"/>
         <registryKey key="inline.completion.rem.dev.use.rhizome" description="Defined by IntelliJ. Used for Amazon Q to display suggestions on remote."
                      defaultValue="false" restartRequired="true"/>


### PR DESCRIPTION
We do not need to stuff the prod configuration into the plugin.xml. Additionally we should gracefully handle invalid configuration instead of giving up
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
