### PR TITLE
feat(jetbrains): add 2025.3 builds

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -152,6 +152,50 @@ object IdeVersions {
                 rdGenVersion = "2025.2.2",
                 nugetVersion = "2025.2.0"
             )
+        ),
+        Profile(
+            name = "2025.3",
+            gateway = ProductProfile(
+                sdkVersion = "2025.3",
+                bundledPlugins = listOf("org.jetbrains.plugins.terminal")
+            ),
+            community = ProductProfile(
+                sdkVersion = "2025.3",
+                bundledPlugins = commonPlugins + listOf(
+                    "com.intellij.java",
+                    "com.intellij.gradle",
+                    "org.jetbrains.idea.maven",
+                    "com.jetbrains.codeWithMe",
+                    "com.intellij.properties"
+                ),
+                marketplacePlugins = listOf(
+                    "org.toml.lang:253.22441.34",
+                    "PythonCore:253.22441.33",
+                    "Docker:253.22441.33",
+                    "com.intellij.modules.json:253.520.16"
+                )
+            ),
+            ultimate = ProductProfile(
+                sdkVersion = "2025.3",
+                bundledPlugins = commonPlugins + listOf(
+                    "JavaScript",
+                    "JavaScriptDebugger",
+                    "com.intellij.database",
+                    "com.jetbrains.codeWithMe",
+                ),
+                marketplacePlugins = listOf(
+                    "Pythonid:253.22441.33",
+                    "org.jetbrains.plugins.go:253.22441.33",
+                    "com.intellij.modules.json:253.520.16"
+                )
+            ),
+            rider = RiderProfile(
+                sdkVersion = "2025.3-SNAPSHOT",
+                bundledPlugins = commonPlugins,
+                netFrameworkTarget = "net472",
+                rdGenVersion = "2025.3.0",
+                nugetVersion = "2025.3.0-eap03"
+            )
         )
     ).associateBy { it.name }
 


### PR DESCRIPTION
Add the 2025.3 version to the release pipeline. https://blog.jetbrains.com/idea/2025/09/intellij-idea-2025-3-eap/

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Added support for JetBrains IntelliJ IDEA 2025.3 EAP by adding a new IDE profile to `IdeVersions.kt`. This includes:

- Gateway, Community, Ultimate, and Rider profiles for 2025.3
- Updated plugin versions compatible with build 253.* 
- Follows the same pattern as previous version additions (2025.1, 2025.2)

Plugin versions used:
- TOML: 253.22441.34
- Python: 253.22441.33  
- Docker: 253.22441.33
- JSON: 253.520.16
- Go: 253.22441.33
- Rider SDK: 2025.3.0-eap03

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
