### PR TITLE
fix(amazonq): only send `textDocument/didOpen` for explicitly focused editors

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -89,9 +89,9 @@ class TextDocumentServiceHandler(
 
             Disposer.register(this) {
                 ApplicationManager.getApplication().runReadAction {
-                    val listener = file.getUserData(KEY_REAL_TIME_EDIT_LISTENER)
-                    if (listener != null) {
-                        FileDocumentManager.getInstance().getDocument(file)?.removeDocumentListener(listener)
+                    val existingListener = file.getUserData(KEY_REAL_TIME_EDIT_LISTENER)
+                    if (existingListener != null) {
+                        FileDocumentManager.getInstance().getDocument(file)?.removeDocumentListener(existingListener)
                         file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, null)
                     }
                 }

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -84,8 +84,8 @@ class TextDocumentServiceHandler(
             }
             ApplicationManager.getApplication().runReadAction {
                 FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(listener)
-                file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, listener)
             }
+            file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, listener)
 
             Disposer.register(this) {
                 ApplicationManager.getApplication().runReadAction {

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -23,7 +24,6 @@ import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.eclipse.lsp4j.DidChangeTextDocumentParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
@@ -46,6 +46,7 @@ class TextDocumentServiceHandler(
     BulkFileListener,
     DocumentListener,
     Disposable {
+
     init {
         // didOpen & didClose events
         project.messageBus.connect(this).subscribe(
@@ -68,9 +69,8 @@ class TextDocumentServiceHandler(
         // open files on startup
         cs.launch {
             val fileEditorManager = FileEditorManager.getInstance(project)
-            fileEditorManager.openFiles.forEach { file ->
+            fileEditorManager.selectedFiles.forEach { file ->
                 handleFileOpened(file)
-                delay(100)
             }
         }
     }
@@ -86,21 +86,31 @@ class TextDocumentServiceHandler(
                 FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(listener)
                 file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, listener)
             }
-        }
 
-        cs.launch {
-            AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
-                toUriString(file)?.let { uri ->
-                    languageServer.textDocumentService.didOpen(
-                        DidOpenTextDocumentParams().apply {
-                            textDocument = TextDocumentItem().apply {
-                                this.uri = uri
-                                text = file.inputStream.readAllBytes().decodeToString()
-                                languageId = file.fileType.name.lowercase()
-                                version = file.modificationStamp.toInt()
+            Disposer.register(this) {
+                ApplicationManager.getApplication().runReadAction {
+                    val listener = file.getUserData(KEY_REAL_TIME_EDIT_LISTENER)
+                    if (listener != null) {
+                        FileDocumentManager.getInstance().getDocument(file)?.removeDocumentListener(listener)
+                        file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, null)
+                    }
+                }
+            }
+
+            cs.launch {
+                AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
+                    toUriString(file)?.let { uri ->
+                        languageServer.textDocumentService.didOpen(
+                            DidOpenTextDocumentParams().apply {
+                                textDocument = TextDocumentItem().apply {
+                                    this.uri = uri
+                                    text = file.inputStream.readAllBytes().decodeToString()
+                                    languageId = file.fileType.name.lowercase()
+                                    version = file.modificationStamp.toInt()
+                                }
                             }
-                        }
-                    )
+                        )
+                    }
                 }
             }
         }
@@ -116,6 +126,7 @@ class TextDocumentServiceHandler(
                             textDocument = TextDocumentIdentifier().apply {
                                 this.uri = uri
                             }
+                            // TODO: should respect `textDocumentSync.save.includeText` server capability config
                             text = document.text
                         }
                     )
@@ -125,10 +136,12 @@ class TextDocumentServiceHandler(
     }
 
     override fun after(events: MutableList<out VFileEvent>) {
-        cs.launch {
-            AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
-                events.filterIsInstance<VFileContentChangeEvent>().forEach { event ->
-                    val document = FileDocumentManager.getInstance().getCachedDocument(event.file) ?: return@forEach
+        events.filterIsInstance<VFileContentChangeEvent>().forEach { event ->
+            val document = FileDocumentManager.getInstance().getCachedDocument(event.file) ?: return@forEach
+
+            handleFileOpened(event.file)
+            cs.launch {
+                AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
                     toUriString(event.file)?.let { uri ->
                         languageServer.textDocumentService.didChange(
                             DidChangeTextDocumentParams().apply {
@@ -164,17 +177,18 @@ class TextDocumentServiceHandler(
         if (listener != null) {
             FileDocumentManager.getInstance().getDocument(file)?.removeDocumentListener(listener)
             file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, null)
-        }
-        cs.launch {
-            AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
-                toUriString(file)?.let { uri ->
-                    languageServer.textDocumentService.didClose(
-                        DidCloseTextDocumentParams().apply {
-                            textDocument = TextDocumentIdentifier().apply {
-                                this.uri = uri
+
+            cs.launch {
+                AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
+                    toUriString(file)?.let { uri ->
+                        languageServer.textDocumentService.didClose(
+                            DidCloseTextDocumentParams().apply {
+                                textDocument = TextDocumentIdentifier().apply {
+                                    this.uri = uri
+                                }
                             }
-                        }
-                    )
+                        )
+                    }
                 }
             }
         }
@@ -185,10 +199,12 @@ class TextDocumentServiceHandler(
     }
 
     private fun handleActiveEditorChange(fileEditor: FileEditor?) {
+        val editor = (fileEditor as? TextEditor)?.editor ?: return
+        editor.virtualFile?.let { handleFileOpened(it) }
+
         // Extract text editor if it's a TextEditor, otherwise null
-        val editor = (fileEditor as? TextEditor)?.editor
-        val textDocumentIdentifier = editor?.let { TextDocumentIdentifier(toUriString(it.virtualFile)) }
-        val cursorState = editor?.let { getCursorState(it) }
+        val textDocumentIdentifier = TextDocumentIdentifier(toUriString(editor.virtualFile))
+        val cursorState = getCursorState(editor)
 
         val params = mapOf(
             "textDocument" to textDocumentIdentifier,


### PR DESCRIPTION
delay does not appear sufficent to satisfy LSP sensitivity to message floods on start (perhaps some weird stdio buffer overflow issue on windows)

instead, match observed behavior of VSC/Eclipse and only send editors that have seen focus at least once

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
