### PR TITLE
Adding Python3.14 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# _3.101_ (2025-12-16)
+- **(Bug Fix)** Adding missing test for Python 3.12 completion support
+- **(Feature)** Add support for Python 3.14
+
 # _3.100_ (2025-12-09)
 
 # _3.99_ (2025-11-21)

--- a/plugins/core/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
+++ b/plugins/core/core/src/software/aws/toolkits/core/lambda/LambdaRuntime.kt
@@ -31,6 +31,7 @@ enum class LambdaRuntime(
     PYTHON3_10(Runtime.PYTHON3_10, minSamDebugging = "1.78.0", minSamInit = "1.78.0", architectures = ARM_COMPATIBLE),
     PYTHON3_11(Runtime.PYTHON3_11, minSamDebugging = "1.87.0", minSamInit = "1.87.0", architectures = ARM_COMPATIBLE),
     PYTHON3_12(Runtime.PYTHON3_12, minSamDebugging = "1.103.0", minSamInit = "1.103.0", architectures = ARM_COMPATIBLE),
+    PYTHON3_14(Runtime.PYTHON3_14, minSamDebugging = "1.150.1", minSamInit = "1.150.1", architectures = ARM_COMPATIBLE),
     DOTNET6_0(Runtime.DOTNET6, minSamDebugging = "1.40.1", minSamInit = "1.40.1", architectures = ARM_COMPATIBLE),
     ;
 

--- a/plugins/toolkit/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
+++ b/plugins/toolkit/jetbrains-core/it/software/aws/toolkits/jetbrains/services/lambda/python/PythonLocalLambdaRunConfigurationIntegrationTest.kt
@@ -48,6 +48,7 @@ class PythonLocalLambdaRunConfigurationIntegrationTest(private val runtime: Runt
             arrayOf(Runtime.PYTHON3_10),
             arrayOf(Runtime.PYTHON3_11),
             arrayOf(Runtime.PYTHON3_12),
+            arrayOf(Runtime,PYTHON3_14),
         )
     }
 

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonDebugSupport.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonDebugSupport.kt
@@ -106,6 +106,13 @@ class Python312ImageDebugSupport : PythonImageDebugSupport() {
     override val bootstrapPath: String = "/var/runtime/bootstrap.py"
 }
 
+class Python314ImageDebugSupport : PythonImageDebugSupport() {
+    override val id: String = LambdaRuntime.PYTHON3_14.toString()
+    override fun displayName() = LambdaRuntime.PYTHON3_14.toString().capitalize()
+    override val pythonPath: String = "/var/lang/bin/python3.14"
+    override val bootstrapPath: String = "/var/runtime/bootstrap.py"
+}
+
 private const val DEBUGGER_VOLUME_PATH = "/tmp/lambci_debug_files"
 
 private fun createDebugProcess(

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroup.kt
@@ -25,12 +25,14 @@ class PythonRuntimeGroup : SdkBasedRuntimeGroup() {
         LambdaRuntime.PYTHON3_9,
         LambdaRuntime.PYTHON3_10,
         LambdaRuntime.PYTHON3_11,
-        LambdaRuntime.PYTHON3_12
+        LambdaRuntime.PYTHON3_12,
+        LambdaRuntime.PYTHON3_14
     )
 
     override fun runtimeForSdk(sdk: Sdk): LambdaRuntime? = when {
         !PythonSdkUtil.isPythonSdk(sdk) -> null
 
+        PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON314) -> LambdaRuntime.PYTHON3_14
         PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON312) -> LambdaRuntime.PYTHON3_12
         PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON311) -> LambdaRuntime.PYTHON3_11
         PythonSdkType.getLanguageLevelForSdk(sdk).isAtLeast(LanguageLevel.PYTHON310) -> LambdaRuntime.PYTHON3_10

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/python/PythonSamProjectWizard.kt
@@ -23,9 +23,11 @@ import software.aws.toolkits.jetbrains.services.lambda.wizard.TemplateParameters
 import software.aws.toolkits.resources.message
 
 private val pythonTemplateRuntimes =
-    setOf(LambdaRuntime.PYTHON3_8, LambdaRuntime.PYTHON3_9, LambdaRuntime.PYTHON3_10, LambdaRuntime.PYTHON3_11, LambdaRuntime.PYTHON3_12)
+    setOf(LambdaRuntime.PYTHON3_8, LambdaRuntime.PYTHON3_9, LambdaRuntime.PYTHON3_10, LambdaRuntime.PYTHON3_11, LambdaRuntime.PYTHON3_12,
+        LambdaRuntime.PYTHON3_14)
 private val eventBridgeTemplateRuntimes =
-    setOf(LambdaRuntime.PYTHON3_8, LambdaRuntime.PYTHON3_9, LambdaRuntime.PYTHON3_10, LambdaRuntime.PYTHON3_11, LambdaRuntime.PYTHON3_12)
+    setOf(LambdaRuntime.PYTHON3_8, LambdaRuntime.PYTHON3_9, LambdaRuntime.PYTHON3_10, LambdaRuntime.PYTHON3_11, LambdaRuntime.PYTHON3_12,
+        LambdaRuntime.PYTHON3_14)
 
 class PythonSamProjectWizard : SamProjectWizard {
     override fun createSdkSelectionPanel(projectLocation: TextFieldWithBrowseButton?): SdkSelector = when {

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonHandlerCompletionProviderTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonHandlerCompletionProviderTest.kt
@@ -46,4 +46,9 @@ class PythonHandlerCompletionProviderTest {
         assertThat(provider.isCompletionSupported).isFalse()
     }
 
+    @Test
+    fun completionIsNotSupportedPython314() {
+        val provider = HandlerCompletionProvider(projectRule.project, LambdaRuntime.PYTHON3_14)
+        assertThat(provider.isCompletionSupported).isFalse()
+    }
 }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroupTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonRuntimeGroupTest.kt
@@ -57,4 +57,13 @@ class PythonRuntimeGroupTest {
 
         assertThat(sut.determineRuntime(module)).isEqualTo(LambdaRuntime.PYTHON3_12)
     }
+
+    @Test
+    fun testRuntimeDetection312() {
+        val module = projectRule.module
+        // PythonCodeInsightTestFixtureRule already sets SDK to 3.14
+        // projectRule.setModuleSdk(module, PyTestSdk.create("3.14.0"))
+
+        assertThat(sut.determineRuntime(module)).isEqualTo(LambdaRuntime.PYTHON3_14)
+    }
 }


### PR DESCRIPTION
Adding support for python 3.14.
Adding missing test for python 3.12 completion

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Adding general python3.14 support
While doing this I stumbled into missing python3.12 support in `plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/python/PythonHandlerCompletionProviderTest.kt`. Please double check if intended or my patch is fixing a missing feature.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
