### PR TITLE
fix(amazonq): render drag&drop overlay and fix the issue that images …

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQPanel.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQPanel.kt
@@ -49,7 +49,9 @@ import software.aws.toolkits.jetbrains.services.codemodernizer.utils.isCodeTrans
 import software.aws.toolkits.resources.message
 import java.awt.datatransfer.DataFlavor
 import java.awt.dnd.DropTarget
+import java.awt.dnd.DropTargetDragEvent
 import java.awt.dnd.DropTargetDropEvent
+import java.awt.dnd.DropTargetEvent
 import java.io.File
 import java.util.concurrent.CompletableFuture
 import javax.imageio.ImageIO.read
@@ -138,6 +140,39 @@ class AmazonQPanel(val project: Project, private val scope: CoroutineScope) : Di
                             // As an alternative, enabling the native drag in JCEF,
                             // and let the native handling the drop event, and update the UI through JS bridge.
                             val dropTarget = object : DropTarget() {
+                                override fun dragEnter(dtde: DropTargetDragEvent) {
+                                    try {
+                                        browserInstance.jcefBrowser.cefBrowser.executeJavaScript(
+                                            "window.setDragAndDropVisible('true')",
+                                            browserInstance.jcefBrowser.cefBrowser.url,
+                                            0
+                                        )
+                                    } catch (e: Exception) {
+                                        LOG.error { "Failed to handle dragEnter: ${e.message}" }
+                                    }
+                                }
+                                override fun dragOver(dtde: DropTargetDragEvent) {
+                                    try {
+                                        browserInstance.jcefBrowser.cefBrowser.executeJavaScript(
+                                            "window.setDragAndDropVisible('true')",
+                                            browserInstance.jcefBrowser.cefBrowser.url,
+                                            0
+                                        )
+                                    } catch (e: Exception) {
+                                        LOG.error { "Failed to handle dragOver: ${e.message}" }
+                                    }
+                                }
+                                override fun dragExit(dte: DropTargetEvent) {
+                                    try {
+                                        browserInstance.jcefBrowser.cefBrowser.executeJavaScript(
+                                            "window.setDragAndDropVisible('false')",
+                                            browserInstance.jcefBrowser.cefBrowser.url,
+                                            0
+                                        )
+                                    } catch (e: Exception) {
+                                        LOG.error { "Failed to handle dragExit: ${e.message}" }
+                                    }
+                                }
                                 override fun drop(dtde: DropTargetDropEvent) {
                                     try {
                                         dtde.acceptDrop(dtde.dropAction)
@@ -165,6 +200,18 @@ class AmazonQPanel(val project: Project, private val scope: CoroutineScope) : Di
                                                 errorMessages.add("A maximum of 20 images can be added to a single message.")
                                                 validImages.subList(20, validImages.size).clear()
                                             }
+
+                                            browserInstance.jcefBrowser.cefBrowser.executeJavaScript(
+                                                "window.resetTopBarClicked()",
+                                                browserInstance.jcefBrowser.cefBrowser.url,
+                                                0
+                                            )
+
+                                            browserInstance.jcefBrowser.cefBrowser.executeJavaScript(
+                                                "window.setDragAndDropVisible('false')",
+                                                browserInstance.jcefBrowser.cefBrowser.url,
+                                                0
+                                            )
 
                                             val json = OBJECT_MAPPER.writeValueAsString(validImages)
                                             browserInstance.jcefBrowser.cefBrowser.executeJavaScript(

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
@@ -181,6 +181,15 @@ class Browser(parent: Disposable, private val webUri: URI, val project: Project)
                             })
                         });
                     };
+                    
+                    window.setDragAndDropVisible = function(visibility) {
+                        const parsedVisibility = JSON.parse(visibility);
+                        qChat.setDragOverlayVisible(qChat.getSelectedTabId(), parsedVisibility)
+                    };
+                    
+                    window.resetTopBarClicked = function() {
+                        qChat.resetTopBarClicked(qChat.getSelectedTabId())
+                    };
                 }
             </script>        
         """.trimIndent()


### PR DESCRIPTION
…added to pinned context from drag&drop

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

Fix the bug
1) Dragging an image sometimes adds it to pinned context instead of in the prompt
2) Drag overlay is not rendered

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

1. Images added via drag & drop are incorrectly routing to pinned contexts due to the topBarClicked signal not resetting properly. This occurs after interacting with the `@Pinned Context` menu and dismissing it, as the signal remains in a true state instead of resetting.
2. Handling the dragEnter/dragover/dragExit by calling Mynah UI public method to show/hide overlay 

## Checklist
- [ x ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
