### PR TITLE
Fix region/credential picker dropdown not closing after selection

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ConnectionSettingsMenuBuilder.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/credentials/ConnectionSettingsMenuBuilder.kt
@@ -10,8 +10,6 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.Separator
-import com.intellij.openapi.actionSystem.ToggleAction
-import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import software.aws.toolkits.core.credentials.CredentialIdentifier
@@ -72,7 +70,7 @@ class ConnectionSettingsMenuBuilder private constructor() {
             val actions = when (settings) {
                 is SelectableIdentitySelectionSettings -> {
                     connections.map {
-                        object : DumbAwareToggleAction<AwsBearerTokenConnection>(
+                        object : DumbAwareSelectAction<AwsBearerTokenConnection>(
                             title = it.label,
                             value = it,
                             selected = it == settings.currentSelection,
@@ -196,18 +194,20 @@ class ConnectionSettingsMenuBuilder private constructor() {
 
     // Helper actions, note: these are public to help make tests easier by leveraging instanceOf checks
 
-    abstract inner class DumbAwareToggleAction<T>(
+    abstract inner class DumbAwareSelectAction<T>(
         title: String,
         val value: T,
         private val selected: Boolean,
         private val onSelect: (T) -> Unit,
-    ) : ToggleAction(title), DumbAware {
+    ) : DumbAwareAction(title) {
         override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
-        override fun isSelected(e: AnActionEvent): Boolean = selected
+        override fun update(e: AnActionEvent) {
+            e.presentation.icon = if (selected) AllIcons.Actions.Checked else null
+        }
 
-        override fun setSelected(e: AnActionEvent, state: Boolean) {
-            if (!isSelected(e)) {
+        override fun actionPerformed(e: AnActionEvent) {
+            if (!selected) {
                 onSelect.invoke(value)
             }
         }
@@ -217,13 +217,13 @@ class ConnectionSettingsMenuBuilder private constructor() {
         value: AwsRegion,
         selected: Boolean,
         onSelect: (AwsRegion) -> Unit,
-    ) : DumbAwareToggleAction<AwsRegion>(value.displayName, value, selected, onSelect)
+    ) : DumbAwareSelectAction<AwsRegion>(value.displayName, value, selected, onSelect)
 
     inner class SwitchCredentialsAction(
         value: CredentialIdentifier,
         selected: Boolean,
         onSelect: (CredentialIdentifier) -> Unit,
-    ) : DumbAwareToggleAction<CredentialIdentifier>(value.displayName, value, selected, onSelect)
+    ) : DumbAwareSelectAction<CredentialIdentifier>(value.displayName, value, selected, onSelect)
 
     inner class IndividualIdentityActionGroup(private val value: AwsBearerTokenConnection) :
         DefaultActionGroup(


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
The region and credential picker dropdowns in the AWS Toolkit status bar and explorer toolbar were not closing after making a selection. This was caused by using `ToggleAction` which keeps popups open by design for multi-selection scenarios.

Changed `DumbAwareToggleAction` to `DumbAwareSelectAction` (extending `DumbAwareAction`) which closes the popup after selection while still showing a checkmark icon for the currently selected item.

Before:
https://github.com/user-attachments/assets/af1d7994-642d-456b-b10a-130fd85c86c2

After:
https://github.com/user-attachments/assets/17d05a45-4026-4c59-bd52-ec64c6c2a085

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.