### PR TITLE
fix(amazonq): always send latest document on any document change

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManagerListener
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
@@ -22,8 +23,6 @@ import org.eclipse.lsp4j.DidChangeTextDocumentParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
-import org.eclipse.lsp4j.Position
-import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentItem
@@ -66,15 +65,16 @@ class TextDocumentServiceHandler(
     }
 
     private fun handleFileOpened(file: VirtualFile) {
-        ApplicationManager.getApplication().runReadAction {
-            FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(
-                object : DocumentListener {
-                    override fun documentChanged(event: DocumentEvent) {
-                        realTimeEdit(event)
-                    }
-                },
-                this
-            )
+        if (file.getUserData(KEY_REAL_TIME_EDIT_LISTENER) == null) {
+            val listener = object : DocumentListener {
+                override fun documentChanged(event: DocumentEvent) {
+                    realTimeEdit(event)
+                }
+            }
+            file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, listener)
+            ApplicationManager.getApplication().runReadAction {
+                FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(listener, this)
+            }
         }
         AmazonQLspService.executeIfRunning(project) { languageServer ->
             toUriString(file)?.let { uri ->
@@ -148,6 +148,11 @@ class TextDocumentServiceHandler(
         source: FileEditorManager,
         file: VirtualFile,
     ) {
+        val listener = file.getUserData(KEY_REAL_TIME_EDIT_LISTENER)
+        if (listener != null) {
+            FileDocumentManager.getInstance().getDocument(file)?.removeDocumentListener(listener)
+            file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, null)
+        }
         AmazonQLspService.executeIfRunning(project) { languageServer ->
             toUriString(file)?.let { uri ->
                 languageServer.textDocumentService.didClose(
@@ -166,9 +171,6 @@ class TextDocumentServiceHandler(
             pluginAwareExecuteOnPooledThread {
                 val vFile = FileDocumentManager.getInstance().getFile(event.document) ?: return@pluginAwareExecuteOnPooledThread
                 toUriString(vFile)?.let { uri ->
-                    val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@pluginAwareExecuteOnPooledThread
-                    val logicalPosition = editor.offsetToLogicalPosition(event.offset)
-                    val newLogicalPosition = editor.offsetToLogicalPosition(event.offset + event.newLength)
                     languageServer.textDocumentService.didChange(
                         DidChangeTextDocumentParams().apply {
                             textDocument = VersionedTextDocumentIdentifier().apply {
@@ -177,11 +179,7 @@ class TextDocumentServiceHandler(
                             }
                             contentChanges = listOf(
                                 TextDocumentContentChangeEvent().apply {
-                                    text = event.newFragment.toString()
-                                    range = Range(
-                                        Position(logicalPosition.line, logicalPosition.column),
-                                        Position(newLogicalPosition.line, newLogicalPosition.column)
-                                    )
+                                    text = event.document.text
                                 }
                             )
                         }
@@ -193,5 +191,9 @@ class TextDocumentServiceHandler(
     }
 
     override fun dispose() {
+    }
+
+    companion object {
+        private val KEY_REAL_TIME_EDIT_LISTENER = Key.create<DocumentListener>("amazonq.textdocument.realtimeedit.listener")
     }
 }


### PR DESCRIPTION
1. Previously we are using the range() field to send incremental updates, but it appears to be buggy for many edge cases, so remove the range field to send the whole document since IDE always has the latest version.


https://github.com/user-attachments/assets/5a31d4b7-e17f-4f94-9d39-1f006b0fa3c0


<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
