### PR TITLE
fix(amazonq): ensure plan opens for min JDK upgrades

### DIFF
--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerManager.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerManager.kt
@@ -477,7 +477,7 @@ class CodeModernizerManager(private val project: Project) : PersistentStateCompo
         transformType,
         jobId
     ) { new, plan ->
-        codeModernizerBottomWindowPanelManager.handleJobTransition(new, plan, session.sessionContext.sourceJavaVersion, transformType)
+        codeModernizerBottomWindowPanelManager.handleJobTransition(new, plan, session.sessionContext, transformType)
     }
 
     private suspend fun handleJobStarted(jobId: JobId, session: CodeModernizerSession): CodeModernizerJobCompletedResult {
@@ -491,7 +491,7 @@ class CodeModernizerManager(private val project: Project) : PersistentStateCompo
         val transformType = if (session.sessionContext.sqlMetadataZip != null) CodeTransformType.SQL_CONVERSION else CodeTransformType.LANGUAGE_UPGRADE
 
         return session.pollUntilJobCompletion(transformType, jobId) { new, plan ->
-            codeModernizerBottomWindowPanelManager.handleJobTransition(new, plan, session.sessionContext.sourceJavaVersion, transformType)
+            codeModernizerBottomWindowPanelManager.handleJobTransition(new, plan, session.sessionContext, transformType)
         }
     }
 

--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/CodeModernizerSession.kt
@@ -478,8 +478,8 @@ class CodeModernizerSession(
                 }
 
                 if (!isTransformationPlanEditorOpened && transformType == CodeTransformType.LANGUAGE_UPGRADE) {
-                    val isPlanComplete = isPlanComplete(state.transformationPlan)
-                    if (isPlanComplete) {
+                    val isPlanComplete = isPlanComplete(state.transformationPlan, sessionContext)
+                    if (isPlanComplete && state.transformationPlan != null) {
                         tryOpenTransformationPlanEditor()
                         isTransformationPlanEditorOpened = true
                     }

--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/panels/managers/CodeModernizerBottomWindowPanelManager.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/panels/managers/CodeModernizerBottomWindowPanelManager.kt
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.codewhispererruntime.model.Transformation
 import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.warn
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.CodeModernizerJobCompletedResult
+import software.aws.toolkits.jetbrains.services.codemodernizer.model.CodeModernizerSessionContext
 import software.aws.toolkits.jetbrains.services.codemodernizer.model.CodeTransformType
 import software.aws.toolkits.jetbrains.services.codemodernizer.panels.CodeModernizerBanner
 import software.aws.toolkits.jetbrains.services.codemodernizer.panels.CodeModernizerJobHistoryTablePanel
@@ -244,7 +245,7 @@ class CodeModernizerBottomWindowPanelManager(private val project: Project) : JPa
         return actionManager.createActionToolbar(ACTION_PLACE, group, false)
     }
 
-    fun handleJobTransition(new: TransformationStatus, plan: TransformationPlan?, sourceJdk: JavaSdkVersion, transformType: CodeTransformType) = invokeLater {
+    fun handleJobTransition(new: TransformationStatus, plan: TransformationPlan?, sessionContext: CodeModernizerSessionContext, transformType: CodeTransformType) = invokeLater {
         if (new in listOf(
                 TransformationStatus.PLANNED,
                 TransformationStatus.TRANSFORMING,
@@ -252,12 +253,12 @@ class CodeModernizerBottomWindowPanelManager(private val project: Project) : JPa
                 TransformationStatus.PAUSED,
                 TransformationStatus.COMPLETED,
                 TransformationStatus.PARTIALLY_COMPLETED
-            ) && transformType == CodeTransformType.LANGUAGE_UPGRADE && isPlanComplete(plan)
+            ) && transformType == CodeTransformType.LANGUAGE_UPGRADE && isPlanComplete(plan, sessionContext)
         ) {
             addPlanToBanner()
         }
         buildProgressSplitterPanelManager.apply {
-            handleProgressStateChanged(new, plan, sourceJdk, transformType)
+            handleProgressStateChanged(new, plan, sessionContext.sourceJavaVersion, transformType)
             if (timer == null) {
                 timer = Timer()
                 timer?.scheduleAtFixedRate(

--- a/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/panels/managers/CodeModernizerBottomWindowPanelManager.kt
+++ b/plugins/amazonq/codetransform/jetbrains-community/src/software/aws/toolkits/jetbrains/services/codemodernizer/panels/managers/CodeModernizerBottomWindowPanelManager.kt
@@ -245,7 +245,12 @@ class CodeModernizerBottomWindowPanelManager(private val project: Project) : JPa
         return actionManager.createActionToolbar(ACTION_PLACE, group, false)
     }
 
-    fun handleJobTransition(new: TransformationStatus, plan: TransformationPlan?, sessionContext: CodeModernizerSessionContext, transformType: CodeTransformType) = invokeLater {
+    fun handleJobTransition(
+        new: TransformationStatus,
+        plan: TransformationPlan?,
+        sessionContext: CodeModernizerSessionContext,
+        transformType: CodeTransformType,
+    ) = invokeLater {
         if (new in listOf(
                 TransformationStatus.PLANNED,
                 TransformationStatus.TRANSFORMING,


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Transformation plan was not opening for min JDK upgrades due to `isPlanComplete` method bug: if doing a JDK upgrade, as soon as plan is non-null, plan is complete, so open it.
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
