### PR TITLE
telemetry(amazonq): expose FileCreationFailed exceptions

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevExceptions.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/FeatureDevExceptions.kt
@@ -82,6 +82,9 @@ class GuardrailsException(operation: String, desc: String?, cause: Throwable? = 
 class PromptRefusalException(operation: String, desc: String?, cause: Throwable? = null) :
     ClientException(message("amazonqFeatureDev.exception.prompt_refusal"), operation, desc, cause)
 
+class FileCreationFailedException(operation: String, desc: String?, cause: Throwable? = null) :
+    ServiceException(message("amazonqFeatureDev.exception.failed_generation"), operation, desc, cause)
+
 class ThrottlingException(operation: String, desc: String?, cause: Throwable? = null) :
     ClientException(message("amazonqFeatureDev.exception.throttling"), operation, desc, cause)
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonqFeatureDev/session/CodeGenerationState.kt
@@ -13,6 +13,7 @@ import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.EmptyPatchExce
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FEATURE_NAME
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FeatureDevOperation
+import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.FileCreationFailedException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.GuardrailsException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.NoChangeRequiredException
 import software.aws.toolkits.jetbrains.services.amazonqFeatureDev.PromptRefusalException
@@ -260,6 +261,10 @@ private suspend fun CodeGenerationState.generateCode(
                     -> throw PromptRefusalException(operation = FeatureDevOperation.GenerateCode.toString(), desc = "Prompt refusal")
                     codeGenerationResultState.codeGenerationStatusDetail()?.contains(
                         "EmptyPatch",
+                    ),
+                    -> throw FileCreationFailedException(operation = FeatureDevOperation.GenerateCode.toString(), desc = "File creation failed")
+                    codeGenerationResultState.codeGenerationStatusDetail()?.contains(
+                        "FileCreationFailed",
                     ),
                     -> {
                         if (codeGenerationResultState.codeGenerationStatusDetail().contains("NO_CHANGE_REQUIRED")) {


### PR DESCRIPTION
Problem
FileCreationFailed exceptions are displayed as UnknownException in telemetry. This exception is new and we want to separate this out from other unknown exceptions.

Solution
Return API service error with FileCreationFailedException

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) -- not really a bug fix but this is just adding some data for telemetry
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes -- not needed + no existing tests for these messages
- [X] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [X] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
