### PR TITLE
fix(amazonq): don't reset profile config if validation fails to list profiles

### DIFF
--- a/.changes/next-release/bugfix-31222d0f-5ff2-4495-9bf2-e354eabc82c7.json
+++ b/.changes/next-release/bugfix-31222d0f-5ff2-4495-9bf2-e354eabc82c7.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Amazon Q: Fix issue where context menu items are not available after re-opening projects or restarting the IDE"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/QRegionProfileManagerTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/QRegionProfileManagerTest.kt
@@ -15,7 +15,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.stub
@@ -201,10 +200,14 @@ class QRegionProfileManagerTest {
             this.connectionIdToActiveProfile[activeConn.id] = fooProfile
             this.connectionIdToActiveProfile[anotherConn.id] = barProfile
         }
-        resourceCache.addEntry(activeConn.getConnectionSettings(), QProfileResources.LIST_REGION_PROFILES, listOf(
-            QRegionProfile("foo", "foo-arn-v2"),
-            QRegionProfile("bar", "bar-arn"),
-        ))
+        resourceCache.addEntry(
+            activeConn.getConnectionSettings(),
+            QProfileResources.LIST_REGION_PROFILES,
+            listOf(
+                QRegionProfile("foo", "foo-arn-v2"),
+                QRegionProfile("bar", "bar-arn"),
+            )
+        )
 
         sut.loadState(state)
         assertThat(sut.activeProfile(project)).isEqualTo(fooProfile)


### PR DESCRIPTION
After user selects a profile, if subsequent validation fails because of networking / etc, then we incorrectly clear their selected profile
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
