### PR TITLE
fix(amazonq): fix warnings when metrics fields are null

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -77,7 +77,7 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
             val name = telemetryMap["name"] as? String ?: return
 
             @Suppress("UNCHECKED_CAST")
-            val data = telemetryMap["data"] as? Map<String, Any> ?: return
+            val data = telemetryMap["data"] as? Map<String, Any?> ?: return
 
             TelemetryService.getInstance().record(project) {
                 datum(name) {
@@ -90,7 +90,7 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
                     }
 
                     data.forEach { (key, value) ->
-                        metadata(key, value.toString())
+                        metadata(key, value?.toString() ?: "null")
                     }
                 }
             }


### PR DESCRIPTION

 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
