### PR TITLE
fix: delete `println("handling TabBarActions")`

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -385,7 +385,6 @@ class BrowserConnector(
 
             CHAT_TAB_BAR_ACTIONS -> {
                 handleChat(AmazonQChatServer.tabBarActions, node) { params, invoke ->
-                    println("handling TabBarActions")
                     invoke()
                         .whenComplete { actions, error ->
                             try {


### PR DESCRIPTION

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
