### PR TITLE
fix(amazonq): update statusbar icon after selecting profile

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
@@ -85,7 +85,7 @@ class CodeWhispererStatusBarWidget(project: Project) :
             object : QRegionProfileSelectedListener {
                 override fun onProfileSelected(
                     project: Project,
-                    profile: QRegionProfile?
+                    profile: QRegionProfile?,
                 ) {
                     if (project == this@CodeWhispererStatusBarWidget.project) {
                         statusBar.updateWidget(ID)

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/status/CodeWhispererStatusBarWidget.kt
@@ -23,7 +23,9 @@ import software.aws.toolkits.jetbrains.core.credentials.profiles.ProfileWatcher
 import software.aws.toolkits.jetbrains.core.credentials.sso.bearer.BearerTokenProviderListener
 import software.aws.toolkits.jetbrains.services.amazonq.CodeWhispererFeatureConfigService
 import software.aws.toolkits.jetbrains.services.amazonq.gettingstarted.QActionGroups.Q_SIGNED_OUT_ACTION_GROUP
+import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfile
 import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager
+import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileSelectedListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererCustomizationListener
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
 import software.aws.toolkits.jetbrains.services.codewhisperer.explorer.QStatusBarLoggedInActionGroup
@@ -74,6 +76,20 @@ class CodeWhispererStatusBarWidget(project: Project) :
             object : ToolkitConnectionManagerListener {
                 override fun activeConnectionChanged(newConnection: ToolkitConnection?) {
                     statusBar.updateWidget(ID)
+                }
+            }
+        )
+
+        ApplicationManager.getApplication().messageBus.connect(this).subscribe(
+            QRegionProfileSelectedListener.TOPIC,
+            object : QRegionProfileSelectedListener {
+                override fun onProfileSelected(
+                    project: Project,
+                    profile: QRegionProfile?
+                ) {
+                    if (project == this@CodeWhispererStatusBarWidget.project) {
+                        statusBar.updateWidget(ID)
+                    }
                 }
             }
         )


### PR DESCRIPTION
Follow up to #5615

icon/text are not updated unless an explicit call has been made

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
