### PR TITLE
fix(amazonq): cancel chat export doesn't bubble error up to user

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -401,7 +401,9 @@ class BrowserConnector(
                                 val cause = if (e is CompletionException) e.cause else e
 
                                 // dont post error to UI if user cancels export
-                                if (!(cause is ResponseErrorException && cause.responseError.message == "Export cancelled by user")) {
+                                if (cause is ResponseErrorException && cause.responseError.code == "ResponseErrorCode.RequestCancelled) {
+                                    return@whenComplete
+}
                                     LOG.error { "Failed to perform chat tab bar action $e" }
                                     params.tabId?.let {
                                         browser.postChat(chatCommunicationManager.getErrorUiMessage(it, e, null))

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -384,7 +384,6 @@ class BrowserConnector(
 
             CHAT_TAB_BAR_ACTIONS -> {
                 handleChat(AmazonQChatServer.tabBarActions, node) { params, invoke ->
-                    println("handling TabBarActions")
                     invoke()
                         .whenComplete { actions, error ->
                             try {

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.launch
 import org.cef.browser.CefBrowser
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
@@ -384,6 +385,7 @@ class BrowserConnector(
 
             CHAT_TAB_BAR_ACTIONS -> {
                 handleChat(AmazonQChatServer.tabBarActions, node) { params, invoke ->
+                    println("handling TabBarActions")
                     invoke()
                         .whenComplete { actions, error ->
                             try {
@@ -401,13 +403,12 @@ class BrowserConnector(
                                 val cause = if (e is CompletionException) e.cause else e
 
                                 // dont post error to UI if user cancels export
-                                if (cause is ResponseErrorException && cause.responseError.code == "ResponseErrorCode.RequestCancelled) {
+                                if (cause is ResponseErrorException && cause.responseError.code == ResponseErrorCode.RequestCancelled.getValue()) {
                                     return@whenComplete
-}
-                                    LOG.error { "Failed to perform chat tab bar action $e" }
-                                    params.tabId?.let {
-                                        browser.postChat(chatCommunicationManager.getErrorUiMessage(it, e, null))
-                                    }
+                                }
+                                LOG.error { "Failed to perform chat tab bar action $e" }
+                                params.tabId?.let {
+                                    browser.postChat(chatCommunicationManager.getErrorUiMessage(it, e, null))
                                 }
                             }
                         }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/languages/CodeWhispererAbap.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/languages/CodeWhispererAbap.kt
@@ -11,8 +11,6 @@ class CodeWhispererAbap private constructor() : CodeWhispererProgrammingLanguage
 
     override fun toTelemetryType(): CodewhispererLanguage = CodewhispererLanguage.Abap
 
-    override fun isCodeCompletionSupported(): Boolean = true
-
     companion object {
         const val ID = "abap"
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -233,7 +233,7 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
 
                 chosenFile?.let {
                     ShowSaveFileDialogResult(chosenFile.file.path)
-                }?: throw ResponseErrorException(ResponseError(ResponseErrorCode.RequestCancelled, "Export cancelled by user", null))
+                } ?: throw ResponseErrorException(ResponseError(ResponseErrorCode.RequestCancelled, "Export cancelled by user", null))
             },
             ApplicationManager.getApplication()::invokeLater
         )

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -22,6 +22,9 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.ShowDocumentParams
 import org.eclipse.lsp4j.ShowDocumentResult
 import org.eclipse.lsp4j.ShowMessageRequestParams
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode
 import org.slf4j.event.Level
 import software.aws.toolkits.core.utils.error
 import software.aws.toolkits.core.utils.getLogger
@@ -215,8 +218,7 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
 
                 chosenFile?.let {
                     ShowSaveFileDialogResult(chosenFile.file.path)
-                    // TODO: Add error state shown in chat ui instead of throwing
-                } ?: throw Error("Export failed")
+                } ?: throw ResponseErrorException(ResponseError(ResponseErrorCode.RequestCancelled, "Export cancelled by user", null))
             },
             ApplicationManager.getApplication()::invokeLater
         )

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -233,7 +233,7 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
 
                 chosenFile?.let {
                     ShowSaveFileDialogResult(chosenFile.file.path)
-                } ?: throw ResponseErrorException(ResponseError(ResponseErrorCode.RequestCancelled, "Export cancelled by user", null))
+                }?: throw ResponseErrorException(ResponseError(ResponseErrorCode.RequestCancelled, "Export cancelled by user", null))
             },
             ApplicationManager.getApplication()::invokeLater
         )


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
Clicking cancel after save popup window would bubble up an error to the user in the IDE, and also print the error to the chat UI. 

This change throws the right error when a user selects cancel on the save window and filters out the error from being printed in the chat.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
