### PR TITLE
fix(amazonq): save previously-used JDK name

### DIFF
--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/constants/CodeTransformChatItems.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/constants/CodeTransformChatItems.kt
@@ -356,10 +356,16 @@ fun buildUserInputCustomDependencyVersionsChatContent(message: String) = CodeTra
     type = CodeTransformChatMessageType.PendingAnswer,
 )
 
-fun buildPromptTargetJDKNameChatContent(version: String) = CodeTransformChatMessageContent(
-    message = message("codemodernizer.chat.message.enter_jdk_name", version),
-    type = CodeTransformChatMessageType.FinalizedAnswer,
-)
+fun buildPromptTargetJDKNameChatContent(version: String, currentJdkName: String?): CodeTransformChatMessageContent {
+    var message = message("codemodernizer.chat.message.enter_jdk_name", version)
+    if (currentJdkName != null) {
+        message += "\n\ncurrent: `$currentJdkName`"
+    }
+    return CodeTransformChatMessageContent(
+        message = message,
+        type = CodeTransformChatMessageType.FinalizedAnswer,
+    )
+}
 
 fun buildInvalidTargetJdkNameChatContent(jdkName: String) = CodeTransformChatMessageContent(
     message = message("codemodernizer.chat.message.enter_jdk_name_error", jdkName),


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Save previously-entered JDK name so that users can see it easily.
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
