### PR TITLE
fix: Use JetBrains default font for inline chat popup

### DIFF
--- a/.changes/next-release/bugfix-061149bd-c6ef-4c86-9f12-98e38fe3b576.json
+++ b/.changes/next-release/bugfix-061149bd-c6ef-4c86-9f12-98e38fe3b576.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Support full Unicode range in inline chat panel on Windows"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/InlineChatPopupPanel.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/InlineChatPopupPanel.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import com.intellij.openapi.editor.actionSystem.EditorActionManager
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.IdeBorderFactory
 import icons.AwsIcons
@@ -18,7 +17,6 @@ import software.aws.toolkits.jetbrains.services.codewhisperer.util.CodeWhisperer
 import software.aws.toolkits.resources.AmazonQBundle.message
 import java.awt.BorderLayout
 import java.awt.Dimension
-import java.awt.Font
 import javax.swing.BorderFactory
 import javax.swing.JButton
 import javax.swing.JLabel

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/InlineChatPopupPanel.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/inline/InlineChatPopupPanel.kt
@@ -95,12 +95,10 @@ class InlineChatPopupPanel(private val parentDisposable: Disposable) : JPanel() 
     override fun getPreferredSize(): Dimension = Dimension(popupWidth, popupHeight)
 
     private fun createTextField(): JTextField = JTextField().apply {
-        val editorColorsScheme = EditorColorsManager.getInstance().globalScheme
         preferredSize = Dimension(popupInputWidth, popupInputHeight)
         border = IdeBorderFactory.createRoundedBorder().apply {
             setColor(POPUP_BUTTON_BORDER)
         }
-        font = Font(editorColorsScheme.editorFontName, Font.PLAIN, editorColorsScheme.editorFontSize)
     }
 
     private fun createButton(text: String): JButton = JButton(text).apply {


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Use the JetBrains default font for the inline chat popup.
* Canonical with fonts in other popups (e.g find all, search everywhere), instead of editor font
* Supports full Unicode fonts in Windows
  * MacOS unaffected

![image](https://github.com/user-attachments/assets/162cced4-cb8d-4578-95a0-1f01560402e7)


## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
