### PR TITLE
fix(amazonq): isolate flare from user aws config files

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -463,6 +463,7 @@ private class AmazonQServerInstance(private val project: Project, private val cs
 
         val node = if (SystemInfo.isWindows) "node.exe" else "node"
         val nodePath = getNodeRuntimePath(artifact.resolve(node))
+        val emptyFile = Files.createTempFile("empty", null).toAbsolutePath().toString()
 
         val cmd = NodeExePatcher.patch(nodePath)
             .withParameters(
@@ -475,6 +476,9 @@ private class AmazonQServerInstance(private val project: Project, private val cs
                         LOG.info { "Starting Flare with NODE_EXTRA_CA_CERTS: $it" }
                         put("NODE_EXTRA_CA_CERTS", it)
                     }
+
+                    put("AWS_CONFIG_FILE", emptyFile)
+                    put("AWS_SHARED_CREDENTIALS_FILE", emptyFile)
 
                     // assume default endpoint will pick correct proxy if needed
                     val qUri = URI(QDefaultServiceConfig.ENDPOINT)


### PR DESCRIPTION
due to an AWS JS SDK v2 bug (which is EoL), profile redeclarion, though spec compliant, will result in a flare crash
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
