### PR TITLE
feat(amazonq): client emits linkClick events when user clicks links in chat

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -28,15 +28,21 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption.JwtEncryptionManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.ChatCommunicationManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.getTextDocumentIdentifier
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_INFO_LINK_CLICK
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_LINK_CLICK
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_QUICK_ACTION
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_SOURCE_LINK_CLICK
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ChatParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ChatPrompt
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CursorState
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedChatParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedQuickActionChatParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InfoLinkClickNotification
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.LinkClickNotification
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.QuickChatActionRequest
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SEND_CHAT_COMMAND_PROMPT
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SendChatPromptRequest
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SourceLinkClickNotification
 import software.aws.toolkits.jetbrains.services.amazonq.util.command
 import software.aws.toolkits.jetbrains.services.amazonq.util.tabType
 import software.aws.toolkits.jetbrains.services.amazonq.webview.theme.AmazonQTheme
@@ -204,6 +210,24 @@ class BrowserConnector(
                 } ?: (CompletableFuture.failedFuture(IllegalStateException("LSP Server not running")))
 
                 showResult(result, partialResultToken, tabId, encryptionManager, browser)
+            }
+            CHAT_LINK_CLICK -> {
+                val requestFromUi = serializer.deserializeChatMessages(node, LinkClickNotification::class.java)
+                AmazonQLspService.executeIfRunning(project) { server ->
+                    server.linkClick(requestFromUi.params)
+                } ?: CompletableFuture.failedFuture<Unit>(IllegalStateException("LSP Server not running"))
+            }
+            CHAT_INFO_LINK_CLICK -> {
+                val requestFromUi = serializer.deserializeChatMessages(node, InfoLinkClickNotification::class.java)
+                AmazonQLspService.executeIfRunning(project) { server ->
+                    server.infoLinkClick(requestFromUi.params)
+                } ?: CompletableFuture.failedFuture<Unit>(IllegalStateException("LSP Server not running"))
+            }
+            CHAT_SOURCE_LINK_CLICK -> {
+                val requestFromUi = serializer.deserializeChatMessages(node, SourceLinkClickNotification::class.java)
+                AmazonQLspService.executeIfRunning(project) { server ->
+                    server.sourceLinkClick(requestFromUi.params)
+                } ?: CompletableFuture.failedFuture<Unit>(IllegalStateException("LSP Server not running"))
             }
         }
     }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
@@ -11,6 +11,9 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.GetConfigu
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.LspServerConfigurations
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedChatParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedQuickActionChatParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InfoLinkClickParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.LinkClickParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SourceLinkClickParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.UpdateCredentialsPayload
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 import java.util.concurrent.CompletableFuture
@@ -37,4 +40,13 @@ interface AmazonQLanguageServer : LanguageServer {
 
     @JsonRequest("aws/chat/sendChatQuickAction")
     fun sendQuickAction(params: EncryptedQuickActionChatParams): CompletableFuture<String>
+
+    @JsonNotification("aws/chat/linkClick")
+    fun linkClick(params: LinkClickParams): CompletableFuture<Unit>
+
+    @JsonNotification("aws/chat/infoLinkClick")
+    fun infoLinkClick(params: InfoLinkClickParams): CompletableFuture<Unit>
+
+    @JsonNotification("aws/chat/feedback/sourceLinkClick")
+    fun sourceLinkClick(params: SourceLinkClickParams): CompletableFuture<Unit>
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/FlareChatCommands.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/FlareChatCommands.kt
@@ -5,3 +5,6 @@ package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat
 
 const val SEND_CHAT_COMMAND_PROMPT = "aws/chat/sendChatPrompt"
 const val CHAT_QUICK_ACTION = "aws/chat/sendChatQuickAction"
+const val CHAT_LINK_CLICK = "aws/chat/linkClick"
+const val CHAT_INFO_LINK_CLICK = "aws/chat/infoLinkClick"
+const val CHAT_SOURCE_LINK_CLICK = "aws/chat/sourceLinkClick"

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/LinkClick.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/LinkClick.kt
@@ -1,0 +1,38 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat
+
+data class InfoLinkClickNotification(
+    val command: String,
+    val params: InfoLinkClickParams,
+)
+
+data class SourceLinkClickNotification(
+    val command: String,
+    val params: SourceLinkClickParams,
+)
+
+data class LinkClickNotification(
+    val command: String,
+    val params: LinkClickParams,
+)
+
+data class InfoLinkClickParams(
+    val tabId: String,
+    val link: String,
+    val eventId: String? = null,
+)
+
+data class LinkClickParams(
+    val tabId: String,
+    val link: String,
+    val eventId: String? = null,
+    val messageId: String,
+)
+
+data class SourceLinkClickParams(
+    val tabId: String,
+    val link: String,
+    val eventId: String? = null,
+    val messageId: String,
+)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
LSP client emits  `aws/chat/linkClick ``aws/chat/infoLinkClick`` aws/chat/sourceLinkClick`
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
