### PR TITLE
fix(amazonq): do not decode uri if `window/showDocument` is external

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -149,14 +149,14 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
                 return CompletableFuture.completedFuture(ShowDocumentResult(false))
             }
 
-            // The filepath sent by the server contains unicode characters which need to be
-            // decoded for JB file handling APIs to be handle to handle file operations
-            val fileToOpen = URLDecoder.decode(params.uri, StandardCharsets.UTF_8.name())
             if (params.external == true) {
-                BrowserUtil.open(fileToOpen)
+                BrowserUtil.open(params.uri)
                 return CompletableFuture.completedFuture(ShowDocumentResult(true))
             }
 
+            // The filepath sent by the server contains unicode characters which need to be
+            // decoded for JB file handling APIs to be handle to handle file operations
+            val fileToOpen = URLDecoder.decode(params.uri, StandardCharsets.UTF_8.name())
             ApplicationManager.getApplication().invokeLater {
                 try {
                     val virtualFile = VirtualFileManager.getInstance().findFileByUrl(fileToOpen)


### PR DESCRIPTION
Browser open expects an encoded uri

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
