### PR TITLE
fix(amazonq): Update telemetry preference setting

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImpl.kt
@@ -295,7 +295,7 @@ class AmazonQLanguageClientImpl(private val project: Project) : AmazonQLanguageC
                         AmazonQLspConstants.LSP_Q_CONFIGURATION_KEY -> {
                             add(
                                 AmazonQLspConfiguration(
-                                    optOutTelemetry = AwsSettings.getInstance().isTelemetryEnabled,
+                                    optOutTelemetry = !AwsSettings.getInstance().isTelemetryEnabled,
                                     customization = CodeWhispererModelConfigurator.getInstance().activeCustomization(project)?.arn,
                                     // local context
                                     projectContext = ProjectContextConfiguration(

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImplTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLanguageClientImplTest.kt
@@ -475,7 +475,7 @@ class AmazonQLanguageClientImplTest {
             .singleElement()
             .isEqualTo(
                 AmazonQLspConfiguration(
-                    optOutTelemetry = telemetryEnabled,
+                    optOutTelemetry = !telemetryEnabled,
                     customization = customizationArn,
                     projectContext = ProjectContextConfiguration(
                         enableLocalIndexing = enableIndexing,


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
The telemetry sent from the client respects the correct preference, however we send the opposite preference to flare. We need to send whether telemetry has been opted out in Flare

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
