### PR TITLE
fix(amazonq): handle displayFindings output properly, remove /review language

### DIFF
--- a/.changes/next-release/bugfix-629f7494-5072-401f-bb18-b16e7a79ddac.json
+++ b/.changes/next-release/bugfix-629f7494-5072-401f-bb18-b16e7a79ddac.json
@@ -1,4 +1,0 @@
-{
-  "type" : "bugfix",
-  "description" : "fix language referring to /review"
-}

--- a/.changes/next-release/bugfix-629f7494-5072-401f-bb18-b16e7a79ddac.json
+++ b/.changes/next-release/bugfix-629f7494-5072-401f-bb18-b16e7a79ddac.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "fix language referring to /review"
+}

--- a/.changes/next-release/bugfix-f071cf54-2c8d-4504-9326-6bce9619cee6.json
+++ b/.changes/next-release/bugfix-f071cf54-2c8d-4504-9326-6bce9619cee6.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "fix findings not being populated in the display panel"
+  "description" : "DisplayFindings tool findings were not being populated in the display panel, instead sending json to chat"
 }

--- a/.changes/next-release/bugfix-f071cf54-2c8d-4504-9326-6bce9619cee6.json
+++ b/.changes/next-release/bugfix-f071cf54-2c8d-4504-9326-6bce9619cee6.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "fix displayFinding tool handling"
+  "description" : "fix findings not being populated in the display panel"
 }

--- a/.changes/next-release/bugfix-f071cf54-2c8d-4504-9326-6bce9619cee6.json
+++ b/.changes/next-release/bugfix-f071cf54-2c8d-4504-9326-6bce9619cee6.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "fix displayFinding tool handling"
+}

--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/FlareAdditionalFindings.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/FlareAdditionalFindings.kt
@@ -49,7 +49,7 @@ data class FlareCodeScanIssue(
     val language: String,
     val autoDetected: Boolean,
     val filePath: String,
-    val findingContext: String,
+    val findingContext: String?,
 )
 
 data class AggregatedCodeScanIssue(

--- a/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -910,7 +910,7 @@ codewhisperer.codescan.regenerate_fix_button_label=Regenerate Fix
 codewhisperer.codescan.run_scan_complete=<html><body> Code Review completed for {0, choice, 1#1 file|2#{0,number} files}. {1, choice, 0#No issues|1#1 issue|2#{1,number} issues} found in {2}. <font color="{3}">  Last Run {4} </font></body></html>
 codewhisperer.codescan.run_scan_error=Amazon Q encountered an error while reviewing for code issues. Please try again later.
 codewhisperer.codescan.run_scan_error_telemetry=Code Review failed.
-codewhisperer.codescan.run_scan_info=Enter /review in Amazon Q Chat Panel to run code reviews.
+codewhisperer.codescan.run_scan_info=Ask the agent in Amazon Q Chat Panel to run code reviews.
 codewhisperer.codescan.scan_complete_count=- {0}: `{1, choice, 1#{1,number} issue|2#{1,number} issues}`
 codewhisperer.codescan.scan_complete_file=Reviewing your File is complete. Here's what I found:
 codewhisperer.codescan.scan_complete_project=Reviewing your Project is complete. Here's what I found:


### PR DESCRIPTION
The findingContext field was marked as required in Jetbrains, but was not being populated in displayFindings usages, causing the message to not be picked up as a findings message. This sent the whole json to the chat and did not populate the code issues panel.

Also, changed the language referring to /review

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
