### PR TITLE
Fix environment variable injection on IntelliJ IDEA 2025.2+

### DIFF
--- a/.changes/next-release/bugfix-567f40d9-10f6-4531-a4c9-19e832bc131e.json
+++ b/.changes/next-release/bugfix-567f40d9-10f6-4531-a4c9-19e832bc131e.json
@@ -1,4 +1,4 @@
 {
   "type" : "bugfix",
-  "description" : "Fix Fix environment variable injection on IntelliJ IDEA 2025.2+, fixes #6197"
+  "description" : "Fix environment variable injection on IntelliJ IDEA 2025.2+, fixes #6197"
 }

--- a/.changes/next-release/bugfix-567f40d9-10f6-4531-a4c9-19e832bc131e.json
+++ b/.changes/next-release/bugfix-567f40d9-10f6-4531-a4c9-19e832bc131e.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fix Fix environment variable injection on IntelliJ IDEA 2025.2+, fixes #6197"
+}

--- a/plugins/amazonq/mynah-ui/package-lock.json
+++ b/plugins/amazonq/mynah-ui/package-lock.json
@@ -366,8 +366,7 @@
         "node_modules/@types/node": {
             "version": "14.18.63",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-            "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-            "peer": true
+            "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
         },
         "node_modules/@types/sanitize-html": {
             "version": "2.9.5",
@@ -423,7 +422,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -777,7 +775,6 @@
             "version": "8.11.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -816,7 +813,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -990,7 +986,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001580",
                 "electron-to-chromium": "^1.4.648",
@@ -1479,7 +1474,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
             "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -2709,7 +2703,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -3010,7 +3003,6 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
             "integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -3085,7 +3077,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -3499,7 +3490,6 @@
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -3614,7 +3604,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
             "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.5",
                 "@webassemblyjs/ast": "^1.12.1",
@@ -3661,7 +3650,6 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",

--- a/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
+++ b/plugins/amazonq/shared/jetbrains-community/src/software/aws/toolkits/jetbrains/services/amazonq/lsp/flareChat/ChatCommunicationManager.kt
@@ -9,8 +9,6 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import org.eclipse.lsp4j.ProgressParams
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 import software.aws.toolkits.core.utils.getLogger
@@ -39,16 +37,21 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
 @Service(Service.Level.PROJECT)
-class ChatCommunicationManager(private val project: Project, private val cs: CoroutineScope) {
+class ChatCommunicationManager(private val project: Project) {
     val uiReady = CompletableDeferred<Boolean>()
     private val chatPartialResultMap = ConcurrentHashMap<String, String>()
     private val inflightRequestByTabId = ConcurrentHashMap<String, CompletableFuture<String>>()
     private val pendingSerializedChatRequests = ConcurrentHashMap<String, CompletableFuture<GetSerializedChatResult>>()
     private val pendingTabRequests = ConcurrentHashMap<String, CompletableFuture<LSPAny>>()
     private val openTabs = mutableSetOf<String>()
+    private val pendingMessages = ArrayDeque<FlareUiMessage>()
 
     fun setUiReady() {
         uiReady.complete(true)
+        synchronized(pendingMessages) {
+            pendingMessages.forEach { chatUpdateCallback?.invoke(it) }
+            pendingMessages.clear()
+        }
     }
 
     private var chatUpdateCallback: ((FlareUiMessage) -> Unit)? = null
@@ -58,10 +61,23 @@ class ChatCommunicationManager(private val project: Project, private val cs: Cor
     }
 
     fun notifyUi(uiMessage: FlareUiMessage) {
-        cs.launch {
-            uiReady.await()
-            chatUpdateCallback?.invoke(uiMessage)
+        if (!uiReady.isCompleted) {
+            synchronized(pendingMessages) {
+                if (!uiReady.isCompleted) { // Double-check
+                    if (uiMessage.command == "aws/chat/sendContextCommands") {
+                        val removed = pendingMessages.removeAll { it.command == "aws/chat/sendContextCommands" }
+                        if (removed) {
+                            LOG.warn { "Removed old aws/chat/sendContextCommands message(s) before UI ready" }
+                        }
+                    }
+                    pendingMessages.addLast(uiMessage)
+                    return
+                }
+            }
         }
+
+        // UI is ready, invoke immediately
+        chatUpdateCallback?.invoke(uiMessage)
     }
 
     fun setInflightRequestForTab(tabId: String, result: CompletableFuture<String>) {

--- a/plugins/core/webview/package-lock.json
+++ b/plugins/core/webview/package-lock.json
@@ -304,8 +304,7 @@
         "node_modules/@types/node": {
             "version": "14.18.63",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-            "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-            "peer": true
+            "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
         },
         "node_modules/@types/sanitize-html": {
             "version": "2.11.0",
@@ -361,7 +360,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -810,7 +808,6 @@
             "version": "8.11.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -849,7 +846,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -1032,7 +1028,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001587",
                 "electron-to-chromium": "^1.4.668",
@@ -1527,7 +1522,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -2789,7 +2783,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -3090,7 +3083,6 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.71.1.tgz",
             "integrity": "sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -3165,7 +3157,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -3579,7 +3570,6 @@
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -3658,7 +3648,6 @@
             "version": "3.4.20",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.20.tgz",
             "integrity": "sha512-xF4zDKXp67NjgORFX/HOuaiaKYjgxkaToK0KWglFQEYlCw9AqgBlj1yu5xa6YaRek47w2IGiuvpvrGg/XuQFCw==",
-            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.4.20",
                 "@vue/compiler-sfc": "3.4.20",
@@ -3747,7 +3736,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
             "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.5",
                 "@webassemblyjs/ast": "^1.12.1",
@@ -3794,7 +3782,6 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",

--- a/plugins/toolkit/jetbrains-core/resources/META-INF/ext-java.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/ext-java.xml
@@ -7,6 +7,10 @@
         <runConfigurationExtension implementation="software.aws.toolkits.jetbrains.core.execution.JavaAwsConnectionExtension"/>
     </extensions>
 
+    <extensions defaultExtensionNs="org.jetbrains.plugins.gradle">
+        <executionEnvironmentProvider implementation="software.aws.toolkits.jetbrains.core.execution.GradleAwsConnectionEnvironmentProvider" order="first"/>
+    </extensions>
+
     <extensions defaultExtensionNs="aws.toolkit">
         <experiment implementation="software.aws.toolkits.jetbrains.core.execution.JavaAwsConnectionExperiment"/>
     </extensions>

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/execution/GradleAwsConnectionEnvironmentProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/execution/GradleAwsConnectionEnvironmentProvider.kt
@@ -1,0 +1,88 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.execution
+
+import com.intellij.execution.CommonJavaRunConfigurationParameters
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.RunConfigurationBase
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.project.Project
+import com.intellij.task.ExecuteRunConfigurationTask
+import org.jetbrains.plugins.gradle.execution.build.GradleExecutionEnvironmentProvider
+import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration
+import software.aws.toolkits.jetbrains.core.experiments.isEnabled
+
+/**
+ * This provider intercepts Gradle executions that originate from Java/Kotlin run configurations
+ * and transfers AWS connection settings to the Gradle run configuration.
+ *
+ * When running a Java/Kotlin app via Gradle in IntelliJ 2025.2+, the IDE:
+ * 1. Creates a JavaRunConfiguration/KotlinRunConfiguration (where AWS settings are configured)
+ * 2. Internally creates a separate GradleRunConfiguration to execute via Gradle
+ *
+ * Without this provider, AWS connection settings from the original configuration would not
+ * be transferred to the Gradle execution.
+ *
+ * This provider is registered with order="first" so it gets called before other providers,
+ * allowing it to intercept the execution and delegate to other providers while adding
+ * AWS environment variables to the resulting GradleRunConfiguration.
+ */
+class GradleAwsConnectionEnvironmentProvider : GradleExecutionEnvironmentProvider {
+    private val delegate = AwsConnectionRunConfigurationExtension<RunConfigurationBase<*>>()
+
+    override fun isApplicable(task: ExecuteRunConfigurationTask): Boolean {
+        if (!JavaAwsConnectionExperiment.isEnabled()) {
+            return false
+        }
+
+        val runProfile = task.runProfile
+
+        // Check if the run profile is a RunConfigurationBase with AWS connection settings
+        // and implements CommonJavaRunConfigurationParameters
+        if (runProfile is RunConfigurationBase<*> && runProfile is CommonJavaRunConfigurationParameters) {
+            val awsSettings = runProfile.getCopyableUserData(AWS_CONNECTION_RUN_CONFIGURATION_KEY)
+            return awsSettings != null && awsSettings != AwsCredentialInjectionOptions.DEFAULT_OPTIONS
+        }
+
+        return false
+    }
+
+    override fun createExecutionEnvironment(
+        project: Project,
+        task: ExecuteRunConfigurationTask,
+        executor: Executor,
+    ): ExecutionEnvironment? {
+        // Delegate to other providers to create the actual execution environment
+        val environment = GradleExecutionEnvironmentProvider.EP_NAME.extensionList
+            .asSequence()
+            .filter { it !== this }
+            .mapNotNull { provider ->
+                if (provider.isApplicable(task)) {
+                    provider.createExecutionEnvironment(project, task, executor)
+                } else {
+                    null
+                }
+            }
+            .firstOrNull()
+
+        // If we got an environment with a GradleRunConfiguration, apply AWS settings
+        if (environment != null && environment.runProfile is GradleRunConfiguration) {
+            val runProfile = task.runProfile
+            if (runProfile is RunConfigurationBase<*>) {
+                applyAwsConnection(runProfile, environment.runProfile as GradleRunConfiguration)
+            }
+        }
+
+        return environment
+    }
+
+    private fun applyAwsConnection(
+        sourceConfig: RunConfigurationBase<*>,
+        targetConfig: GradleRunConfiguration,
+    ) {
+        val environment = targetConfig.settings.env.toMutableMap()
+        delegate.addEnvironmentVariables(sourceConfig, environment)
+        targetConfig.settings.env = environment
+    }
+}

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/execution/GradleAwsConnectionEnvironmentProviderTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/execution/GradleAwsConnectionEnvironmentProviderTest.kt
@@ -1,0 +1,102 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.execution
+
+import com.intellij.execution.RunManager
+import com.intellij.execution.application.ApplicationConfiguration
+import com.intellij.execution.application.ApplicationConfigurationType
+import com.intellij.task.ExecuteRunConfigurationTask
+import com.intellij.testFramework.ProjectRule
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
+import software.aws.toolkits.jetbrains.core.region.MockRegionProviderRule
+import software.aws.toolkits.jetbrains.settings.AwsSettingsRule
+import software.aws.toolkits.jetbrains.utils.rules.ExperimentRule
+
+class GradleAwsConnectionEnvironmentProviderTest {
+
+    @Rule
+    @JvmField
+    val projectRule = ProjectRule()
+
+    @Rule
+    @JvmField
+    val settingsRule = AwsSettingsRule()
+
+    @Rule
+    @JvmField
+    val regionProvider = MockRegionProviderRule()
+
+    @Rule
+    @JvmField
+    val registryRule = ExperimentRule(JavaAwsConnectionExperiment)
+
+    private val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
+
+    @Before
+    fun setUp() {
+        MockCredentialsManager.getInstance().addCredentials("MockCredentials", mockCreds)
+    }
+
+    @Test
+    fun `isApplicable returns true for ApplicationConfiguration with AWS settings`() {
+        val runManager = RunManager.getInstance(projectRule.project)
+        val configuration = runManager.createConfiguration("test", ApplicationConfigurationType::class.java).configuration as ApplicationConfiguration
+
+        val data = AwsCredentialInjectionOptions {
+            region = regionProvider.defaultRegion().id
+            credential = "MockCredentials"
+        }
+        configuration.putCopyableUserData(AWS_CONNECTION_RUN_CONFIGURATION_KEY, data)
+
+        val task = mock<ExecuteRunConfigurationTask>()
+        whenever(task.runProfile).thenReturn(configuration)
+
+        val provider = GradleAwsConnectionEnvironmentProvider()
+        assertThat(provider.isApplicable(task)).isTrue()
+    }
+
+    @Test
+    fun `isApplicable returns false for ApplicationConfiguration without AWS settings`() {
+        val runManager = RunManager.getInstance(projectRule.project)
+        val configuration = runManager.createConfiguration("test", ApplicationConfigurationType::class.java).configuration as ApplicationConfiguration
+
+        val task = mock<ExecuteRunConfigurationTask>()
+        whenever(task.runProfile).thenReturn(configuration)
+
+        val provider = GradleAwsConnectionEnvironmentProvider()
+        assertThat(provider.isApplicable(task)).isFalse()
+    }
+
+    @Test
+    fun `isApplicable returns false for ApplicationConfiguration with default AWS options`() {
+        val runManager = RunManager.getInstance(projectRule.project)
+        val configuration = runManager.createConfiguration("test", ApplicationConfigurationType::class.java).configuration as ApplicationConfiguration
+        configuration.putCopyableUserData(AWS_CONNECTION_RUN_CONFIGURATION_KEY, AwsCredentialInjectionOptions.DEFAULT_OPTIONS)
+
+        val task = mock<ExecuteRunConfigurationTask>()
+        whenever(task.runProfile).thenReturn(configuration)
+
+        val provider = GradleAwsConnectionEnvironmentProvider()
+        assertThat(provider.isApplicable(task)).isFalse()
+    }
+
+    @Test
+    fun `isApplicable returns false for GradleRunConfiguration`() {
+        val configuration = mock<GradleRunConfiguration>()
+
+        val task = mock<ExecuteRunConfigurationTask>()
+        whenever(task.runProfile).thenReturn(configuration)
+
+        val provider = GradleAwsConnectionEnvironmentProvider()
+        assertThat(provider.isApplicable(task)).isFalse()
+    }
+}


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

Similar to https://github.com/ashald/EnvFile/pull/253, IntelliJ IDEA 2025.2+ changed the way environment variables are passed to Java and Kotlin applications.

When running a Kotlin app, IntelliJ:
1. Creates a `KotlinRunConfiguration` (where AWS settings are configured)
3. Internally creates a **separate** `GradleRunConfiguration` to execute via Gradle

As a result, the AWS settings from the original Kotlin run configuration were never transferred to the Gradle execution. The same goes for Java apps.

Fixes https://github.com/aws/aws-toolkit-jetbrains/issues/6197

Tested by creating a small sample app that validates whether the env vars are applied at runtime:

<img width="1822" height="1096" alt="afbeelding" src="https://github.com/user-attachments/assets/25570c94-4054-4217-b98a-8cd3d297f3c4" />

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
