### PR TITLE
fix(amazonq): update chat color classes

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/AmazonQTheme.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/AmazonQTheme.kt
@@ -37,8 +37,6 @@ data class AmazonQTheme(
     val warning: Color,
     val error: Color,
 
-    val cardBackground: Color,
-
     val editorFont: Font,
     val editorBackground: Color,
     val editorForeground: Color,
@@ -49,5 +47,5 @@ data class AmazonQTheme(
     val editorKeyword: Color,
     val editorString: Color,
     val editorProperty: Color,
-
+    val editorClassName: Color,
 )

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/CssVariable.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/CssVariable.kt
@@ -13,6 +13,7 @@ enum class CssVariable(
     FontFamily("--mynah-font-family"),
 
     TextColorDefault("--mynah-color-text-default"),
+    TextColorAlt("--mynah-color-text-alternate"),
     TextColorStrong("--mynah-color-text-strong"),
     TextColorWeak("--mynah-color-text-weak"),
     TextColorLink("--mynah-color-text-link"),
@@ -25,7 +26,7 @@ enum class CssVariable(
     ColorDeep("--mynah-color-deep"),
     ColorDeepReverse("--mynah-color-deep-reverse"),
     BorderDefault("--mynah-color-border-default"),
-    InputBackground("--mynah-color-input-bg"),
+    InputBackground("--mynah-input-bg"),
 
     SyntaxBackground("--mynah-color-syntax-bg"),
     SyntaxVariable("--mynah-color-syntax-variable"),
@@ -36,6 +37,9 @@ enum class CssVariable(
     SyntaxProperty("--mynah-color-syntax-property"),
     SyntaxComment("--mynah-color-syntax-comment"),
     SyntaxCode("--mynah-color-syntax-code"),
+    SyntaxKeyword("--mynah-color-syntax-keyword"),
+    SyntaxString("--mynah-color-syntax-string"),
+    SyntaxClassName("--mynah-color-syntax-class-name"),
     SyntaxCodeFontFamily("--mynah-syntax-code-font-family"),
     SyntaxCodeFontSize("--mynah-syntax-code-font-size"),
 
@@ -50,10 +54,9 @@ enum class CssVariable(
     SecondaryButtonBackground("--mynah-color-alternate"),
     SecondaryButtonForeground("--mynah-color-alternate-reverse"),
 
-    CodeText("--mynah-color-code-text"),
-
     MainBackground("--mynah-color-main"),
     MainForeground("--mynah-color-main-reverse"),
 
     CardBackground("--mynah-card-bg"),
+    CardBackgroundAlt("--mynah-card-bg-alternate"),
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/EditorThemeAdapter.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/EditorThemeAdapter.kt
@@ -113,11 +113,9 @@ class EditorThemeAdapter {
                 warning = themeColor("Component.warningFocusColor", default = 0xE2A53A),
                 error = themeColor("ProgressBar.failedColor", default = 0xD64F4F, darkDefault = 0xE74848),
 
-                cardBackground = cardBackground,
-
                 editorFont = currentScheme.getFont(EditorFontType.PLAIN),
-                editorBackground = chatBackground,
-                editorForeground = text,
+                editorBackground = currentScheme.defaultBackground,
+                editorForeground = currentScheme.defaultForeground,
                 editorVariable = currentScheme.foregroundColor(DefaultLanguageHighlighterColors.LOCAL_VARIABLE),
                 editorOperator = currentScheme.foregroundColor(DefaultLanguageHighlighterColors.OPERATION_SIGN),
                 editorFunction = currentScheme.foregroundColor(DefaultLanguageHighlighterColors.FUNCTION_DECLARATION),
@@ -125,6 +123,7 @@ class EditorThemeAdapter {
                 editorKeyword = currentScheme.foregroundColor(DefaultLanguageHighlighterColors.KEYWORD),
                 editorString = currentScheme.foregroundColor(DefaultLanguageHighlighterColors.STRING),
                 editorProperty = currentScheme.foregroundColor(DefaultLanguageHighlighterColors.INSTANCE_FIELD),
+                editorClassName = currentScheme.foregroundColor(DefaultLanguageHighlighterColors.CLASS_NAME),
             )
         }
 

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
@@ -3,8 +3,6 @@
 
 package software.aws.toolkits.jetbrains.services.amazonq.webview.theme
 
-import com.intellij.openapi.editor.colors.EditorColorsManager
-import com.intellij.ui.JBColor
 import kotlinx.coroutines.CompletableDeferred
 import org.cef.browser.CefBrowser
 import java.awt.Color

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
@@ -3,6 +3,8 @@
 
 package software.aws.toolkits.jetbrains.services.amazonq.webview.theme
 
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.ui.JBColor
 import kotlinx.coroutines.CompletableDeferred
 import org.cef.browser.CefBrowser
 import java.awt.Color
@@ -35,6 +37,7 @@ class ThemeBrowserAdapter {
         append(CssVariable.FontFamily, theme.font.toCssFontFamily())
 
         append(CssVariable.TextColorDefault, theme.defaultText)
+        append(CssVariable.TextColorAlt, theme.defaultText)
         append(CssVariable.TextColorStrong, theme.textFieldForeground)
         append(CssVariable.TextColorInput, theme.textFieldForeground)
         append(CssVariable.TextColorLink, theme.linkText)
@@ -42,7 +45,8 @@ class ThemeBrowserAdapter {
 
         append(CssVariable.Background, theme.background)
         append(CssVariable.BackgroundAlt, theme.background)
-        append(CssVariable.CardBackground, theme.cardBackground)
+        append(CssVariable.CardBackground, theme.editorBackground)
+        append(CssVariable.CardBackgroundAlt, theme.editorBackground)
         append(CssVariable.BorderDefault, theme.border)
         append(CssVariable.TabActive, theme.activeTab)
 
@@ -63,6 +67,7 @@ class ThemeBrowserAdapter {
 
         append(CssVariable.SyntaxCodeFontFamily, theme.editorFont.toCssFontFamily("monospace"))
         append(CssVariable.SyntaxCodeFontSize, theme.editorFont.toCssSize())
+        append(CssVariable.SyntaxCode, theme.editorForeground)
         append(CssVariable.SyntaxBackground, theme.editorBackground)
         append(CssVariable.SyntaxVariable, theme.editorVariable)
         append(CssVariable.SyntaxOperator, theme.editorOperator)
@@ -71,7 +76,9 @@ class ThemeBrowserAdapter {
         append(CssVariable.SyntaxAttributeValue, theme.editorKeyword)
         append(CssVariable.SyntaxAttribute, theme.editorString)
         append(CssVariable.SyntaxProperty, theme.editorProperty)
-        append(CssVariable.SyntaxCode, theme.editorForeground)
+        append(CssVariable.SyntaxKeyword, theme.editorKeyword)
+        append(CssVariable.SyntaxString, theme.editorString)
+        append(CssVariable.SyntaxClassName, theme.editorClassName)
 
         append(CssVariable.MainBackground, theme.buttonBackground)
         append(CssVariable.MainForeground, theme.buttonForeground)


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/74dd3ab8-7e4f-4845-9660-765ed7b6cfcb)

![image](https://github.com/user-attachments/assets/22a571b3-446a-49c4-92fa-32f85394529e)

![image](https://github.com/user-attachments/assets/5d085de4-2818-49f3-a78c-0d80064916f8)

![image](https://github.com/user-attachments/assets/c7ac4118-d0d7-4cf0-b9fa-c795db81450f)

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
