### PR TITLE
fix(amazonq): Increase scan time

### DIFF
--- a/.changes/next-release/bugfix-7e09465d-6cb8-4180-9131-7ec6543db20c.json
+++ b/.changes/next-release/bugfix-7e09465d-6cb8-4180-9131-7ec6543db20c.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "increase /review timeout"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererConstants.kt
@@ -70,7 +70,7 @@ object CodeWhispererConstants {
     // Code scan feature constants
     val ISSUE_HIGHLIGHT_TEXT_ATTRIBUTES = TextAttributes(null, null, JBColor.YELLOW, EffectType.WAVE_UNDERSCORE, Font.PLAIN)
     const val CODE_SCAN_ISSUE_TITLE_MAX_LENGTH = 60
-    const val DEFAULT_CODE_SCAN_TIMEOUT_IN_SECONDS: Long = 60 * 10 // 10 minutes
+    const val DEFAULT_CODE_SCAN_TIMEOUT_IN_SECONDS: Long = 60 * 15 // 15 minutes
     const val DEFAULT_PAYLOAD_LIMIT_IN_BYTES: Long = 1 * 1024 * 1024 * 1024 // 1GB
     const val CODE_SCAN_POLLING_INTERVAL_IN_SECONDS: Long = 1
     const val FILE_SCAN_INITIAL_POLLING_INTERVAL_IN_SECONDS: Long = 10


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

- we are getting quite a noteworthy amount of scan timeout errors on the front end.
- VSC PR: https://github.com/aws/aws-toolkit-vscode/pull/6765

#Solution
- increase front-end timeout

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
