### PR TITLE
fix(amazonq): emit sessionDuration

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/ToolkitAuthManager.kt
@@ -32,6 +32,7 @@ import software.aws.toolkits.telemetry.AuthTelemetry
 import software.aws.toolkits.telemetry.CredentialSourceId
 import software.aws.toolkits.telemetry.CredentialType
 import software.aws.toolkits.telemetry.Result
+import java.time.Duration
 import java.time.Instant
 
 sealed interface ToolkitConnection {
@@ -265,6 +266,7 @@ fun reauthConnectionIfNeeded(
                         isReAuth = true,
                         result = Result.Succeeded,
                         source = source,
+                        tokenProvider = tokenProvider,
                     )
                     recordAddConnection(
                         credentialSourceId = getCredentialIdForTelemetry(connection),
@@ -282,6 +284,7 @@ fun reauthConnectionIfNeeded(
                         isReAuth = true,
                         result = result,
                         source = source,
+                        tokenProvider = tokenProvider,
                     )
                     recordAddConnection(
                         credentialSourceId = getCredentialIdForTelemetry(connection),
@@ -371,6 +374,7 @@ private fun recordLoginWithBrowser(
     isReAuth: Boolean,
     result: Result,
     source: String? = null,
+    tokenProvider: BearerTokenProvider? = null,
 ) {
     TelemetryService.getInstance().record(null as Project?) {
         datum("aws_loginWithBrowser") {
@@ -385,6 +389,9 @@ private fun recordLoginWithBrowser(
             reason?.let { metadata("reason", it) }
             metadata("result", result.toString())
             source?.let { metadata("source", it) }
+            tokenProvider?.currentToken()?.let { token ->
+                metadata("sessionDuration", Duration.between(token.createdAt, Instant.now()).toMillis().toString())
+            }
         }
     }
 }


### PR DESCRIPTION
#### Premature Builder ID Session Expiration Definition
```
/ Metric for premature expiration, specifically for BuilderId since we know the expected expiration time
// Basically, if the user has to log in to the browser again, we look at the time diff between last login.
// If the diff is too early (< 90 days) we assume premature. 
```

## Problem
In the `Premature Builder ID Session Expiration` Cloudwatch graph, we do not have data for JB (either AmazonQForJetbrains or AwsToolkitForJetbrains products). 

This is because we the EMF metric only gets created when our `credentialStartUrl` is `https://view.awsapps.com/start` and `sessionDuration` < 90 days, which means we aren't sending the correct data from the client

## Solution
Emit `sessionDuration` field

## Testing
Ran in sandbox and emit data to kibana. This is somewhat experimental, as I'm not able to fully replicate this scenario, but at least we can see what data we get in cloudwatch now after emitting this new field
<img width="1558" height="108" alt="Screenshot 2025-11-13 at 9 04 03 AM" src="https://github.com/user-attachments/assets/aa749bf7-dc04-4ac8-b8f3-b3526f72f5b0" />

