### PR TITLE
fix(amazonq): refreshVfs async to try to avoid slow EDT op

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -413,7 +413,7 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
         if (currPath.startsWith(localHistoryPath)) return
         try {
             ApplicationManager.getApplication().invokeLater {
-                VfsUtil.markDirtyAndRefresh(false, true, true, currPath.toFile())
+                VfsUtil.markDirtyAndRefresh(true, true, true, currPath.toFile())
             }
         } catch (e: Exception) {
             LOG.warn(e) { "Could not refresh file" }


### PR DESCRIPTION
```
java.lang.Throwable: Slow operations are prohibited on EDT. See SlowOperations.assertSlowOperationsAreAllowed javadoc.
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:375)
	at com.intellij.util.SlowOperations.assertSlowOperationsAreAllowed(SlowOperations.java:113)
	at com.intellij.openapi.vfs.newvfs.persistent.FSRecordsImpl.update(FSRecordsImpl.java:756)
	at com.intellij.openapi.vfs.newvfs.persistent.PersistentFSImpl.findChildInfo(PersistentFSImpl.java:620)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.findInPersistence(VirtualDirectoryImpl.java:155)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.doFindChild(VirtualDirectoryImpl.java:138)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.findChild(VirtualDirectoryImpl.java:84)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.refreshAndFindChild(VirtualDirectoryImpl.java:387)
	at com.intellij.openapi.vfs.newvfs.VfsImplUtil.refreshAndFindFileByPath(VfsImplUtil.java:118)
	at com.intellij.openapi.vfs.impl.local.LocalFileSystemBase.refreshAndFindFileByPath(LocalFileSystemBase.java:67)
	at com.intellij.openapi.vfs.LocalFileSystem.refreshAndFindFileByIoFile(LocalFileSystem.java:45)
	at com.intellij.util.containers.ContainerUtil.map(ContainerUtil.java:2165)
	at com.intellij.openapi.vfs.VfsUtil.markDirtyAndRefresh(VfsUtil.java:489)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLanguageClientImpl.refreshVfs$lambda$33(AmazonQLanguageClientImpl.kt:416)
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
