### PR TITLE
build(amazonq): include jackson in dependency closure

### DIFF
--- a/plugins/amazonq/build.gradle.kts
+++ b/plugins/amazonq/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(project(":plugin-amazonq:codewhisperer"))
     implementation(project(":plugin-amazonq:mynah-ui"))
     implementation(project(":plugin-amazonq:shared"))
+    implementation(libs.bundles.jackson)
 
     testImplementation(project(":plugin-core"))
 }


### PR DESCRIPTION
With https://github.com/aws/aws-toolkit-jetbrains/commit/f331fb6372f4e6bac8db14da491f7adcf8e92fec,

we include jackson as part of core/toolkit, but not amazonq. in theory amazonq should be pulling jackson classes from core, but there appears to be a hard to reproduce edge case where a customer is hitting the same issue with jackson-kotlin deserialization

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
