### PR TITLE
fix(toolkit): fix plugin descriptor not formed correctly

### DIFF
--- a/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
 //        create(type, version, useInstaller = false)
 //    }
 
+    implementation(project(":plugin-toolkit:jetbrains-core"))
     implementation(project(":plugin-toolkit:jetbrains-ultimate"))
     project.findProject(":plugin-toolkit:jetbrains-gateway")?.let {
         // does this need to be the instrumented variant?

--- a/plugins/toolkit/intellij-standalone/build.gradle.kts
+++ b/plugins/toolkit/intellij-standalone/build.gradle.kts
@@ -21,9 +21,6 @@ intellijPlatform {
 dependencies {
     intellijPlatform {
         localPlugin(project(":plugin-core"))
-        pluginModule(project(":plugin-toolkit:jetbrains-core"))
-
-        plugin("PythonCore:243.18137.10")
     }
 }
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
The plugin descriptor wasnt getting formed correctly for toolkit. We don't need to create modules anymore

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
