### PR TITLE
fix(amazonq): change to use promptStickyCard to for image verificatio…

### DIFF
--- a/.changes/next-release/bugfix-7ceafecb-844d-46ce-a68d-b28360840ab6.json
+++ b/.changes/next-release/bugfix-7ceafecb-844d-46ce-a68d-b28360840ab6.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "change to use promptStickyCard to for image verification notification"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQPanel.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/toolwindow/AmazonQPanel.kt
@@ -173,12 +173,15 @@ class AmazonQPanel(val project: Project, private val scope: CoroutineScope) : Di
                                                 0
                                             )
 
-                                            val errorJson = OBJECT_MAPPER.writeValueAsString(errorMessages)
-                                            browserInstance.jcefBrowser.cefBrowser.executeJavaScript(
-                                                "window.handleNativeNotify('$errorJson')",
-                                                browserInstance.jcefBrowser.cefBrowser.url,
-                                                0
-                                            )
+                                            if (errorMessages.isNotEmpty()) {
+                                                val errorJson = OBJECT_MAPPER.writeValueAsString(errorMessages)
+                                                browserInstance.jcefBrowser.cefBrowser.executeJavaScript(
+                                                    "window.handleNativeNotify('$errorJson')",
+                                                    browserInstance.jcefBrowser.cefBrowser.url,
+                                                    0
+                                                )
+                                            }
+
                                             dtde.dropComplete(true)
                                         } else {
                                             dtde.dropComplete(false)

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
@@ -175,11 +175,19 @@ class Browser(parent: Disposable, private val webUri: URI, val project: Project)
                       
                     window.handleNativeNotify = function(errorMessages) {
                         const messages = JSON.parse(errorMessages);
-                        messages.forEach(msg => {
-                            qChat.notify({
-                                content: msg
-                            })
-                        });
+                        let message = messages.join('\n');
+                        qChat.updateStore(qChat.getSelectedTabId(), {
+                            promptInputStickyCard: {
+                                messageId: 'image-verification-banner',
+                                header: {
+                                    icon: 'warning',
+                                    iconStatus: 'warning',
+                                    body: '### Invalid Image',
+                                },
+                                body: message,
+                                canBeDismissed: true,
+                            },
+                        })
                     };
                 }
             </script>        


### PR DESCRIPTION
…n notification

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
all errors are displayed near the top of the chat view and it's very easy to miss.

<img width="682" height="431" alt="Screenshot 2025-07-15 at 9 11 48 PM" src="https://github.com/user-attachments/assets/2ca79750-fdf7-4eb3-9866-57ce6f8ce397" />

After switch to use prompt sticky card, the error message are shown near the chat prompt

<img width="800" height="418" alt="Screenshot 2025-07-15 at 9 12 59 PM" src="https://github.com/user-attachments/assets/a8cf5dd9-aab2-48da-b289-f4d410989fb6" />



## Checklist
- [ x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
