### PR TITLE
fix: CNFE from ProjectContextEditorListener due to deleted class

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/resources/META-INF/plugin-chat.xml
+++ b/plugins/amazonq/chat/jetbrains-community/resources/META-INF/plugin-chat.xml
@@ -8,8 +8,6 @@
     <projectListeners>
         <listener class="software.aws.toolkits.jetbrains.services.amazonq.toolwindow.AmazonQToolWindowListener"
                   topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener"/>
-        <listener class="software.aws.toolkits.jetbrains.services.amazonq.project.ProjectContextEditorListener"
-                  topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
     </projectListeners>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
it is deleted
```
Caused by: java.lang.ClassNotFoundException: software.aws.toolkits.jetbrains.services.amazonq.project.ProjectContextEditorListener PluginClassLoader(plugin=PluginDescriptor(name=Amazon Q, id=amazon.q, descriptorPath=plugin.xml, path=/Users/
...
```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
