### PR TITLE
feat(amazonq): surface profile selection step requried in statusbar

### DIFF
--- a/.changes/next-release/feature-b8767b53-e30f-4c76-afa3-26d16a35f937.json
+++ b/.changes/next-release/feature-b8767b53-e30f-4c76-afa3-26d16a35f937.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Amazon Q: Show visual indicator in status bar if profile selection is needed to continue with Q Inline / Q Chat"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanIssueDetailsPanel.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/CodeWhispererCodeScanIssueDetailsPanel.kt
@@ -37,8 +37,8 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.utils.ope
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.utils.sendCodeFixGeneratedTelemetryToServiceAPI
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.utils.truncateIssueTitle
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererColorUtil.getHexString
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.getHexString
 import software.aws.toolkits.jetbrains.settings.CodeWhispererSettings
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.Component

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/codescan/listeners/CodeWhispererCodeScanEditorMouseMotionListener.kt
@@ -41,8 +41,8 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.utils.sen
 import software.aws.toolkits.jetbrains.services.codewhisperer.codescan.utils.truncateIssueTitle
 import software.aws.toolkits.jetbrains.services.codewhisperer.language.programmingLanguage
 import software.aws.toolkits.jetbrains.services.codewhisperer.telemetry.CodeWhispererTelemetryService
-import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererColorUtil.getHexString
 import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhispererConstants
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.getHexString
 import software.aws.toolkits.resources.message
 import software.aws.toolkits.telemetry.CodeFixAction
 import software.aws.toolkits.telemetry.MetricResult

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
@@ -23,6 +23,7 @@ import software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileWatcher
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
 import software.aws.toolkits.jetbrains.services.amazonq.CodeWhispererFeatureConfigService
 import software.aws.toolkits.jetbrains.services.amazonq.gettingstarted.QActionGroups.Q_SIGNED_OUT_ACTION_GROUP
+import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomizationListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.QStatusBarLoggedInActionGroup
@@ -121,7 +122,7 @@ class CodeWhispererStatusBarWidget(project: Project) :
     }
 
     override fun getIcon(): Icon =
-        if (isQExpired(project)) {
+        if (isQExpired(project) || QRegionProfileManager.getInstance().isPendingProfileSelection(project)) {
             AllIcons.General.BalloonWarning
         } else if (!isQConnected(project)) {
             AllIcons.RunConfigurations.TestState.Run

--- a/plugins/amazonq/shared/jetbrains-community/resources/software/aws/toolkits/resources/AmazonQBundle.properties
+++ b/plugins/amazonq/shared/jetbrains-community/resources/software/aws/toolkits/resources/AmazonQBundle.properties
@@ -12,6 +12,7 @@ amazonq.workspace.settings.open.prompt=Workspace index is now enabled. You can d
 action.q.profile.usage.text=You changed your profile
 action.q.profile.usage=You''re using the ''<b>{0}</b>'' profile for Amazon Q.
 action.q.switchProfiles.text=Change Profile
+action.q.switchProfiles.text.action_required=<html><body>Change Profile <font color="{0}}">Select a profile to proceed</font></body></html>
 action.q.switchProfiles.dialog.text=Amazon Q Developer Profile
 action.q.switchProfiles.dialog.account.label=Account: {0}
 action.q.switchProfiles.dialog.panel.text=Change your Q Developer profile

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/actions/QSwitchProfilesAction.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/actions/QSwitchProfilesAction.kt
@@ -22,9 +22,7 @@ class QSwitchProfilesAction : AnAction(message("action.q.switchProfiles.text")),
         e.presentation.icon = AllIcons.Actions.SwapPanels
         val project = e.project ?: return
         if (QRegionProfileManager.getInstance().isPendingProfileSelection(project)) {
-            e.presentation.text = """
-                <html><body>Change profile <font color="${JBColor.GRAY.getHexString()}">(Select a profile to proceed)</font></body></html>
-            """.trimIndent()
+            e.presentation.text = message("action.q.switchProfiles.text.action_required", JBColor.GRAY.getHexString())
         }
     }
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/actions/QSwitchProfilesAction.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/actions/QSwitchProfilesAction.kt
@@ -8,8 +8,10 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
+import com.intellij.ui.JBColor
 import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileDialog
 import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager
+import software.aws.toolkits.jetbrains.services.codewhisperer.util.getHexString
 import software.aws.toolkits.resources.AmazonQBundle.message
 
 class QSwitchProfilesAction : AnAction(message("action.q.switchProfiles.text")), DumbAware {
@@ -18,6 +20,12 @@ class QSwitchProfilesAction : AnAction(message("action.q.switchProfiles.text")),
 
     override fun update(e: AnActionEvent) {
         e.presentation.icon = AllIcons.Actions.SwapPanels
+        val project = e.project ?: return
+        if (QRegionProfileManager.getInstance().isPendingProfileSelection(project)) {
+            e.presentation.text = """
+                <html><body>Change profile <font color="${JBColor.GRAY.getHexString()}">(Select a profile to proceed)</font></body></html>
+            """.trimIndent()
+        }
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererColorUtil.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererColorUtil.kt
@@ -21,6 +21,6 @@ object CodeWhispererColorUtil {
     val EDITOR_CODE_REFERENCE_HOVER = JBColor(0x4B4D4D, 0x4B4D4D)
     val INACTIVE_TEXT_COLOR = UIUtil.getInactiveTextColor().getHexString()
     val TRY_EXAMPLE_EVEN_ROW_COLOR = JBColor(0xCACACA, 0x252525)
-
-    fun Color.getHexString() = String.format("#%02x%02x%02x", this.red, this.green, this.blue)
 }
+
+fun Color.getHexString() = String.format(null, "#%02x%02x%02x", this.red, this.green, this.blue)


### PR DESCRIPTION
Addresses two issues:
* Next step is unclear for users if they do not have webviews available
* Users who don't use chat are unlikely to see action required in the webview


![image](https://github.com/user-attachments/assets/0f0d24b5-6936-4d2a-9bd4-dd8d83ec5cc6)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
