### PR TITLE
fix(amazonq): switch to ulong to avoid overflow when input is larger than 2gb

### DIFF
--- a/.changes/next-release/bugfix-d2a9278c-d71f-463f-b899-f56a587829e8.json
+++ b/.changes/next-release/bugfix-d2a9278c-d71f-463f-b899-f56a587829e8.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix integer overflow when local context index input is larger than 2GB"
+}

--- a/.changes/next-release/bugfix-f31946b6-3709-44a5-b23f-9fa202bd5cb5.json
+++ b/.changes/next-release/bugfix-f31946b6-3709-44a5-b23f-9fa202bd5cb5.json
@@ -1,4 +1,0 @@
-{
-  "type" : "bugfix",
-  "description" : "Fix infinite loop when workspace indexing server fails to initialize"
-}

--- a/.changes/next-release/bugfix-f31946b6-3709-44a5-b23f-9fa202bd5cb5.json
+++ b/.changes/next-release/bugfix-f31946b6-3709-44a5-b23f-9fa202bd5cb5.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix infinite loop when workspace indexing server fails to initialize"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererConfigurable.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/settings/CodeWhispererConfigurable.kt
@@ -133,7 +133,7 @@ class CodeWhispererConfigurable(private val project: Project) :
 
             row(message("aws.settings.codewhisperer.project_context_index_thread")) {
                 intTextField(
-                    range = IntRange(0, 50)
+                    range = CodeWhispererSettings.CONTEXT_INDEX_THREADS
                 ).bindIntText(codeWhispererSettings::getProjectContextIndexThreadCount, codeWhispererSettings::setProjectContextIndexThreadCount)
                     .apply {
                         connect.subscribe(
@@ -150,7 +150,7 @@ class CodeWhispererConfigurable(private val project: Project) :
 
             row(message("aws.settings.codewhisperer.project_context_index_max_size")) {
                 intTextField(
-                    range = IntRange(1, 4096)
+                    range = CodeWhispererSettings.CONTEXT_INDEX_SIZE
                 ).bindIntText(codeWhispererSettings::getProjectContextIndexMaxSize, codeWhispererSettings::setProjectContextIndexMaxSize)
                     .apply {
                         connect.subscribe(

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererSettingsTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererSettingsTest.kt
@@ -211,6 +211,42 @@ class CodeWhispererSettingsTest : CodeWhispererTestBase() {
         assertThat(actual.autoBuildSetting).hasSize(1)
         assertThat(actual.autoBuildSetting["project1"]).isTrue()
     }
+
+    @Test
+    fun `context thread count is returned in range`() {
+        val sut = CodeWhispererSettings.getInstance()
+
+        mapOf(
+            1 to 1,
+            0 to 0,
+            -1 to 0,
+            123 to 50,
+            50 to 50,
+            51 to 50,
+        ).forEach { s, expected ->
+            sut.setProjectContextIndexThreadCount(s)
+            assertThat(sut.getProjectContextIndexThreadCount()).isEqualTo(expected)
+        }
+
+    }
+
+    @Test
+    fun `context index size is returned in range`() {
+        val sut = CodeWhispererSettings.getInstance()
+
+        mapOf(
+            1 to 1,
+            0 to 1,
+            -1 to 1,
+            123 to 123,
+            2047 to 2047,
+            4096 to 4096,
+            4097 to 4096,
+        ).forEach { s, expected ->
+            sut.setProjectContextIndexMaxSize(s)
+            assertThat(sut.getProjectContextIndexMaxSize()).isEqualTo(expected)
+        }
+    }
 }
 
 class CodeWhispererSettingUnitTest {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererSettingsTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererSettingsTest.kt
@@ -227,7 +227,6 @@ class CodeWhispererSettingsTest : CodeWhispererTestBase() {
             sut.setProjectContextIndexThreadCount(s)
             assertThat(sut.getProjectContextIndexThreadCount()).isEqualTo(expected)
         }
-
     }
 
     @Test

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -116,10 +116,14 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
                     logger.info { "project context index starting" }
                     delay(300)
                     val isIndexSuccess = index()
-                    if (isIndexSuccess) isIndexComplete.set(true)
+                    if (isIndexSuccess) {
+                        isIndexComplete.set(true)
+                    }
                     return
                 }
+                retryCount.incrementAndGet()
             } catch (e: Exception) {
+                logger.warn(e) { "failed to init project context" }
                 if (e.stackTraceToString().contains("Connection refused")) {
                     retryCount.incrementAndGet()
                     delay(10000)
@@ -133,6 +137,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
     private suspend fun initEncryption(): Boolean {
         val request = encoderServer.getEncryptionRequest()
         val response = sendMsgToLsp(LspMessage.Initialize, request)
+        logger.info { "received response to init encryption: $response"}
         return response?.responseCode == 200
     }
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -116,14 +116,10 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
                     logger.info { "project context index starting" }
                     delay(300)
                     val isIndexSuccess = index()
-                    if (isIndexSuccess) {
-                        isIndexComplete.set(true)
-                    }
+                    if (isIndexSuccess) isIndexComplete.set(true)
                     return
                 }
-                retryCount.incrementAndGet()
             } catch (e: Exception) {
-                logger.warn(e) { "failed to init project context" }
                 if (e.stackTraceToString().contains("Connection refused")) {
                     retryCount.incrementAndGet()
                     delay(10000)
@@ -137,7 +133,6 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
     private suspend fun initEncryption(): Boolean {
         val request = encoderServer.getEncryptionRequest()
         val response = sendMsgToLsp(LspMessage.Initialize, request)
-        logger.info { "received response to init encryption: $response"}
         return response?.responseCode == 200
     }
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -241,7 +241,7 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
         }
     }
 
-    fun collectFiles(): FileCollectionResult  = collectFiles(project.getBaseDirectories(), ChangeListManager.getInstance(project))
+    fun collectFiles(): FileCollectionResult = collectFiles(project.getBaseDirectories(), ChangeListManager.getInstance(project))
 
     private fun queryResultToRelevantDocuments(queryResult: List<Chunk>): List<RelevantDocument> {
         val documents: MutableList<RelevantDocument> = mutableListOf()

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -302,15 +302,14 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
     companion object {
         private val logger = getLogger<ProjectContextProvider>()
         private val regex = Regex("""bin|build|node_modules|venv|\.venv|env|\.idea|\.conda""", RegexOption.IGNORE_CASE)
-        private val mega = 1024u * 1024u
+        private val mega = (1024 * 1024).toULong()
         private val tenMb = 10 * mega.toInt()
 
         private fun willExceedPayloadLimit(maxSize: ULong, currentTotalFileSize: ULong, currentFileSize: Long) =
             currentTotalFileSize.let { totalSize -> totalSize > (maxSize - currentFileSize.toUInt()) }
 
-        private fun isBuildOrBin(fileName: String): Boolean {
-            return regex.find(fileName) != null
-        }
+        private fun isBuildOrBin(fileName: String): Boolean =
+            regex.find(fileName) != null
 
         fun collectFiles(projectBaseDirectories: Set<VirtualFile>, changeListManager: ChangeListManager): FileCollectionResult {
             val maxSize = CodeWhispererSettings.getInstance()

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/ProjectContextProvider.kt
@@ -301,20 +301,20 @@ class ProjectContextProvider(val project: Project, private val encoderServer: En
 
     companion object {
         private val logger = getLogger<ProjectContextProvider>()
+        private val regex = Regex("""bin|build|node_modules|venv|\.venv|env|\.idea|\.conda""", RegexOption.IGNORE_CASE)
+        private val mega = 1024u * 1024u
+        private val tenMb = 10 * mega.toInt()
 
         private fun willExceedPayloadLimit(maxSize: ULong, currentTotalFileSize: ULong, currentFileSize: Long) =
             currentTotalFileSize.let { totalSize -> totalSize > (maxSize - currentFileSize.toUInt()) }
 
         private fun isBuildOrBin(fileName: String): Boolean {
-            val regex = Regex("""bin|build|node_modules|venv|\.venv|env|\.idea|\.conda""", RegexOption.IGNORE_CASE)
             return regex.find(fileName) != null
         }
 
         fun collectFiles(projectBaseDirectories: Set<VirtualFile>, changeListManager: ChangeListManager): FileCollectionResult {
-            val mega = 1024u * 1024u
             val maxSize = CodeWhispererSettings.getInstance()
                 .getProjectContextIndexMaxSize().toULong() * mega
-            val tenMb = 10 * mega.toInt()
             val collectedFiles = mutableListOf<String>()
             var currentTotalFileSize = 0UL
             val allFiles = mutableListOf<VirtualFile>()

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/settings/CodeWhispererSettings.kt
@@ -92,7 +92,7 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
     fun getProjectContextIndexThreadCount(): Int = state.intValue.getOrDefault(
         CodeWhispererIntConfigurationType.ProjectContextIndexThreadCount,
         0
-    )
+    ).coerceIn(CONTEXT_INDEX_THREADS)
 
     fun setProjectContextIndexThreadCount(value: Int) {
         state.intValue[CodeWhispererIntConfigurationType.ProjectContextIndexThreadCount] = value
@@ -101,7 +101,7 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
     fun getProjectContextIndexMaxSize(): Int = state.intValue.getOrDefault(
         CodeWhispererIntConfigurationType.ProjectContextIndexMaxSize,
         250
-    )
+    ).coerceIn(CONTEXT_INDEX_SIZE)
 
     fun setProjectContextIndexMaxSize(value: Int) {
         state.intValue[CodeWhispererIntConfigurationType.ProjectContextIndexMaxSize] = value
@@ -134,10 +134,6 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
         state.value[CodeWhispererConfigurationType.IsTabAcceptPriorityNotificationShownOnce] = value
     }
 
-    companion object {
-        fun getInstance(): CodeWhispererSettings = service()
-    }
-
     override fun getState(): CodeWhispererConfiguration = CodeWhispererConfiguration().apply {
         value.putAll(state.value)
         intValue.putAll(state.intValue)
@@ -154,6 +150,13 @@ class CodeWhispererSettings : PersistentStateComponent<CodeWhispererConfiguratio
         this.state.intValue.putAll(state.intValue)
         this.state.stringValue.putAll(state.stringValue)
         this.state.autoBuildSetting.putAll(state.autoBuildSetting)
+    }
+
+    companion object {
+        fun getInstance(): CodeWhispererSettings = service()
+
+        val CONTEXT_INDEX_SIZE = IntRange(1, 4096)
+        val CONTEXT_INDEX_THREADS = IntRange(0, 50)
     }
 }
 


### PR DESCRIPTION
2GB in bytes > INT_MAX
so use ULong, which can handle 18 PB

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
