### PR TITLE
fix(rider): move off snapshot builds to stable 2025.3 release

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -186,7 +186,7 @@ object IdeVersions {
                 )
             ),
             rider = RiderProfile(
-                sdkVersion = "2025.3-SNAPSHOT",
+                sdkVersion = "2025.3",
                 bundledPlugins = commonPlugins,
                 netFrameworkTarget = "net472",
                 rdGenVersion = "2025.3.1",


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
Fixes CI build failures caused by Rider dependency resolution issues. The build was failing because it couldn't resolve the 
RD-2025.3-SNAPSHOT (non-installer) dependency. This change moves Rider from the problematic snapshot build to the stable 2025.3 release.

Error resolved:
No IntelliJ Platform dependency found with 'RD-2025.3-SNAPSHOT (non-installer)'.


This is an infrastructure fix that doesn't affect any customer-facing functionality.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes (N/A - infrastructure configuration change)
- [ ] A short description of the change has been added to the [CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#
contributing-via-pull-requests) if the change is customer-facing in the IDE. (N/A - internal build configuration)
- [ ] I have added metrics for my changes (if required) (N/A - no metrics needed)
