### PR TITLE
fix(toolkit): fix NCDFE on com.intellij.lang.javascript.JavascriptLanguage

### DIFF
--- a/.changes/next-release/bugfix-814bffb3-03aa-44ad-b639-008cf2929063.json
+++ b/.changes/next-release/bugfix-814bffb3-03aa-44ad-b639-008cf2929063.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix JavascriptLanguage not found on 2025.1+"
+}

--- a/plugins/core/jetbrains-ultimate/src-242-243/compat/com/intellij/lang/javascript/JavascriptLanguage.kt
+++ b/plugins/core/jetbrains-ultimate/src-242-243/compat/com/intellij/lang/javascript/JavascriptLanguage.kt
@@ -3,6 +3,6 @@
 
 package compat.com.intellij.lang.javascript
 
-// probably not necessary, but inline to avoid loading this through core classpath
+// inline to avoid loading this through core classpath
 inline val JavascriptLanguage
     get() = com.intellij.lang.javascript.JavascriptLanguage.INSTANCE

--- a/plugins/core/jetbrains-ultimate/src-251+/compat/com/intellij/lang/javascript/JavascriptLanguage.kt
+++ b/plugins/core/jetbrains-ultimate/src-251+/compat/com/intellij/lang/javascript/JavascriptLanguage.kt
@@ -3,4 +3,6 @@
 
 package compat.com.intellij.lang.javascript
 
-val JavascriptLanguage = com.intellij.lang.javascript.JavascriptLanguage
+// inline to avoid loading this through core classpath
+inline val JavascriptLanguage
+    get() = com.intellij.lang.javascript.JavascriptLanguage


### PR DESCRIPTION
```
Caused by: com.intellij.diagnostic.PluginException: Cannot create class software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsRuntimeGroup (classloader=PluginClassLoader(plugin=PluginDescriptor(name=AWS Toolkit, id=aws.toolkit, descriptorPath=plugin.xml, 
[...]
	at com.intellij.serviceContainer.ComponentManagerImpl.doInstantiateClass(ComponentManagerImpl.kt:927)
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClass(ComponentManagerImpl.kt:903)
	at com.intellij.openapi.extensions.impl.SimpleConstructorInjectionAdapter.instantiateClass(XmlExtensionAdapter.kt:102)
	at com.intellij.openapi.extensions.impl.XmlExtensionAdapter.doCreateInstance(XmlExtensionAdapter.kt:52)
	... 40 more
Caused by: java.lang.NoClassDefFoundError: com/intellij/lang/javascript/JavascriptLanguage
	at compat.com.intellij.lang.javascript.JavascriptLanguageKt.<clinit>(JavascriptLanguage.kt:6)
	at software.aws.toolkits.jetbrains.services.lambda.nodejs.NodeJsRuntimeGroup.<init>(NodeJsRuntimeGroup.kt:21)
	at com.intellij.serviceContainer.ComponentManagerImpl.findConstructorAndInstantiateClass(ComponentManagerImpl.kt:909)
	at com.intellij.serviceContainer.ComponentManagerImpl.doInstantiateClass(ComponentManagerImpl.kt:918)
	... 43 more
```


 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
