### PR TITLE
fix(amazonq): handle scenario where user does not have access to all q endpoints

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QProfileResources.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QProfileResources.kt
@@ -5,6 +5,9 @@ package software.aws.toolkits.jetbrains.services.amazonq.profile
 
 import software.amazon.awssdk.services.codewhispererruntime.CodeWhispererRuntimeClient
 import software.aws.toolkits.core.ClientConnectionSettings
+import software.aws.toolkits.core.utils.debug
+import software.aws.toolkits.core.utils.getLogger
+import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.core.AwsClientManager
 import software.aws.toolkits.jetbrains.core.Resource
 import software.aws.toolkits.jetbrains.core.region.AwsRegionProvider
@@ -27,13 +30,23 @@ object QProfileResources {
                     .getInstance()
                     .getClient(CodeWhispererRuntimeClient::class, connectionSettings.withRegion(awsRegion))
 
-                client.listAvailableProfilesPaginator {}
-                    .profiles()
-                    .map { p -> QRegionProfile(arn = p.arn(), profileName = p.profileName() ?: "<no name>") }
+                try {
+                    val profiles = client.listAvailableProfilesPaginator {}
+                        .profiles()
+                        .map { p -> QRegionProfile(arn = p.arn(), profileName = p.profileName() ?: "<no name>") }
+                    LOG.debug { "Found profiles for region $regionKey : $profiles" }
+
+                    profiles
+                } catch (e: Exception) {
+                    LOG.warn(e) { "Failed to list Q profiles for region $regionKey" }
+                    emptyList()
+                }
             }
             return mappedProfiles
         }
 
         override fun expiry(): Duration = Duration.ofSeconds(60)
     }
+
+    private val LOG = getLogger<QProfileResources>()
 }


### PR DESCRIPTION
If user only has access to subset of the Q endpoints, don't fail the entire iteration sequence

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
