### PR TITLE
fix(amazonq): fix refresh button breaking chat history for tabs that were open

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QRefreshPanelAction.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QRefreshPanelAction.kt
@@ -9,6 +9,9 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.util.messages.Topic
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.flareChat.ChatCommunicationManager
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.CHAT_TAB_REMOVE
 import software.aws.toolkits.jetbrains.services.amazonq.toolwindow.AmazonQToolWindow
 import software.aws.toolkits.resources.AmazonQBundle
 import java.util.EventListener
@@ -16,6 +19,15 @@ import java.util.EventListener
 class QRefreshPanelAction : DumbAwareAction(AmazonQBundle.message("amazonq.refresh.panel"), null, AllIcons.Actions.Refresh) {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
+        
+        // Notify LSP server about all open tabs being removed
+        val chatManager = ChatCommunicationManager.getInstance(project)
+        chatManager.getAllTabIds().forEach { tabId ->
+            AmazonQLspService.executeIfRunning(project) { server ->
+                rawEndpoint.notify(CHAT_TAB_REMOVE, mapOf("tabId" to tabId))
+            }
+        }
+        
         // recreate chat browser
         AmazonQToolWindow.getInstance(project).disposeAndRecreate()
         // recreate signin browser

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QRefreshPanelAction.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/QRefreshPanelAction.kt
@@ -19,7 +19,7 @@ import java.util.EventListener
 class QRefreshPanelAction : DumbAwareAction(AmazonQBundle.message("amazonq.refresh.panel"), null, AllIcons.Actions.Refresh) {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        
+
         // Notify LSP server about all open tabs being removed
         val chatManager = ChatCommunicationManager.getInstance(project)
         chatManager.getAllTabIds().forEach { tabId ->
@@ -27,7 +27,7 @@ class QRefreshPanelAction : DumbAwareAction(AmazonQBundle.message("amazonq.refre
                 rawEndpoint.notify(CHAT_TAB_REMOVE, mapOf("tabId" to tabId))
             }
         }
-        
+
         // recreate chat browser
         AmazonQToolWindow.getInstance(project).disposeAndRecreate()
         // recreate signin browser

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/BrowserConnector.kt
@@ -307,14 +307,19 @@ class BrowserConnector(
             }
 
             CHAT_TAB_ADD -> {
-                handleChat(AmazonQChatServer.tabAdd, node)
+                handleChat(AmazonQChatServer.tabAdd, node) { params, invoke ->
+                    // Track the tab ID when a tab is added
+                    chatCommunicationManager.addTabId(params.tabId)
+                    invoke()
+                }
             }
 
             CHAT_TAB_REMOVE -> {
                 handleChat(AmazonQChatServer.tabRemove, node) { params, invoke ->
                     chatCommunicationManager.removePartialChatMessage(params.tabId)
                     cancelInflightRequests(params.tabId)
-
+                    // Remove the tab ID from tracking when a tab is removed
+                    chatCommunicationManager.removeTabId(params.tabId)
                     invoke()
                 }
             }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
@@ -45,6 +45,7 @@ class ChatCommunicationManager(private val project: Project, private val cs: Cor
     private val pendingTabRequests = ConcurrentHashMap<String, CompletableFuture<LSPAny>>()
     private val partialResultLocks = ConcurrentHashMap<String, Any>()
     private val finalResultProcessed = ConcurrentHashMap<String, Boolean>()
+    private val openTabs = mutableSetOf<String>()
 
     fun setUiReady() {
         uiReady.complete(true)
@@ -79,6 +80,24 @@ class ChatCommunicationManager(private val project: Project, private val cs: Cor
 
     fun removePartialChatMessage(partialResultToken: String) =
         chatPartialResultMap.remove(partialResultToken)
+
+    fun addTabId(tabId: String) {
+        synchronized(openTabs) {
+            openTabs.add(tabId)
+        }
+    }
+
+    fun removeTabId(tabId: String) {
+        synchronized(openTabs) {
+            openTabs.remove(tabId)
+        }
+    }
+
+    fun getAllTabIds(): Set<String> {
+        synchronized(openTabs) {
+            return openTabs.toSet()
+        }
+    }
 
     fun addSerializedChatRequest(requestId: String, result: CompletableFuture<GetSerializedChatResult>) {
         pendingSerializedChatRequests[requestId] = result


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->
When users clicked the refresh button to refresh the webview, any open tabs in the Q chat tab were closed without notifying the server. So when users tried clicking their conversation history to open it back up, the chat would be sent to a tabID that is no longer displayed in the UI. 

This fix allows users to bring back up the chat history of tabs that got closed by refreshing the webview.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
