### PR TITLE
fix(amazonq): profile name not visible in light mode

### DIFF
--- a/plugins/core/webview/src/q-ui/components/profileSelection.vue
+++ b/plugins/core/webview/src/q-ui/components/profileSelection.vue
@@ -184,7 +184,6 @@ export default defineComponent({
 .profile-name {
     font-weight: bold;
     margin-bottom: 2px;
-    color: white;
 }
 
 .profile-region {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->






 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
