### PR TITLE
fix(amazonq): suppress IDE error when editor does not actually contain text

### DIFF
--- a/.changes/next-release/bugfix-846e7004-5426-4f6b-970f-2b9437314b98.json
+++ b/.changes/next-release/bugfix-846e7004-5426-4f6b-970f-2b9437314b98.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Suppress IDE error when current editor context is not valid for Amazon Q"
+}

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -33,7 +33,10 @@ import org.eclipse.lsp4j.TextDocumentContentChangeEvent
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentItem
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
+import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.tryOrNull
+import software.aws.toolkits.core.utils.warn
+import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLanguageServer
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.model.aws.chat.ACTIVE_EDITOR_CHANGED_NOTIFICATION
 import software.aws.toolkits.jetbrains.services.amazonq.lsp.util.LspEditorUtil.getCursorState
@@ -98,40 +101,36 @@ class TextDocumentServiceHandler(
                 }
             }
 
-            cs.launch {
-                AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
-                    toUriString(file)?.let { uri ->
-                        languageServer.textDocumentService.didOpen(
-                            DidOpenTextDocumentParams().apply {
-                                textDocument = TextDocumentItem().apply {
-                                    this.uri = uri
-                                    text = file.inputStream.readAllBytes().decodeToString()
-                                    languageId = file.fileType.name.lowercase()
-                                    version = file.modificationStamp.toInt()
-                                }
+            trySendIfValid { languageServer ->
+                toUriString(file)?.let { uri ->
+                    languageServer.textDocumentService.didOpen(
+                        DidOpenTextDocumentParams().apply {
+                            textDocument = TextDocumentItem().apply {
+                                this.uri = uri
+                                text = file.inputStream.readAllBytes().decodeToString()
+                                languageId = file.fileType.name.lowercase()
+                                version = file.modificationStamp.toInt()
                             }
-                        )
-                    }
+                        }
+                    )
                 }
             }
         }
     }
 
     override fun beforeDocumentSaving(document: Document) {
-        cs.launch {
-            AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
-                val file = FileDocumentManager.getInstance().getFile(document) ?: return@executeAsyncIfRunning
-                toUriString(file)?.let { uri ->
-                    languageServer.textDocumentService.didSave(
-                        DidSaveTextDocumentParams().apply {
-                            textDocument = TextDocumentIdentifier().apply {
-                                this.uri = uri
-                            }
-                            // TODO: should respect `textDocumentSync.save.includeText` server capability config
-                            text = document.text
+        trySendIfValid { languageServer ->
+            val file = FileDocumentManager.getInstance().getFile(document) ?: return@trySendIfValid
+            toUriString(file)?.let { uri ->
+                languageServer.textDocumentService.didSave(
+                    DidSaveTextDocumentParams().apply {
+                        textDocument = TextDocumentIdentifier().apply {
+                            this.uri = uri
                         }
-                    )
-                }
+                        // TODO: should respect `textDocumentSync.save.includeText` server capability config
+                        text = document.text
+                    }
+                )
             }
         }
     }
@@ -141,23 +140,21 @@ class TextDocumentServiceHandler(
             val document = FileDocumentManager.getInstance().getCachedDocument(event.file) ?: return@forEach
 
             handleFileOpened(event.file)
-            cs.launch {
-                AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
-                    toUriString(event.file)?.let { uri ->
-                        languageServer.textDocumentService.didChange(
-                            DidChangeTextDocumentParams().apply {
-                                textDocument = VersionedTextDocumentIdentifier().apply {
-                                    this.uri = uri
-                                    version = document.modificationStamp.toInt()
-                                }
-                                contentChanges = listOf(
-                                    TextDocumentContentChangeEvent().apply {
-                                        text = document.text
-                                    }
-                                )
+            trySendIfValid { languageServer ->
+                toUriString(event.file)?.let { uri ->
+                    languageServer.textDocumentService.didChange(
+                        DidChangeTextDocumentParams().apply {
+                            textDocument = VersionedTextDocumentIdentifier().apply {
+                                this.uri = uri
+                                version = document.modificationStamp.toInt()
                             }
-                        )
-                    }
+                            contentChanges = listOf(
+                                TextDocumentContentChangeEvent().apply {
+                                    text = document.text
+                                }
+                            )
+                        }
+                    )
                 }
             }
         }
@@ -179,17 +176,15 @@ class TextDocumentServiceHandler(
             tryOrNull { FileDocumentManager.getInstance().getDocument(file)?.removeDocumentListener(listener) }
             file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, null)
 
-            cs.launch {
-                AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
-                    toUriString(file)?.let { uri ->
-                        languageServer.textDocumentService.didClose(
-                            DidCloseTextDocumentParams().apply {
-                                textDocument = TextDocumentIdentifier().apply {
-                                    this.uri = uri
-                                }
+            trySendIfValid { languageServer ->
+                toUriString(file)?.let { uri ->
+                    languageServer.textDocumentService.didClose(
+                        DidCloseTextDocumentParams().apply {
+                            textDocument = TextDocumentIdentifier().apply {
+                                this.uri = uri
                             }
-                        )
-                    }
+                        }
+                    )
                 }
             }
         }
@@ -221,24 +216,22 @@ class TextDocumentServiceHandler(
     }
 
     private fun realTimeEdit(event: DocumentEvent) {
-        cs.launch {
-            AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
-                val vFile = FileDocumentManager.getInstance().getFile(event.document) ?: return@executeAsyncIfRunning
-                toUriString(vFile)?.let { uri ->
-                    languageServer.textDocumentService.didChange(
-                        DidChangeTextDocumentParams().apply {
-                            textDocument = VersionedTextDocumentIdentifier().apply {
-                                this.uri = uri
-                                version = event.document.modificationStamp.toInt()
-                            }
-                            contentChanges = listOf(
-                                TextDocumentContentChangeEvent().apply {
-                                    text = event.document.text
-                                }
-                            )
+        trySendIfValid { languageServer ->
+            val vFile = FileDocumentManager.getInstance().getFile(event.document) ?: return@trySendIfValid
+            toUriString(vFile)?.let { uri ->
+                languageServer.textDocumentService.didChange(
+                    DidChangeTextDocumentParams().apply {
+                        textDocument = VersionedTextDocumentIdentifier().apply {
+                            this.uri = uri
+                            version = event.document.modificationStamp.toInt()
                         }
-                    )
-                }
+                        contentChanges = listOf(
+                            TextDocumentContentChangeEvent().apply {
+                                text = event.document.text
+                            }
+                        )
+                    }
+                )
             }
         }
         // Process document changes here
@@ -247,7 +240,20 @@ class TextDocumentServiceHandler(
     override fun dispose() {
     }
 
+    private fun trySendIfValid(runnable: (AmazonQLanguageServer) -> Unit) {
+        cs.launch {
+            AmazonQLspService.executeAsyncIfRunning(project) { languageServer ->
+                try {
+                    runnable(languageServer)
+                } catch (e: Exception) {
+                    LOG.warn { "Invalid document: $e" }
+                }
+            }
+        }
+    }
+
     companion object {
         private val KEY_REAL_TIME_EDIT_LISTENER = Key.create<DocumentListener>("amazonq.textdocument.realtimeedit.listener")
+        private val LOG = getLogger<TextDocumentServiceHandler>()
     }
 }

--- a/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandlerTest.kt
+++ b/plugins/amazonq/shared/jetbrains-community/tst/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandlerTest.kt
@@ -189,6 +189,19 @@ class TextDocumentServiceHandlerTest {
     }
 
     @Test
+    fun `fileOpened suppreses document read failure`() = runTest {
+        sut = TextDocumentServiceHandler(projectRule.project, this)
+        advanceUntilIdle()
+
+        val document = mockk<VirtualFile> {
+            every { inputStream } throws RuntimeException("read failure")
+        }
+        sut.fileOpened(mockk(), document)
+
+        verify(exactly = 0) { mockTextDocumentService.didOpen(any()) }
+    }
+
+    @Test
     fun `didClose runs on fileClosed`() = runTest {
         sut = TextDocumentServiceHandler(projectRule.project, this)
         val file = withContext(EDT) {


### PR DESCRIPTION
```
java.lang.UnsupportedOperationException: No read for table file
	at com.intellij.database.vfs.DatabaseElementVirtualFileImpl.getInputStream(DatabaseElementVirtualFileImpl.java:216)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler$handleFileOpened$3$1.invokeSuspend(TextDocumentServiceHandler.kt:108)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler$handleFileOpened$3$1.invoke(TextDocumentServiceHandler.kt)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler$handleFileOpened$3$1.invoke(TextDocumentServiceHandler.kt)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService$executeIfRunning$2.invokeSuspend(AmazonQLspService.kt:318)
	at _COROUTINE._BOUNDARY._(CoroutineDebugging.kt:42)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler$handleFileOpened$3.invokeSuspend(TextDocumentServiceHandler.kt:102)
Caused by: java.lang.UnsupportedOperationException: No read for table file
	at com.intellij.database.vfs.DatabaseElementVirtualFileImpl.getInputStream(DatabaseElementVirtualFileImpl.java:216)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler$handleFileOpened$3$1.invokeSuspend(TextDocumentServiceHandler.kt:108)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler$handleFileOpened$3$1.invoke(TextDocumentServiceHandler.kt)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler$handleFileOpened$3$1.invoke(TextDocumentServiceHandler.kt)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQLspService$executeIfRunning$2.invokeSuspend(AmazonQLspService.kt:318)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:21)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:88)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:123)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler.handleFileOpened(TextDocumentServiceHandler.kt:101)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler.access$handleFileOpened(TextDocumentServiceHandler.kt:42)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler$1.invokeSuspend(TextDocumentServiceHandler.kt:74)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:21)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:88)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:123)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.textdocument.TextDocumentServiceHandler.<init>(TextDocumentServiceHandler.kt:71)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance._init_$lambda$34(AmazonQLspService.kt:594)
	at software.aws.toolkits.jetbrains.services.amazonq.lsp.AmazonQServerInstance._init_$lambda$35(AmazonQLspService.kt:585)
	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934)
	at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:911)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1491)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:2073)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2035)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
```
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
