### PR TITLE
fix(amazonq): Adjust resource requirement for starting workspace indexing

### DIFF
--- a/.changes/next-release/bugfix-9e482571-c40a-42d3-906e-ceab1d6440b1.json
+++ b/.changes/next-release/bugfix-9e482571-c40a-42d3-906e-ceab1d6440b1.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Adjust resource requirement for starting workspace indexing"
+}

--- a/.changes/next-release/bugfix-de10b7d3-8c8a-4968-88cb-ed28ce3a553e.json
+++ b/.changes/next-release/bugfix-de10b7d3-8c8a-4968-88cb-ed28ce3a553e.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix workspace index process quits when hitting a race condition"
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/project/manifest/ManifestManager.kt
@@ -15,7 +15,7 @@ import software.aws.toolkits.jetbrains.core.getTextFromUrl
 
 class ManifestManager {
     private val cloudFrontUrl = "https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json"
-    val currentVersion = "0.1.46"
+    val currentVersion = "0.1.49"
     val currentOs = getOs()
     private val arch = CpuArch.CURRENT
     private val mapper = jacksonObjectMapper()


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
We implemented a mechanism to only start the workspace indexing when there is sufficient CPU resources, but the threshold was not fine tuned and in certain cases it did not start the workspace indexing when in fact it should. This PR is to 
1. Slightly lift the threshold
2. Add more logs for debugging.

In the very near future, we will utilize server side indexing as the default option. 

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
