### PR TITLE
fix(amazonq): Fix devfile detection on Feature Dev invocation.

### DIFF
--- a/.changes/next-release/bugfix-2301aeeb-f36e-4776-8e9b-4238c55e43f4.json
+++ b/.changes/next-release/bugfix-2301aeeb-f36e-4776-8e9b-4238c55e43f4.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "/dev: Fix prompt to enable devfile build not triggering when devfile is present."
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -479,7 +479,7 @@ class FeatureDevController(
                 ),
             )
 
-            if (!session.context.checkForDevFile()) {
+            if (!session.context.hasDevFile()) {
                 followUps.add(
                     FollowUp(
                         pillText = message("amazonqFeatureDev.follow_up.generate_dev_file"),
@@ -741,7 +741,7 @@ class FeatureDevController(
             }
 
             val codeWhispererSettings = CodeWhispererSettings.getInstance().getAutoBuildSetting()
-            val hasDevFile = session.context.checkForDevFile()
+            val hasDevFile = session.context.hasDevFile()
             val isPromptedForAutoBuildFeature = codeWhispererSettings.containsKey(session.context.workspaceRoot.path)
 
             if (hasDevFile && !isPromptedForAutoBuildFeature) {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/FeatureDevSessionContext.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/FeatureDevSessionContext.kt
@@ -18,6 +18,7 @@ import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.io.FileUtils
 import software.aws.toolkits.jetbrains.core.coroutines.getCoroutineBgContext
 import software.aws.toolkits.jetbrains.services.amazonq.QConstants.MAX_FILE_SIZE_BYTES
+import software.aws.toolkits.jetbrains.utils.getWorkspaceDevFile
 import software.aws.toolkits.jetbrains.utils.isWorkspaceDevFile
 import software.aws.toolkits.resources.AwsCoreBundle
 import software.aws.toolkits.telemetry.AmazonqTelemetry
@@ -57,11 +58,8 @@ open class FeatureDevSessionContext(val project: Project, val maxProjectSizeByte
 
     private var _selectionRoot = workspaceRoot
 
-    // This function checks for existence of `devfile.yaml` in customer's repository, currently only `devfile.yaml` is supported for this feature.
-    fun checkForDevFile(): Boolean {
-        val devFile = File(addressableRoot.toString(), "devfile.yaml")
-        return devFile.exists()
-    }
+    fun hasDevFile(): Boolean =
+        getWorkspaceDevFile(addressableRoot) != null
 
     fun getProjectZip(isAutoBuildFeatureEnabled: Boolean?): ZipCreationResult {
         val zippedProject = runBlocking {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/DevFileUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/DevFileUtils.kt
@@ -5,6 +5,11 @@ package software.aws.toolkits.jetbrains.utils
 
 import com.intellij.openapi.vfs.VirtualFile
 
+fun isDevFile(file: VirtualFile): Boolean =
+    file.name.matches(Regex("devfile\\.ya?ml", RegexOption.IGNORE_CASE))
+
 fun isWorkspaceDevFile(file: VirtualFile, addressableRoot: VirtualFile): Boolean =
-    file.name.matches(Regex("devfile\\.ya?ml", RegexOption.IGNORE_CASE)) &&
-        file.parent?.path == addressableRoot.path
+    isDevFile(file) && file.parent?.path == addressableRoot.path
+
+fun getWorkspaceDevFile(addressableRoot: VirtualFile): VirtualFile? =
+    addressableRoot.children.find { isDevFile(it) }


### PR DESCRIPTION


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Problem: An incorrect path lookup led to devfile existence check (`checkForDevFile`) not detecting presence of devfile on /dev invocation. As a result, a prompt to opt-in to devfile-based build functionality would not be displayed.

Solution: Fix the check, ensuring that the devfile is now located, and the configuration prompt now triggers for a user to enable devfile-based build for /dev invocations.

## Checklist
- [x] My code follows the code style of this project
- [N/A] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [M/A] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
