### PR TITLE
fix(amazonq): do not call didChangeDependencyPaths on EDT

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependenciesService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependenciesService.kt
@@ -7,5 +7,5 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependenci
 import java.util.concurrent.CompletableFuture
 
 interface ModuleDependenciesService {
-    fun didChangeDependencyPaths(params: DidChangeDependencyPathsParams): CompletableFuture<Unit>
+    fun didChangeDependencyPaths(params: DidChangeDependencyPathsParams)
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependenciesService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/ModuleDependenciesService.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies
 
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependencies.DidChangeDependencyPathsParams
-import java.util.concurrent.CompletableFuture
 
 interface ModuleDependenciesService {
     fun didChangeDependencyPaths(params: DidChangeDependencyPathsParams)

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesServiceTest.kt
@@ -3,14 +3,13 @@
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.Application
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.serviceIfCreated
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootEvent
+import com.intellij.testFramework.ApplicationExtension
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import io.mockk.every
@@ -23,6 +22,7 @@ import io.mockk.verify
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLanguageServer
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.ModuleDependencyProvider.Companion.EP_NAME
@@ -30,12 +30,12 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.dependenci
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 
+@ExtendWith(ApplicationExtension::class)
 class DefaultModuleDependenciesServiceTest {
     private lateinit var project: Project
     private lateinit var mockLanguageServer: AmazonQLanguageServer
     private lateinit var mockModuleManager: ModuleManager
     private lateinit var sut: DefaultModuleDependenciesService
-    private lateinit var mockApplication: Application
     private lateinit var mockDependencyProvider: ModuleDependencyProvider
 
     @BeforeEach
@@ -46,11 +46,6 @@ class DefaultModuleDependenciesServiceTest {
         mockLanguageServer = mockk()
 
         every { mockLanguageServer.didChangeDependencyPaths(any()) } returns CompletableFuture<Unit>()
-
-        // Mock Application
-        mockApplication = mockk()
-        mockkStatic(ApplicationManager::class)
-        every { ApplicationManager.getApplication() } returns mockApplication
 
         // Mock message bus
         val messageBus = mockk<MessageBus>()


### PR DESCRIPTION
```
Freeze for 51 seconds
Sampled time: 37800ms, sampling rate: 100ms, GC time: 312ms (0%), Class loading: 0%, CPU load: 46%

com.intellij.diagnostic.Freeze
	at java.base@21.0.6/java.io.FileOutputStream.writeBytes(Native Method)
	at java.base@21.0.6/java.io.FileOutputStream.write(FileOutputStream.java:367)
	at java.base@21.0.6/java.io.BufferedOutputStream.implWrite(BufferedOutputStream.java:217)
	at java.base@21.0.6/java.io.BufferedOutputStream.write(BufferedOutputStream.java:206)
	at java.base@21.0.6/java.io.FilterOutputStream.write(FilterOutputStream.java:110)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer.consume(StreamMessageConsumer.java:68)
	at org.eclipse.lsp4j.jsonrpc.TracingMessageConsumer.consume(TracingMessageConsumer.java:119)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance.lambda$12$lambda$11(AmazonQLspService.kt:332)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance$$Lambda/0x0000007003314b80.consume(Unknown Source)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.notify(RemoteEndpoint.java:135)
	at org.eclipse.lsp4j.jsonrpc.services.EndpointProxy.invoke(EndpointProxy.java:88)
	at jdk.proxy13/jdk.proxy13.$Proxy186.didChangeDependencyPaths(Unknown Source)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.DefaultModuleDependenciesService.didChangeDependencyPaths$lambda$0(DefaultModuleDependenciesService.kt:39)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.dependencies.DefaultModuleDependenciesService$$Lambda/0x00000070037e4238.invoke(Unknown Source)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService$Companion.executeIfRunning$suspendConversion1(AmazonQLspService.kt:209)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService$Companion.access$executeIfRunning$suspendConversion1(AmazonQLspService.kt:204)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService$Companion$executeIfRunning$1.invoke(AmazonQLspService.kt:209)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService$Companion$executeIfRunning$1.invoke(AmazonQLspService.kt:209)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService.execute(AmazonQLspService.kt:196)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService$executeSync$1.invokeSuspend(AmazonQLspService.kt:201)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
