### PR TITLE
fix(amazonq): fix connection manager deadlock when q ListAvailableProfiles is long

### DIFF
--- a/.changes/next-release/bugfix-1162ea20-1fcf-43a6-b502-16d8b7d588d7.json
+++ b/.changes/next-release/bugfix-1162ea20-1fcf-43a6-b502-16d8b7d588d7.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix issue where IDE freezes when logging into Amazon Q"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.amazonq.toolwindow
 
 import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -66,9 +65,6 @@ class AmazonQToolWindowFactory : ToolWindowFactory, DumbAware {
                 override fun activeConnectionChanged(newConnection: ToolkitConnection?) {
                     ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())?.let { qConn ->
                         openMeetQPage(project)
-                        ApplicationManager.getApplication().executeOnPooledThread {
-                            QRegionProfileManager.getInstance().validateProfile(project)
-                        }
                     }
                     prepareChatContent(project, qPanel)
                 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindowFactory.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.amazonq.toolwindow
 
 import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -65,7 +66,9 @@ class AmazonQToolWindowFactory : ToolWindowFactory, DumbAware {
                 override fun activeConnectionChanged(newConnection: ToolkitConnection?) {
                     ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())?.let { qConn ->
                         openMeetQPage(project)
-                        QRegionProfileManager.getInstance().validateProfile(project)
+                        ApplicationManager.getApplication().executeOnPooledThread {
+                            QRegionProfileManager.getInstance().validateProfile(project)
+                        }
                     }
                     prepareChatContent(project, qPanel)
                 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import com.intellij.util.xmlb.annotations.MapAnnotation
 import com.intellij.util.xmlb.annotations.Property
 import software.amazon.awssdk.core.SdkClient
@@ -43,6 +44,7 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
     private val connectionIdToProfileList = mutableMapOf<String, Int>()
 
     // should be call on project startup to validate if profile is still active
+    @RequiresBackgroundThread
     fun validateProfile(project: Project) {
         val conn = getIdcConnectionOrNull(project)
         val selected = activeProfile(project) ?: return

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkits.jetbrains.services.amazonq.profile
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.BaseState
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
@@ -26,6 +27,7 @@ import software.aws.toolkits.jetbrains.core.credentials.AwsBearerTokenConnection
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
 import software.aws.toolkits.jetbrains.core.credentials.sono.isSono
+import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
 import software.aws.toolkits.jetbrains.utils.notifyInfo
 import software.aws.toolkits.resources.AmazonQBundle.message
@@ -41,7 +43,20 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
 
     // Map to store connectionId to its active profile
     private val connectionIdToActiveProfile = Collections.synchronizedMap<String, QRegionProfile>(mutableMapOf())
-    private val connectionIdToProfileList = mutableMapOf<String, Int>()
+    private val connectionIdToProfileCount = mutableMapOf<String, Int>()
+
+    init {
+        ApplicationManager.getApplication().messageBus.connect(this)
+            .subscribe(
+                BearerTokenProviderListener.TOPIC,
+                object : BearerTokenProviderListener {
+                    override fun invalidate(providerId: String) {
+                        connectionIdToActiveProfile.remove(providerId)
+                        connectionIdToProfileCount.remove(providerId)
+                    }
+                }
+            )
+    }
 
     // should be call on project startup to validate if profile is still active
     @RequiresBackgroundThread
@@ -80,7 +95,7 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
                 switchProfile(project, mappedProfiles.first(), intent = QProfileSwitchIntent.Update)
             }
             mappedProfiles.takeIf { it.isNotEmpty() }?.also {
-                connectionIdToProfileList[connection.id] = it.size
+                connectionIdToProfileCount[connection.id] = it.size
             } ?: error("You don't have access to the resource")
         } catch (e: Exception) {
             LOG.warn(e) { "Failed to list region profiles: ${e.message}" }
@@ -112,7 +127,7 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
                 Telemetry.amazonq.didSelectProfile.use { span ->
                     span.source(intent.value)
                         .amazonQProfileRegion(newProfile.region)
-                        .profileCount(connectionIdToProfileList[conn.id])
+                        .profileCount(connectionIdToProfileCount[conn.id])
                         .ssoRegion(conn.region)
                         .credentialStartUrl(conn.startUrl)
                         .result(MetricResult.Succeeded)
@@ -141,13 +156,13 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
 
     // for each idc connection, user should have a profile, otherwise should show the profile selection error page
     fun isPendingProfileSelection(project: Project): Boolean = getIdcConnectionOrNull(project)?.let { conn ->
-        val profileCounts = connectionIdToProfileList[conn.id] ?: 0
+        val profileCounts = connectionIdToProfileCount[conn.id] ?: 0
         val activeProfile = connectionIdToActiveProfile[conn.id]
         profileCounts == 0 || (profileCounts > 1 && activeProfile?.arn.isNullOrEmpty())
     } ?: false
 
     fun shouldDisplayProfileInfo(project: Project): Boolean = getIdcConnectionOrNull(project)?.let { conn ->
-        (connectionIdToProfileList[conn.id] ?: 0) > 1
+        (connectionIdToProfileCount[conn.id] ?: 0) > 1
     } ?: false
 
     fun getQClientSettings(project: Project): TokenConnectionSettings {
@@ -193,7 +208,7 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
     override fun getState(): QProfileState {
         val state = QProfileState()
         state.connectionIdToActiveProfile.putAll(this.connectionIdToActiveProfile)
-        state.connectionIdToProfileList.putAll(this.connectionIdToProfileList)
+        state.connectionIdToProfileList.putAll(this.connectionIdToProfileCount)
         return state
     }
 
@@ -201,8 +216,8 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
         connectionIdToActiveProfile.clear()
         connectionIdToActiveProfile.putAll(state.connectionIdToActiveProfile)
 
-        connectionIdToProfileList.clear()
-        connectionIdToProfileList.putAll(state.connectionIdToProfileList)
+        connectionIdToProfileCount.clear()
+        connectionIdToProfileCount.putAll(state.connectionIdToProfileList)
     }
 }
 


### PR DESCRIPTION

`CodeWhispererStatusBarWidget` attempts to query active connections, but lock is being held while trying to list profiles

```
"AWT-EventQueue-0" prio=0 tid=0x0 nid=0x0 blocked
     java.lang.Thread.State: BLOCKED
 on software.aws.toolkits.jetbrains.core.credentials.DefaultToolkitConnectionManager@37995400 owned by "ApplicationImpl pooled thread 5 @coroutine#17104" Id=128
	at software.aws.toolkits.jetbrains.core.credentials.DefaultToolkitConnectionManager.activeConnectionForFeature(DefaultToolkitConnectionManager.kt)
	at software.aws.toolkits.jetbrains.services.amazonq.QUtilsKt.calculateIfIamIdentityCenterConnection(QUtils.kt:18)
	at software.aws.toolkits.jetbrains.services.codewhisperer.customization.DefaultCodeWhispererModelConfigurator.activeCustomization(CodeWhispererModelConfigurator.kt:171)
	at software.aws.toolkits.jetbrains.services.codewhisperer.status.CodeWhispererStatusBarWidget.getSelectedValue(CodeWhispererStatusBarWidget.kt:114)
	at com.intellij.openapi.wm.impl.status.MultipleTextValues.beforeUpdate(IdeStatusBarImpl.kt:983)
```

```
- "coroutine#17104":BlockingCoroutine{Active}@7dced952, state: RUNNING [CoroutineId(17104), BlockingEventLoop@2da7461c]
	at java.base/jdk.internal.misc.Unsafe.park(Native Method)
	at java.base/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:269)
	at java.base/java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1866)
	at java.base/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:4013)
	at java.base/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3961)
	at java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1939)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
	at migration.software.aws.toolkits.jetbrains.core.AwsResourceCache$Companion.wait(AwsResourceCache.kt:150)
	at migration.software.aws.toolkits.jetbrains.core.AwsResourceCache$Companion.access$wait(AwsResourceCache.kt:145)
	at migration.software.aws.toolkits.jetbrains.core.AwsResourceCache.getResourceNow(AwsResourceCache.kt:92)
	at migration.software.aws.toolkits.jetbrains.core.AwsResourceCache.getResourceNow(AwsResourceCache.kt:105)
	at software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager.listRegionProfiles(QRegionProfileManager.kt:70)
	at software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager.validateProfile$lambda$0(QRegionProfileManager.kt:50)
	at software.aws.toolkits.core.utils.ExceptionUtils.tryOrNull(ExceptionUtils.kt:11)
	at software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager.validateProfile(QRegionProfileManager.kt:49)
	at software.aws.toolkits.jetbrains.services.amazonq.toolwindow.AmazonQToolWindowFactory$createToolWindowContent$2.activeConnectionChanged(AmazonQToolWindowFactory.kt:68)
[...]
	at software.aws.toolkits.jetbrains.core.credentials.DefaultToolkitConnectionManager.switchConnection(DefaultToolkitConnectionManager.kt:159)
```


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
