### PR TITLE
fix(amaonq): unable to find Amazon Q feature dev auto build setting

### DIFF
--- a/.changes/next-release/bugfix-7920ece4-99d6-4828-931e-29b66994dc10.json
+++ b/.changes/next-release/bugfix-7920ece4-99d6-4828-931e-29b66994dc10.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "/dev: Fix missing Amazon Q feature dev auto build setting."
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt
@@ -544,7 +544,8 @@ class FeatureDevController(
     }
 
     private suspend fun handleDevCommandUserSetting(tabId: String, value: Boolean) {
-        CodeWhispererSettings.getInstance().toggleAutoBuildFeature(context.project.basePath, value)
+        val session = getSessionInfo(tabId)
+        CodeWhispererSettings.getInstance().toggleAutoBuildFeature(session.context.workspaceRoot.path, value)
         messenger.sendAnswer(
             tabId = tabId,
             message = message("amazonqFeatureDev.chat_message.setting_updated"),


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Fix issue where is unable to find the Amazon Q feature dev auto build setting for multi root workspace. 

The path value should align with the following code:
https://github.com/aws/aws-toolkit-jetbrains/blob/db297743c91543c8d0a180a5faa2600147dc6aa6/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/controller/FeatureDevController.kt#L745

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
