### PR TITLE
fix(amazonq): fix LinkageError when starting AmazonQLspService

### DIFF
--- a/.changes/next-release/bugfix-7c7e1720-545f-4b5e-8d21-511f40fabf38.json
+++ b/.changes/next-release/bugfix-7c7e1720-545f-4b5e-8d21-511f40fabf38.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix LinkageError while attempting to do Amazon Q inline suggestions in certain environments"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ junit5 = "5.11.0"
 kotlin = "2.0.0"
 # set in <root>/settings.gradle.kts
 kotlinCoroutines = "1.8.0"
+lsp4j = "0.24.0"
 mockito = "5.12.0"
 mockitoKotlin = "5.4.0"
 mockk = "1.13.17"
@@ -105,6 +106,7 @@ kotlin-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-tes
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdLibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+lsp4j = { module = "org.eclipse.lsp4j:org.eclipse.lsp4j", version.ref = "lsp4j" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }

--- a/plugins/amazonq/build.gradle.kts
+++ b/plugins/amazonq/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(project(":plugin-amazonq:codewhisperer"))
     implementation(project(":plugin-amazonq:mynah-ui"))
     implementation(project(":plugin-amazonq:shared"))
+    implementation(libs.lsp4j)
 
     testImplementation(project(":plugin-core"))
 }


### PR DESCRIPTION
In certain IDE environments, for example when user has the latest Scala plugin, Amazon Q attempts to load lsp4j through transitive optional dependencies instead of through the IDE.

Ideally we do not bundle the library, but this is not possible until JetBrains can guarantee stronger isolation between plugins

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
