### PR TITLE
feat(amazonq): include minimal flare assets in plugin bundle

### DIFF
--- a/plugins/amazonq/build.gradle.kts
+++ b/plugins/amazonq/build.gradle.kts
@@ -97,7 +97,7 @@ val downloadFlareArtifacts by tasks.registering(Download::class) {
     val latest = manifest.map { it.versions.first() }
     val latestVersion = latest.map { it.serverVersion }
     val licensesUrl = latest.map { it.thirdPartyLicenses }
-    val darwin = latest.map { it.targets.first { it.platform == "darwin" && it.arch == "arm64" } }
+    val darwin = latest.map { it.targets.first { target -> target.platform == "darwin" && target.arch == "arm64" } }
     val contentUrls = darwin.map { it.contents.map { content -> content.url } }
 
     val destination = layout.buildDirectory.dir(latestVersion.map { "flare/$it" })
@@ -116,7 +116,7 @@ val prepareBundledFlare by tasks.registering(Copy::class) {
     val dest = layout.buildDirectory.dir("tmp/extractFlare")
     into(dest)
 
-    from(downloadFlareArtifacts.map { it.outputFiles.filterNot { it.name.endsWith(".zip") } })
+    from(downloadFlareArtifacts.map { it.outputFiles.filterNot { file -> file.name.endsWith(".zip") } })
     doLast {
         copy {
             into(dest)


### PR DESCRIPTION
as discussed internally
```
$ 7zz plugins/amazonq/build/distributions/plugin-amazonq-[...].zip | grep flare
2025-05-30 12:56:02 D....            0            2  plugin-amazonq/flare
2025-05-30 12:56:02 .....     15211717      2363455  plugin-amazonq/flare/aws-lsp-codewhisperer.js
2025-05-30 12:56:02 .....      6316632      1604490  plugin-amazonq/flare/amazonq-ui.js
2025-05-30 12:56:02 .....            0            2  plugin-amazonq/flare/1.7.0
2025-05-30 12:56:02 .....      1668250       100619  plugin-amazonq/flare/THIRD_PARTY_LICENSES
2025-05-30 12:56:02 .....         3888         1052  plugin-amazonq/flare/aws-lsp-codewhisperer.js.LICENSE.txt
```

build avoidance:
```
$ ./gradlew :p-a:pBF

> Configure project :plugin-toolkit:jetbrains-rider
Using rd-gen: 2025.1.1

> Task :plugin-amazonq:downloadFlareManifest UP-TO-DATE
Download https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json

> Task :plugin-amazonq:downloadFlareArtifacts UP-TO-DATE
Download https://aws-language-servers.us-east-1.amazonaws.com/8a9212d9-901b-4d96-ab9b-b26342258356/qAgenticChatServer/mac-arm64/servers.zip
Download https://aws-language-servers.us-east-1.amazonaws.com/8a9212d9-901b-4d96-ab9b-b26342258356/clients.zip
Download https://aws-language-servers.us-east-1.amazonaws.com/8a9212d9-901b-4d96-ab9b-b26342258356/THIRD_PARTY_LICENSES
Kotlin build report is written to file:///Users/richali/idetools/aws-toolkit-jetbrains/build/reports/kotlin-build/aws-toolkit-jetbrains-build-2025-05-30-12-45-58-0.txt
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
