### PR TITLE
fix(amazonq): fix createWorkspaceFolders

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/util/WorkspaceFolderUtil.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/util/WorkspaceFolderUtil.kt
@@ -3,8 +3,8 @@
 
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.util
 
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
 import org.eclipse.lsp4j.WorkspaceFolder
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.util.FileUriUtil.toUriString

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/util/WorkspaceFolderUtil.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/util/WorkspaceFolderUtil.kt
@@ -4,7 +4,8 @@
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.util
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.ModuleRootManager
 import org.eclipse.lsp4j.WorkspaceFolder
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.util.FileUriUtil.toUriString
 
@@ -13,10 +14,12 @@ object WorkspaceFolderUtil {
         if (project.isDefault) {
             emptyList()
         } else {
-            ProjectRootManager.getInstance(project).contentRoots.map { contentRoot ->
-                WorkspaceFolder().apply {
-                    name = contentRoot.name
-                    this.uri = toUriString(contentRoot)
+            ModuleManager.getInstance(project).modules.mapNotNull { module ->
+                ModuleRootManager.getInstance(module).contentRoots.firstOrNull()?.let { contentRoot ->
+                    WorkspaceFolder().apply {
+                        name = module.name
+                        uri = toUriString(contentRoot)
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

CreateWorkspaceFolders util function now collects Module URI and name, and does not collect it's subfolders. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
