### PR TITLE
build(amazonq): fix logging regression introduced by #5627

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-publishing-conventions.gradle.kts
@@ -55,7 +55,6 @@ configurations {
     // Make sure we exclude stuff we either A) ships with IDE, B) we don't use to cut down on size
     runtimeClasspath {
         exclude(group = "com.google.code.gson")
-        exclude(group = "org.slf4j", module = "slf4j-jdk14")
         exclude(group = "org.jetbrains.kotlin")
         exclude(group = "org.jetbrains.kotlinx")
     }

--- a/plugins/core/build.gradle.kts
+++ b/plugins/core/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(project(":plugin-core:sdk-codegen"))
     implementation(project(":plugin-core:webview"))
     implementation(libs.slf4j.api)
+    implementation(libs.slf4j.jdk14)
 }
 
 tasks.check {


### PR DESCRIPTION
By bundling slf4j-api, it is loaded under our classloader, which subsequently picks the Noop logger since there is no logging implementation available.

Fix by providing an implementation as well.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
