### PR TITLE
refacotr(amazonq): reduce extra call of listAvailableCustomization

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/customization/CodeWhispererModelConfigurator.kt
@@ -89,9 +89,7 @@ class DefaultCodeWhispererModelConfigurator : CodeWhispererModelConfigurator, Pe
             QRegionProfileSelectedListener.TOPIC,
             object : QRegionProfileSelectedListener {
                 override fun onProfileSelected(project: Project, profile: QRegionProfile?) {
-                    pluginAwareExecuteOnPooledThread {
-                        CodeWhispererModelConfigurator.getInstance().listCustomizations(project, passive = true)
-                    }
+                    switchCustomization(project, null)
                 }
             }
         )

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererModelConfiguratorTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererModelConfiguratorTest.kt
@@ -566,7 +566,7 @@ class CodeWhispererModelConfiguratorTest {
     }
 
     @Test
-    fun `profile switch should keep using existing customization if new list still contains that arn`() {
+    fun `should switch to default customization on profile changed`() {
         val ssoConn = spy(LegacyManagedBearerSsoConnection(region = "us-east-1", startUrl = "url 1", scopes = Q_SCOPES))
         ToolkitConnectionManager.getInstance(projectRule.project).switchConnection(ssoConn)
         val oldCustomization = CodeWhispererCustomization("oldArn", "oldName", "oldDescription")
@@ -574,16 +574,11 @@ class CodeWhispererModelConfiguratorTest {
 
         assertThat(sut.activeCustomization(projectRule.project)).isEqualTo(oldCustomization)
 
-        val fakeCustomizations = listOf(
-            CodeWhispererCustomization("oldArn", "oldName", "oldDescription")
-        )
-        mockClintAdaptor.stub { on { listAvailableCustomizations() } doReturn fakeCustomizations }
-
         ApplicationManager.getApplication().messageBus
             .syncPublisher(QRegionProfileSelectedListener.TOPIC)
             .onProfileSelected(projectRule.project, null)
 
-        assertThat(sut.activeCustomization(projectRule.project)).isEqualTo(oldCustomization)
+        assertThat(sut.activeCustomization(projectRule.project)).isEqualTo(null)
     }
 
     @Test


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->



## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Customization will only have "1" parent profile, so theoretically we don't need another call of listAvailableCustomization to check if the new profile has access to given profile or not. Instead, we could simply switch to default.

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
