### PR TITLE
feat(amazonq): hook up showMessage/logMessage/showDocument correctly

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -7,6 +7,8 @@ import com.intellij.diff.DiffContentFactory
 import com.intellij.diff.DiffManager
 import com.intellij.diff.DiffManagerEx
 import com.intellij.diff.requests.SimpleDiffRequest
+import com.intellij.ide.BrowserUtil
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileChooser.FileChooserFactory
 import com.intellij.openapi.fileChooser.FileSaverDescriptor
@@ -48,6 +50,8 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credential
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.credentials.SsoProfileData
 import software.aws.toolkits.jetbrains.services.codewhisperer.customization.CodeWhispererModelConfigurator
 import software.aws.toolkits.jetbrains.settings.CodeWhispererSettings
+import software.aws.toolkits.jetbrains.utils.getCleanedContent
+import software.aws.toolkits.jetbrains.utils.notify
 import software.aws.toolkits.resources.message
 import java.io.File
 import java.nio.file.Files
@@ -70,19 +74,12 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
 
     override fun showMessage(messageParams: MessageParams) {
         val type = when (messageParams.type) {
-            MessageType.Error -> Level.ERROR
-            MessageType.Warning -> Level.WARN
-            MessageType.Info, MessageType.Log -> Level.INFO
+            MessageType.Error -> NotificationType.ERROR
+            MessageType.Warning -> NotificationType.WARNING
+            MessageType.Info, MessageType.Log -> NotificationType.INFORMATION
         }
 
-        if (type == Level.ERROR &&
-            messageParams.message.lineSequence().firstOrNull()?.contains("NOTE: The AWS SDK for JavaScript (v2) is in maintenance mode.") == true
-        ) {
-            LOG.info { "Suppressed Flare AWS JS SDK v2 EoL error message" }
-            return
-        }
-
-        LOG.atLevel(type).log(messageParams.message)
+        notify(type, message("q.window.title"), getCleanedContent(messageParams.message, true), project, emptyList())
     }
 
     override fun showMessageRequest(requestParams: ShowMessageRequestParams): CompletableFuture<MessageActionItem?>? {
@@ -92,13 +89,31 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
     }
 
     override fun logMessage(message: MessageParams) {
-        showMessage(message)
+        val type = when (message.type) {
+            MessageType.Error -> Level.ERROR
+            MessageType.Warning -> Level.WARN
+            MessageType.Info, MessageType.Log -> Level.INFO
+        }
+
+        if (type == Level.ERROR &&
+            message.message.lineSequence().firstOrNull()?.contains("NOTE: The AWS SDK for JavaScript (v2) is in maintenance mode.") == true
+        ) {
+            LOG.info { "Suppressed Flare AWS JS SDK v2 EoL error message" }
+            return
+        }
+
+        LOG.atLevel(type).log(message.message)
     }
 
-    override fun showDocument(params: ShowDocumentParams?): CompletableFuture<ShowDocumentResult> {
+    override fun showDocument(params: ShowDocumentParams): CompletableFuture<ShowDocumentResult> {
         try {
-            if (params == null || params.uri.isNullOrEmpty()) {
+            if (params.uri.isNullOrEmpty()) {
                 return CompletableFuture.completedFuture(ShowDocumentResult(false))
+            }
+
+            if (params.external == true) {
+                BrowserUtil.open(params.uri)
+                return CompletableFuture.completedFuture(ShowDocumentResult(true))
             }
 
             ApplicationManager.getApplication().invokeLater {

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/NotificationUtils.kt
@@ -42,7 +42,7 @@ fun Throwable.notifyError(title: String = "", project: Project? = null, stripHtm
     )
 }
 
-private fun notify(type: NotificationType, title: String, content: String = "", project: Project? = null, notificationActions: Collection<AnAction>) {
+fun notify(type: NotificationType, title: String, content: String = "", project: Project? = null, notificationActions: Collection<AnAction>) {
     val notification = Notification(GROUP_DISPLAY_ID, title, content, type)
     notificationActions.forEach {
         notification.addAction(if (it !is NotificationAction) createNotificationExpiringAction(it) else it)
@@ -182,4 +182,4 @@ fun createShowMoreInfoDialogAction(actionName: String?, title: String?, message:
         }
     }
 
-private fun getCleanedContent(content: String, stripHtml: Boolean): String = if (stripHtml) StringUtil.stripHtml(content, true) else content
+fun getCleanedContent(content: String, stripHtml: Boolean): String = if (stripHtml) StringUtil.stripHtml(content, true) else content


### PR DESCRIPTION
logMessage incorrectly piped everything through showMessage, and showDocument did not respect the `external` flag

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
