### PR TITLE
fix(amazonq): Laf update trigger should be on EDT

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindow.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQToolWindow.kt
@@ -67,7 +67,9 @@ class AmazonQToolWindow private constructor(
         connectUi()
         connectApps()
 
-        ApplicationManager.getApplication().messageBus.syncPublisher(LafManagerListener.TOPIC).lookAndFeelChanged(LafManager.getInstance())
+        runInEdt {
+            ApplicationManager.getApplication().messageBus.syncPublisher(LafManagerListener.TOPIC).lookAndFeelChanged(LafManager.getInstance())
+        }
     }
 
     private fun sendMessage(message: AmazonQMessage, tabType: String) {


### PR DESCRIPTION
```
com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Access is allowed from Event Dispatch Thread (EDT) only; If you access or modify model on EDT consider wrapping your code in WriteIntentReadAction  or ReadAction; see https://jb.gg/ij-platform-threading for details
Current thread: Thread[#170,CefHandlers-execution-0,6,main] 432844899 (EventQueue.isDispatchThread()=false)
SystemEventQueueThread: Thread[#68,AWT-EventQueue-0,6,main] 1801390534
	at com.intellij.util.concurrency.ThreadingAssertions.createThreadAccessException(ThreadingAssertions.java:257)
	at com.intellij.util.concurrency.ThreadingAssertions.throwThreadAccessException(ThreadingAssertions.java:248)
	at com.intellij.util.concurrency.ThreadingAssertions.assertEventDispatchThread(ThreadingAssertions.java:89)
	at com.intellij.openapi.editor.impl.ScrollingModelImpl.getVisibleAreaOnScrollingFinished(ScrollingModelImpl.java:113)
	at com.intellij.codeInsight.documentation.render.DocRenderItemUpdater.lambda$getVisibleOffset$9(DocRenderItemUpdater.java:110)
	at it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap.computeIfAbsent(Object2IntOpenHashMap.java:482)
	at it.unimi.dsi.fastutil.objects.Object2IntMap.computeIntIfAbsent(Object2IntMap.java:398)
	at com.intellij.codeInsight.documentation.render.DocRenderItemUpdater.getVisibleOffset(DocRenderItemUpdater.java:109)
	at com.intellij.codeInsight.documentation.render.DocRenderItemUpdater.lambda$processChunk$2(DocRenderItemUpdater.java:77)
	at java.base/java.util.Comparator.lambda$comparingInt$7b0bb60$1(Comparator.java:494)
	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
	at java.base/java.util.TimSort.sort(TimSort.java:220)
	at java.base/java.util.Arrays.sort(Arrays.java:1308)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1804)
	at com.intellij.codeInsight.documentation.render.DocRenderItemUpdater.processChunk(DocRenderItemUpdater.java:77)
	at com.intellij.codeInsight.documentation.render.DocRenderItemUpdater.updateFoldRegions(DocRenderItemUpdater.java:60)
	at com.intellij.codeInsight.documentation.render.DocRenderItemUpdater.updateRenderers(DocRenderItemUpdater.java:34)
	at com.intellij.codeInsight.documentation.render.DocRenderItemUpdater.updateRenderers(DocRenderItemUpdater.java:42)
	at com.intellij.codeInsight.documentation.render.DocRenderItemManager.setupListeners$lambda$1(DocRenderItemManager.kt:59)
	at com.intellij.util.messages.MessageBusConnection.setDefaultHandler$lambda$0(MessageBusConnection.kt:28)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeListener(MessageBusImpl.kt:705)
	at com.intellij.util.messages.impl.MessageBusImplKt.executeOrAddToQueue(MessageBusImpl.kt:533)
	at com.intellij.util.messages.impl.MessagePublisher.publish$intellij_platform_core(MessageBusImpl.kt:504)
	at com.intellij.util.messages.impl.MessagePublisher.invoke(MessageBusImpl.kt:481)
	at jdk.proxy2/jdk.proxy2.$Proxy270.lookAndFeelChanged(Unknown Source)
	at software.aws.toolkits.jetbrains.services.amazonq.toolwindow.AmazonQToolWindow.disposeAndRecreate(AmazonQToolWindow.kt:70)
	at software.aws.toolkits.jetbrains.services.amazonq.toolwindow.AmazonQToolWindowFactory$createToolWindowContent$5.onProfileSelected(AmazonQToolWindowFactory.kt:101)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeMethod(MessageBusImpl.kt:768)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeListener(MessageBusImpl.kt:708)
	at com.intellij.util.messages.impl.MessageBusImplKt.deliverMessage(MessageBusImpl.kt:451)
	at com.intellij.util.messages.impl.MessageBusImplKt.pumpWaiting(MessageBusImpl.kt:430)
	at com.intellij.util.messages.impl.MessageBusImplKt.access$pumpWaiting(MessageBusImpl.kt:1)
	at com.intellij.util.messages.impl.MessagePublisher.invoke(MessageBusImpl.kt:493)
	at jdk.proxy15/jdk.proxy15.$Proxy269.onProfileSelected(Unknown Source)
	at software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager.switchProfile(QRegionProfileManager.kt:149)
	at software.aws.toolkits.jetbrains.services.amazonq.QWebviewBrowser.handleBrowserMessage(QLoginWebview.kt:218)
	at software.aws.toolkits.jetbrains.core.webview.LoginBrowser.jcefHandler$lambda$1(LoginBrowser.kt:77)
	at com.intellij.ui.jcef.JBCefJSQuery$1.onQuery(JBCefJSQuery.java:123)
	at jcef/com.jetbrains.cef.remote.ClientHandlersImpl.MessageRouterHandler_onQuery(ClientHandlersImpl.java:996)
	at jcef/com.jetbrains.cef.remote.thrift_codegen.ClientHandlers$Processor$MessageRouterHandler_onQuery.getResult(ClientHandlers.java:6618)
	at jcef/com.jetbrains.cef.remote.thrift_codegen.ClientHandlers$Processor$MessageRouterHandler_onQuery.getResult(ClientHandlers.java:6595)
	at jcef/com.jetbrains.cef.remote.thrift.ProcessFunction.process(ProcessFunction.java:38)
	at jcef/com.jetbrains.cef.remote.thrift.TBaseProcessor.process(TBaseProcessor.java:40)
	at jcef/com.jetbrains.cef.remote.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:257)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
