### PR TITLE
fix(amazonq): Revert putting empty files for aws credential locations for q

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/AmazonQLspService.kt
@@ -453,7 +453,6 @@ private class AmazonQServerInstance(private val project: Project, private val cs
 
         val node = if (SystemInfo.isWindows) "node.exe" else "node"
         val nodePath = NodeExePatcher.getNodeRuntimePath(project, artifact.resolve(node))
-        val emptyFile = Files.createTempFile("empty", null).toAbsolutePath().toString()
 
         val cmd = NodeExePatcher.patch(nodePath)
             .withParameters(
@@ -466,9 +465,6 @@ private class AmazonQServerInstance(private val project: Project, private val cs
                         LOG.info { "Starting Flare with NODE_EXTRA_CA_CERTS: $it" }
                         put("NODE_EXTRA_CA_CERTS", it)
                     }
-
-                    put("AWS_CONFIG_FILE", emptyFile)
-                    put("AWS_SHARED_CREDENTIALS_FILE", emptyFile)
 
                     // assume default endpoint will pick correct proxy if needed
                     val qUri = URI(QDefaultServiceConfig.ENDPOINT)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
This allows running aws commands through Q chat

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
