### PR TITLE
Revert "fix(amazonq): support displaying customizations across all profiles of an Idc connection"

### DIFF
--- a/.changes/next-release/feature-ae7d15f4-ae07-4faf-963a-6d83a85852e4.json
+++ b/.changes/next-release/feature-ae7d15f4-ae07-4faf-963a-6d83a85852e4.json
@@ -1,4 +1,0 @@
-{
-  "type" : "feature",
-  "description" : "Amazon Q: Support selecting customizations across all Q profiles with automatic profile switching for enterprise users"
-}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/credentials/CodeWhispererClientAdaptor.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/credentials/CodeWhispererClientAdaptor.kt
@@ -38,7 +38,6 @@ import software.amazon.awssdk.services.codewhispererruntime.model.UserIntent
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.jetbrains.services.amazonq.codeWhispererUserContext
-import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfile
 import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomization
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.CodeWhispererProgrammingLanguage
@@ -79,7 +78,7 @@ interface CodeWhispererClientAdaptor {
 
     fun getCodeFixJob(request: GetCodeFixJobRequest): GetCodeFixJobResponse
 
-    fun listAvailableCustomizations(profile: QRegionProfile): List<CodeWhispererCustomization>
+    fun listAvailableCustomizations(): List<CodeWhispererCustomization>
 
     fun startTestGeneration(uploadId: String, targetCode: List<TargetCode>, userInput: String): StartTestGenerationResponse
 
@@ -283,9 +282,9 @@ open class CodeWhispererClientAdaptorImpl(override val project: Project) : CodeW
     override fun getCodeFixJob(request: GetCodeFixJobRequest): GetCodeFixJobResponse = bearerClient().getCodeFixJob(request)
 
     // DO NOT directly use this method to fetch customizations, use wrapper [CodeWhispererModelConfigurator.listCustomization()] instead
-    override fun listAvailableCustomizations(profile: QRegionProfile): List<CodeWhispererCustomization> =
-        QRegionProfileManager.getInstance().getQClient<CodeWhispererRuntimeClient>(project, profile).listAvailableCustomizationsPaginator(
-            ListAvailableCustomizationsRequest.builder().profileArn(profile.arn).build()
+    override fun listAvailableCustomizations(): List<CodeWhispererCustomization> =
+        bearerClient().listAvailableCustomizationsPaginator(
+            ListAvailableCustomizationsRequest.builder().profileArn(QRegionProfileManager.getInstance().activeProfile(project)?.arn).build()
         )
             .stream()
             .toList()
@@ -299,8 +298,7 @@ open class CodeWhispererClientAdaptorImpl(override val project: Project) : CodeW
                     CodeWhispererCustomization(
                         arn = it.arn(),
                         name = it.name(),
-                        description = it.description(),
-                        profile = profile
+                        description = it.description()
                     )
                 }
             }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomizationDialog.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomizationDialog.kt
@@ -26,9 +26,6 @@ import software.amazon.awssdk.arns.Arn
 import software.aws.toolkits.core.utils.debug
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.tryOrNull
-import software.aws.toolkits.jetbrains.services.amazonq.profile.QProfileSwitchIntent
-import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfile
-import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants.Q_CUSTOM_LEARN_MORE_URI
 import software.aws.toolkits.jetbrains.ui.AsyncComboBox
 import software.aws.toolkits.jetbrains.utils.notifyInfo
@@ -37,7 +34,7 @@ import javax.swing.JComponent
 import javax.swing.JList
 
 private val NoDataToDisplay = CustomizationUiItem(
-    CodeWhispererCustomization("", message("codewhisperer.custom.dialog.option.no_data"), "", QRegionProfile("", "")),
+    CodeWhispererCustomization("", message("codewhisperer.custom.dialog.option.no_data"), ""),
     false,
     false
 )
@@ -109,15 +106,6 @@ class CodeWhispererCustomizationDialog(
             RadioButtonOption.Customization -> run {
                 CodeWhispererModelConfigurator.getInstance().switchCustomization(project, modal.selectedCustomization?.customization)
                 notifyCustomizationIsSelected(project, modal.selectedCustomization)
-                // Switch profile if it doesn't match the customization's profile.
-                // Customizations are profile-scoped and must be used under the correct context.
-                if (modal.selectedCustomization?.customization?.profile?.arn != QRegionProfileManager.getInstance().activeProfile(project)?.arn) {
-                    QRegionProfileManager.getInstance().switchProfile(
-                        project,
-                        modal.selectedCustomization?.customization?.profile,
-                        QProfileSwitchIntent.Customization
-                    )
-                }
             }
         }
 
@@ -191,14 +179,12 @@ class CodeWhispererCustomizationDialog(
                         proposeModelUpdate { model ->
                             val activeCustomization = CodeWhispererModelConfigurator.getInstance().activeCustomization(project)
                             val unsorted = myCustomizations ?: CodeWhispererModelConfigurator.getInstance().listCustomizations(project).orEmpty()
-                            val activeProfile = QRegionProfileManager.getInstance().activeProfile(project)
-                            // Group customizations by profile name (active profile first, then alphabetical), with the active customization on top
-                            val sorted = unsorted.sortedWith(
-                                compareBy<CustomizationUiItem> { it.customization.profile?.profileName != activeProfile?.profileName }
-                                    .thenBy { it.customization.profile?.profileName.orEmpty() }
-                                    .thenBy { it.customization.name }
-                            )
-                                .let { list -> activeCustomization?.let { list.putPickedUpFront(setOf(it)) } ?: list }
+
+                            val sorted = activeCustomization?.let {
+                                unsorted.putPickedUpFront(setOf(it))
+                            } ?: run {
+                                unsorted.sortedBy { it.customization.name }
+                            }
 
                             if (
                                 sorted.isNotEmpty() &&
@@ -271,10 +257,6 @@ private object CustomizationRenderer : ColoredListCellRenderer<CustomizationUiIt
                 tryOrNull { Arn.fromString(it.customization.arn).accountId().get() }?.let { accountId ->
                     append(" ($accountId)", SimpleTextAttributes.REGULAR_ATTRIBUTES)
                 }
-            }
-
-            if (it.customization.profile?.profileName?.isNotEmpty() == true) {
-                append("  [${it.customization.profile?.profileName}]", SimpleTextAttributes.REGULAR_ATTRIBUTES)
             }
 
             if (it.isNew) {

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererClientAdaptorTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererClientAdaptorTest.kt
@@ -65,7 +65,6 @@ import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
 import software.aws.toolkits.jetbrains.core.credentials.sono.Q_SCOPES
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_REGION
 import software.aws.toolkits.jetbrains.services.amazonq.FEATURE_EVALUATION_PRODUCT_NAME
-import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfile
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.metadata
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonRequest
 import software.aws.toolkits.jetbrains.services.codewhisperer.CodeWhispererTestUtil.pythonResponseWithToken
@@ -190,13 +189,13 @@ class CodeWhispererClientAdaptorTest {
             on { client.listAvailableCustomizationsPaginator(any<ListAvailableCustomizationsRequest>()) } doReturn sdkIterable
         }
 
-        val actual = sut.listAvailableCustomizations(QRegionProfile("fake_profile", "fake arn"))
+        val actual = sut.listAvailableCustomizations()
         assertThat(actual).hasSize(3)
         assertThat(actual).isEqualTo(
             listOf(
-                CodeWhispererCustomization(name = "custom-1", arn = "arn-1", profile = QRegionProfile("fake_profile", "fake arn")),
-                CodeWhispererCustomization(name = "custom-2", arn = "arn-2", profile = QRegionProfile("fake_profile", "fake arn")),
-                CodeWhispererCustomization(name = "custom-3", arn = "arn-3", profile = QRegionProfile("fake_profile", "fake arn"))
+                CodeWhispererCustomization(name = "custom-1", arn = "arn-1"),
+                CodeWhispererCustomization(name = "custom-2", arn = "arn-2"),
+                CodeWhispererCustomization(name = "custom-3", arn = "arn-3")
             )
         )
     }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererFeatureConfigServiceTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererFeatureConfigServiceTest.kt
@@ -35,7 +35,6 @@ import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager
 import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
 import software.aws.toolkits.jetbrains.core.credentials.sono.SONO_URL
 import software.aws.toolkits.jetbrains.services.amazonq.CodeWhispererFeatureConfigService
-import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfile
 import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager
 import kotlin.reflect.full.memberFunctions
 import kotlin.test.Test
@@ -79,7 +78,7 @@ class CodeWhispererFeatureConfigServiceTest {
 
         projectRule.project.replaceService(
             QRegionProfileManager::class.java,
-            mock<QRegionProfileManager> { on { getQClient(any<Project>(), eq(QRegionProfile()), eq(CodeWhispererRuntimeClient::class)) } doReturn mockClient },
+            mock<QRegionProfileManager> { on { getQClient(any<Project>(), eq(CodeWhispererRuntimeClient::class)) } doReturn mockClient },
             disposableRule.disposable
         )
 

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/QRegionProfileManagerTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/QRegionProfileManagerTest.kt
@@ -178,7 +178,7 @@ class QRegionProfileManagerTest {
         client.stub {
             onGeneric { listAvailableProfilesPaginator(any<Consumer<ListAvailableProfilesRequest.Builder>>()) } doReturn iterable
         }
-        val connectionSettings = sut.getQClientSettings(project, null)
+        val connectionSettings = sut.getQClientSettings(project)
         resourceCache.addEntry(connectionSettings, QProfileResources.LIST_REGION_PROFILES, QProfileResources.LIST_REGION_PROFILES.fetch(connectionSettings))
 
         assertThat(sut.listRegionProfiles(project))
@@ -234,7 +234,7 @@ class QRegionProfileManagerTest {
             sut.activeProfile(project)
         ).isEqualTo(QRegionProfile(arn = "arn:aws:codewhisperer:eu-central-1:123456789012:profile/FOO_PROFILE", profileName = "FOO_PROFILE"))
 
-        val settings = sut.getQClientSettings(project, null)
+        val settings = sut.getQClientSettings(project)
         assertThat(settings.region.id).isEqualTo(Region.EU_CENTRAL_1.id())
 
         sut.switchProfile(
@@ -246,7 +246,7 @@ class QRegionProfileManagerTest {
             sut.activeProfile(project)
         ).isEqualTo(QRegionProfile(arn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/BAR_PROFILE", profileName = "BAR_PROFILE"))
 
-        val settings2 = sut.getQClientSettings(project, null)
+        val settings2 = sut.getQClientSettings(project)
         assertThat(settings2.region.id).isEqualTo(Region.US_EAST_1.id())
     }
 
@@ -262,7 +262,7 @@ class QRegionProfileManagerTest {
         assertThat(
             sut.activeProfile(project)
         ).isEqualTo(QRegionProfile(arn = "arn:aws:codewhisperer:eu-central-1:123456789012:profile/FOO_PROFILE", profileName = "FOO_PROFILE"))
-        assertThat(sut.getQClientSettings(project, null).region.id).isEqualTo(Region.EU_CENTRAL_1.id())
+        assertThat(sut.getQClientSettings(project).region.id).isEqualTo(Region.EU_CENTRAL_1.id())
 
         val client = sut.getQClient<CodeWhispererRuntimeClient>(project)
         assertThat(client).isInstanceOf(CodeWhispererRuntimeClient::class.java)
@@ -279,7 +279,7 @@ class QRegionProfileManagerTest {
         assertThat(
             sut.activeProfile(project)
         ).isEqualTo(QRegionProfile(arn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/BAR_PROFILE", profileName = "BAR_PROFILE"))
-        assertThat(sut.getQClientSettings(project, null).region.id).isEqualTo(Region.US_EAST_1.id())
+        assertThat(sut.getQClientSettings(project).region.id).isEqualTo(Region.US_EAST_1.id())
 
         val client2 = sut.getQClient<CodeWhispererRuntimeClient>(project)
         assertThat(client2).isInstanceOf(CodeWhispererRuntimeClient::class.java)

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QProfileSwitchIntent.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QProfileSwitchIntent.kt
@@ -8,14 +8,12 @@ package software.aws.toolkits.jetbrains.services.amazonq.profile
  * 'auth' -> users change the profile through webview profile selector page
  * 'update' -> plugin auto select the profile on users' behalf as there is only 1 profile
  * 'reload' -> on plugin restart, plugin will try to reload previous selected profile
- * 'customization' -> users selected a customization tied to a different profile, triggering a profile switch
  */
 enum class QProfileSwitchIntent(val value: String) {
     User("user"),
     Auth("auth"),
     Update("update"),
-    Reload("reload"),
-    Customization("customization"), ;
+    Reload("reload"), ;
 
     override fun toString() = value
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
@@ -166,26 +166,27 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
         (connectionIdToProfileCount[conn.id] ?: 0) > 1
     } ?: false
 
-    fun getQClientSettings(project: Project, profile: QRegionProfile?): TokenConnectionSettings {
+    fun getQClientSettings(project: Project): TokenConnectionSettings {
         val conn = ToolkitConnectionManager.getInstance(project).activeConnectionForFeature(QConnection.getInstance())
         if (conn !is AwsBearerTokenConnection) {
             error("not a bearer connection")
         }
 
         val settings = conn.getConnectionSettings()
-        val defaultRegion = AwsRegionProvider.getInstance()[QEndpoints.Q_DEFAULT_SERVICE_CONFIG.REGION] ?: error("unknown region from Q default service config")
+        val awsRegion = AwsRegionProvider.getInstance()[QEndpoints.Q_DEFAULT_SERVICE_CONFIG.REGION] ?: error("unknown region from Q default service config")
 
-        val regionId = profile?.region ?: activeProfile(project)?.region
-        val awsRegion = regionId?.let { AwsRegionProvider.getInstance()[it] } ?: defaultRegion
-
-        return settings.withRegion(awsRegion)
+        // TODO: different window should be able to select different profile
+        return activeProfile(project)?.let { profile ->
+            AwsRegionProvider.getInstance()[profile.region]?.let { region ->
+                settings.withRegion(region)
+            }
+        } ?: settings.withRegion(awsRegion)
     }
 
-    inline fun <reified T : SdkClient> getQClient(project: Project): T = getQClient(project, null, T::class)
-    inline fun <reified T : SdkClient> getQClient(project: Project, profile: QRegionProfile): T = getQClient(project, profile, T::class)
+    inline fun <reified T : SdkClient> getQClient(project: Project): T = getQClient(project, T::class)
 
-    fun <T : SdkClient> getQClient(project: Project, profile: QRegionProfile?, sdkClass: KClass<T>): T {
-        val settings = getQClientSettings(project, profile)
+    fun <T : SdkClient> getQClient(project: Project, sdkClass: KClass<T>): T {
+        val settings = getQClientSettings(project)
         val client = AwsClientManager.getInstance().getClient(sdkClass, settings)
         return client
     }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererCustomization.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.jetbrains.services.codewhisperer.customization
-import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfile
 
 data class CodeWhispererCustomization(
     @JvmField
@@ -13,7 +12,4 @@ data class CodeWhispererCustomization(
 
     @JvmField
     var description: String? = null,
-
-    @JvmField
-    var profile: QRegionProfile? = null,
 )


### PR DESCRIPTION
Due to throttling issue we already encounter now in PROD, we decided to revert it back and fix the throttling issue first then bring this back afterward.

Reverts aws/aws-toolkit-jetbrains#5591