### PR TITLE
Fix Windows URI construction bug causing ENOENT errors in workspace-s…

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/util/LspEditorUtil.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/util/LspEditorUtil.kt
@@ -45,15 +45,10 @@ object LspEditorUtil {
     }
 
     private fun toUri(file: File): URI {
-        try {
-            // URI scheme specified by language server protocol
-            val uri = URI("file", "", file.absoluteFile.toURI().path, null)
-            val fallback = file.toPath().toAbsolutePath().normalize().toUri()
-            return if (uri.isCompliant()) uri else fallback
-        } catch (e: URISyntaxException) {
-            LOG.warn { "${e.localizedMessage}: $e" }
-            return file.absoluteFile.toURI()
-        }
+        // Use Path.toUri() for proper cross-platform URI handling
+        // Fixes Windows MCP workspace configuration bug where malformed URIs
+        // get interpreted as literal file paths during directory creation
+        return file.toPath().toAbsolutePath().normalize().toUri()
     }
 
     private fun URI.isCompliant(): Boolean {


### PR DESCRIPTION
## Problem

Fixes workspace MCP configuration on Windows for JetBrains IDEs.

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Workspace-scoped MCP configuration fails on Windows with:
ENOENT: no such file or directory, mkdir 'C:\Program Files\JetBrains\PyCharm\file:\C:\Users...\workspace.amazonq\agents'

Bug:
Workspace scoped MCP configuration fail under Windows #7774
https://github.com/aws/aws-toolkit-vscode/issues/7774


## Root Cause  
Manual URI construction in `LspEditorUtil.toUri()` creates malformed URIs on Windows that get interpreted as literal file paths.

## Solution
- Replace manual URI construction with `Path.toUri()`
- Ensures proper cross-platform URI handling
- Eliminates malformed path issues


## Checklist
- [X] My code follows the code style of this project
- [New guy Need help with this ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
