### PR TITLE
fix(amazonq): Stop button disappears after being clicked

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -485,7 +485,7 @@ class BrowserConnector(
                 try {
                     chatAsyncResultManager.createRequestId(partialResultToken)
                     chatAsyncResultManager.getResult(partialResultToken)
-                    handleCancellation(tabId, partialResultToken, browser)
+                    handleCancellation(tabId, browser)
                 } catch (ex: Exception) {
                     LOG.warn(ex) { "An error occurred while processing cancellation" }
                 } finally {
@@ -500,7 +500,7 @@ class BrowserConnector(
         }
     }
 
-    private fun handleCancellation(tabId: String, partialResultToken: String, browser: Browser) {
+    private fun handleCancellation(tabId: String, browser: Browser) {
         // Send a message to hide the stop button without showing an error
         val cancelMessage = chatCommunicationManager.getCancellationUiMessage(tabId)
         browser.postChat(cancelMessage)

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -41,6 +41,7 @@ import software.aws.toolkits.jetbrains.services.amazonq.lsp.JsonRpcNotification
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.JsonRpcRequest
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.encryption.JwtEncryptionManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.AwsServerCapabilitiesProvider
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.ChatAsyncResultManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.ChatCommunicationManager
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.FlareUiMessage
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.AUTH_FOLLOW_UP_CLICKED
@@ -98,7 +99,6 @@ import software.aws.toolkits.telemetry.Telemetry
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.function.Function
-import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.ChatAsyncResultManager
 
 class BrowserConnector(
     private val serializer: MessageSerializer = MessageSerializer.getInstance(),
@@ -230,7 +230,6 @@ class BrowserConnector(
                 val tabId = requestFromUi.params.tabId
                 val partialResultToken = chatCommunicationManager.addPartialChatMessage(tabId)
                 chatCommunicationManager.registerPartialResultToken(partialResultToken)
-
 
                 var encryptionManager: JwtEncryptionManager? = null
                 val result = AmazonQLspService.executeIfRunning(project) { server ->
@@ -483,7 +482,7 @@ class BrowserConnector(
                 chatCommunicationManager.removeInflightRequestForTab(tabId)
             } catch (e: CancellationException) {
                 LOG.warn { "Cancelled chat generation" }
-                try{
+                try {
                     chatAsyncResultManager.createRequestId(partialResultToken)
                     chatAsyncResultManager.getResult(partialResultToken)
                     handleCancellation(tabId, partialResultToken, browser)
@@ -500,7 +499,7 @@ class BrowserConnector(
             }
         }
     }
-    
+
     private fun handleCancellation(tabId: String, partialResultToken: String, browser: Browser) {
         // Send a message to hide the stop button without showing an error
         val cancelMessage = chatCommunicationManager.getCancellationUiMessage(tabId)

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatAsyncResultManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatAsyncResultManager.kt
@@ -1,0 +1,75 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Manages asynchronous results for chat operations, particularly handling the coordination
+ * between partial results and final results during cancellation.
+ */
+@Service(Service.Level.PROJECT)
+class ChatAsyncResultManager() {
+    private val results = ConcurrentHashMap<String, CompletableFuture<Any>>()
+    private val completedResults = ConcurrentHashMap<String, Any>()
+    private val timeout = 30L
+    private val timeUnit = TimeUnit.SECONDS
+
+    fun createRequestId(requestId: String) {
+        if (!completedResults.containsKey(requestId)) {
+            results[requestId] = CompletableFuture()
+        }
+    }
+
+    fun removeRequestId(requestId: String) {
+        val future = results.remove(requestId)
+        if (future != null && !future.isDone) {
+            future.cancel(true)
+        }
+        completedResults.remove(requestId)
+    }
+
+    fun setResult(requestId: String, result: Any) {
+        val future = results[requestId]
+        if (future != null) {
+            future.complete(result)
+            results.remove(requestId)
+        }
+        completedResults[requestId] = result
+    }
+
+    fun getResult(requestId: String): Any? {
+        return getResult(requestId, timeout, timeUnit)
+    }
+
+    private fun getResult(requestId: String, timeout: Long, unit: TimeUnit): Any? {
+        val completedResult = completedResults[requestId]
+        if (completedResult != null) {
+            return completedResult
+        }
+
+        val future = results[requestId] ?: throw IllegalArgumentException("Request ID not found: $requestId")
+
+        try {
+            val result = future.get(timeout, unit)
+            completedResults[requestId] = result
+            results.remove(requestId)
+            return result
+        } catch (e: TimeoutException) {
+            future.cancel(true)
+            results.remove(requestId)
+            throw TimeoutException("Operation timed out for requestId: $requestId")
+        }
+    }
+
+    companion object {
+        fun getInstance(project: Project) = project.service<ChatAsyncResultManager>()
+    }
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatAsyncResultManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatAsyncResultManager.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeoutException
  * between partial results and final results during cancellation.
  */
 @Service(Service.Level.PROJECT)
-class ChatAsyncResultManager() {
+class ChatAsyncResultManager {
     private val results = ConcurrentHashMap<String, CompletableFuture<Any>>()
     private val completedResults = ConcurrentHashMap<String, Any>()
     private val timeout = 30L
@@ -45,9 +45,8 @@ class ChatAsyncResultManager() {
         completedResults[requestId] = result
     }
 
-    fun getResult(requestId: String): Any? {
-        return getResult(requestId, timeout, timeUnit)
-    }
+    fun getResult(requestId: String): Any? =
+        getResult(requestId, timeout, timeUnit)
 
     private fun getResult(requestId: String, timeout: Long, unit: TimeUnit): Any? {
         val completedResult = completedResults[requestId]

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
@@ -99,16 +99,8 @@ class ChatCommunicationManager(private val cs: CoroutineScope) {
     fun removeTabOpenRequest(requestId: String) =
         pendingTabRequests.remove(requestId)
 
-    fun setPartialResultLock(token: String, lock: Any) {
-        partialResultLocks[token] = lock
-    }
-
     fun removePartialResultLock(token: String) {
         partialResultLocks.remove(token)
-    }
-
-    fun setFinalResultProcessed(token: String, processed: Boolean) {
-        finalResultProcessed[token] = processed
     }
 
     fun removeFinalResultProcessed(token: String) {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
@@ -147,6 +147,21 @@ class ChatCommunicationManager(private val cs: CoroutineScope) {
         """.trimIndent()
         return uiMessage
     }
+    
+    fun getCancellationUiMessage(tabId: String): String {
+        // Create a minimal error params with empty error message to hide the stop button
+        // without showing an actual error message to the user
+        val errorParams = Gson().toJson(ErrorParams(tabId, null, "", "")).toString()
+        
+        return """
+            {
+            "command":"$CHAT_ERROR_PARAMS",
+            "tabId": "$tabId",
+            "params": $errorParams,
+            "isPartialResult": false
+            }
+        """.trimIndent()
+    }
 
     fun handleAuthFollowUpClicked(project: Project, params: AuthFollowUpClickedParams) {
         val incomingType = params.authFollowupType

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
@@ -43,6 +43,8 @@ class ChatCommunicationManager(private val cs: CoroutineScope) {
     private val inflightRequestByTabId = ConcurrentHashMap<String, CompletableFuture<String>>()
     private val pendingSerializedChatRequests = ConcurrentHashMap<String, CompletableFuture<GetSerializedChatResult>>()
     private val pendingTabRequests = ConcurrentHashMap<String, CompletableFuture<LSPAny>>()
+    private val partialResultLocks = ConcurrentHashMap<String, Any>()
+    private val finalResultProcessed = ConcurrentHashMap<String, Boolean>()
 
     fun setUiReady() {
         uiReady.complete(true)
@@ -97,6 +99,28 @@ class ChatCommunicationManager(private val cs: CoroutineScope) {
     fun removeTabOpenRequest(requestId: String) =
         pendingTabRequests.remove(requestId)
 
+    fun setPartialResultLock(token: String, lock: Any) {
+        partialResultLocks[token] = lock
+    }
+
+    fun removePartialResultLock(token: String) {
+        partialResultLocks.remove(token)
+    }
+
+    fun setFinalResultProcessed(token: String, processed: Boolean) {
+        finalResultProcessed[token] = processed
+    }
+
+    fun removeFinalResultProcessed(token: String) {
+        finalResultProcessed.remove(token)
+    }
+
+    fun registerPartialResultToken(partialResultToken: String) {
+        val lock = Any()
+        partialResultLocks[partialResultToken] = lock
+        finalResultProcessed[partialResultToken] = false
+    }
+
     fun handlePartialResultProgressNotification(project: Project, params: ProgressParams) {
         val token = ProgressNotificationUtils.getToken(params)
         val tabId = getPartialChatMessage(token)
@@ -112,13 +136,49 @@ class ChatCommunicationManager(private val cs: CoroutineScope) {
         val encryptedPartialChatResult = getObject(params, String::class.java)
         if (encryptedPartialChatResult != null) {
             val partialChatResult = AmazonQLspService.getInstance(project).encryptionManager.decrypt(encryptedPartialChatResult)
-            val uiMessage = convertToJsonToSendToChat(
-                command = SEND_CHAT_COMMAND_PROMPT,
-                tabId = tabId,
-                params = partialChatResult,
-                isPartialResult = true
-            )
-            AsyncChatUiListener.notifyPartialMessageUpdate(uiMessage)
+
+            // Special case: check for stop message before proceeding
+            val partialResultMap = tryOrNull {
+                Gson().fromJson(partialChatResult, Map::class.java)
+            }
+
+            if (partialResultMap != null) {
+                @Suppress("UNCHECKED_CAST")
+                val additionalMessages = partialResultMap["additionalMessages"] as? List<Map<String, Any>>
+                if (additionalMessages != null) {
+                    for (message in additionalMessages) {
+                        val messageId = message["messageId"] as? String
+                        if (messageId != null && messageId.startsWith("stopped")) {
+                            // Process stop messages immediately
+                            val uiMessage = convertToJsonToSendToChat(
+                                command = SEND_CHAT_COMMAND_PROMPT,
+                                tabId = tabId,
+                                params = partialChatResult,
+                                isPartialResult = true
+                            )
+                            AsyncChatUiListener.notifyPartialMessageUpdate(uiMessage)
+                            finalResultProcessed[token] = true
+                            ChatAsyncResultManager.getInstance(project).setResult(token, partialResultMap)
+                            return
+                        }
+                    }
+                }
+            }
+
+            // Normal processing for non-stop messages
+            val lock = partialResultLocks[token] ?: return
+            synchronized(lock) {
+                if (finalResultProcessed[token] == true || partialResultLocks[token] == null) {
+                    return@synchronized
+                }
+                val uiMessage = convertToJsonToSendToChat(
+                    command = SEND_CHAT_COMMAND_PROMPT,
+                    tabId = tabId,
+                    params = partialChatResult,
+                    isPartialResult = true
+                )
+                AsyncChatUiListener.notifyPartialMessageUpdate(uiMessage)
+            }
         }
     }
 
@@ -147,12 +207,12 @@ class ChatCommunicationManager(private val cs: CoroutineScope) {
         """.trimIndent()
         return uiMessage
     }
-    
+
     fun getCancellationUiMessage(tabId: String): String {
         // Create a minimal error params with empty error message to hide the stop button
         // without showing an actual error message to the user
         val errorParams = Gson().toJson(ErrorParams(tabId, null, "", "")).toString()
-        
+
         return """
             {
             "command":"$CHAT_ERROR_PARAMS",


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

Fixed an issue where the stop button would not disappear after being clicked to cancel a response from Q. 
<img width="428" alt="Screenshot 2025-05-29 at 2 49 05 PM" src="https://github.com/user-attachments/assets/9a530c9a-abb4-4fe2-9c03-e80c513dadec" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Fixed a race condition between two streams receiving cancellation information. Previously, if the CancellationException from the sendChatPrompt stream was processed before the "You stopped your work" message from the partialResult stream, the UI would not properly display the stop message.

The fix prioritizes stop messages by checking for them before acquiring any locks, ensuring they're processed immediately when detected. This allows the cancellation to complete properly regardless of which stream receives information first.

Key changes:

* Added special case handling for stop messages before lock acquisition
* Immediately mark final result as processed when stop message is detected
* Set result in ChatAsyncResultManager to coordinate between streams

This ensures a consistent user experience when cancelling operations, with the stop message always being displayed properly.

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
