### PR TITLE
fix(amazonq): prevent error when removing document listener on file close

### DIFF
--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/textdocument/TextDocumentServiceHandler.kt
@@ -173,8 +173,12 @@ class TextDocumentServiceHandler(
     ) {
         val listener = file.getUserData(KEY_REAL_TIME_EDIT_LISTENER)
         if (listener != null) {
-            tryOrNull { FileDocumentManager.getInstance().getDocument(file)?.removeDocumentListener(listener) }
             file.putUserData(KEY_REAL_TIME_EDIT_LISTENER, null)
+            ApplicationManager.getApplication().runReadAction {
+                tryOrNull {
+                    FileDocumentManager.getInstance().getCachedDocument(file)?.removeDocumentListener(listener)
+                }
+            }
 
             trySendIfValid { languageServer ->
                 toUriString(file)?.let { uri ->


### PR DESCRIPTION


<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Issue:
- #6018
- #6063
- #6100 
- #6162

## Solution:
Use getCachedDocument instead of getDocument to avoid attempting to remove a listener from a recreated document instance that doesn't have it registered.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
