### PR TITLE
fix(amazonq): enable agentic mode

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
@@ -127,6 +127,7 @@ class Browser(parent: Disposable, private val webUri: URI, val project: Project)
                             }
                         }, 
                         {
+                        agenticMode: true,
                         quickActionCommands: $quickActionConfig,
                         disclaimerAcknowledged: ${MeetQSettings.getInstance().disclaimerAcknowledged},
                         pairProgrammingAcknowledged: ${!MeetQSettings.getInstance().amazonQChatPairProgramming}


### PR DESCRIPTION
new required field in chat client
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
