### PR TITLE
fix(chat): Use editor background for chat background

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
@@ -42,10 +42,10 @@ class ThemeBrowserAdapter {
         append(CssVariable.TextColorWeak, theme.inactiveText)
         append(CssVariable.TextColorDisabled, theme.inactiveText)
 
-        append(CssVariable.Background, theme.background)
+        append(CssVariable.Background, theme.editorBackground)
         append(CssVariable.BackgroundAlt, theme.background)
         append(CssVariable.CardBackground, theme.editorBackground)
-        append(CssVariable.CardBackgroundAlt, theme.editorBackground)
+        append(CssVariable.CardBackgroundAlt, theme.background)
         append(CssVariable.BorderDefault, theme.border)
         append(CssVariable.TabActive, theme.activeTab)
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Chat was using the incorrect color as a background. Converging on the editor's background.
* Note: this matches the card background, but this is similar to VSC. Can revisit at a later time.

Before (Nord theme, JB on left, VSC on right):
![image](https://github.com/user-attachments/assets/1b656be6-67ed-4625-a18c-a127e3726254)

After (Nord theme, JB on left, VSC on right)
![image](https://github.com/user-attachments/assets/860a4ac3-bb03-4f14-bd8c-6914f961f198)

General dark theme (post-fix)
![image](https://github.com/user-attachments/assets/7108e943-f6e4-4385-9f04-0d82b6d81bb4)


## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
