### PR TITLE
fix(cloudformation): Skip credential resolution during transient connection states

### DIFF
--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnCredentialsService.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnCredentialsService.kt
@@ -104,8 +104,6 @@ internal class CfnCredentialsService(private val project: Project) : Disposable 
                         val regionChanged = lastRegionId != null && lastRegionId != newRegionId
                         lastRegionId = newRegionId
                         sendCredentials(onRegionChange = regionChanged)
-                    } else {
-                        sendCredentials()
                     }
                 }
             }
@@ -139,10 +137,10 @@ internal class CfnCredentialsService(private val project: Project) : Disposable 
 
     private fun resolveCredentials(): IamCredentials? {
         val connectionManager = AwsConnectionManager.getInstance(project)
-        val credentialProvider = connectionManager.activeCredentialProvider ?: return null
         val region = connectionManager.selectedRegion ?: return null
 
         return try {
+            val credentialProvider = connectionManager.activeCredentialProvider
             val awsCredentials = credentialProvider.resolveCredentials()
             val sessionCredentials = awsCredentials as? AwsSessionCredentials
 


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Prevents the credentials from being sent to language server during transient connection state which causes an exception.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
