### PR TITLE
fix: close token providers prior to closing OIDC client

### DIFF
--- a/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/BearerTokenProvider.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/BearerTokenProvider.kt
@@ -195,8 +195,8 @@ class InteractiveBearerTokenProvider(
     override fun resolveToken() = supplier.cachedSupplier.get()
 
     override fun close() {
-        ssoOidcClient.close()
         supplier.cachedSupplier.close()
+        ssoOidcClient.close()
     }
 
     override fun dispose() {
@@ -265,11 +265,11 @@ class ProfileSdkTokenProviderWrapper(private val sessionName: String, region: St
 
     override fun close() {
         sdkTokenManager.close()
-        if (ssoOidcClient.isInitialized()) {
-            ssoOidcClient.value.close()
-        }
         if (tokenProvider.isInitialized()) {
             tokenProvider.value.close()
+        }
+        if (ssoOidcClient.isInitialized()) {
+            ssoOidcClient.value.close()
         }
     }
 


### PR DESCRIPTION
If client is closed first, then we can get SDK exceptions from attempting to make requests against a closed client

```
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@53ae8ec0[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@1fb1f80f[Wrapped task = software.amazon.awssdk.core.internal.http.timers.SyncTimeoutTask@684e2cf6]] rejected from java.util.concurrent.ScheduledThreadPoolExecutor@1a21d91d[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0]
	at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2081)
	at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:841)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:340)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:562)
	at software.amazon.awssdk.core.internal.http.timers.TimerUtils.timeSyncTaskIfNeeded(TimerUtils.java:85)
```


TBD: need to figure out how to reliably repro this issue

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
