### PR TITLE
config(amazonq): remove .acds file extension from abap language

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/language/CodeWhispererLanguageManager.kt
@@ -148,7 +148,7 @@ class CodeWhispererLanguageManager {
             listOf("vue") to CodeWhispererVue.INSTANCE,
             listOf("ps1", "psm1") to CodeWhispererPowershell.INSTANCE,
             listOf("r") to CodeWhispererR.INSTANCE,
-            listOf("abap", "acds") to CodeWhispererAbap.INSTANCE,
+            listOf("abap") to CodeWhispererAbap.INSTANCE,
         ).map {
             val exts = it.first
             val lang = it.second

--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/codewhisperer/CodeWhispererLanguageManagerTest.kt
@@ -137,7 +137,7 @@ class CodeWhispererLanguageManagerTest {
         testGetProgrammingLanguageUtil<CodeWhispererSwift>(listOf("foo"), listOf("swift"))
         testGetProgrammingLanguageUtil<CodeWhispererSystemVerilog>(listOf("foo"), listOf("sv", "svh", "vh"))
         testGetProgrammingLanguageUtil<CodeWhispererVue>(listOf("foo"), listOf("vue"))
-        testGetProgrammingLanguageUtil<CodeWhispererAbap>(listOf("foo"), listOf("abap", "acds"))
+        testGetProgrammingLanguageUtil<CodeWhispererAbap>(listOf("foo"), listOf("abap"))
     }
 
     @Test


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Team decides to remove `.acds` and only allow `.abap` as the file extension of `abap` language

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
