### PR TITLE
fix(cloudformation): dedupe resource pagination and add load more rig…

### DIFF
--- a/plugins/toolkit/jetbrains-core/resources-253+/META-INF/aws.toolkit.cloudformation.lsp.xml
+++ b/plugins/toolkit/jetbrains-core/resources-253+/META-INF/aws.toolkit.cloudformation.lsp.xml
@@ -38,6 +38,10 @@
                 class="software.aws.toolkits.jetbrains.services.cfnlsp.explorer.actions.SearchResourceAction"
                 text="Search Resource"/>
 
+        <action id="aws.toolkit.cloudformation.resources.load_more"
+                class="software.aws.toolkits.jetbrains.services.cfnlsp.explorer.actions.LoadMoreResourcesAction"
+                text="Load More Resources"/>
+
         <action id="aws.toolkit.cloudformation.resources.import"
                 class="software.aws.toolkits.jetbrains.services.cfnlsp.explorer.actions.ImportResourceStateAction"
                 text="Import Resource State"/>
@@ -70,6 +74,7 @@
 
         <group id="aws.toolkit.cloudformation.resources.type.actions">
             <reference ref="aws.toolkit.cloudformation.resources.refresh_type"/>
+            <reference ref="aws.toolkit.cloudformation.resources.load_more"/>
             <reference ref="aws.toolkit.cloudformation.resources.remove_type"/>
             <reference ref="aws.toolkit.cloudformation.resources.search"/>
         </group>

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/explorer/actions/ResourceActions.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/explorer/actions/ResourceActions.kt
@@ -251,6 +251,39 @@ class CopyResourceIdentifierAction : AnAction(
     }
 }
 
+class LoadMoreResourcesAction : AnAction(
+    message("cloudformation.explorer.resources.load_more"),
+    null,
+    AllIcons.General.Add
+) {
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
+
+    override fun update(e: AnActionEvent) {
+        val selectedNodes = e.getData(ExplorerTreeToolWindowDataKeys.SELECTED_NODES)
+        val resourceTypeNode = selectedNodes?.filterIsInstance<ResourceTypeNode>()?.firstOrNull()
+        
+        if (resourceTypeNode != null) {
+            val project = e.project ?: return
+            val resourceLoader = ResourceLoader.getInstance(project)
+            val hasMore = resourceLoader.hasMore(resourceTypeNode.resourceType)
+            e.presentation.isVisible = hasMore
+            e.presentation.isEnabled = hasMore
+        } else {
+            e.presentation.isVisible = false
+        }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val resourceLoader = ResourceLoader.getInstance(project)
+
+        val selectedNodes = e.getData(ExplorerTreeToolWindowDataKeys.SELECTED_NODES)
+        val resourceTypeNode = selectedNodes?.filterIsInstance<ResourceTypeNode>()?.firstOrNull() ?: return
+
+        resourceLoader.loadMoreResources(resourceTypeNode.resourceType)
+    }
+}
+
 class GetStackManagementInfoAction : AnAction(
     message("cloudformation.explorer.resources.stack_info"),
     null,

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/resources/ResourceLoader.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/resources/ResourceLoader.kt
@@ -158,8 +158,8 @@ internal class ResourceLoader(
         if (resources != null) {
             val resourceSummary = resources.firstOrNull { it.typeName == resourceType }
             if (resourceSummary != null) {
-                val existingResources = if (loadMore) currentData?.resourceIdentifiers ?: emptyList() else emptyList()
-                val allResources = existingResources + resourceSummary.resourceIdentifiers
+                // LSP server returns cumulative results, use them directly
+                val allResources = resourceSummary.resourceIdentifiers
 
                 cache.put(
                     resourceType,

--- a/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/resources/ResourceStateServiceTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/resources/ResourceStateServiceTest.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.cfnlsp.resources
 
 import com.intellij.testFramework.ProjectRule
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -27,7 +26,7 @@ class ResourceStateServiceTest {
     val projectRule = ProjectRule()
 
     @Test
-    fun `importResourceState calls LSP client with correct params`() = runTest {
+    fun `importResourceState calls LSP client with correct params`() {
         val mockClientService = mock<CfnClientService>()
         val stateService = ResourceStateService(projectRule.project)
         stateService.clientServiceProvider = { mockClientService }
@@ -51,7 +50,6 @@ class ResourceStateServiceTest {
         whenever(resourceNode.resourceIdentifier).thenReturn("test-ec2")
 
         stateService.importResourceState(listOf(resourceNode))
-        testScheduler.advanceUntilIdle()
 
         val paramsCaptor = argumentCaptor<ResourceStateParams>()
         verify(mockClientService).getResourceState(paramsCaptor.capture())
@@ -63,7 +61,7 @@ class ResourceStateServiceTest {
     }
 
     @Test
-    fun `cloneResourceState calls LSP client with correct params`() = runTest {
+    fun `cloneResourceState calls LSP client with correct params`() {
         val mockClientService = mock<CfnClientService>()
         val stateService = ResourceStateService(projectRule.project)
         stateService.clientServiceProvider = { mockClientService }
@@ -87,7 +85,6 @@ class ResourceStateServiceTest {
         whenever(resourceNode.resourceIdentifier).thenReturn("test-bucket")
 
         stateService.cloneResourceState(listOf(resourceNode))
-        testScheduler.advanceUntilIdle()
 
         val paramsCaptor = argumentCaptor<ResourceStateParams>()
         verify(mockClientService).getResourceState(paramsCaptor.capture())
@@ -96,7 +93,7 @@ class ResourceStateServiceTest {
     }
 
     @Test
-    fun `getStackManagementInfo calls LSP client`() = runTest {
+    fun `getStackManagementInfo calls LSP client`() {
         val mockClientService = mock<CfnClientService>()
         val stateService = ResourceStateService(projectRule.project)
         stateService.clientServiceProvider = { mockClientService }
@@ -113,7 +110,6 @@ class ResourceStateServiceTest {
         whenever(resourceNode.resourceIdentifier).thenReturn("test-ec2")
 
         stateService.getStackManagementInfo(resourceNode)
-        testScheduler.advanceUntilIdle()
 
         verify(mockClientService).getStackManagementInfo("test-ec2")
     }

--- a/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/resources/ResourceTypesManagerTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/resources/ResourceTypesManagerTest.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.cfnlsp.resources
 
 import com.intellij.testFramework.ProjectRule
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -46,7 +45,7 @@ class ResourceTypesManagerTest {
     }
 
     @Test
-    fun `loads available types from LSP server`() = runTest {
+    fun `loads available types from LSP server`() {
         val mockClientService = mock<CfnClientService>()
         val manager = ResourceTypesManager(projectRule.project)
 
@@ -56,7 +55,6 @@ class ResourceTypesManagerTest {
         manager.clientServiceProvider = { mockClientService }
 
         manager.loadAvailableTypes()
-        testScheduler.advanceUntilIdle()
 
         verify(mockClientService).listResourceTypes()
         assertThat(manager.getAvailableResourceTypes()).containsExactlyInAnyOrder("AWS::EC2::Instance", "AWS::S3::Bucket")
@@ -64,7 +62,7 @@ class ResourceTypesManagerTest {
     }
 
     @Test
-    fun `removeResourceType sends request to LSP server`() = runTest {
+    fun `removeResourceType sends request to LSP server`() {
         val mockClientService = mock<CfnClientService>()
         val manager = ResourceTypesManager(projectRule.project)
 
@@ -76,7 +74,6 @@ class ResourceTypesManagerTest {
         assertThat(manager.getSelectedResourceTypes()).containsExactly("AWS::EC2::Instance")
 
         manager.removeResourceType("AWS::EC2::Instance")
-        testScheduler.advanceUntilIdle()
 
         verify(mockClientService).removeResourceType("AWS::EC2::Instance")
         assertThat(manager.getSelectedResourceTypes()).isEmpty()
@@ -93,7 +90,7 @@ class ResourceTypesManagerTest {
     }
 
     @Test
-    fun `removeResourceType removes from state immediately even when LSP server fails`() = runTest {
+    fun `removeResourceType removes from state immediately even when LSP server fails`() {
         val mockClientService = mock<CfnClientService>()
         val manager = ResourceTypesManager(projectRule.project)
 
@@ -105,7 +102,6 @@ class ResourceTypesManagerTest {
         assertThat(manager.getSelectedResourceTypes()).containsExactly("AWS::EC2::Instance")
 
         manager.removeResourceType("AWS::EC2::Instance")
-        testScheduler.advanceUntilIdle()
 
         verify(mockClientService).removeResourceType("AWS::EC2::Instance")
         // Should remove from state immediately for responsive UI, even if LSP call fails
@@ -113,20 +109,19 @@ class ResourceTypesManagerTest {
     }
 
     @Test
-    fun `removeResourceType does nothing for non-existent type`() = runTest {
+    fun `removeResourceType does nothing for non-existent type`() {
         val mockClientService = mock<CfnClientService>()
         val manager = ResourceTypesManager(projectRule.project)
         manager.clientServiceProvider = { mockClientService }
 
         manager.removeResourceType("AWS::EC2::Instance")
-        testScheduler.advanceUntilIdle()
 
         verify(mockClientService, never()).removeResourceType(any())
         assertThat(manager.getSelectedResourceTypes()).isEmpty()
     }
 
     @Test
-    fun `loadAvailableTypes handles null result gracefully`() = runTest {
+    fun `loadAvailableTypes handles null result gracefully`() {
         val mockClientService = mock<CfnClientService>()
         val manager = ResourceTypesManager(projectRule.project)
 
@@ -135,7 +130,6 @@ class ResourceTypesManagerTest {
         manager.clientServiceProvider = { mockClientService }
 
         manager.loadAvailableTypes()
-        testScheduler.advanceUntilIdle()
 
         verify(mockClientService).listResourceTypes()
         assertThat(manager.getAvailableResourceTypes()).isEmpty()
@@ -162,7 +156,7 @@ class ResourceTypesManagerTest {
     }
 
     @Test
-    fun `listeners are notified when resource types are removed successfully`() = runTest {
+    fun `listeners are notified when resource types are removed successfully`() {
         val mockClientService = mock<CfnClientService>()
         val manager = ResourceTypesManager(projectRule.project)
 
@@ -178,13 +172,12 @@ class ResourceTypesManagerTest {
         assertThat(notificationCount).isEqualTo(1)
 
         manager.removeResourceType("AWS::EC2::Instance")
-        testScheduler.advanceUntilIdle()
 
         assertThat(notificationCount).isEqualTo(2)
     }
 
     @Test
-    fun `listeners are notified immediately when resource type removal is requested`() = runTest {
+    fun `listeners are notified immediately when resource type removal is requested`() {
         val mockClientService = mock<CfnClientService>()
         val manager = ResourceTypesManager(projectRule.project)
 
@@ -200,7 +193,6 @@ class ResourceTypesManagerTest {
         assertThat(notificationCount).isEqualTo(1)
 
         manager.removeResourceType("AWS::EC2::Instance")
-        testScheduler.advanceUntilIdle()
 
         // Should notify immediately when removal is requested (responsive UI)
         assertThat(notificationCount).isEqualTo(2)


### PR DESCRIPTION
Fixes for the cloudformation resources node

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Currently, the pagination shows duplicates because the client appends resources following a load more resources call. However, the lsp server call returns cumulative results. The client should replace the entire list with the lsp result. Additionally, added a right click action to load more resources for a specific resource. Finally, removed coroutine logic from the resource unit tests, which isn't necessary since the methods return completable futures.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
