### PR TITLE
fix(amazonq): fix issue where AmazonQLspService subservices are never disposed

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -476,10 +476,18 @@ private class AmazonQServerInstance(private val project: Project, private val cs
             }
 
             this@AmazonQServerInstance.apply {
-                DefaultAuthCredentialsService(project, encryptionManager, this)
-                TextDocumentServiceHandler(project, this)
-                WorkspaceServiceHandler(project, lspInitResult, this)
-                DefaultModuleDependenciesService(project, this)
+                DefaultAuthCredentialsService(project, encryptionManager).also {
+                    Disposer.register(this, it)
+                }
+                TextDocumentServiceHandler(project).also {
+                    Disposer.register(this, it)
+                }
+                WorkspaceServiceHandler(project, lspInitResult).also {
+                    Disposer.register(this, it)
+                }
+                DefaultModuleDependenciesService(project).also {
+                    Disposer.register(this, it)
+                }
             }
         }
     }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/auth/DefaultAuthCredentialsService.kt
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit
 class DefaultAuthCredentialsService(
     private val project: Project,
     private val encryptionManager: JwtEncryptionManager,
-    serverInstance: Disposable,
 ) : AuthCredentialsService,
     BearerTokenProviderListener,
     ToolkitConnectionManagerListener,
@@ -50,7 +49,7 @@ class DefaultAuthCredentialsService(
     private val tokenSyncIntervalMinutes = 5L
 
     init {
-        project.messageBus.connect(serverInstance).apply {
+        project.messageBus.connect(this).apply {
             subscribe(BearerTokenProviderListener.TOPIC, this@DefaultAuthCredentialsService)
             subscribe(ToolkitConnectionManagerListener.TOPIC, this@DefaultAuthCredentialsService)
             subscribe(QRegionProfileSelectedListener.TOPIC, this@DefaultAuthCredentialsService)

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/dependencies/DefaultModuleDependenciesService.kt
@@ -15,12 +15,12 @@ import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 
 class DefaultModuleDependenciesService(
     private val project: Project,
-    serverInstance: Disposable,
 ) : ModuleDependenciesService,
-    ModuleRootListener {
-
+    ModuleRootListener,
+    Disposable
+{
     init {
-        project.messageBus.connect(serverInstance).subscribe(
+        project.messageBus.connect(this).subscribe(
             ModuleRootListener.TOPIC,
             this
         )
@@ -51,5 +51,8 @@ class DefaultModuleDependenciesService(
                 }
             }
         }
+    }
+
+    override fun dispose() {
     }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -32,27 +32,27 @@ import software.aws.toolkits.jetbrains.utils.pluginAwareExecuteOnPooledThread
 
 class TextDocumentServiceHandler(
     private val project: Project,
-    private val serverInstance: Disposable,
 ) : FileDocumentManagerListener,
     FileEditorManagerListener,
     BulkFileListener,
-    DocumentListener {
-
+    DocumentListener,
+    Disposable
+{
     init {
         // didOpen & didClose events
-        project.messageBus.connect(serverInstance).subscribe(
+        project.messageBus.connect(this).subscribe(
             FileEditorManagerListener.FILE_EDITOR_MANAGER,
             this
         )
 
         // didChange events
-        project.messageBus.connect(serverInstance).subscribe(
+        project.messageBus.connect(this).subscribe(
             VirtualFileManager.VFS_CHANGES,
             this
         )
 
         // didSave events
-        project.messageBus.connect(serverInstance).subscribe(
+        project.messageBus.connect(this).subscribe(
             FileDocumentManagerListener.TOPIC,
             this
         )
@@ -72,7 +72,7 @@ class TextDocumentServiceHandler(
                         realTimeEdit(event)
                     }
                 },
-                serverInstance
+                this
             )
         }
         AmazonQLspService.executeIfRunning(project) { languageServer ->
@@ -182,5 +182,8 @@ class TextDocumentServiceHandler(
             }
         }
         // Process document changes here
+    }
+
+    override fun dispose() {
     }
 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/workspace/WorkspaceServiceHandler.kt
@@ -45,9 +45,8 @@ import java.nio.file.Paths
 class WorkspaceServiceHandler(
     private val project: Project,
     initializeResult: InitializeResult,
-    serverInstance: Disposable,
 ) : BulkFileListener,
-    ModuleRootListener {
+    ModuleRootListener, Disposable {
 
     private var lastSnapshot: List<WorkspaceFolder> = emptyList()
     private val operationMatchers: MutableMap<FileOperationType, List<Pair<PathMatcher, String>>> = mutableMapOf()
@@ -55,12 +54,12 @@ class WorkspaceServiceHandler(
     init {
         operationMatchers.putAll(initializePatterns(initializeResult))
 
-        project.messageBus.connect(serverInstance).subscribe(
+        project.messageBus.connect(this).subscribe(
             VirtualFileManager.VFS_CHANGES,
             this
         )
 
-        project.messageBus.connect(serverInstance).subscribe(
+        project.messageBus.connect(this).subscribe(
             ModuleRootListener.TOPIC,
             this
         )
@@ -312,5 +311,8 @@ class WorkspaceServiceHandler(
 
             lastSnapshot = currentSnapshot
         }
+    }
+
+    override fun dispose() {
     }
 }


### PR DESCRIPTION
```
2025-05-22 13:48:20,938 [ 325907]   WARN - software.aws.toolkits.jetbrains.services.amazonq.lsp.auth.DefaultAuthCredentialsService - Failed to sync bearer token to Flare
com.intellij.serviceContainer.AlreadyDisposedException: Container is already disposed
	at com.intellij.serviceContainer.ComponentManagerImplKt.throwAlreadyDisposedIfNotUnderIndicatorOrJob(ComponentManagerImpl.kt:1669)
	at com.intellij.serviceContainer.ComponentManagerImplKt.access$throwAlreadyDisposedIfNotUnderIndicatorOrJob(ComponentManagerImpl.kt:1)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:722)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:696)
	at software.aws.toolkits.jetbrains.core.credentials.ToolkitConnectionManager$Companion.getInstance(ToolkitAuthManager.kt:419)
	at software.aws.toolkits.jetbrains.utils.FunctionUtilsKt.isQConnected(FunctionUtils.kt:43)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.auth.DefaultAuthCredentialsService.startPeriodicTokenSync$lambda$5(DefaultAuthCredentialsService.kt:73)
	at com.intellij.util.concurrency.Propagation$capturePropagationContext$$inlined$Runnable$1.run(Runnable.kt:17)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.runAndReset$$$capture(FutureTask.java:358)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at java.base/java.util.concurrent.FutureTask.<init>(FutureTask.java:151)
	at com.intellij.util.concurrency.SchedulingWrapper$MyScheduledFutureTask.<init>(SchedulingWrapper.java:193)
	at com.intellij.util.concurrency.CancellationScheduledFutureTask.<init>(CancellationScheduledFutureTask.java:35)
	at com.intellij.util.concurrency.Propagation.capturePropagationContext(propagation.kt:478)
	at com.intellij.util.concurrency.SchedulingWrapper.createTask(SchedulingWrapper.java:414)
	at com.intellij.util.concurrency.SchedulingWrapper.scheduleWithFixedDelay(SchedulingWrapper.java:403)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.auth.DefaultAuthCredentialsService.startPeriodicTokenSync(DefaultAuthCredentialsService.kt:70)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.auth.DefaultAuthCredentialsService.<init>(DefaultAuthCredentialsService.kt:66)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance._init_$lambda$9(AmazonQLspService.kt:326)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance._init_$lambda$10(AmazonQLspService.kt:320)
	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934)
	at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:911)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1491)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:2073)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2035)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: com.intellij.platform.instanceContainer.internal.ContainerDisposedException: Container 'ProjectImpl@1222416271 services' was disposed
	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.state(InstanceContainerImpl.kt:59)
	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.state(InstanceContainerImpl.kt:39)
	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.getInstanceHolder(InstanceContainerImpl.kt:276)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:718)
	... 27 more
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
