### PR TITLE
feat(amazonq): pass workspaceIdentifier when initializing AmazonQLanguageServer

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -244,7 +244,7 @@ private class AmazonQServerInstance(private val project: Project, private val cs
             capabilities = createClientCapabilities()
             clientInfo = createClientInfo()
             workspaceFolders = createWorkspaceFolders(project)
-            initializationOptions = createExtendedClientMetadata()
+            initializationOptions = createExtendedClientMetadata(project)
         }
 
     init {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/ExtendedClientMetadata.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/model/ExtendedClientMetadata.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.amazonq.lsp.model
 
+import com.intellij.openapi.project.Project
 import software.aws.toolkits.jetbrains.services.telemetry.ClientMetadata
 
 data class ExtendedClientMetadata(
@@ -12,6 +13,7 @@ data class ExtendedClientMetadata(
 data class AwsMetadata(
     val clientInfo: ClientInfoMetadata,
     val awsClientCapabilities: AwsClientCapabilities,
+    val contextConfiguration: ContextConfiguration?,
 )
 
 data class AwsClientCapabilities(
@@ -34,7 +36,11 @@ data class ExtensionMetadata(
     val version: String,
 )
 
-fun createExtendedClientMetadata(): ExtendedClientMetadata {
+data class ContextConfiguration(
+    val workspaceIdentifier: String?,
+)
+
+fun createExtendedClientMetadata(project: Project): ExtendedClientMetadata {
     val metadata = ClientMetadata.getDefault()
     return ExtendedClientMetadata(
         aws = AwsMetadata(
@@ -51,6 +57,9 @@ fun createExtendedClientMetadata(): ExtendedClientMetadata {
                 q = DeveloperProfiles(
                     developerProfiles = true
                 )
+            ),
+            contextConfiguration = ContextConfiguration(
+                workspaceIdentifier = project.getBasePath()
             )
         )
     )


### PR DESCRIPTION
## Problem

AmazonQ LSP needs an identifier for the IDE workspace, which should be stable and unique for each workspace, regardless of IDE restarts or system reboots.

Related `aws/language-server-runtimes` change:
- https://github.com/aws/language-server-runtimes/pull/497

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Description

Use `Project.getBasePath()` as such an identifier and pass it when initializing AmazonQ language server.

Similar change on `aws/aws-toolkit-vscode` side:
- https://github.com/aws/aws-toolkit-vscode/pull/7291

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
