### PR TITLE
fix(amazonq): include more context on chat response error

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
@@ -200,7 +200,7 @@ class ChatCommunicationManager(private val project: Project, private val cs: Cor
         var errorMessage: String? = null
         if (exception is ResponseErrorException) {
             errorMessage = tryOrNull {
-                Gson().fromJson(exception.responseError.data as JsonObject, ChatMessage::class.java).body
+                "${exception.responseError.message}: ${Gson().fromJson(exception.responseError.data as JsonObject, ChatMessage::class.java).body}"
             } ?: exception.responseError.message
         }
 


### PR DESCRIPTION
Sometimes the error body is not actually useful
```
An unexpected error occurred, check the logs for more information.
```

After:
```
McpManager not initialized—call McpManager.init(...) first: An unexpected error occurred, check the logs for more information.
```

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
