### PR TITLE
build(253): upgrade 2025.3 SDK to stable release

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -157,32 +157,32 @@ object IdeVersions {
                 bundledPlugins = listOf("org.jetbrains.plugins.terminal")
             ),
             community = ProductProfile(
-                sdkVersion = "253.28294-EAP-CANDIDATE-SNAPSHOT",
+                sdkVersion = "2025.3.1",
                 bundledPlugins = commonPlugins + listOf(
                     "com.intellij.java",
                     "com.intellij.gradle",
                     "org.jetbrains.idea.maven",
-                    "com.intellij.properties"
+                    "com.intellij.properties",
+                    "org.toml.lang",
+                    "com.intellij.modules.json"
                 ),
                 marketplacePlugins = listOf(
-                    "org.toml.lang:253.28294.86",
-                    "PythonCore:253.28294.51",
-                    "Docker:253.28294.90",
-                    "com.intellij.modules.json:253.28294.51"
+                    "PythonCore:253.29346.138",
+                    "Docker:253.29346.125"
                 )
             ),
             ultimate = ProductProfile(
-                sdkVersion = "253.28294-EAP-CANDIDATE-SNAPSHOT",
+                sdkVersion = "2025.3.1",
                 bundledPlugins = commonPlugins + listOf(
                     "JavaScript",
                     "JavaScriptDebugger",
                     "com.intellij.database",
-                    "com.jetbrains.codeWithMe"
+                    "com.jetbrains.codeWithMe",
+                    "com.intellij.modules.json"
                 ),
                 marketplacePlugins = listOf(
-                    "Pythonid:253.28294.51",
-                    "org.jetbrains.plugins.go:253.28294.51",
-                    "com.intellij.modules.json:253.28294.51"
+                    "Pythonid:253.29346.138",
+                    "org.jetbrains.plugins.go:253.29346.50"
                 )
             ),
             rider = RiderProfile(

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -103,7 +103,7 @@ dependencies {
 
         // OAuth modules split in 2025.3 (253) - must be explicitly bundled
         val versionStr = version.get()
-        if (versionStr.contains("253")) {
+        if (versionStr.contains("253") || versionStr.contains("2025.3")) {
             bundledModule("intellij.platform.collaborationTools")
             bundledModule("intellij.platform.collaborationTools.auth.base")
             bundledModule("intellij.platform.collaborationTools.auth")


### PR DESCRIPTION
- Update community/ultimate SDK from EAP snapshot to 2025.3.1 stable
- Move org.toml.lang and com.intellij.modules.json to bundledPlugins (now bundled in 2025.3)
- Update marketplace plugin versions to stable 253.29346.x releases
- Fix version check in gradle plugin to handle '2025.3.x' format for OAuth module bundling
- Gateway SDK remains on EAP (no stable 253 release available yet)

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
