### PR TITLE
fix(toolkit): fix plugin version mismatch between core/toolkit

### DIFF
--- a/plugins/toolkit/jetbrains-core/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-core/build.gradle.kts
@@ -56,7 +56,7 @@ PatchPluginXmlTask.register(project)
 val patchPluginXml = tasks.named<PatchPluginXmlTask>("patchPluginXml")
 patchPluginXml.configure {
     val buildSuffix = if (!project.isCi()) "+${buildMetadata()}" else ""
-    pluginVersion.set("$toolkitVersion-${ideProfile.shortName}$buildSuffix")
+    pluginVersion.set("$toolkitVersion.${ideProfile.shortName}$buildSuffix")
 }
 
 tasks.jar {


### PR DESCRIPTION
Users incorrectly receive incompatibility warnings

#5794
 
<img width="276" alt="image" src="https://github.com/user-attachments/assets/773f45bc-0082-4caa-808b-c9e6b638115b" />


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
