### PR TITLE
fix(amazonq): tweak CA resolution and add additional logging

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -381,18 +381,18 @@ private class AmazonQServerInstance(private val project: Project, private val cs
                 val trustRoot = rtsTrustChain.last()
                 // ATS is cross-signed against starfield certs: https://www.amazontrust.com/repository/
                 if (listOf("Amazon Root CA", "Starfield Technologies").any { trustRoot.subjectX500Principal.name.contains(it) }) {
-                    LOG.info { "Trust chain for $endpoint ends with public-like CA with sha256 fingerprint: ${DigestUtil.sha256Hex(trustRoot.encoded)}"}
+                    LOG.info { "Trust chain for $endpoint ends with public-like CA with sha256 fingerprint: ${DigestUtil.sha256Hex(trustRoot.encoded)}" }
                 } else {
                     LOG.info {
                         """
                             |Trust chain for $endpoint transits private CA:
                             |${buildString {
-                                rtsTrustChain.forEach { cert ->
-                                    append("Issuer: ${cert.issuerX500Principal}, ")
-                                    append("Subject: ${cert.subjectX500Principal}, ")
-                                    append("Fingerprint: ${DigestUtil.sha256Hex(cert.encoded)}\n\t")
-                                }
-                            }}
+                            rtsTrustChain.forEach { cert ->
+                                append("Issuer: ${cert.issuerX500Principal}, ")
+                                append("Subject: ${cert.subjectX500Principal}, ")
+                                append("Fingerprint: ${DigestUtil.sha256Hex(cert.encoded)}\n\t")
+                            }
+                        }}
                         """.trimMargin("|")
                     }
                     LOG.debug { "Full trust chain info for $endpoint: $rtsTrustChain" }
@@ -405,7 +405,7 @@ private class AmazonQServerInstance(private val project: Project, private val cs
         val userEnvNodeCaCerts = EnvironmentUtil.getValue("NODE_EXTRA_CA_CERTS")
         // if user has NODE_EXTRA_CA_CERTS in their environment, assume they know what they're doing
         val extraCaCerts = if (!userEnvNodeCaCerts.isNullOrEmpty()) {
-            LOG.info { "Skipping injection of IDE trust store, user already defines NODE_EXTRA_CA_CERTS: $userEnvNodeCaCerts"}
+            LOG.info { "Skipping injection of IDE trust store, user already defines NODE_EXTRA_CA_CERTS: $userEnvNodeCaCerts" }
 
             null
         } else {
@@ -413,7 +413,9 @@ private class AmazonQServerInstance(private val project: Project, private val cs
                 // otherwise include everything the IDE knows about
                 val allAcceptedIssuers = CertificateManager.getInstance().trustManager.acceptedIssuers
                 val customIssuers = CertificateManager.getInstance().customTrustManager.acceptedIssuers
-                LOG.info { "Injecting ${allAcceptedIssuers.size} IDE trusted certificates (${customIssuers.size} from IDE custom manager) into NODE_EXTRA_CA_CERTS" }
+                LOG.info {
+                    "Injecting ${allAcceptedIssuers.size} IDE trusted certificates (${customIssuers.size} from IDE custom manager) into NODE_EXTRA_CA_CERTS"
+                }
 
                 Files.createTempFile("q-extra-ca", ".pem").apply {
                     writeText(
@@ -438,7 +440,7 @@ private class AmazonQServerInstance(private val project: Project, private val cs
             ).withEnvironment(
                 buildMap {
                     extraCaCerts?.let {
-                        LOG.info { "Starting Flare with NODE_EXTRA_CA_CERTS: $it"}
+                        LOG.info { "Starting Flare with NODE_EXTRA_CA_CERTS: $it" }
                         put("NODE_EXTRA_CA_CERTS", it)
                     }
 

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -417,7 +417,7 @@ private class AmazonQServerInstance(private val project: Project, private val cs
 
                 Files.createTempFile("q-extra-ca", ".pem").apply {
                     writeText(
-                        TrustChainUtil.certsToPem(CertificateManager.getInstance().trustManager.acceptedIssuers.toList())
+                        TrustChainUtil.certsToPem(allAcceptedIssuers.toList())
                     )
                 }.toAbsolutePath().toString()
             } catch (e: Exception) {


### PR DESCRIPTION
Instead of trying to intelligently select the specific custom CA needed to connect to Amazon Q, just send all IDE trust anchors along to Flare.

Additionally, if user already defines NODE_EXTRA_CA_CERTS, use it directly and noop our logic

```
2025-06-11 15:29:58,126 [   5616]   INFO - software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance - Trust chain for https://q.us-east-1.amazonaws.com/ ends with public-like CA with sha256 fingerprint: 568d6905a2c88708a4b3025190edcfedb1974a606a13c6e5290fcb2ae63edab5
2025-06-11 15:29:58,618 [   6108]   INFO - software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance - Trust chain for https://q.eu-central-1.amazonaws.com/ ends with public-like CA with sha256 fingerprint: 568d6905a2c88708a4b3025190edcfedb1974a606a13c6e5290fcb2ae63edab5
2025-06-11 15:29:58,868 [   6358]   INFO - software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance - Trust chain for https://codewhisperer.us-east-1.amazonaws.com/ ends with public-like CA with sha256 fingerprint: 568d6905a2c88708a4b3025190edcfedb1974a606a13c6e5290fcb2ae63edab5
```

```
2025-06-11 15:31:17,563 [  85053]   INFO - software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance - Trust chain for https://q.us-east-1.amazonaws.com/ transits private CA:
Issuer: O=mitmproxy, CN=mitmproxy,Subject: CN=q.us-east-1.amazonaws.com,Fingerprint: 78fcf2780d6ae65d41b3adb2ef46aebd2586e2037ca2fd7232bf4d1b1bbd3ac4
	Issuer: O=mitmproxy, CN=mitmproxy,Subject: O=mitmproxy, CN=mitmproxy,Fingerprint: d01cc3dbb35db82cec01cb221d81fa7d4b2a7280a88bd3e1f961c402c76a67e0
	
2025-06-11 15:31:18,085 [  85575]   INFO - software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance - Trust chain for https://q.eu-central-1.amazonaws.com/ transits private CA:
Issuer: O=mitmproxy, CN=mitmproxy,Subject: CN=q.eu-central-1.amazonaws.com,Fingerprint: 840b8421cd4945f2fb6da4c4add7651845c0e4752941cca48826eb826b00f054
	Issuer: O=mitmproxy, CN=mitmproxy,Subject: O=mitmproxy, CN=mitmproxy,Fingerprint: d01cc3dbb35db82cec01cb221d81fa7d4b2a7280a88bd3e1f961c402c76a67e0
	
2025-06-11 15:31:18,345 [  85835]   INFO - software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance - Trust chain for https://codewhisperer.us-east-1.amazonaws.com/ transits private CA:
Issuer: O=mitmproxy, CN=mitmproxy,Subject: CN=codewhisperer.us-east-1.amazonaws.com,Fingerprint: 4c3dbf4a7e91627b01158a83ae05773d9aef06190bbccdaf219f5677349a7861
	Issuer: O=mitmproxy, CN=mitmproxy,Subject: O=mitmproxy, CN=mitmproxy,Fingerprint: d01cc3dbb35db82cec01cb221d81fa7d4b2a7280a88bd3e1f961c402c76a67e0
```
 
```
2025-06-11 15:53:16,734 [   7324]   INFO - software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance - Injecting 119 trusted certificates (1 from IDE custom manager) into NODE_EXTRA_CA_CERTS
2025-06-11 15:53:16,750 [   7340]   INFO - software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance - Starting Flare with NODE_EXTRA_CA_CERTS: /var/folders/qp/tj7sfstn0qb5nl6vg9t47qg40000gq/T/q-extra-ca14146856742507934480.pem
```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
