### PR TITLE
ci: run with --stacktrace to try to understand generateSdks failure

### DIFF
--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -40,7 +40,7 @@ phases:
         fi
 
       - chmod +x gradlew
-      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME check coverageReport --info --console plain --continue"
+      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME check coverageReport --info --stacktrace --console plain --continue"
       - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME buildPlugin"
       - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
       - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site


### PR DESCRIPTION
```

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':plugin-core:sdk-codegen:generateSdks'.
> Failed to generate code. Exception message : java.lang.RuntimeException: java.lang.NullPointerException
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
