### PR TITLE
fix(amazonq): prevent double login screen on IdC authentication

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt
@@ -179,7 +179,7 @@ class QRegionProfileManager : PersistentStateComponent<QProfileState>, Disposabl
     fun isPendingProfileSelection(project: Project): Boolean = getIdcConnectionOrNull(project)?.let { conn ->
         val profileCounts = connectionIdToProfileCount[conn.id] ?: 0
         val activeProfile = connectionIdToActiveProfile[conn.id]
-        profileCounts == 0 || (profileCounts > 1 && activeProfile?.arn.isNullOrEmpty())
+        profileCounts > 1 && activeProfile?.arn.isNullOrEmpty()
     } ?: false
 
     fun shouldDisplayProfileInfo(project: Project): Boolean = getIdcConnectionOrNull(project)?.let { conn ->


### PR DESCRIPTION
## Double Login Screen Bug Fix

### The Bug
When logging into Amazon Q with a company account (IdC), users see the login screen twice:
1. First login screen → authenticate in browser → comes back
2. Same login screen appears again → select company account again → chat opens



### Root Cause
In QRegionProfileManager.kt, the isPendingProfileSelection() method:
kotlin
profileCounts == 0 || (profileCounts > 1 && activeProfile?.arn.isNullOrEmpty())


The profileCounts == 0 check returns true immediately after login because profiles haven't been fetched yet, causing the login screen to show again.

### The Fix
One line change - remove the profileCounts == 0 check:
kotlin
// Before
profileCounts == 0 || (profileCounts > 1 && activeProfile?.arn.isNullOrEmpty())

// After  
profileCounts > 1 && activeProfile?.arn.isNullOrEmpty()


### Files Changed
- plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/profile/QRegionProfileManager.kt

### How to Demo
1. Log out of Amazon Q
2. Log back in with company account (IdC)
4. Before fix: Login screen appears twice
5. After fix: Chat opens directly after browser authentication