### PR TITLE
fix(chat): always use the lightest bg color we can find for the chat input box

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
@@ -26,6 +26,7 @@ class ThemeBrowserAdapter {
     }
 
     private fun buildJsCodeToUpdateTheme(theme: AmazonQTheme) = buildString {
+        var (bg, altBg, inputBg) = determineInputAndBgColor(theme)
         appendDarkMode(theme.darkMode)
 
         append("{\n")
@@ -42,14 +43,14 @@ class ThemeBrowserAdapter {
         append(CssVariable.TextColorWeak, theme.inactiveText)
         append(CssVariable.TextColorDisabled, theme.inactiveText)
 
-        append(CssVariable.Background, theme.editorBackground)
-        append(CssVariable.BackgroundAlt, theme.background)
-        append(CssVariable.CardBackground, theme.editorBackground)
-        append(CssVariable.CardBackgroundAlt, theme.background)
+        append(CssVariable.Background, bg)
+        append(CssVariable.BackgroundAlt, altBg)
+        append(CssVariable.CardBackground, bg)
+        append(CssVariable.CardBackgroundAlt, altBg)
         append(CssVariable.BorderDefault, theme.border)
         append(CssVariable.TabActive, theme.activeTab)
 
-        append(CssVariable.InputBackground, theme.textFieldBackground)
+        append(CssVariable.InputBackground, inputBg)
 
         append(CssVariable.ButtonBackground, theme.buttonBackground)
         append(CssVariable.ButtonForeground, theme.buttonForeground)
@@ -110,4 +111,13 @@ class ThemeBrowserAdapter {
 
     // Some font names have characters that require them to be wrapped in quotes in the CSS variable, for example if they have spaces or a period.
     private fun Font.toCssFontFamily(fallback: String = "system-ui") = "\"$family\", $fallback"
+
+    // darkest = bg, second darkest is alt bg, lightest is input bg
+    private fun determineInputAndBgColor(theme: AmazonQTheme): Triple<Color, Color, Color> {
+        val colors = arrayOf(theme.editorBackground, theme.background, theme.textFieldBackground).sortedWith(Comparator.comparing {
+            // luma calculation for brightness
+            (0.2126 * it.red) + (0.7152 * it.green) + (0.0722 * it.blue)
+        })
+        return Triple(colors[0], colors[1], colors[2])
+    }
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
@@ -114,10 +114,12 @@ class ThemeBrowserAdapter {
 
     // darkest = bg, second darkest is alt bg, lightest is input bg
     private fun determineInputAndBgColor(theme: AmazonQTheme): Triple<Color, Color, Color> {
-        val colors = arrayOf(theme.editorBackground, theme.background, theme.textFieldBackground).sortedWith(Comparator.comparing {
-            // luma calculation for brightness
-            (0.2126 * it.red) + (0.7152 * it.green) + (0.0722 * it.blue)
-        })
+        val colors = arrayOf(theme.editorBackground, theme.background, theme.textFieldBackground).sortedWith(
+            Comparator.comparing {
+                // luma calculation for brightness
+                (0.2126 * it.red) + (0.7152 * it.green) + (0.0722 * it.blue)
+            }
+        )
         return Triple(colors[0], colors[1], colors[2])
     }
 }

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/theme/ThemeBrowserAdapter.kt
@@ -26,7 +26,7 @@ class ThemeBrowserAdapter {
     }
 
     private fun buildJsCodeToUpdateTheme(theme: AmazonQTheme) = buildString {
-        var (bg, altBg, inputBg) = determineInputAndBgColor(theme)
+        val (bg, altBg, inputBg) = determineInputAndBgColor(theme)
         appendDarkMode(theme.darkMode)
 
         append("{\n")


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

Fixing the bg colors again by forcing a lighter color for the text box (based on a luma calculation)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Using the default light/dark themes
![image](https://github.com/user-attachments/assets/7e1c7c66-f4df-4149-b528-13a2c6b83bd5)
![image](https://github.com/user-attachments/assets/5fcea99a-f706-4393-a353-41c1111f386b)

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
