### PR TITLE
fix(toolkit): fix deprecated call to list action group children

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AbstractExplorerTreeToolWindow.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/AbstractExplorerTreeToolWindow.kt
@@ -87,10 +87,10 @@ abstract class AbstractExplorerTreeToolWindow(
                     if (node is ActionGroupOnRightClick) {
                         val actionGroupName = node.actionGroupName()
 
-                        (actionGroupName.let { groupName -> actionManager.getAction(groupName) } as? ActionGroup)?.let { group ->
+                        (actionGroupName.let { groupName -> actionManager.getAction(groupName) } as? DefaultActionGroup)?.let { group ->
                             val context = comp?.let { DataManager.getInstance().getDataContext(it, x, y) } ?: return@let
                             val event = AnActionEvent.createFromDataContext(actionPlace, null, context)
-                            totalActions.addAll(group.getChildren(event))
+                            totalActions.addAll(group.getChildren(actionManager))
                         }
                     }
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/ExplorerToolWindow.kt
@@ -313,7 +313,7 @@ class ExplorerToolWindow(private val project: Project) :
 
                     val totalActions = mutableListOf<AnAction>()
 
-                    (actionGroupName?.let { actionManager.getAction(it) } as? ActionGroup)?.let { totalActions.addAll(it.getChildren(null)) }
+                    (actionGroupName?.let { actionManager.getAction(it) } as? DefaultActionGroup)?.let { totalActions.addAll(it.getChildren(actionManager)) }
 
                     if (explorerNode is AwsExplorerResourceNode<*>) {
                         totalActions.add(CopyArnAction())

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/CawsRootNode.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/explorer/devToolsTab/nodes/CawsRootNode.kt
@@ -5,8 +5,8 @@ package software.aws.toolkits.jetbrains.core.explorer.devToolsTab.nodes
 
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.ide.util.treeView.AbstractTreeNode
-import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.project.Project
 import com.intellij.ui.SimpleTextAttributes
 import software.aws.toolkits.jetbrains.ToolkitPlaces
@@ -28,8 +28,8 @@ class CawsRootNode(private val nodeProject: Project) : AbstractTreeNode<String>(
             is ActiveConnection.ValidBearer -> CAWS_SIGNED_IN_ACTION_GROUP
             else -> CAWS_EXPIRED_TOKEN_ACTION_GROUP
         }
-        val actions = ActionManager.getInstance().getAction(groupId) as ActionGroup
-        return actions.getChildren(null).mapNotNull {
+        val actions = ActionManager.getInstance().getAction(groupId) as DefaultActionGroup
+        return actions.getChildren(ActionManager.getInstance()).mapNotNull {
             if (it is OpenWorkspaceInGateway && isRunningOnRemoteBackend()) {
                 return@mapNotNull null
             }


### PR DESCRIPTION
In 2025.1, `ActionGroup#getChildren(AnActionEvent)` is deprecated

#5605


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
