### PR TITLE
fix(amazonq): add delay between fileOpen messages

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -23,6 +23,7 @@ import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.eclipse.lsp4j.DidChangeTextDocumentParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
@@ -65,9 +66,12 @@ class TextDocumentServiceHandler(
         )
 
         // open files on startup
-        val fileEditorManager = FileEditorManager.getInstance(project)
-        fileEditorManager.openFiles.forEach { file ->
-            handleFileOpened(file)
+        cs.launch {
+            val fileEditorManager = FileEditorManager.getInstance(project)
+            fileEditorManager.openFiles.forEach { file ->
+                handleFileOpened(file)
+                delay(100)
+            }
         }
     }
 


### PR DESCRIPTION
LSP appears fragile and locks up if flooded with messages on startup


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
