### PR TITLE
fix(amazonq): add range field to indicate partial doc change

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -22,6 +22,8 @@ import org.eclipse.lsp4j.DidChangeTextDocumentParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentItem
@@ -164,6 +166,9 @@ class TextDocumentServiceHandler(
             pluginAwareExecuteOnPooledThread {
                 val vFile = FileDocumentManager.getInstance().getFile(event.document) ?: return@pluginAwareExecuteOnPooledThread
                 toUriString(vFile)?.let { uri ->
+                    val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@pluginAwareExecuteOnPooledThread
+                    val logicalPosition = editor.offsetToLogicalPosition(event.offset)
+                    val newLogicalPosition = editor.offsetToLogicalPosition(event.offset + event.newLength)
                     languageServer.textDocumentService.didChange(
                         DidChangeTextDocumentParams().apply {
                             textDocument = VersionedTextDocumentIdentifier().apply {
@@ -173,6 +178,7 @@ class TextDocumentServiceHandler(
                             contentChanges = listOf(
                                 TextDocumentContentChangeEvent().apply {
                                     text = event.newFragment.toString()
+                                    range = Range(Position(logicalPosition.line, logicalPosition.column), Position(newLogicalPosition.line, newLogicalPosition.column))
                                 }
                             )
                         }


### PR DESCRIPTION
For the LSP's TextDocumentContentChangeEvent, if range is not specified, LSP would assume the contentChange is for the whole file and replace the file content with it, so if user is just making edits we need to specify range other wise file content will be replaced by this diff.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
