### PR TITLE
build: fix JVM crash when switching between IDE MV builds

### DIFF
--- a/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
@@ -53,11 +53,13 @@ intellijPlatform {
 tasks.prepareSandbox {
     val pluginName = intellijPlatform.projectName
 
-    from(resharperDlls)
-        .into(pluginName.map { "$it/dotnet" })
+    from(resharperDlls) {
+        into(pluginName.map { "$it/dotnet" })
+    }
 
-    .from(gatewayResources)
-        .into(pluginName.map { "$it/gateway-resources" })
+    from(gatewayResources) {
+        into(pluginName.map { "$it/gateway-resources" })
+    }
 }
 
 // We have no source in this project, so skip test task

--- a/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
@@ -53,11 +53,11 @@ intellijPlatform {
 tasks.prepareSandbox {
     val pluginName = intellijPlatform.projectName
 
-        from(resharperDlls)
-            .into(pluginName.map { "$it/dotnet" })
+    from(resharperDlls)
+        .into(pluginName.map { "$it/dotnet" })
 
-        .from(gatewayResources)
-            .into(pluginName.map { "$it/gateway-resources" })
+    .from(gatewayResources)
+        .into(pluginName.map { "$it/gateway-resources" })
 }
 
 // We have no source in this project, so skip test task

--- a/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
@@ -53,11 +53,11 @@ intellijPlatform {
 tasks.prepareSandbox {
     val pluginName = intellijPlatform.projectName
 
-    intoChild(pluginName.map { "$it/dotnet" })
-        .from(resharperDlls)
+        from(resharperDlls)
+            .into(pluginName.map { "$it/dotnet" })
 
-    intoChild(pluginName.map { "$it/gateway-resources" })
         .from(gatewayResources)
+            .into(pluginName.map { "$it/gateway-resources" })
 }
 
 // We have no source in this project, so skip test task

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ detekt = "1.23.8"
 diff-util = "4.12"
 intellijExt = "1.1.8"
 # match with <root>/settings.gradle.kts
-intellijGradle = "2.6.0"
+intellijGradle = "2.7.1-SNAPSHOT"
 intellijRemoteRobot = "0.11.22"
 jackson = "2.17.2"
 jacoco = "0.8.12"

--- a/plugins/amazonq/build.gradle.kts
+++ b/plugins/amazonq/build.gradle.kts
@@ -133,8 +133,8 @@ val prepareBundledFlare by tasks.registering(Copy::class) {
 }
 
 tasks.withType<PrepareSandboxTask>().configureEach {
-    intoChild(intellijPlatform.projectName.map { "$it/lib" })
-        .from(file("contrib/QCT-Maven-6-16.jar"))
-    intoChild(intellijPlatform.projectName.map { "$it/flare" })
-        .from(prepareBundledFlare)
+    from(intellijPlatform.projectName.map { "$it/lib" })
+        .into(file("contrib/QCT-Maven-6-16.jar"))
+    from(intellijPlatform.projectName.map { "$it/flare" })
+        .into(prepareBundledFlare)
 }

--- a/plugins/amazonq/build.gradle.kts
+++ b/plugins/amazonq/build.gradle.kts
@@ -133,8 +133,10 @@ val prepareBundledFlare by tasks.registering(Copy::class) {
 }
 
 tasks.withType<PrepareSandboxTask>().configureEach {
-    from(intellijPlatform.projectName.map { "$it/lib" })
-        .into(file("contrib/QCT-Maven-6-16.jar"))
-    from(intellijPlatform.projectName.map { "$it/flare" })
-        .into(prepareBundledFlare)
+    from(file("contrib/QCT-Maven-6-16.jar")) {
+        into(intellijPlatform.projectName.map { "$it/lib" })
+    }
+    from(prepareBundledFlare) {
+        into(intellijPlatform.projectName.map { "$it/flare" })
+    }
 }

--- a/plugins/amazonq/codetransform/jetbrains-community/build.gradle.kts
+++ b/plugins/amazonq/codetransform/jetbrains-community/build.gradle.kts
@@ -32,6 +32,7 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-amazonq").tasks.jar
 
     dependsOn(pluginXmlJar)
-    from(intellijPlatform.projectName.map { "$it/lib" })
-        .into(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" }) {
+        into(pluginXmlJar)
+    }
 }

--- a/plugins/amazonq/codetransform/jetbrains-community/build.gradle.kts
+++ b/plugins/amazonq/codetransform/jetbrains-community/build.gradle.kts
@@ -32,6 +32,6 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-amazonq").tasks.jar
 
     dependsOn(pluginXmlJar)
-    intoChild(intellijPlatform.projectName.map { "$it/lib" })
-        .from(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" })
+        .into(pluginXmlJar)
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/build.gradle.kts
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/build.gradle.kts
@@ -31,6 +31,6 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-amazonq").tasks.jar
 
     dependsOn(pluginXmlJar)
-    intoChild(intellijPlatform.projectName.map { "$it/lib" })
-        .from(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" })
+        .into(pluginXmlJar)
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-community/build.gradle.kts
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/build.gradle.kts
@@ -31,6 +31,7 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-amazonq").tasks.jar
 
     dependsOn(pluginXmlJar)
-    from(intellijPlatform.projectName.map { "$it/lib" })
-        .into(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" }) {
+        into(pluginXmlJar)
+    }
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-ultimate/build.gradle.kts
+++ b/plugins/amazonq/codewhisperer/jetbrains-ultimate/build.gradle.kts
@@ -31,6 +31,6 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-amazonq").tasks.jar
 
     dependsOn(pluginXmlJar)
-    intoChild(intellijPlatform.projectName.map { "$it/lib" })
-        .from(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" })
+        .into(pluginXmlJar)
 }

--- a/plugins/amazonq/codewhisperer/jetbrains-ultimate/build.gradle.kts
+++ b/plugins/amazonq/codewhisperer/jetbrains-ultimate/build.gradle.kts
@@ -31,6 +31,7 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-amazonq").tasks.jar
 
     dependsOn(pluginXmlJar)
-    from(intellijPlatform.projectName.map { "$it/lib" })
-        .into(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" }) {
+        into(pluginXmlJar)
+    }
 }

--- a/plugins/amazonq/shared/jetbrains-community/build.gradle.kts
+++ b/plugins/amazonq/shared/jetbrains-community/build.gradle.kts
@@ -30,6 +30,6 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-amazonq").tasks.jar
 
     dependsOn(pluginXmlJar)
-    intoChild(intellijPlatform.projectName.map { "$it/lib" })
-        .from(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" })
+        .into(pluginXmlJar)
 }

--- a/plugins/amazonq/shared/jetbrains-community/build.gradle.kts
+++ b/plugins/amazonq/shared/jetbrains-community/build.gradle.kts
@@ -30,6 +30,7 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-amazonq").tasks.jar
 
     dependsOn(pluginXmlJar)
-    from(intellijPlatform.projectName.map { "$it/lib" })
-        .into(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" }) {
+        into(pluginXmlJar)
+    }
 }

--- a/plugins/core/jetbrains-community/build.gradle.kts
+++ b/plugins/core/jetbrains-community/build.gradle.kts
@@ -95,6 +95,7 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-core").tasks.jar
 
     dependsOn(pluginXmlJar)
-    from(intellijPlatform.projectName.map { "$it/lib" })
-        .into(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" }) {
+        into(pluginXmlJar)
+    }
 }

--- a/plugins/core/jetbrains-community/build.gradle.kts
+++ b/plugins/core/jetbrains-community/build.gradle.kts
@@ -95,6 +95,6 @@ tasks.prepareTestSandbox {
     val pluginXmlJar = project(":plugin-core").tasks.jar
 
     dependsOn(pluginXmlJar)
-    intoChild(intellijPlatform.projectName.map { "$it/lib" })
-        .from(pluginXmlJar)
+    from(intellijPlatform.projectName.map { "$it/lib" })
+        .into(pluginXmlJar)
 }

--- a/plugins/toolkit/jetbrains-gateway/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-gateway/build.gradle.kts
@@ -138,8 +138,9 @@ tasks.jar {
 }
 
 tasks.withType<PrepareSandboxTask>().configureEach {
-    from(intellijPlatform.projectName.map { "$it/gateway-resources" })
-        .into(gatewayResourcesDir)
+    from(intellijPlatform.projectName.map { "$it/gateway-resources" }) {
+        into(gatewayResourcesDir)
+    }
 }
 
 listOf(
@@ -150,8 +151,9 @@ listOf(
         runtimeClasspath.setFrom(gatewayOnlyRuntimeClasspath)
 
         dependsOn(gatewayOnlyResourcesJar)
-        from(intellijPlatform.projectName.map { "$it/lib" })
-            .into(gatewayOnlyResourcesJar)
+        from(intellijPlatform.projectName.map { "$it/lib" }) {
+            into(gatewayOnlyResourcesJar)
+        }
     }
 }
 

--- a/plugins/toolkit/jetbrains-gateway/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-gateway/build.gradle.kts
@@ -138,8 +138,8 @@ tasks.jar {
 }
 
 tasks.withType<PrepareSandboxTask>().configureEach {
-    intoChild(intellijPlatform.projectName.map { "$it/gateway-resources" })
-        .from(gatewayResourcesDir)
+    from(intellijPlatform.projectName.map { "$it/gateway-resources" })
+        .into(gatewayResourcesDir)
 }
 
 listOf(
@@ -150,8 +150,8 @@ listOf(
         runtimeClasspath.setFrom(gatewayOnlyRuntimeClasspath)
 
         dependsOn(gatewayOnlyResourcesJar)
-        intoChild(intellijPlatform.projectName.map { "$it/lib" })
-            .from(gatewayOnlyResourcesJar)
+        from(intellijPlatform.projectName.map { "$it/lib" })
+            .into(gatewayOnlyResourcesJar)
     }
 }
 

--- a/plugins/toolkit/jetbrains-rider/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-rider/build.gradle.kts
@@ -338,8 +338,9 @@ tasks.withType<PrepareSandboxTask>().configureEach {
 
     dependsOn(resharperDllsDir)
 
-    from(intellijPlatform.projectName.map { "$it/dotnet" })
-        .into(resharperDllsDir)
+    from(intellijPlatform.projectName.map { "$it/dotnet" }) {
+        into(resharperDllsDir)
+    }
 }
 
 tasks.compileKotlin {

--- a/plugins/toolkit/jetbrains-rider/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-rider/build.gradle.kts
@@ -338,8 +338,8 @@ tasks.withType<PrepareSandboxTask>().configureEach {
 
     dependsOn(resharperDllsDir)
 
-    intoChild(intellijPlatform.projectName.map { "$it/dotnet" })
-        .from(resharperDllsDir)
+    from(intellijPlatform.projectName.map { "$it/dotnet" })
+        .into(resharperDllsDir)
 }
 
 tasks.compileKotlin {

--- a/sandbox-all/build.gradle.kts
+++ b/sandbox-all/build.gradle.kts
@@ -6,6 +6,7 @@ import software.aws.toolkits.gradle.intellij.IdeFlavor
 import software.aws.toolkits.gradle.intellij.toolkitIntelliJ
 
 plugins {
+    id("toolkit-jvm-conventions")
     id("toolkit-intellij-plugin")
     id("toolkit-publish-root-conventions")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,20 +17,32 @@ val codeArtifactMavenRepo = fun RepositoryHandler.(): MavenArtifactRepository? {
     } else {
         null
     }
-}.also {
-    pluginManagement {
-        repositories {
-            it()
-            maven("https://oss.sonatype.org/content/repositories/snapshots/")
-            gradlePluginPortal()
+}
+
+pluginManagement {
+    repositories {
+        // unfortunately pluginManagement is special, so we need to duplicate
+        val codeArtifactUrl: Provider<String> = providers.environmentVariable("CODEARTIFACT_URL")
+        val codeArtifactToken: Provider<String> = providers.environmentVariable("CODEARTIFACT_AUTH_TOKEN")
+        if (codeArtifactUrl.isPresent && codeArtifactToken.isPresent) {
+            maven {
+                url = uri(codeArtifactUrl.get())
+                credentials {
+                    username = "aws"
+                    password = codeArtifactToken.get()
+                }
+            }
         }
+
+        gradlePluginPortal()
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
     }
 }
 
 plugins {
     id("com.github.burrunan.s3-build-cache") version "1.5"
     id("com.gradle.develocity") version "3.17.6"
-    id("org.jetbrains.intellij.platform.settings") version "2.6.0"
+    id("org.jetbrains.intellij.platform.settings") version "2.7.1-SNAPSHOT"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
In 252, the coroutine debug agent has a new JAR entrypoint. Due to a platform plugin bug, Gradle will always cache the agent jar, which results in a class not found crash when launching the IDE.

Pull in latest SNAPSHOT build to fix in the interim


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
