### PR TITLE
fix(toolkit): fix incompatible version warning

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
@@ -14,7 +14,6 @@ plugins {
 
 tasks.withType<PatchPluginXmlTask>().configureEach {
     sinceBuild.set(toolkitIntelliJ.ideProfile().map { it.sinceVersion })
-    untilBuild.set(toolkitIntelliJ.ideProfile().map { it.untilVersion })
 }
 
 intellijPlatform {

--- a/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
@@ -69,7 +69,7 @@
 
     <vendor email="aws-toolkit-jetbrains@amazon.com" url="https://github.com/aws/aws-toolkit-jetbrains">AWS</vendor>
     <!-- 223.7571.182 is 2022.3 Stable -->
-    <idea-version since-build="223.7571.182" until-build="224.*"/>
+    <idea-version since-build="223.7571.182" />
 
     <!-- a 'resource-bundle' declaration under <idea-plugin> declares the global default for the entire plugin -->
     <!-- use the 'resource-bundle' attribute in 'actions' tag if another bundle is needed -->


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
AWS Toolkit is not upgrading to 252 and stays at 251 causing a plugin mismatch between AWS Core and AWS Toolkit

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
