### PR TITLE
fix(amazonq): fix merge issue in QInlineCompletionProvider

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codewhisperer/popup/QInlineCompletionProvider.kt
@@ -608,9 +608,9 @@ class QInlineCompletionProvider(private val cs: CoroutineScope) : InlineCompleti
                             .activeConnectionForFeature(QConnection.getInstance()) as? AwsBearerTokenConnection
                         connection?.let { it.getConnectionSettings().tokenProvider.delegate as? BearerTokenProvider }
                             ?.invalidate()
-                        } catch (e: Exception) {
-                            LOG.warn(e) { "Failed to invalidate existing token in response to E_AMAZON_Q_CONNECTION_EXPIRED" }
-                        }
+                    } catch (e: Exception) {
+                        LOG.warn(e) { "Failed to invalidate existing token in response to E_AMAZON_Q_CONNECTION_EXPIRED" }
+                    }
                     CodeWhispererUtil.reconnectCodeWhisperer(project)
                 }
             }


### PR DESCRIPTION
refresh() was deleted
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
