### PR TITLE
fix(core): don't retry on InvalidGrantException because it is terminal

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/BearerTokenProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/BearerTokenProvider.kt
@@ -252,13 +252,6 @@ internal val DEFAULT_PREFETCH_DURATION = Duration.ofMinutes(20)
 val ssoOidcClientConfigurationBuilder: (ClientOverrideConfiguration.Builder) -> ClientOverrideConfiguration.Builder = { configuration ->
     configuration.nullDefaultProfileFile()
 
-    // Add InvalidGrantException to the RetryOnExceptionsCondition
-    configuration.retryStrategy { strategy ->
-        strategy.retryOnException {
-            it is InvalidGrantException
-        }
-    }
-
     configuration.addExecutionInterceptor(object : ExecutionInterceptor {
         override fun modifyException(context: Context.FailedExecution, executionAttributes: ExecutionAttributes): Throwable {
             val exception = context.exception()

--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/BearerTokenProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/BearerTokenProvider.kt
@@ -17,7 +17,6 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ssooidc.SsoOidcClient
 import software.amazon.awssdk.services.ssooidc.SsoOidcTokenProvider
 import software.amazon.awssdk.services.ssooidc.internal.OnDiskTokenManager
-import software.amazon.awssdk.services.ssooidc.model.InvalidGrantException
 import software.amazon.awssdk.services.ssooidc.model.SsoOidcException
 import software.amazon.awssdk.utils.SdkAutoCloseable
 import software.amazon.awssdk.utils.cache.CachedSupplier

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderTest.kt
@@ -84,16 +84,14 @@ class InteractiveBearerTokenProviderTest {
     }
 
     @Test
-    fun `oidcClient retries twice on InvalidGrantException failure`() {
+    fun `oidcClient does not retry on InvalidGrantException failure`() {
         fun verifyRetryAttempts(configuration: ClientOverrideConfiguration.Builder) {
             configuration.addExecutionInterceptor(
                 object : ExecutionInterceptor {
                     override fun onExecutionFailure(context: Context.FailedExecution?, executionAttributes: ExecutionAttributes?) {
                         super.onExecutionFailure(context, executionAttributes)
 
-                        // 3 total network calls, showing 4 since the sdk increments the attempt count at the beginning
-                        // of the loop before it checks whether it's allowed to retry.
-                        assertThat(executionAttributes?.getAttribute(InternalCoreExecutionAttribute.EXECUTION_ATTEMPT)).isEqualTo(4)
+                        assertThat(executionAttributes?.getAttribute(InternalCoreExecutionAttribute.EXECUTION_ATTEMPT)).isEqualTo(1)
                     }
                 }
             )


### PR DESCRIPTION
this is not a retryable exception. requested internally by IdC team.
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
