### PR TITLE
fix(amazonq): remove `depends` declarations for languages that do not use IDE classes

### DIFF
--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-dart.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-dart.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererDart"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-datagrip.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-datagrip.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererSql"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-go.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-go.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererGo"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-kotlin.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-kotlin.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererKotlin"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-lua.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-lua.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererLua"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-php.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-php.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererPhp"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-powershell.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-powershell.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererPowershell"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-r.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-r.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererR"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-rider.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-rider.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererCsharp"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-ruby.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-ruby.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererRuby"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-rust-deprecated.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-rust-deprecated.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererRust"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-rust.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-rust.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererRust"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-scala.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-scala.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererScala"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-shell.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-shell.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererShell"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-swift.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-swift.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererSwift"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-systemverfilog.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-systemverfilog.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererSystemVerilog"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-vue.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/amazonq-ext-vue.xml
@@ -1,8 +1,0 @@
-<!-- Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<idea-plugin>
-    <extensions defaultExtensionNs="amazon.q.codewhisperer">
-        <programmingLanguage implementation="software.aws.toolkits.jetbrains.services.codewhisperer.language.languages.CodeWhispererVue"/>
-    </extensions>
-</idea-plugin>

--- a/plugins/amazonq/src/main/resources/META-INF/plugin.xml
+++ b/plugins/amazonq/src/main/resources/META-INF/plugin.xml
@@ -58,26 +58,9 @@
     <depends>aws.toolkit.core</depends>
     <depends>com.intellij.modules.lang</depends>
 
-    <depends optional="true" config-file="amazonq-ext-dart.xml">Dart</depends>
-    <depends optional="true" config-file="amazonq-ext-datagrip.xml">com.intellij.database</depends>
-    <depends optional="true" config-file="amazonq-ext-go.xml">org.jetbrains.plugins.go</depends>
     <depends optional="true" config-file="amazonq-ext-java.xml">com.intellij.java</depends>
-    <depends optional="true" config-file="amazonq-ext-kotlin.xml">org.jetbrains.kotlin</depends>
-    <depends optional="true" config-file="amazonq-ext-lua.xml">com.tang</depends>
     <depends optional="true" config-file="amazonq-ext-nodejs.xml">JavaScriptDebugger</depends>
-    <depends optional="true" config-file="amazonq-ext-php.xml">com.jetbrains.php</depends>
-    <depends optional="true" config-file="amazonq-ext-powershell.xml">com.intellij.plugin.adernov.powershell</depends>
     <depends optional="true" config-file="amazonq-ext-python.xml">com.intellij.modules.python</depends>
-    <depends optional="true" config-file="amazonq-ext-r.xml">R4Intellij</depends>
-    <depends optional="true" config-file="amazonq-ext-rider.xml">com.intellij.modules.rider</depends>
-    <depends optional="true" config-file="amazonq-ext-ruby.xml">org.jetbrains.plugins.ruby</depends>
-    <depends optional="true" config-file="amazonq-ext-rust.xml">com.jetbrains.rust</depends>
-    <depends optional="true" config-file="amazonq-ext-rust-deprecated.xml">org.rust.lang</depends>
-    <depends optional="true" config-file="amazonq-ext-scala.xml">org.intellij.scala</depends>
-    <depends optional="true" config-file="amazonq-ext-swift.xml">com.intellij.swift</depends>
-    <depends optional="true" config-file="amazonq-ext-shell.xml">com.jetbrains.sh</depends>
-    <depends optional="true" config-file="amazonq-ext-systemverfilog.xml">studio.edaphic.sv</depends>
-    <depends optional="true" config-file="amazonq-ext-vue.xml">org.jetbrains.plugins.vue</depends>
 
     <incompatible-with>com.intellij.cwm.guest</incompatible-with>
     <incompatible-with>com.intellij.jetbrains.client</incompatible-with>


### PR DESCRIPTION
Reduce risk of loading classes from incorrect plugin classloader
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
