### PR TITLE
fix(amazonq): skip inline completion when deleting

### DIFF
--- a/.changes/next-release/bugfix-2488e2f1-f725-4e01-b38a-8b6953cf5f18.json
+++ b/.changes/next-release/bugfix-2488e2f1-f725-4e01-b38a-8b6953cf5f18.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Skip inline completion when deleting characters"
+}

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src-242/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QManualCall.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src-242/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QManualCall.kt
@@ -19,3 +19,5 @@ fun getManualCallEvent(editor: Editor, isIntelliSenseAccept: Boolean): InlineCom
     }
     return InlineCompletionEvent.DirectCall(editor, editor.caretModel.currentCaret, dataContext)
 }
+
+fun InlineCompletionEvent.isDeletion(): Boolean = false

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src-242/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QManualCall.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src-242/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QManualCall.kt
@@ -20,4 +20,5 @@ fun getManualCallEvent(editor: Editor, isIntelliSenseAccept: Boolean): InlineCom
     return InlineCompletionEvent.DirectCall(editor, editor.caretModel.currentCaret, dataContext)
 }
 
+@Suppress("FunctionOnlyReturningConstant")
 fun InlineCompletionEvent.isDeletion(): Boolean = false

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src-243+/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QManualCall.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src-243+/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QManualCall.kt
@@ -5,6 +5,7 @@ package software.aws.toolkits.jetbrains.services.codewhisperer.popup
 import com.intellij.codeInsight.inline.completion.InlineCompletionEvent
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.UserDataHolderBase
+import software.aws.toolkits.jetbrains.services.codewhisperer.popup.QInlineCompletionProvider.Companion.DATA_KEY_Q_AUTO_TRIGGER_INTELLISENSE
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.QInlineCompletionProvider.Companion.KEY_Q_AUTO_TRIGGER_INTELLISENSE
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.QInlineCompletionProvider.Companion.Q_INLINE_PROVIDER_ID
 
@@ -15,3 +16,7 @@ fun getManualCallEvent(editor: Editor, isIntelliSenseAccept: Boolean): InlineCom
     val data = UserDataHolderBase().apply { this.putUserData(KEY_Q_AUTO_TRIGGER_INTELLISENSE, isIntelliSenseAccept) }
     return InlineCompletionEvent.ManualCall(editor, Q_INLINE_PROVIDER_ID, data)
 }
+
+fun InlineCompletionEvent.isDeletion(): Boolean =
+    this is InlineCompletionEvent.Backspace
+

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src-243+/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QManualCall.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src-243+/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QManualCall.kt
@@ -5,7 +5,6 @@ package software.aws.toolkits.jetbrains.services.codewhisperer.popup
 import com.intellij.codeInsight.inline.completion.InlineCompletionEvent
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.UserDataHolderBase
-import software.aws.toolkits.jetbrains.services.codewhisperer.popup.QInlineCompletionProvider.Companion.DATA_KEY_Q_AUTO_TRIGGER_INTELLISENSE
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.QInlineCompletionProvider.Companion.KEY_Q_AUTO_TRIGGER_INTELLISENSE
 import software.aws.toolkits.jetbrains.services.codewhisperer.popup.QInlineCompletionProvider.Companion.Q_INLINE_PROVIDER_ID
 
@@ -19,4 +18,3 @@ fun getManualCallEvent(editor: Editor, isIntelliSenseAccept: Boolean): InlineCom
 
 fun InlineCompletionEvent.isDeletion(): Boolean =
     this is InlineCompletionEvent.Backspace
-

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
@@ -404,6 +404,14 @@ class QInlineCompletionProvider(private val cs: CoroutineScope) : InlineCompleti
             CodeWhispererInvocationStatus.getInstance().setIsInvokingQInline(session, false)
         }
 
+        if (request.event is InlineCompletionEvent.Backspace) {
+            logInline(triggerSessionId) {
+                "Skip inline completion when deleting"
+            }
+            return InlineCompletionSuggestion.Empty
+        }
+
+
         val sessionContext = InlineCompletionSessionContext(triggerOffset = request.endOffset)
 
         // Pagination workaround: Always return exactly 5 variants

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
@@ -411,7 +411,6 @@ class QInlineCompletionProvider(private val cs: CoroutineScope) : InlineCompleti
             return InlineCompletionSuggestion.Empty
         }
 
-
         val sessionContext = InlineCompletionSessionContext(triggerOffset = request.endOffset)
 
         // Pagination workaround: Always return exactly 5 variants

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
@@ -404,7 +404,9 @@ class QInlineCompletionProvider(private val cs: CoroutineScope) : InlineCompleti
             CodeWhispererInvocationStatus.getInstance().setIsInvokingQInline(session, false)
         }
 
-        if (request.event is InlineCompletionEvent.Backspace) {
+        // ideally we want to use if (request.event is InlineCompletionEvent.Backspace) {
+        // but this API is marked as experimental and it will not compile on 2024.2
+        if (request.startOffset == request.endOffset) {
             logInline(triggerSessionId) {
                 "Skip inline completion when deleting"
             }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
@@ -404,9 +404,8 @@ class QInlineCompletionProvider(private val cs: CoroutineScope) : InlineCompleti
             CodeWhispererInvocationStatus.getInstance().setIsInvokingQInline(session, false)
         }
 
-        // ideally we want to use if (request.event is InlineCompletionEvent.Backspace) {
-        // but this API is marked as experimental and it will not compile on 2024.2
-        if (request.startOffset == request.endOffset) {
+        // this is only available in 2024.3+
+        if (request.event.isDeletion()) {
             logInline(triggerSessionId) {
                 "Skip inline completion when deleting"
             }


### PR DESCRIPTION

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Previous before LSP inline completion migration, we do not make auto trigger when deleting characters. But after LSP inline migration, we are making such triggers. These triggers are not what backend expects, it triggers more, causing server side throttling, and the quality isn't good. 

Now we are bringing back the previous auto trigger conditions. 

This entire file does not have unit test and the getSuggestion method is integrated with JB inline completion API which makes it hard to add unit test. The test was done manually.  

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
