### PR TITLE
fix(amazonq): Fix empty conversationId in telemetry

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/clients/chat/v1/ChatSessionV1.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/cwc/clients/chat/v1/ChatSessionV1.kt
@@ -51,6 +51,7 @@ import software.aws.toolkits.jetbrains.services.cwc.clients.chat.model.Suggested
 import software.aws.toolkits.jetbrains.services.cwc.clients.chat.model.Suggestion
 import software.aws.toolkits.jetbrains.services.cwc.clients.chat.model.TriggerType
 import software.aws.toolkits.jetbrains.services.cwc.editor.context.ActiveFileContext
+import java.util.UUID
 
 class ChatSessionV1(
     private val project: Project,
@@ -62,13 +63,13 @@ class ChatSessionV1(
         var requestId: String = ""
         var statusCode: Int = 0
         val responseHandler = GenerateAssistantResponseResponseHandler.builder()
-            .onResponse {
-                requestId = it.responseMetadata().requestId()
-                statusCode = it.sdkHttpResponse().statusCode()
-                conversationId = it.conversationId()
+            .onResponse { response ->
+                requestId = response.responseMetadata().requestId()
+                statusCode = response.sdkHttpResponse().statusCode()
+                conversationId = response.conversationId().takeIf { !it.isNullOrBlank() } ?: "client-inline-${UUID.randomUUID()}"
 
                 logger.info {
-                    val metadata = it.responseMetadata()
+                    val metadata = response.responseMetadata()
                     "Response to tab: ${data.tabId}, conversationId: $conversationId, requestId: ${metadata.requestId()}, metadata: $metadata"
                 }
             }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

JetBrains inline chat generates code successfully but users cannot see the results due to a 400 validation error when sending telemetry events. The backend rejects telemetry with empty `conversationId` field, returning:

```
com.amazon.coral.validate.ValidationException: 1 validation error detected: Value at telemetryEvent.chatAddMessageEvent.conversationId failed to satisfy constraint: Member must have length greater than or equal to 1
```

From the JB logs:

```
Request from tab: 3703d901-dadd-4e80-8e9d-222557105bc6, conversationId: null
Response to tab: 3703d901-dadd-4e80-8e9d-222557105bc6, conversationId: 

```

The API returns an empty string for conversationId in inline chat scenarios, which gets stored and later causes telemetry validation failures.

### Flow:

- JetBrains creates new inline chat tab → conversationId = null

- API call made → API returns empty string conversationId: ""

- ChatSessionV1 stores empty string → conversationId = it.conversationId()

- TelemetryHelper retrieves empty string → getConversationId(tabId) returns ""

- Backend rejects telemetry → 400 error


## Solution
Generate a UUID when the API returns null or empty conversationId. This ensures telemetry always has a valid conversationId.


## Testing

Testing was conducted in sandbox and was not able to reproduce issue. From logs in Sandbox:


```
2025-09-09 14:44:22,582 [ 181075]   INFO - software.aws.toolkits.jetbrains.services.cwc.clients.chat.v1.ChatSessionV1 - Request from tab: 31e9a81e-e5fa-4aab-8fc7-eeefb8188b15, conversationId: null, request: GenerateAssistantResponseRequest(ConversationState=ConversationState(CurrentMessage=ChatMessage(UserInputMessage=UserInputMessage(Content=*** Sensitive Data Redacted ***, UserInputMessageContext=UserInputMessageContext(EditorState=EditorState(Document=TextDocument(RelativeFilePath=*** Sensitive Data Redacted ***, ProgrammingLanguage=ProgrammingLanguage(LanguageName=python), Text=*** Sensitive Data Redacted ***, DocumentSymbols=[]), CursorState=CursorState(Range=Range(Start=Position(Line=13, Character=8), End=Position(Line=18, Character=19))), RelevantDocuments=[], UseRelevantDocuments=false, WorkspaceFolders=*** Sensitive Data Redacted ***)))), ChatTriggerType=INLINE_CHAT, CustomizationArn=arn:aws:codewhisperer:us-east-1:011528293760:customization/XMAXDH7RXN44), ProfileArn=arn:aws:codewhisperer:us-east-1:724904587780:profile/KGGD9MM7EMNX)
2025-09-09 14:44:24,846 [ 183339]   INFO - software.aws.toolkits.jetbrains.services.cwc.clients.chat.v1.ChatSessionV1 - Response to tab: 31e9a81e-e5fa-4aab-8fc7-eeefb8188b15, conversationId: aaa78bb9-07af-4ecc-993e-2ed14384e1a6, requestId: 9ddb092a-9495-4668-b504-0b24d1948269, metadata: AwsResponseMetadata(metadata=[AWS_REQUEST_ID, x-amzn-RequestId, :content-type, :event-type, :message-type])
```

We can see that a random UUID was generated

## Checklist
- [X] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
