### PR TITLE
fix(amazonq): remove parentDispoable for realTimeListener add

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -71,9 +71,9 @@ class TextDocumentServiceHandler(
                     realTimeEdit(event)
                 }
             }
-            file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, listener)
             ApplicationManager.getApplication().runReadAction {
-                FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(listener, this)
+                FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(listener)
+                file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, listener)
             }
         }
         AmazonQLspService.executeIfRunning(project) { languageServer ->


### PR DESCRIPTION
1. listener will be completed managed by fileOpen/fileClose, otherwise killing Amazon Q Context process will dispose TextDocumentServiceHandler which will remove this listener before fileClose and logs an error during fileClose

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
