### PR TITLE
fix(amazonq): use progress bar decorator while loading q chat on remote

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQPanel.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQPanel.kt
@@ -9,8 +9,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.components.JBLoadingPanel
 import com.intellij.ui.components.JBTextArea
-import com.intellij.ui.components.panels.Wrapper
 import com.intellij.ui.components.ProgressBarLoadingDecorator
+import com.intellij.ui.components.panels.Wrapper
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.AlignY


### PR DESCRIPTION
animated icons do not show up on remote

<img width="1228" alt="Screenshot 2025-05-21 at 5 38 29 PM" src="https://github.com/user-attachments/assets/bd201e09-7647-460a-b28d-a6f277543273" />

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
