### PR TITLE
fix(amazonq): add custom modal dropdown for model selection

### DIFF
--- a/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
+++ b/plugins/amazonq/chat/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/webview/Browser.kt
@@ -409,18 +409,8 @@ class Browser(parent: Disposable, private val mynahAsset: Path, val project: Pro
                                     }
 
                                     // Only replace if this is the model selection dropdown
-                                    // Check if any option contains "Claude" or model-related text
-                                    let isModelDropdown = false;
-                                    for (let i = 0; i < select.options.length; i++) {
-                                        const optionText = select.options[i].text.toLowerCase();
-                                        if (optionText.includes('claude') || optionText.includes('sonnet') ||
-                                            optionText.includes('opus') || optionText.includes('haiku')) {
-                                            isModelDropdown = true;
-                                            break;
-                                        }
-                                    }
-
-                                    if (!isModelDropdown) {
+                                    // Model selector has autoWidth which adds 'auto-width' class
+                                    if (!select.classList.contains('auto-width')) {
                                         console.log('[JB Modal Dropdown] Skipping non-model dropdown');
                                         return;
                                     }


### PR DESCRIPTION
 ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)

  ## Description

  The model selection dropdown in Amazon Q chat was getting cut off at the bottom, showing only 2-3 out of 4 available models. This was caused by overflow clipping in the JCEF webview environment.

  **Solution:**
  Implemented a custom modal dropdown that replaces the native `<select>` element specifically for model selection. The modal overlay approach ensures the dropdown appears above all other UI elements without
  z-index conflicts.

  **Key features:**
  - Modal overlay with semi-transparent background
  - Dynamic font sizing (9px-12px) based on model name length to prevent text truncation
  - Position-absolute trigger to prevent shifting when changing selections
  - Only applies to model dropdown (detected by checking for "Claude"/"Sonnet"/"Opus"/"Haiku" in options)
  - JetBrains-specific implementation via Browser.kt, no mynah-ui changes required

  **Before:** Dropdown cut off, showing only 2-3 options
  **After:** All 4 model options visible in centered modal

  **Note:** This is a temporary workaround. Future improvements could include migrating to a proper mynah-ui component or refining the positioning logic.

## Demo : 



https://github.com/user-attachments/assets/9179a6d5-f1d4-42aa-97d5-631f5c8b1af9

https://github.com/user-attachments/assets/7b4e9810-7444-49f4-8d33-a7cef487e13b



  ## Checklist
  - [x] My code follows the code style of this project
  - [ ] I have added tests to cover my changes *(UI-only change in Browser.kt webview, difficult to test)*
  - [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is
  customer-facing in the IDE. *(Will add)*
  - [ ] I have added metrics for my changes (if required) *(No metrics needed for UI fix)*

  ## License
  I confirm that my contribution is made under the terms of the Apache 2.0 license.

  CHANGELOG entry to add:

  ### Fixed
  - **Amazon Q Chat**: Fixed model selection dropdown being cut off at the bottom in JetBrains IDE