### PR TITLE
fix(amazonq): avoid using modeled types in chat message proxy

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/commands/MessageSerializer.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/commands/MessageSerializer.kt
@@ -40,6 +40,9 @@ class MessageSerializer @VisibleForTesting constructor() {
     inline fun <reified T> deserializeChatMessages(value: JsonNode): T =
         objectMapper.treeToValue<T>(value)
 
+    inline fun <reified T> deserializeChatMessages(value: JsonNode, clazz: Class<T>): T =
+        objectMapper.treeToValue(value, clazz)
+
     // Provide singleton global access
     companion object {
         private val instance = MessageSerializer()

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -4,6 +4,8 @@
 package software.aws.toolkits.jetbrains.services.amazonq.webview
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.treeToValue
 import com.google.gson.Gson
 import com.intellij.ide.BrowserUtil
 import com.intellij.ide.util.RunOnceUtil
@@ -30,16 +32,17 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.amazonq.apps.AppConnection
 import software.aws.toolkits.jetbrains.services.amazonq.commands.MessageSerializer
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLanguageServer
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQChatServer
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.JsonRpcMethod
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.JsonRpcNotification
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.JsonRpcRequest
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption.JwtEncryptionManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.AwsServerCapabilitiesProvider
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.ChatCommunicationManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.FlareUiMessage
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.AUTH_FOLLOW_UP_CLICKED
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.AuthFollowUpClickNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ButtonClickNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ButtonClickParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ButtonClickResult
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_BUTTON_CLICK
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_CONVERSATION_CLICK
@@ -62,50 +65,23 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_BAR_ACTIONS
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_CHANGE
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_REMOVE
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ChatNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ChatParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ChatPrompt
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ChatReadyNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ConversationClickRequest
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CopyCodeToClipboardNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CopyCodeToClipboardParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CreatePromptNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CreatePromptParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedChatParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedQuickActionChatParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FeedbackNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FeedbackParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FileClickNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FileClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FollowUpClickNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FollowUpClickParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GET_SERIALIZED_CHAT_REQUEST_METHOD
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GetSerializedChatResponse
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InfoLinkClickNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InfoLinkClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InsertToCursorPositionNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InsertToCursorPositionParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.LinkClickNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.LinkClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ListConversationsRequest
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OPEN_SETTINGS
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OPEN_WORKSPACE_SETTINGS_KEY
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenSettingsNotification
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenTabResponse
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenTabResult
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenTabResultError
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenTabResultSuccess
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.PROMPT_INPUT_OPTIONS_CHANGE
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.PromptInputOptionChangeNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.PromptInputOptionChangeParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.QuickChatActionRequest
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SEND_CHAT_COMMAND_PROMPT
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.STOP_CHAT_RESPONSE
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SendChatPromptRequest
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SourceLinkClickNotification
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SourceLinkClickParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.StopResponseMessage
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.TabBarActionParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.TabBarActionRequest
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.TabEventParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.TabEventRequest
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.util.LspEditorUtil
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.util.LspEditorUtil.toUriString
 import software.aws.toolkits.jetbrains.services.amazonq.util.command
@@ -232,22 +208,18 @@ class BrowserConnector(
         when (node.command) {
             SEND_CHAT_COMMAND_PROMPT -> {
                 val requestFromUi = serializer.deserializeChatMessages<SendChatPromptRequest>(node)
-                val chatPrompt = ChatPrompt(
-                    requestFromUi.params.prompt.prompt,
-                    requestFromUi.params.prompt.escapedPrompt,
-                    node.command
-                )
                 val editor = FileEditorManager.getInstance(project).selectedTextEditor
                 val textDocumentIdentifier = editor?.let { TextDocumentIdentifier(toUriString(it.virtualFile)) }
                 val cursorState = editor?.let { LspEditorUtil.getCursorState(it) }
 
-                val chatParams = ChatParams(
-                    requestFromUi.params.tabId,
-                    chatPrompt,
-                    textDocumentIdentifier,
-                    cursorState,
-                    context = requestFromUi.params.context
+                val enrichmentParams = mapOf(
+                    "textDocument" to textDocumentIdentifier,
+                    "cursorState" to cursorState,
                 )
+
+                val serializedEnrichmentParams = serializer.objectMapper.valueToTree<ObjectNode>(enrichmentParams)
+                val chatParams: ObjectNode = (node as ObjectNode)
+                    .setAll(serializedEnrichmentParams)
 
                 val tabId = requestFromUi.params.tabId
                 val partialResultToken = chatCommunicationManager.addPartialChatMessage(tabId)
@@ -256,8 +228,8 @@ class BrowserConnector(
                 val result = AmazonQLspService.executeIfRunning(project) { server ->
                     encryptionManager = this.encryptionManager
 
-                    val encryptedParams = EncryptedChatParams(this.encryptionManager.encrypt(chatParams), partialResultToken)
-                    server.sendChatPrompt(encryptedParams)
+                    val encryptedParams = EncryptedChatParams(this.encryptionManager.encrypt(chatParams.params), partialResultToken)
+                    rawEndpoint.request(SEND_CHAT_COMMAND_PROMPT, encryptedParams) as CompletableFuture<String>
                 } ?: (CompletableFuture.failedFuture(IllegalStateException("LSP Server not running")))
 
                 // We assume there is only one outgoing request per tab because the input is
@@ -265,17 +237,18 @@ class BrowserConnector(
                 chatCommunicationManager.setInflightRequestForTab(tabId, result)
                 showResult(result, partialResultToken, tabId, encryptionManager, browser)
             }
+
             CHAT_QUICK_ACTION -> {
                 val requestFromUi = serializer.deserializeChatMessages<QuickChatActionRequest>(node)
                 val tabId = requestFromUi.params.tabId
-                val quickActionParams = requestFromUi.params
+                val quickActionParams = node.params ?: error("empty payload")
                 val partialResultToken = chatCommunicationManager.addPartialChatMessage(tabId)
                 var encryptionManager: JwtEncryptionManager? = null
                 val result = AmazonQLspService.executeIfRunning(project) { server ->
                     encryptionManager = this.encryptionManager
 
                     val encryptedParams = EncryptedQuickActionChatParams(this.encryptionManager.encrypt(quickActionParams), partialResultToken)
-                    server.sendQuickAction(encryptedParams)
+                    rawEndpoint.request(CHAT_QUICK_ACTION, encryptedParams) as CompletableFuture<String>
                 } ?: (CompletableFuture.failedFuture(IllegalStateException("LSP Server not running")))
 
                 // We assume there is only one outgoing request per tab because the input is
@@ -284,139 +257,118 @@ class BrowserConnector(
 
                 showResult(result, partialResultToken, tabId, encryptionManager, browser)
             }
+
             CHAT_LIST_CONVERSATIONS -> {
-                val requestFromUi = serializer.deserializeChatMessages<ListConversationsRequest>(node)
-                val result = AmazonQLspService.executeIfRunning(project) { server ->
-                    server.listConversations(requestFromUi.params)
-                } ?: (CompletableFuture.failedFuture(IllegalStateException("LSP Server not running")))
-
-                result.whenComplete { response, _ ->
-                    val uiMessage = """
-                        {
-                            "command": "$CHAT_LIST_CONVERSATIONS",
-                            "params": ${Gson().toJson(response)}
-                        }
-                    """.trimIndent()
-                    browser.postChat(uiMessage)
-                }
+                handleChat(AmazonQChatServer.listConversations, node)
+                    .whenComplete { response, _ ->
+                        browser.postChat(
+                            FlareUiMessage(
+                                command = CHAT_LIST_CONVERSATIONS,
+                                params = response
+                            )
+                        )
+                    }
             }
+
             CHAT_CONVERSATION_CLICK -> {
-                val requestFromUi = serializer.deserializeChatMessages<ConversationClickRequest>(node)
-                val result = AmazonQLspService.executeIfRunning(project) { server ->
-                    server.conversationClick(requestFromUi.params)
-                } ?: (CompletableFuture.failedFuture(IllegalStateException("LSP Server not running")))
+                handleChat(AmazonQChatServer.conversationClick, node)
+                    .whenComplete { response, _ ->
+                        browser.postChat(
+                            FlareUiMessage(
+                                command = CHAT_CONVERSATION_CLICK,
+                                params = response
+                            )
+                        )
+                    }
+            }
 
-                result.whenComplete { response, _ ->
-                    val uiMessage = """
-                        {
-                            "command": "$CHAT_CONVERSATION_CLICK",
-                            "params": ${Gson().toJson(response)}
-                        }
-                    """.trimIndent()
-                    browser.postChat(uiMessage)
-                }
-            }
             CHAT_FEEDBACK -> {
-                handleChatNotification<FeedbackNotification, FeedbackParams>(node) { server, params ->
-                    server.feedback(params)
-                }
+                handleChat(AmazonQChatServer.feedback, node)
             }
+
             CHAT_READY -> {
-                handleChatNotification<ChatReadyNotification, Unit>(node) { server, _ ->
+                handleChat(AmazonQChatServer.chatReady, node) { params, invoke ->
                     uiReady.complete(true)
                     chatCommunicationManager.setUiReady()
                     RunOnceUtil.runOnceForApp("AmazonQ-UI-Ready") {
                         MeetQSettings.getInstance().reinvent2024OnboardingCount += 1
                     }
-                    server.chatReady()
+
+                    invoke()
                 }
             }
+
             CHAT_TAB_ADD -> {
-                handleChatNotification<TabEventRequest, TabEventParams>(node) { server, params ->
-                    server.tabAdd(params)
-                }
+                handleChat(AmazonQChatServer.tabAdd, node)
             }
+
             CHAT_TAB_REMOVE -> {
-                handleChatNotification<TabEventRequest, TabEventParams>(node) { server, params ->
+                handleChat(AmazonQChatServer.tabRemove, node) { params, invoke ->
                     chatCommunicationManager.removePartialChatMessage(params.tabId)
                     cancelInflightRequests(params.tabId)
-                    server.tabRemove(params)
+
+                    invoke()
                 }
             }
+
             CHAT_TAB_CHANGE -> {
-                handleChatNotification<TabEventRequest, TabEventParams>(node) { server, params ->
-                    server.tabChange(params)
-                }
+                handleChat(AmazonQChatServer.tabChange, node)
             }
+
             CHAT_OPEN_TAB -> {
                 val response = serializer.deserializeChatMessages<OpenTabResponse>(node)
-                chatCommunicationManager.completeTabOpen(
-                    response.requestId,
-                    response.params.result.tabId
-                )
+                val future = chatCommunicationManager.removeTabOpenRequest(response.requestId) ?: return
+                try {
+                    val id = serializer.deserializeChatMessages<OpenTabResultSuccess>(node.params).result.tabId
+                    future.complete(OpenTabResult(id))
+                } catch (e: Exception) {
+                    try {
+                        val err = serializer.deserializeChatMessages<OpenTabResultError>(node.params)
+                        future.complete(err.error)
+                    } catch (_: Exception) {
+                        future.completeExceptionally(e)
+                    }
+                }
             }
+
             CHAT_INSERT_TO_CURSOR -> {
-                handleChatNotification<InsertToCursorPositionNotification, InsertToCursorPositionParams>(node) { server, params ->
-                    server.insertToCursorPosition(params)
-                }
+                handleChat(AmazonQChatServer.insertToCursorPosition, node)
             }
+
             CHAT_LINK_CLICK -> {
-                handleChatNotification<LinkClickNotification, LinkClickParams>(node) { server, params ->
-                    server.linkClick(params)
-                }
+                handleChat(AmazonQChatServer.linkClick, node)
             }
+
             CHAT_INFO_LINK_CLICK -> {
-                handleChatNotification<InfoLinkClickNotification, InfoLinkClickParams>(node) { server, params ->
-                    server.infoLinkClick(params)
-                }
+                handleChat(AmazonQChatServer.infoLinkClick, node)
             }
+
             CHAT_SOURCE_LINK_CLICK -> {
-                handleChatNotification<SourceLinkClickNotification, SourceLinkClickParams>(node) { server, params ->
-                    server.sourceLinkClick(params)
-                }
+                handleChat(AmazonQChatServer.sourceLinkClick, node)
             }
+
             CHAT_FILE_CLICK -> {
-                handleChatNotification<FileClickNotification, FileClickParams>(node) { server, params ->
-                    server.fileClick(params)
-                }
+                handleChat(AmazonQChatServer.fileClick, node)
             }
+
             PROMPT_INPUT_OPTIONS_CHANGE -> {
-                handleChatNotification<PromptInputOptionChangeNotification, PromptInputOptionChangeParams>(node) {
-                        server, params ->
-                    server.promptInputOptionsChange(params)
-                }
+                handleChat(AmazonQChatServer.promptInputOptionsChange, node)
             }
-            CHAT_PROMPT_OPTION_ACKNOWLEDGED -> {
-                val acknowledgedMessage = node.get("params").get("messageId")
-                if (acknowledgedMessage.asText() == "programmerModeCardId") {
-                    MeetQSettings.getInstance().amazonQChatPairProgramming = false
-                }
-            }
+
             CHAT_FOLLOW_UP_CLICK -> {
-                handleChatNotification<FollowUpClickNotification, FollowUpClickParams>(node) { server, params ->
-                    server.followUpClick(params)
-                }
+                handleChat(AmazonQChatServer.followUpClick, node)
             }
+
             CHAT_BUTTON_CLICK -> {
-                handleChatNotification<ButtonClickNotification, ButtonClickParams>(node) { server, params ->
-                    server.buttonClick(params)
-                }.thenApply { response ->
+                handleChat(AmazonQChatServer.buttonClick, node).thenApply { response ->
                     if (response is ButtonClickResult && !response.success) {
                         LOG.warn { "Failed to execute action associated with button with reason: ${response.failureReason}" }
                     }
                 }
             }
-            AUTH_FOLLOW_UP_CLICKED -> {
-                val message = serializer.deserializeChatMessages<AuthFollowUpClickNotification>(node)
-                chatCommunicationManager.handleAuthFollowUpClicked(
-                    project,
-                    message.params
-                )
-            }
+
             CHAT_COPY_CODE_TO_CLIPBOARD -> {
-                handleChatNotification<CopyCodeToClipboardNotification, CopyCodeToClipboardParams>(node) { server, params ->
-                    server.copyCodeToClipboard(params)
-                }
+                handleChat(AmazonQChatServer.copyCodeToClipboard, node)
             }
 
             GET_SERIALIZED_CHAT_REQUEST_METHOD -> {
@@ -428,36 +380,34 @@ class BrowserConnector(
             }
 
             CHAT_TAB_BAR_ACTIONS -> {
-                handleChatNotification<TabBarActionRequest, TabBarActionParams>(node) {
-                        server, params ->
-                    val result = server.tabBarActions(params)
-                    result.whenComplete { actions, error ->
-                        try {
-                            if (error != null) {
-                                throw error
-                            }
+                handleChat(AmazonQChatServer.tabBarActions, node) { params, invoke ->
+                    invoke()
+                        .whenComplete { actions, error ->
+                            try {
+                                if (error != null) {
+                                    throw error
+                                }
 
-                            browser.postChat(
-                                FlareUiMessage(
-                                    command = CHAT_TAB_BAR_ACTIONS,
-                                    params = actions ?: emptyMap<Any, Any>()
+                                browser.postChat(
+                                    FlareUiMessage(
+                                        command = CHAT_TAB_BAR_ACTIONS,
+                                        params = actions
+                                    )
                                 )
-                            )
-                        } catch (e: Exception) {
-                            LOG.error { "Failed to perform chat tab bar action $e" }
-                            params.tabId?.let {
-                                browser.postChat(chatCommunicationManager.getErrorUiMessage(it, e, null))
+                            } catch (e: Exception) {
+                                LOG.error { "Failed to perform chat tab bar action $e" }
+                                params.tabId?.let {
+                                    browser.postChat(chatCommunicationManager.getErrorUiMessage(it, e, null))
+                                }
                             }
                         }
-                    }
                 }
             }
+
             CHAT_CREATE_PROMPT -> {
-                handleChatNotification<CreatePromptNotification, CreatePromptParams>(node) {
-                        server, params ->
-                    server.createPrompt(params)
-                }
+                handleChat(AmazonQChatServer.createPrompt, node)
             }
+
             STOP_CHAT_RESPONSE -> {
                 val stopResponseRequest = serializer.deserializeChatMessages<StopResponseMessage>(node)
                 if (!chatCommunicationManager.hasInflightRequest(stopResponseRequest.params.tabId)) {
@@ -466,6 +416,22 @@ class BrowserConnector(
                 cancelInflightRequests(stopResponseRequest.params.tabId)
                 chatCommunicationManager.removePartialChatMessage(stopResponseRequest.params.tabId)
             }
+
+            AUTH_FOLLOW_UP_CLICKED -> {
+                val message = serializer.deserializeChatMessages<AuthFollowUpClickNotification>(node)
+                chatCommunicationManager.handleAuthFollowUpClicked(
+                    project,
+                    message.params
+                )
+            }
+
+            CHAT_PROMPT_OPTION_ACKNOWLEDGED -> {
+                val acknowledgedMessage = node.params?.get("messageId")
+                if (acknowledgedMessage?.asText() == "programmerModeCardId") {
+                    MeetQSettings.getInstance().amazonQChatPairProgramming = false
+                }
+            }
+
             OPEN_SETTINGS -> {
                 val openSettingsNotification = serializer.deserializeChatMessages<OpenSettingsNotification>(node)
                 if (openSettingsNotification.params.settingKey != OPEN_WORKSPACE_SETTINGS_KEY) return
@@ -492,15 +458,15 @@ class BrowserConnector(
                 val messageToChat = ChatCommunicationManager.convertToJsonToSendToChat(
                     SEND_CHAT_COMMAND_PROMPT,
                     tabId,
-                    encryptionManager?.decrypt(value).orEmpty(),
+                    value?.let { encryptionManager?.decrypt(it) }.orEmpty(),
                     isPartialResult = false
                 )
                 browser.postChat(messageToChat)
                 chatCommunicationManager.removeInflightRequestForTab(tabId)
-            } catch (e: CancellationException) {
+            } catch (_: CancellationException) {
                 LOG.warn { "Cancelled chat generation" }
             } catch (e: Exception) {
-                LOG.error { "Failed to send chat message $e" }
+                LOG.error(e) { "Failed to send chat message" }
                 browser.postChat(chatCommunicationManager.getErrorUiMessage(tabId, e, partialResultToken))
             }
         }
@@ -513,15 +479,49 @@ class BrowserConnector(
         }
     }
 
-    private inline fun <reified T, R> handleChatNotification(
+    private inline fun <reified Request, Response> handleChat(
+        lspMethod: JsonRpcMethod<Request, Response>,
         node: JsonNode,
-        crossinline serverAction: (server: AmazonQLanguageServer, params: R) -> CompletableFuture<*>,
-    ): CompletableFuture<*> where T : ChatNotification<R> {
-        val requestFromUi = serializer.deserializeChatMessages<T>(node)
-        return AmazonQLspService.executeIfRunning(project) { server ->
-            serverAction(server, requestFromUi.params)
-        } ?: CompletableFuture.failedFuture<Unit>(IllegalStateException("LSP Server not running"))
+        crossinline serverAction: (params: Request, invokeService: () -> CompletableFuture<Response>) -> CompletableFuture<Response>,
+    ): CompletableFuture<Response> {
+        val requestFromUi = if (node.params == null) {
+            Unit as Request
+        } else {
+            serializer.deserializeChatMessages<Request>(node.params, lspMethod.params)
+        }
+
+        return AmazonQLspService.executeIfRunning(project) { _ ->
+            val invokeService = when (lspMethod) {
+                is JsonRpcNotification<Request> -> {
+                    // notify is Unit
+                    { CompletableFuture.completedFuture(rawEndpoint.notify(lspMethod.name, node.params?.let { serializer.objectMapper.treeToValue<Any>(it) })) }
+                }
+
+                is JsonRpcRequest<Request, Response> -> {
+                    {
+                        rawEndpoint.request(lspMethod.name, node.params?.let { serializer.objectMapper.treeToValue<Any>(it) }).thenApply {
+                            serializer.objectMapper.readValue(
+                                Gson().toJson(it),
+                                lspMethod.response
+                            )
+                        }
+                    }
+                }
+            } as () -> CompletableFuture<Response>
+            serverAction(requestFromUi, invokeService)
+        } ?: CompletableFuture.failedFuture<Response>(IllegalStateException("LSP Server not running"))
     }
+
+    private inline fun <reified Request, Response> handleChat(
+        lspMethod: JsonRpcMethod<Request, Response>,
+        node: JsonNode,
+    ): CompletableFuture<Response> = handleChat(
+        lspMethod,
+        node,
+    ) { _, invokeService -> invokeService() }
+
+    private val JsonNode.params
+        get() = get("params")
 
     companion object {
         private val LOG = getLogger<BrowserConnector>()

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQChatServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQChatServer.kt
@@ -1,0 +1,204 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp
+
+import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethodProvider
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ButtonClickParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ButtonClickResult
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_BUTTON_CLICK
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_CONVERSATION_CLICK
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_COPY_CODE_TO_CLIPBOARD_NOTIFICATION
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_CREATE_PROMPT
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_FEEDBACK
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_FILE_CLICK
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_FOLLOW_UP_CLICK
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_INFO_LINK_CLICK
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_INSERT_TO_CURSOR_NOTIFICATION
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_LINK_CLICK
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_LIST_CONVERSATIONS
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_QUICK_ACTION
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_READY
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_SOURCE_LINK_CLICK
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_ADD
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_BAR_ACTIONS
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_CHANGE
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_REMOVE
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ConversationClickParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CopyCodeToClipboardParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CreatePromptParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedChatParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedQuickActionChatParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FeedbackParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FileClickParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FollowUpClickParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GET_SERIALIZED_CHAT_REQUEST_METHOD
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GetSerializedChatParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GetSerializedChatResult
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InfoLinkClickParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InsertToCursorPositionParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.LinkClickParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ListConversationsParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.PROMPT_INPUT_OPTIONS_CHANGE
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.PromptInputOptionChangeParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SEND_CHAT_COMMAND_PROMPT
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SourceLinkClickParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.TabBarActionParams
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.TabEventParams
+import kotlin.reflect.KProperty
+import kotlin.reflect.full.declaredMembers
+
+sealed interface JsonRpcMethod<Request, Response> {
+    val name: String
+    val params: Class<Request>
+}
+
+data class JsonRpcNotification<Request>(
+    override val name: String,
+    override val params: Class<Request>,
+) : JsonRpcMethod<Request, Unit>
+
+@Suppress("FunctionNaming")
+fun JsonRpcNotification(name: String) = JsonRpcNotification(name, Unit::class.java)
+
+data class JsonRpcRequest<Request, Response>(
+    override val name: String,
+    override val params: Class<Request>,
+    val response: Class<Response>,
+) : JsonRpcMethod<Request, Response>
+
+/**
+ * Messaging for the Chat feature follows this pattern:
+ *     Mynah-UI <-> Plugin <-> Flare LSP
+ *
+ * However, the default scenario is that the plugin only cares about a subset of request/response payload and should otherwise transparently passthrough data.
+ * To obtain some semblance of type safety, we model the subset of values that are relevant and passthrough the rest.
+ *
+ * Generally, methods MUST be modeled here if the response type is needed, or LSP4J will return null
+ */
+object AmazonQChatServer : JsonRpcMethodProvider {
+    override fun supportedMethods() = buildMap {
+        AmazonQChatServer::class.declaredMembers.filter { it is KProperty }.forEach {
+            val method = it.call(AmazonQChatServer) as JsonRpcMethod<*, *>
+
+            // trick lsp4j into returning the complete message even if we didn't model it completely
+            val lsp4jMethod = when (method) {
+                is JsonRpcNotification<*> -> org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod.notification(method.name, Any::class.java)
+                is JsonRpcRequest<*, *> -> org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod.request(method.name, Any::class.java, Any::class.java)
+            }
+
+            put(method.name, lsp4jMethod)
+        }
+    }
+
+    val sendChatPrompt = JsonRpcRequest(
+        SEND_CHAT_COMMAND_PROMPT,
+        EncryptedChatParams::class.java,
+        String::class.java
+    )
+
+    val sendQuickAction = JsonRpcRequest(
+        CHAT_QUICK_ACTION,
+        EncryptedQuickActionChatParams::class.java,
+        String::class.java
+    )
+
+    val copyCodeToClipboard = JsonRpcNotification(
+        CHAT_COPY_CODE_TO_CLIPBOARD_NOTIFICATION,
+        CopyCodeToClipboardParams::class.java,
+    )
+
+    val chatReady = JsonRpcNotification(
+        CHAT_READY,
+    )
+
+    val tabAdd = JsonRpcNotification(
+        CHAT_TAB_ADD,
+        TabEventParams::class.java
+    )
+
+    val tabRemove = JsonRpcNotification(
+        CHAT_TAB_REMOVE,
+        TabEventParams::class.java
+    )
+
+    val tabChange = JsonRpcNotification(
+        CHAT_TAB_CHANGE,
+        TabEventParams::class.java
+    )
+
+    val feedback = JsonRpcNotification(
+        CHAT_FEEDBACK,
+        FeedbackParams::class.java
+    )
+
+    val insertToCursorPosition = JsonRpcNotification(
+        CHAT_INSERT_TO_CURSOR_NOTIFICATION,
+        InsertToCursorPositionParams::class.java
+    )
+
+    val linkClick = JsonRpcNotification(
+        CHAT_LINK_CLICK,
+        LinkClickParams::class.java
+    )
+
+    val infoLinkClick = JsonRpcNotification(
+        CHAT_INFO_LINK_CLICK,
+        InfoLinkClickParams::class.java
+    )
+
+    val sourceLinkClick = JsonRpcNotification(
+        CHAT_SOURCE_LINK_CLICK,
+        SourceLinkClickParams::class.java
+    )
+
+    val promptInputOptionsChange = JsonRpcNotification(
+        PROMPT_INPUT_OPTIONS_CHANGE,
+        PromptInputOptionChangeParams::class.java
+    )
+
+    val followUpClick = JsonRpcNotification(
+        CHAT_FOLLOW_UP_CLICK,
+        FollowUpClickParams::class.java
+    )
+
+    val fileClick = JsonRpcNotification(
+        CHAT_FILE_CLICK,
+        FileClickParams::class.java
+    )
+
+    val listConversations = JsonRpcRequest(
+        CHAT_LIST_CONVERSATIONS,
+        ListConversationsParams::class.java,
+        Any::class.java
+    )
+
+    val conversationClick = JsonRpcRequest(
+        CHAT_CONVERSATION_CLICK,
+        ConversationClickParams::class.java,
+        Any::class.java
+    )
+
+    val buttonClick = JsonRpcRequest(
+        CHAT_BUTTON_CLICK,
+        ButtonClickParams::class.java,
+        ButtonClickResult::class.java
+    )
+
+    val tabBarActions = JsonRpcRequest(
+        CHAT_TAB_BAR_ACTIONS,
+        TabBarActionParams::class.java,
+        Any::class.java
+    )
+
+    val getSerializedActions = JsonRpcRequest(
+        GET_SERIALIZED_CHAT_REQUEST_METHOD,
+        GetSerializedChatParams::class.java,
+        GetSerializedChatResult::class.java
+    )
+
+    val createPrompt = JsonRpcNotification(
+        CHAT_CREATE_PROMPT,
+        CreatePromptParams::class.java
+    )
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClient.kt
@@ -7,13 +7,13 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 import org.eclipse.lsp4j.services.LanguageClient
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.LSPAny
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_OPEN_TAB
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_SEND_CONTEXT_COMMANDS
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_SEND_UPDATE
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GET_SERIALIZED_CHAT_REQUEST_METHOD
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GetSerializedChatResult
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OPEN_FILE_DIFF
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenFileDiffParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenTabResult
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SHOW_SAVE_FILE_DIALOG_REQUEST_METHOD
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ShowSaveFileDialogParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ShowSaveFileDialogResult
@@ -28,8 +28,8 @@ interface AmazonQLanguageClient : LanguageClient {
     @JsonRequest("aws/credentials/getConnectionMetadata")
     fun getConnectionMetadata(): CompletableFuture<ConnectionMetadata>
 
-    @JsonRequest("aws/chat/openTab")
-    fun openTab(params: LSPAny): CompletableFuture<OpenTabResult>
+    @JsonRequest(CHAT_OPEN_TAB)
+    fun openTab(params: LSPAny): CompletableFuture<LSPAny>
 
     @JsonRequest(SHOW_SAVE_FILE_DIALOG_REQUEST_METHOD)
     fun showSaveFileDialog(params: ShowSaveFileDialogParams): CompletableFuture<ShowSaveFileDialogResult>

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -42,7 +42,6 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GET_SERIALIZED_CHAT_REQUEST_METHOD
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GetSerializedChatResult
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenFileDiffParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenTabResult
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ShowSaveFileDialogParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ShowSaveFileDialogResult
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.ConnectionMetadata
@@ -140,9 +139,9 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
             }
         }
 
-    override fun openTab(params: LSPAny): CompletableFuture<OpenTabResult> {
+    override fun openTab(params: LSPAny): CompletableFuture<LSPAny> {
         val requestId = UUID.randomUUID().toString()
-        val result = CompletableFuture<OpenTabResult>()
+        val result = CompletableFuture<LSPAny>()
         val chatManager = ChatCommunicationManager.getInstance(project)
         chatManager.addTabOpenRequest(requestId, result)
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageServer.kt
@@ -11,50 +11,6 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.GetConfigu
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.LogInlineCompletionSessionResultsParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.LspServerConfigurations
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.UpdateConfigurationParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ButtonClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ButtonClickResult
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_BUTTON_CLICK
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_CONVERSATION_CLICK
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_COPY_CODE_TO_CLIPBOARD_NOTIFICATION
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_CREATE_PROMPT
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_FEEDBACK
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_FILE_CLICK
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_FOLLOW_UP_CLICK
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_INFO_LINK_CLICK
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_INSERT_TO_CURSOR_NOTIFICATION
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_LINK_CLICK
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_LIST_CONVERSATIONS
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_QUICK_ACTION
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_READY
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_SOURCE_LINK_CLICK
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_ADD
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_BAR_ACTIONS
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_CHANGE
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_REMOVE
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ConversationClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ConversationClickResult
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CopyCodeToClipboardParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CreatePromptParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedChatParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.EncryptedQuickActionChatParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FeedbackParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FileClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.FollowUpClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GET_SERIALIZED_CHAT_REQUEST_METHOD
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GetSerializedChatParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GetSerializedChatResult
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InfoLinkClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.InsertToCursorPositionParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.LinkClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ListConversationsParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ListConversationsResult
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.PROMPT_INPUT_OPTIONS_CHANGE
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.PromptInputOptionChangeParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SEND_CHAT_COMMAND_PROMPT
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SourceLinkClickParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.TabBarActionParams
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.TabBarActionResult
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.TabEventParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.UpdateCredentialsPayload
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.textDocument.InlineCompletionListWithReferences
@@ -86,67 +42,4 @@ interface AmazonQLanguageServer : LanguageServer {
 
     @JsonRequest("aws/updateConfiguration")
     fun updateConfiguration(params: UpdateConfigurationParams): CompletableFuture<LspServerConfigurations>
-
-    @JsonRequest(SEND_CHAT_COMMAND_PROMPT)
-    fun sendChatPrompt(params: EncryptedChatParams): CompletableFuture<String>
-
-    @JsonNotification(CHAT_COPY_CODE_TO_CLIPBOARD_NOTIFICATION)
-    fun copyCodeToClipboard(params: CopyCodeToClipboardParams): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_TAB_ADD)
-    fun tabAdd(params: TabEventParams): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_TAB_REMOVE)
-    fun tabRemove(params: TabEventParams): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_TAB_CHANGE)
-    fun tabChange(params: TabEventParams): CompletableFuture<Unit>
-
-    @JsonRequest(CHAT_QUICK_ACTION)
-    fun sendQuickAction(params: EncryptedQuickActionChatParams): CompletableFuture<String>
-
-    @JsonNotification(CHAT_INSERT_TO_CURSOR_NOTIFICATION)
-    fun insertToCursorPosition(params: InsertToCursorPositionParams): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_FEEDBACK)
-    fun feedback(params: FeedbackParams): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_READY)
-    fun chatReady(): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_LINK_CLICK)
-    fun linkClick(params: LinkClickParams): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_INFO_LINK_CLICK)
-    fun infoLinkClick(params: InfoLinkClickParams): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_SOURCE_LINK_CLICK)
-    fun sourceLinkClick(params: SourceLinkClickParams): CompletableFuture<Unit>
-
-    @JsonNotification(PROMPT_INPUT_OPTIONS_CHANGE)
-    fun promptInputOptionsChange(params: PromptInputOptionChangeParams): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_FOLLOW_UP_CLICK)
-    fun followUpClick(params: FollowUpClickParams): CompletableFuture<Unit>
-
-    @JsonNotification(CHAT_FILE_CLICK)
-    fun fileClick(params: FileClickParams): CompletableFuture<Unit>
-
-    @JsonRequest(CHAT_LIST_CONVERSATIONS)
-    fun listConversations(params: ListConversationsParams): CompletableFuture<ListConversationsResult>
-
-    @JsonRequest(CHAT_CONVERSATION_CLICK)
-    fun conversationClick(params: ConversationClickParams): CompletableFuture<ConversationClickResult>
-
-    @JsonRequest(CHAT_BUTTON_CLICK)
-    fun buttonClick(params: ButtonClickParams): CompletableFuture<ButtonClickResult>
-
-    @JsonRequest(CHAT_TAB_BAR_ACTIONS)
-    fun tabBarActions(params: TabBarActionParams): CompletableFuture<TabBarActionResult>
-
-    @JsonRequest(GET_SERIALIZED_CHAT_REQUEST_METHOD)
-    fun getSerializedActions(params: GetSerializedChatParams): CompletableFuture<GetSerializedChatResult>
-
-    @JsonNotification(CHAT_CREATE_PROMPT)
-    fun createPrompt(params: CreatePromptParams): CompletableFuture<Unit>
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -47,6 +47,8 @@ import org.eclipse.lsp4j.TextDocumentClientCapabilities
 import org.eclipse.lsp4j.WorkspaceClientCapabilities
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer
+import org.eclipse.lsp4j.jsonrpc.RemoteEndpoint
+import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import org.eclipse.lsp4j.launch.LSPLauncher
 import org.slf4j.event.Level
@@ -123,8 +125,12 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
     private var instance: Deferred<AmazonQServerInstance>
     val capabilities
         get() = instance.getCompleted().initializeResult.getCompleted().capabilities
+
     val encryptionManager
         get() = instance.getCompleted().encryptionManager
+
+    val rawEndpoint
+        get() = instance.getCompleted().rawEndpoint
 
     // dont allow lsp commands if server is restarting
     private val mutex = Mutex(false)
@@ -135,7 +141,7 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
         var attempts = 0
         while (attempts < 3) {
             try {
-                return@async withTimeout(30.seconds) {
+                val result = withTimeout(30.seconds) {
                     val instance = AmazonQServerInstance(project, cs).also {
                         Disposer.register(this@AmazonQLspService, it)
                     }
@@ -146,6 +152,9 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
                         _flowInstance.emit(it)
                     }
                 }
+
+                // withTimeout can throw
+                return@async result
             } catch (e: Exception) {
                 LOG.warn(e) { "Failed to start LSP server" }
             }
@@ -196,7 +205,7 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
         return runnable(lsp)
     }
 
-    fun<T> executeSync(runnable: suspend AmazonQLspService.(AmazonQLanguageServer) -> T): T =
+    private fun<T> executeSync(runnable: suspend AmazonQLspService.(AmazonQLanguageServer) -> T): T =
         runBlocking(cs.coroutineContext) {
             execute(runnable)
         }
@@ -205,8 +214,12 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
         private val LOG = getLogger<AmazonQLspService>()
         fun getInstance(project: Project) = project.service<AmazonQLspService>()
 
+        @Deprecated("Easy to accidentally freeze EDT")
         fun <T> executeIfRunning(project: Project, runnable: AmazonQLspService.(AmazonQLanguageServer) -> T): T? =
             project.serviceIfCreated<AmazonQLspService>()?.executeSync(runnable)
+
+        suspend fun <T> asyncExecuteIfRunning(project: Project, runnable: suspend AmazonQLspService.(AmazonQLanguageServer) -> T): T? =
+            project.serviceIfCreated<AmazonQLspService>()?.execute(runnable)
 
         fun didChangeConfiguration(project: Project) {
             executeIfRunning(project) {
@@ -223,6 +236,9 @@ private class AmazonQServerInstance(private val project: Project, private val cs
 
     val languageServer: AmazonQLanguageServer
         get() = launcher.remoteProxy
+
+    val rawEndpoint: RemoteEndpoint
+        get() = launcher.remoteEndpoint
 
     @Suppress("ForbiddenVoid")
     private val launcherFuture: Future<Void>
@@ -322,7 +338,10 @@ private class AmazonQServerInstance(private val project: Project, private val cs
         launcherHandler.addProcessListener(inputWrapper)
         launcherHandler.startNotify()
 
-        launcher = LSPLauncher.Builder<AmazonQLanguageServer>()
+        launcher = object : LSPLauncher.Builder<AmazonQLanguageServer>() {
+            override fun getSupportedMethods(): Map<String, JsonRpcMethod> =
+                super.getSupportedMethods() + AmazonQChatServer.supportedMethods()
+        }
             .wrapMessages { consumer ->
                 MessageConsumer { message ->
                     if (message is ResponseMessage && message.result is AwsExtendedInitializeResult) {
@@ -414,5 +433,3 @@ private class AmazonQServerInstance(private val project: Project, private val cs
         private val LOG = getLogger<AmazonQServerInstance>()
     }
 }
-
-typealias AmazonQInitializeMessageReceivedListener = () -> Unit

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -205,7 +205,7 @@ class AmazonQLspService(private val project: Project, private val cs: CoroutineS
         return runnable(lsp)
     }
 
-    private fun<T> executeSync(runnable: suspend AmazonQLspService.(AmazonQLanguageServer) -> T): T =
+    fun<T> executeSync(runnable: suspend AmazonQLspService.(AmazonQLanguageServer) -> T): T =
         runBlocking(cs.coroutineContext) {
             execute(runnable)
         }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
@@ -46,7 +46,7 @@ class DefaultAuthCredentialsService(
 
     private val scheduler: ScheduledExecutorService = AppExecutorUtil.getAppScheduledExecutorService()
     private var tokenSyncTask: ScheduledFuture<*>? = null
-    private val tokenSyncIntervalSeconds = 10L
+    private val tokenSyncIntervalSeconds = 900L
 
     init {
         project.messageBus.connect(serverInstance).apply {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
@@ -18,12 +18,12 @@ import software.aws.toolkits.jetbrains.core.credentials.pinning.QConnection
 import software.aws.toolkits.jetbrains.core.credentials.reauthConnectionIfNeeded
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.ProgressNotificationUtils.getObject
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.LSPAny
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.AuthFollowUpClickedParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.AuthFollowupType
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_ERROR_PARAMS
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ErrorParams
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.GetSerializedChatResult
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.OpenTabResult
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.SEND_CHAT_COMMAND_PROMPT
 import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileManager
 import software.aws.toolkits.jetbrains.services.amazonq.profile.QRegionProfileSelectedListener
@@ -37,7 +37,7 @@ class ChatCommunicationManager(private val cs: CoroutineScope) {
     private val chatPartialResultMap = ConcurrentHashMap<String, String>()
     private val inflightRequestByTabId = ConcurrentHashMap<String, CompletableFuture<String>>()
     private val pendingSerializedChatRequests = ConcurrentHashMap<String, CompletableFuture<GetSerializedChatResult>>()
-    private val pendingTabRequests = ConcurrentHashMap<String, CompletableFuture<OpenTabResult>>()
+    private val pendingTabRequests = ConcurrentHashMap<String, CompletableFuture<LSPAny>>()
 
     fun setUiReady() {
         uiReady.complete(true)
@@ -85,17 +85,12 @@ class ChatCommunicationManager(private val cs: CoroutineScope) {
         pendingSerializedChatRequests.remove(requestId)
     }
 
-    fun addTabOpenRequest(requestId: String, result: CompletableFuture<OpenTabResult>) {
+    fun addTabOpenRequest(requestId: String, result: CompletableFuture<LSPAny>) {
         pendingTabRequests[requestId] = result
     }
 
-    fun completeTabOpen(requestId: String, tabId: String) {
-        pendingTabRequests.remove(requestId)?.complete(OpenTabResult(tabId))
-    }
-
-    fun removeTabOpenRequest(requestId: String) {
+    fun removeTabOpenRequest(requestId: String) =
         pendingTabRequests.remove(requestId)
-    }
 
     fun handlePartialResultProgressNotification(project: Project, params: ProgressParams) {
         val token = ProgressNotificationUtils.getToken(params)

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/ChatMessage.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/ChatMessage.kt
@@ -71,18 +71,9 @@ data class Changes(
     val total: Int? = null,
 )
 
-@JsonAdapter(EnumJsonValueAdapter::class)
-enum class IconType(@JsonValue val repr: String) {
-    FILE("file"),
-    FOLDER("folder"),
-    CODE_BLOCK("code-block"),
-    LIST_ADD("list-add"),
-    MAGIC("magic"),
-    HELP("help"),
-    TRASH("trash"),
-    SEARCH("search"),
-    CALENDAR("calendar"),
-}
+// i don't want to model 70+ icon types
+// https://github.com/aws/mynah-ui/blob/38608dff905b3790d85c73e2911ec7071c8a8cdf/src/components/icon.ts#L12
+typealias IconType = String
 
 @JsonAdapter(EnumJsonValueAdapter::class)
 enum class Status(@JsonValue val repr: String) {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/TabEvent.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/TabEvent.kt
@@ -25,10 +25,10 @@ data class OpenTabResult(
 )
 
 data class OpenTabResultError(
-    val error: OpenTabResultErrorError,
+    val error: OpenTabResultErrorData,
 )
 
-data class OpenTabResultErrorError(
+data class OpenTabResultErrorData(
     val type: String,
     val message: String,
 )

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/TabEvent.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/TabEvent.kt
@@ -14,15 +14,21 @@ data class TabEventParams(
 
 data class OpenTabResponse(
     val requestId: String,
-    val command: String,
-    val params: OpenTabResponseParams,
 )
 
-data class OpenTabResponseParams(
-    val success: Boolean,
+data class OpenTabResultSuccess(
     val result: OpenTabResult,
 )
 
 data class OpenTabResult(
     val tabId: String,
+)
+
+data class OpenTabResultError(
+    val error: OpenTabResultErrorError,
+)
+
+data class OpenTabResultErrorError(
+    val type: String,
+    val message: String,
 )

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/ChatMessageTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/aws/chat/ChatMessageTest.kt
@@ -20,14 +20,14 @@ class ChatMessageTest {
     @Test
     fun `sanity check`() {
         val jackson = jacksonObjectMapper()
-        assertThat(IconType.CODE_BLOCK).satisfiesKt {
+        assertThat(MessageType.SYSTEM_PROMPT).satisfiesKt {
             // language=JSON
-            val expected = """"code-block""""
+            val expected = """"system-prompt""""
             assertThat(Gson().toJson(it)).isEqualTo(expected)
             assertThat(jackson.writeValueAsString(it)).isEqualTo(expected)
 
-            assertThat(Gson().fromJson(expected, IconType::class.java)).isEqualTo(it)
-            assertThat(jackson.readValue<IconType>(expected)).isEqualTo(it)
+            assertThat(Gson().fromJson(expected, MessageType::class.java)).isEqualTo(it)
+            assertThat(jackson.readValue<MessageType>(expected)).isEqualTo(it)
         }
     }
 


### PR DESCRIPTION
There is a high possibiltiy of drift in our modeling as the UI <-> Server evolves.

To avoid a treadmill in making sure these are always up to date, avoid materializing these messages into concrete types
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
