### PR TITLE
fix(cloudformation): persist resource types list

### DIFF
--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/resources/ResourceTypesManager.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/resources/ResourceTypesManager.kt
@@ -29,6 +29,7 @@ internal class ResourceTypesManager(
     private val listeners = java.util.concurrent.CopyOnWriteArrayList<ResourceTypesChangeListener>()
 
     override fun getState(): ResourceTypesManagerState = state
+
     override fun loadState(state: ResourceTypesManagerState) { this.state = state }
 
     fun addListener(listener: ResourceTypesChangeListener) {
@@ -95,7 +96,7 @@ internal class ResourceTypesManager(
 }
 
 internal data class ResourceTypesManagerState(
-    val selectedTypes: MutableSet<String> = mutableSetOf(),
+    var selectedTypes: MutableSet<String> = mutableSetOf(),
 )
 
 typealias ResourceTypesChangeListener = () -> Unit


### PR DESCRIPTION
Changing selectedTypes attribute from val to var so that it can be persisted following IDE close.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
State attributes must be mutable, so they cannot be val. This fix allows users to see their resource types selected from previous IDE sessions.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
