### PR TITLE
build: temporarily change version scheme for internal

### DIFF
--- a/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
@@ -35,7 +35,7 @@ val toolkitVersion: String by project
 
 // please check changelog generation logic if this format is changed
 // also sync with gateway version
-version = "$toolkitVersion-${ideProfile.shortName}"
+version = "$toolkitVersion.${ideProfile.shortName}"
 
 val resharperDlls = configurations.register("resharperDlls") {
     isCanBeConsumed = false


### PR DESCRIPTION
internal only allows dots
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
