### PR TITLE
fix(cloudformation): auto focus search bar, allow for entire checkbox…

### DIFF
--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/ui/ResourceTypeSelectionDialog.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/ui/ResourceTypeSelectionDialog.kt
@@ -3,59 +3,72 @@
 
 package software.aws.toolkits.jetbrains.services.cfnlsp.ui
 
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.psi.codeStyle.NameUtil
-import com.intellij.ui.CheckBoxList
 import com.intellij.ui.SearchTextField
-import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.EmptyIcon
+import com.intellij.util.ui.JBUI
 import software.aws.toolkits.resources.AwsToolkitBundle.message
-import java.awt.BorderLayout
-import java.awt.Dimension
-import javax.swing.JComponent
-import javax.swing.JPanel
+import java.awt.Component
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.JTable
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
+import javax.swing.table.AbstractTableModel
+import javax.swing.table.DefaultTableCellRenderer
 
 internal class ResourceTypeSelectionDialog(
     project: Project,
     private val availableTypes: List<String>,
     selectedTypes: Set<String> = emptySet(),
 ) : DialogWrapper(project) {
-
     var selectedResourceTypes: List<String> = emptyList()
         private set
 
-    private val typesList = CheckBoxList<String>()
     private val searchField = SearchTextField(false)
-    private val currentSelections = selectedTypes.toMutableSet() // Track selections separately
+    private val currentSelections = selectedTypes.toMutableSet()
+    private val tableModel = ResourceTypeTableModel(availableTypes, currentSelections)
+    private val table = createTable()
 
     init {
         title = message("cloudformation.explorer.resources.dialog.title")
         init()
-        setupList()
         setupSearch()
-    }
-
-    private fun setupList() {
-        // Add listener to track checkbox changes
-        typesList.setCheckBoxListListener { index, value ->
-            val item = typesList.getItemAt(index)
-            if (item != null) {
-                if (value) {
-                    currentSelections.add(item)
-                } else {
-                    currentSelections.remove(item)
-                }
-            }
-        }
-
-        // Initial population - this will show pre-selected items as checked
         filterList()
     }
 
+    override fun getPreferredFocusedComponent() = searchField
+
+    private fun createTable() = JBTable(tableModel).apply {
+        setShowGrid(false)
+
+        tableHeader = null
+        rowHeight = TABLE_ROW_HEIGHT
+
+        setDefaultRenderer(Boolean::class.java, ResourceTypeCellRenderer(tableModel))
+
+        addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                val table = e.source as JTable
+                val row = table.rowAtPoint(e.point)
+                if (row >= 0) {
+                    val currentValue = tableModel.getValueAt(row, 0)
+                    tableModel.setValueAt(!currentValue, row, 0)
+                    searchField.requestFocus()
+                }
+            }
+        })
+    }
+
     private fun setupSearch() {
-        searchField.textEditor.emptyText.text = "Search resource types..."
         searchField.addDocumentListener(object : DocumentListener {
             override fun insertUpdate(e: DocumentEvent?) = filterList()
             override fun removeUpdate(e: DocumentEvent?) = filterList()
@@ -65,33 +78,94 @@ internal class ResourceTypeSelectionDialog(
 
     private fun filterList() {
         val searchText = searchField.text
-        typesList.clear()
-
         val filteredTypes = if (searchText.isEmpty()) {
             availableTypes
         } else {
             val matcher = NameUtil.buildMatcher("*$searchText*", NameUtil.MatchingCaseSensitivity.NONE)
-            availableTypes.filter { resourceType -> matcher.matches(resourceType) }
+            availableTypes.filter { matcher.matches(it) }
         }
 
-        filteredTypes.forEach { type ->
-            val isSelected = type in currentSelections // Use tracked selections
-            typesList.addItem(type, type, isSelected)
-        }
+        tableModel.updateFilter(filteredTypes)
     }
 
-    override fun createCenterPanel(): JComponent {
-        val panel = JPanel(BorderLayout())
-
-        panel.add(searchField, BorderLayout.NORTH)
-        panel.add(JBScrollPane(typesList), BorderLayout.CENTER)
-        panel.preferredSize = Dimension(400, 300)
-
-        return panel
+    override fun createCenterPanel() = panel {
+        row {
+            cell(searchField).align(AlignX.FILL)
+        }
+        row {
+            scrollCell(table).align(Align.FILL)
+        }.resizableRow()
+    }.apply {
+        preferredSize = JBUI.size(DIALOG_WIDTH, DIALOG_HEIGHT)
     }
 
     override fun doOKAction() {
-        selectedResourceTypes = currentSelections.toList() // Use tracked selections
+        selectedResourceTypes = currentSelections.toList()
         super.doOKAction()
+    }
+
+    companion object {
+        private const val TABLE_ROW_HEIGHT = 24
+        private const val DIALOG_WIDTH = 400
+        private const val DIALOG_HEIGHT = 300
+    }
+}
+
+private class ResourceTypeTableModel(
+    availableTypes: List<String>,
+    private val selections: MutableSet<String>,
+) : AbstractTableModel() {
+    private var filteredTypes = availableTypes.toList()
+
+    override fun getRowCount() = filteredTypes.size
+    override fun getColumnCount() = 1
+    override fun getColumnClass(col: Int) = Boolean::class.java
+    override fun getValueAt(row: Int, col: Int) = filteredTypes[row] in selections
+    override fun isCellEditable(row: Int, col: Int) = true
+
+    override fun setValueAt(value: Any, row: Int, col: Int) {
+        if (value is Boolean) {
+            val type = filteredTypes[row]
+
+            if (value) selections.add(type) else selections.remove(type)
+
+            fireTableCellUpdated(row, col)
+        }
+    }
+
+    fun updateFilter(types: List<String>) {
+        filteredTypes = types
+        fireTableDataChanged()
+    }
+
+    fun getResourceType(row: Int) = filteredTypes[row]
+}
+
+private class ResourceTypeCellRenderer(
+    private val tableModel: ResourceTypeTableModel,
+) : DefaultTableCellRenderer() {
+    override fun getTableCellRendererComponent(
+        table: JTable,
+        value: Any?,
+        isSelected: Boolean,
+        hasFocus: Boolean,
+        row: Int,
+        column: Int,
+    ): Component {
+        val label = JBLabel(tableModel.getResourceType(row))
+
+        label.icon = if (value as Boolean) AllIcons.Actions.Checked else EmptyIcon.ICON_16
+        label.iconTextGap = ICON_TEXT_GAP
+        label.border = JBUI.Borders.emptyLeft(LEFT_BORDER)
+        label.background = if (isSelected) table.selectionBackground else table.background
+        label.foreground = if (isSelected) table.selectionForeground else table.foreground
+        label.isOpaque = true
+
+        return label
+    }
+
+    companion object {
+        private const val ICON_TEXT_GAP = 8
+        private const val LEFT_BORDER = 8
     }
 }


### PR DESCRIPTION
Modified the resource type selection dialog to always have the search focused, even after selecting a resource type. Additionally, modified the table so that any part of the row can be clicked to select the item.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
The `CheckBoxList` component does not allow for users to click on the text to select the item. Implemented the AbstractTableModel instead. Once the dialog is opened and after selecting an item, the search field will automatically be focused. Replaced all applicable swing components with their corresponding intellij ui components. Some additional swing components were necessary for this fix, including AbstractTableModel.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.


https://github.com/user-attachments/assets/5f1cbac4-5912-4e18-baf7-cdee7fb71a7a

