### PR TITLE
feat(amazonq): limit remote to amzn-internal compute

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/utils/RemoteEnvUtils.kt
@@ -5,6 +5,10 @@ package software.aws.toolkits.jetbrains.utils
 
 import com.intellij.idea.AppMode
 import com.intellij.ui.jcef.JBCefApp
+import software.aws.toolkits.core.utils.exists
+import software.aws.toolkits.core.utils.tryOrNull
+import software.aws.toolkits.jetbrains.isDeveloperMode
+import java.nio.file.Paths
 
 /**
  * @return true if running in any type of remote environment
@@ -16,4 +20,20 @@ fun isRunningOnRemoteBackend() = AppMode.isRemoteDevHost()
  */
 fun isCodeCatalystDevEnv() = System.getenv("__DEV_ENVIRONMENT_ID") != null
 
-fun isQWebviewsAvailable() = JBCefApp.isSupported()
+/**
+ * @return low fidelity "is internal compute". is not exact and may fail at any time
+ */
+private val isInternalAmznLinuxCompute by lazy {
+    tryOrNull {
+        Paths.get("/apollo").exists()
+    } ?: false
+}
+
+/**
+ * On remote, only enabled experimentally and for internal
+ */
+fun isQWebviewsAvailable() = JBCefApp.isSupported() && if (!isRunningOnRemoteBackend()) {
+    true
+} else {
+    isDeveloperMode() || isInternalAmznLinuxCompute
+}


### PR DESCRIPTION
Per internal discussion, feature deemed not ready for external users due to https://youtrack.jetbrains.com/issue/IJPL-203169

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
