### PR TITLE
Add stack resources panel

### DIFF
--- a/.changes/next-release/feature-ce7e72bc-2be1-4d79-8003-79c81af78535.json
+++ b/.changes/next-release/feature-ce7e72bc-2be1-4d79-8003-79c81af78535.json
@@ -1,0 +1,4 @@
+{
+  "type" : "feature",
+  "description" : "Add the stack resource panel to the cloudformation tool window. This allows the user to quickly view the logical ID, physical ID, resource type, and status for all of the resources in their stack"
+}

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnClientService.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnClientService.kt
@@ -20,11 +20,13 @@ import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.DescribeStackPar
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.DescribeStackResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.DescribeValidationStatusResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.GetStackActionStatusResult
+import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.GetStackResourcesParams
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.Identifiable
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListChangeSetsParams
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListChangeSetsResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListResourcesParams
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListResourcesResult
+import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListStackResourcesResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListStacksParams
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListStacksResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.RefreshResourcesParams
@@ -137,6 +139,9 @@ internal class CfnClientService(project: Project) {
         }
         return future
     }
+
+    fun getStackResources(params: GetStackResourcesParams): CompletableFuture<ListStackResourcesResult?> =
+        sendRequest { it.getStackResources(params) }
 
     companion object {
         fun getInstance(project: Project): CfnClientService = project.service()

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/stacks/views/StackPanelLayoutBuilder.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/stacks/views/StackPanelLayoutBuilder.kt
@@ -5,11 +5,16 @@ package software.aws.toolkits.jetbrains.services.cfnlsp.stacks.views
 
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.Font
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
+import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.JPanel
 
@@ -65,5 +70,33 @@ internal object StackPanelLayoutBuilder {
         gbc.weighty = 1.0
         gbc.fill = GridBagConstraints.BOTH
         parent.add(JPanel(), gbc)
+    }
+
+    fun createTableWithPaginationPanel(
+        title: String,
+        consoleLink: JComponent,
+        pageLabel: JComponent,
+        prevButton: JButton,
+        nextButton: JButton,
+        table: JBTable,
+    ): JComponent = panel {
+        row {
+            panel {
+                row {
+                    label(title).bold()
+                    cell(consoleLink)
+                }
+            }
+            panel {
+                row {
+                    cell(pageLabel)
+                    cell(prevButton)
+                    cell(nextButton)
+                }
+            }.align(AlignX.RIGHT)
+        }
+        row {
+            scrollCell(table).align(Align.FILL)
+        }.resizableRow()
     }
 }

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/stacks/views/StackResourcesPanel.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/stacks/views/StackResourcesPanel.kt
@@ -1,0 +1,241 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cfnlsp.stacks.views
+
+import com.intellij.icons.AllIcons
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.table.JBTable
+import com.intellij.util.Alarm
+import software.aws.toolkit.core.utils.getLogger
+import software.aws.toolkits.jetbrains.services.cfnlsp.CfnClientService
+import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.GetStackResourcesParams
+import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.StackResourceSummary
+import software.aws.toolkits.jetbrains.services.cfnlsp.ui.ConsoleUrlGenerator
+import software.aws.toolkits.jetbrains.services.cfnlsp.ui.IconUtils
+import java.awt.Cursor
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.util.concurrent.CompletableFuture
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.table.DefaultTableModel
+import kotlin.math.ceil
+
+internal class StackResourcesPanel(
+    project: Project,
+    private val coordinator: StackViewCoordinator,
+    private val stackArn: String,
+    private val stackName: String,
+    private val autoRefreshDelayMs: Int = 5000,
+) : Disposable, StackPanelListener {
+
+    private val cfnClientService = CfnClientService.getInstance(project)
+    private val disposables = mutableListOf<Disposable>()
+
+    private var autoRefreshAlarm: Alarm? = null
+
+    // Resource data management
+    private var allResources: List<StackResourceSummary> = emptyList()
+    private var currentPage: Int = 0
+    private var nextToken: String? = null
+    private val resourcesPerPage = 50
+    private var isLoading = false // Prevents rapid-fire clicks from triggering multiple concurrent operations
+
+    private val tableModel = DefaultTableModel(
+        arrayOf("Logical ID", "Physical ID", "Type", "Status"),
+        0
+    )
+
+    private val resourceTable = JBTable(tableModel).apply {
+        setDefaultEditor(Any::class.java, null) // Make table non-editable
+    }
+
+    internal val pageLabel = JBLabel("Page 1")
+    internal val prevButton = JButton("Previous").apply { addActionListener { loadPrevPage() } }
+    internal val nextButton = JButton("Next").apply { addActionListener { loadNextPage() } }
+
+    private val consoleLink = JBLabel(IconUtils.createBlueIcon(AllIcons.Ide.External_link_arrow)).apply {
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                val consoleUrl = ConsoleUrlGenerator.generateStackResourcesUrl(stackArn)
+                BrowserUtil.browse(consoleUrl)
+            }
+        })
+    }
+
+    val component: JComponent = StackPanelLayoutBuilder.createTableWithPaginationPanel(
+        stackName,
+        consoleLink,
+        pageLabel,
+        prevButton,
+        nextButton,
+        resourceTable
+    )
+
+    init {
+        loadResources()
+        disposables.add(coordinator.addListener(stackArn, this))
+    }
+
+    override fun onStackUpdated() {
+        val stackState = coordinator.getStackState(stackArn)
+        val currentStatus = stackState?.status
+
+        currentPage = 0
+        allResources = emptyList()
+        nextToken = null
+        loadResources()
+
+        if (currentStatus?.let { StackStatusUtils.isInTransientState(it) } == true) {
+            startAutoRefresh()
+        } else {
+            stopAutoRefresh()
+        }
+    }
+
+    private fun loadResources(): CompletableFuture<Void> {
+        if (isLoading) return CompletableFuture.completedFuture(null)
+        isLoading = true
+
+        val tokenToUse = nextToken
+        val params = GetStackResourcesParams(stackName, tokenToUse)
+
+        return cfnClientService.getStackResources(params).whenComplete { result, error ->
+            ApplicationManager.getApplication().invokeLater {
+                isLoading = false
+                if (error != null) {
+                    LOG.warn("Failed to load stack resources", error)
+                } else {
+                    result?.let { response ->
+                        if (tokenToUse == null) {
+                            // Fresh load - replace all resources
+                            allResources = response.resources
+                            currentPage = 0
+                        } else {
+                            // Pagination load - append resources
+                            allResources = allResources + response.resources
+                        }
+                        nextToken = response.nextToken
+                        updateTable()
+                    } ?: LOG.warn("No result received from getStackResources")
+                }
+            }
+        }.thenApply { null }
+    }
+
+    private fun updateTable() {
+        tableModel.rowCount = 0
+        val startIndex = currentPage * resourcesPerPage
+        val endIndex = minOf(startIndex + resourcesPerPage, allResources.size)
+        val pageResources = allResources.subList(startIndex, endIndex)
+
+        pageResources.forEach { resource ->
+            tableModel.addRow(
+                arrayOf(
+                    resource.logicalResourceId,
+                    resource.physicalResourceId ?: "N/A",
+                    resource.resourceType,
+                    resource.resourceStatus
+                )
+            )
+        }
+
+        // Update pagination controls
+        pageLabel.text = "Page ${currentPage + 1}"
+        prevButton.isEnabled = currentPage > 0 && !isLoading
+        nextButton.isEnabled = hasMorePages() && !isLoading
+
+        // Update button text based on whether NEXT click will need to load more from server
+        nextButton.text = if ((currentPage + 1) * resourcesPerPage >= allResources.size && nextToken != null) {
+            "Load More"
+        } else {
+            "Next"
+        }
+    }
+
+    private fun loadNextPage() {
+        if (isLoading) return
+
+        val totalPages = ceil(allResources.size.toDouble() / resourcesPerPage).toInt()
+        val nextPageIndex = currentPage + 1
+
+        if (nextPageIndex >= totalPages && nextToken == null) {
+            return
+        }
+
+        if (nextPageIndex < totalPages) {
+            currentPage = nextPageIndex
+            updateTable()
+        } else {
+            loadResources().whenComplete { _, _ ->
+                ApplicationManager.getApplication().invokeLater {
+                    if (allResources.size > nextPageIndex * resourcesPerPage) {
+                        currentPage = nextPageIndex
+                        updateTable()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun loadPrevPage() {
+        if (isLoading) return
+        if (currentPage > 0) {
+            currentPage--
+            updateTable()
+        }
+    }
+
+    private fun hasMorePages(): Boolean =
+        (currentPage + 1) * resourcesPerPage < allResources.size || nextToken != null
+
+    private fun startAutoRefresh() {
+        if (autoRefreshAlarm != null) {
+            return
+        }
+
+        LOG.info("Starting auto-refresh for stack $stackName with ${autoRefreshDelayMs}ms interval")
+        autoRefreshAlarm = Alarm(this).apply {
+            fun scheduleNext() {
+                addRequest({
+                    val stackState = coordinator.getStackState(stackArn)
+
+                    if (stackState?.status?.let { StackStatusUtils.isInTransientState(it) } == true) {
+                        currentPage = 0
+                        allResources = emptyList()
+                        nextToken = null
+                        loadResources()
+                        scheduleNext()
+                    } else {
+                        stopAutoRefresh()
+                    }
+                }, autoRefreshDelayMs)
+            }
+            scheduleNext()
+        }
+    }
+
+    private fun stopAutoRefresh() {
+        if (autoRefreshAlarm != null) {
+            LOG.info("Stopping auto-refresh for stack $stackName")
+            autoRefreshAlarm?.cancelAllRequests()
+            autoRefreshAlarm = null
+        }
+    }
+
+    override fun dispose() {
+        stopAutoRefresh()
+        disposables.forEach { it.dispose() }
+        disposables.clear()
+    }
+
+    companion object {
+        private val LOG = getLogger<StackResourcesPanel>()
+    }
+}

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/stacks/views/StackViewPanelTabber.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/stacks/views/StackViewPanelTabber.kt
@@ -21,6 +21,7 @@ internal class StackViewPanelTabber(
     private val coordinator = StackViewCoordinator.getInstance(project)
     private val poller = StackStatusPoller(project, stackName, stackArn, coordinator)
     private val overviewPanel = StackOverviewPanel(project, coordinator, stackArn, stackName)
+    private val resourcesPanel = StackResourcesPanel(project, coordinator, stackArn, stackName)
 
     private val tabbedPane = JBTabbedPane().apply {
         addTab("Overview", createOverviewPanel())
@@ -55,9 +56,7 @@ internal class StackViewPanelTabber(
 
     private fun createOverviewPanel(): JComponent = overviewPanel.component
 
-    private fun createResourcesPanel(): JPanel = JBPanel<JBPanel<*>>().apply {
-        add(JBLabel("Stack Resources - Coming Soon"))
-    }
+    private fun createResourcesPanel(): JComponent = resourcesPanel.component
 
     private fun createEventsPanel(): JPanel = JBPanel<JBPanel<*>>().apply {
         add(JBLabel("Stack Events - Coming Soon"))
@@ -77,6 +76,7 @@ internal class StackViewPanelTabber(
     override fun dispose() {
         poller.dispose()
         overviewPanel.dispose()
+        resourcesPanel.dispose()
         coordinator.removeStack(stackArn)
     }
 }

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/ui/Utils.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/ui/Utils.kt
@@ -14,6 +14,14 @@ import javax.swing.ImageIcon
 internal object ConsoleUrlGenerator {
     fun generateUrl(arn: String): String =
         "https://console.aws.amazon.com/go/view?arn=${URLEncoder.encode(arn, "UTF-8")}"
+
+    fun generateStackResourcesUrl(stackArn: String): String =
+        arnToConsoleTabUrl(stackArn, "resources")
+
+    private fun arnToConsoleTabUrl(arn: String, tab: String): String {
+        val region = arn.split(":").getOrNull(3) ?: "us-east-1"
+        return "https://$region.console.aws.amazon.com/cloudformation/home?region=$region#/stacks/$tab?stackId=${URLEncoder.encode(arn, "UTF-8")}"
+    }
 }
 
 internal object IconUtils {

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/CfnLspServerProtocol.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/CfnLspServerProtocol.kt
@@ -11,11 +11,13 @@ import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.DescribeStackPar
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.DescribeStackResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.DescribeValidationStatusResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.GetStackActionStatusResult
+import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.GetStackResourcesParams
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.Identifiable
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListChangeSetsParams
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListChangeSetsResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListResourcesParams
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListResourcesResult
+import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListStackResourcesResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListStacksParams
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListStacksResult
 import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.RefreshResourcesParams
@@ -78,4 +80,7 @@ internal interface CfnLspServerProtocol : LanguageServer {
     // Stack View
     @JsonRequest("aws/cfn/stack/describe")
     fun describeStack(params: DescribeStackParams): CompletableFuture<DescribeStackResult>
+
+    @JsonRequest("aws/cfn/stack/resources")
+    fun getStackResources(params: GetStackResourcesParams): CompletableFuture<ListStackResourcesResult>
 }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/protocol/StackProtocol.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/protocol/StackProtocol.kt
@@ -76,3 +76,27 @@ internal data class StackOutput(
     @SerializedName("Description")
     val description: String? = null,
 )
+
+// Stack Resources Protocol
+internal data class GetStackResourcesParams(
+    val stackName: String,
+    val nextToken: String? = null,
+)
+
+internal data class StackResourceSummary(
+    @SerializedName("LogicalResourceId")
+    val logicalResourceId: String,
+    @SerializedName("PhysicalResourceId")
+    val physicalResourceId: String?,
+    @SerializedName("ResourceType")
+    val resourceType: String,
+    @SerializedName("ResourceStatus")
+    val resourceStatus: String,
+    @SerializedName("Timestamp")
+    val timestamp: String?,
+)
+
+internal data class ListStackResourcesResult(
+    val resources: List<StackResourceSummary>,
+    val nextToken: String? = null,
+)

--- a/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/stacks/views/StackResourcesPanelTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/stacks/views/StackResourcesPanelTest.kt
@@ -1,0 +1,258 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cfnlsp.stacks.views
+
+import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.runInEdtAndWait
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import software.aws.toolkits.jetbrains.services.cfnlsp.CfnClientService
+import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.ListStackResourcesResult
+import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.StackResourceSummary
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+
+class StackResourcesPanelTest {
+
+    @get:Rule
+    val projectRule = ProjectRule()
+
+    private val testStackArn = "arn:aws:cloudformation:us-east-1:123456789012:stack/my-test-stack/12345"
+    private lateinit var mockCfnClient: CfnClientService
+    private lateinit var mockCoordinator: StackViewCoordinator
+
+    @Before
+    fun setUp() {
+        mockCfnClient = mockk()
+        mockCoordinator = mockk()
+        mockkObject(CfnClientService)
+        every { CfnClientService.getInstance(projectRule.project) } returns mockCfnClient
+        every { mockCoordinator.addListener(any(), any()) } returns mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(CfnClientService)
+        // Ensure all EDT events are processed to prevent test interference
+        runInEdtAndWait {
+            PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        }
+    }
+
+    @Test
+    fun `loads resources on initialization`() {
+        val futureResult = CompletableFuture<ListStackResourcesResult?>()
+        every { mockCfnClient.getStackResources(any()) } returns futureResult
+
+        val panel = StackResourcesPanel(projectRule.project, mockCoordinator, testStackArn, "test-stack")
+
+        try {
+            verify { mockCfnClient.getStackResources(any()) }
+        } finally {
+            panel.dispose()
+        }
+    }
+
+    @Test
+    fun `displays resources in table correctly`() {
+        val resources = listOf(
+            StackResourceSummary("LogicalId1", "PhysicalId1", "AWS::S3::Bucket", "CREATE_COMPLETE", null),
+            StackResourceSummary("LogicalId2", null, "AWS::Lambda::Function", "CREATE_IN_PROGRESS", null)
+        )
+        val result = ListStackResourcesResult(resources, null)
+        val futureResult = CompletableFuture.completedFuture(result)
+        every { mockCfnClient.getStackResources(any()) } returns futureResult
+
+        val panel = StackResourcesPanel(projectRule.project, mockCoordinator, testStackArn, "test-stack")
+
+        runInEdtAndWait {
+            PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        }
+
+        try {
+            assertThat(panel.component).isNotNull()
+            // Resources should be loaded and displayed in the table
+        } finally {
+            panel.dispose()
+        }
+    }
+
+    @Test
+    fun `pagination buttons work correctly`() {
+        val resources = (1..100).map {
+            StackResourceSummary("LogicalId$it", "PhysicalId$it", "AWS::S3::Bucket", "CREATE_COMPLETE", null)
+        }
+        val result = ListStackResourcesResult(resources, "nextToken123")
+        val futureResult = CompletableFuture.completedFuture(result)
+        every { mockCfnClient.getStackResources(any()) } returns futureResult
+
+        val panel = StackResourcesPanel(projectRule.project, mockCoordinator, testStackArn, "test-stack")
+
+        runInEdtAndWait {
+            PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        }
+
+        try {
+            assertThat(panel.nextButton.isEnabled).isTrue()
+            assertThat(panel.nextButton.text).isEqualTo("Next") // First page shows "Next", not "Load More"
+        } finally {
+            panel.dispose()
+        }
+    }
+
+    @Test
+    fun `shows load more button when more data needed from server`() {
+        val resources = (1..50).map {
+            StackResourceSummary("LogicalId$it", "PhysicalId$it", "AWS::S3::Bucket", "CREATE_COMPLETE", null)
+        }
+        val result = ListStackResourcesResult(resources, "nextToken123")
+        val futureResult = CompletableFuture.completedFuture(result)
+        every { mockCfnClient.getStackResources(any()) } returns futureResult
+
+        val panel = StackResourcesPanel(projectRule.project, mockCoordinator, testStackArn, "test-stack")
+
+        runInEdtAndWait {
+            PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        }
+
+        try {
+            assertThat(panel.nextButton.isEnabled).isTrue()
+            assertThat(panel.nextButton.text).isEqualTo("Load More") // Exactly 50 resources + nextToken = "Load More"
+        } finally {
+            panel.dispose()
+        }
+    }
+
+    @Test
+    fun `prevents rapid fire clicks with isLoading flag`() {
+        val futureResult = CompletableFuture<ListStackResourcesResult?>()
+        every { mockCfnClient.getStackResources(any()) } returns futureResult
+
+        val panel = StackResourcesPanel(projectRule.project, mockCoordinator, testStackArn, "test-stack")
+
+        // Simulate rapid clicks - should only make one call due to isLoading flag
+        repeat(5) {
+            val loadResourcesMethod = panel.javaClass.getDeclaredMethod("loadResources").apply {
+                isAccessible = true
+            }
+            loadResourcesMethod.invoke(panel)
+        }
+
+        try {
+            verify(exactly = 1) { mockCfnClient.getStackResources(any()) }
+        } finally {
+            panel.dispose()
+        }
+    }
+
+    @Test
+    fun `timer based auto refresh resets to page 1 and reloads data`() {
+        val initialResources = (1..100).map {
+            StackResourceSummary("LogicalId$it", "PhysicalId$it", "AWS::S3::Bucket", "CREATE_COMPLETE", null)
+        }
+        val refreshedResources = (1..75).map {
+            StackResourceSummary("NewId$it", "NewPhysical$it", "AWS::Lambda::Function", "UPDATE_COMPLETE", null)
+        }
+
+        val initialResult = CompletableFuture.completedFuture(ListStackResourcesResult(initialResources, null))
+        val refreshResult = CompletableFuture.completedFuture(ListStackResourcesResult(refreshedResources, null))
+
+        every { mockCfnClient.getStackResources(any()) } returnsMany listOf(initialResult, refreshResult)
+
+        // Mock coordinator for transient state (enables auto-refresh alarm)
+        every { mockCoordinator.addListener(any(), any()) } returns mockk(relaxed = true)
+        every { mockCoordinator.getStackState(any()) } returns StackState("test-stack", testStackArn, "UPDATE_IN_PROGRESS", Instant.now())
+
+        val panel = StackResourcesPanel(projectRule.project, mockCoordinator, testStackArn, "test-stack", 100) // 100ms delay for testing
+
+        try {
+            runInEdtAndWait {
+                PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+            }
+
+            // Navigate to page 2 first
+            val loadNextPageMethod = panel.javaClass.getDeclaredMethod("loadNextPage").apply {
+                isAccessible = true
+            }
+            loadNextPageMethod.invoke(panel)
+
+            runInEdtAndWait {
+                PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+            }
+
+            // Verify we're on page 2
+            assertThat(panel.pageLabel.text).isEqualTo("Page 2")
+
+            // Start auto-refresh (happens when stack is in transient state)
+            val startAutoRefreshMethod = panel.javaClass.getDeclaredMethod("startAutoRefresh").apply {
+                isAccessible = true
+            }
+            startAutoRefreshMethod.invoke(panel)
+
+            // Use IntelliJ's alarm testing - wait for 100ms alarm to fire
+            runInEdtAndWait {
+                PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+            }
+
+            // Verify alarm-based auto-refresh made new LSP call
+            verify(timeout = 1000, atLeast = 2) { mockCfnClient.getStackResources(any()) }
+        } finally {
+            panel.dispose()
+        }
+    }
+
+    @Test
+    fun `makes additional LSP calls when navigating beyond cached data`() {
+        val firstCall = CompletableFuture.completedFuture(
+            ListStackResourcesResult(
+                (1..50).map {
+                    StackResourceSummary("LogicalId$it", "PhysicalId$it", "AWS::S3::Bucket", "CREATE_COMPLETE", null)
+                },
+                "token1"
+            )
+        )
+        val secondCall = CompletableFuture.completedFuture(
+            ListStackResourcesResult(
+                (51..75).map {
+                    StackResourceSummary("LogicalId$it", "PhysicalId$it", "AWS::S3::Bucket", "CREATE_COMPLETE", null)
+                },
+                null
+            )
+        )
+
+        every { mockCfnClient.getStackResources(match { it.nextToken == null }) } returns firstCall
+        every { mockCfnClient.getStackResources(match { it.nextToken == "token1" }) } returns secondCall
+
+        val panel = StackResourcesPanel(projectRule.project, mockCoordinator, testStackArn, "test-stack")
+
+        runInEdtAndWait {
+            PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        }
+
+        // Simulate navigation that triggers server call
+        val loadNextPageMethod = panel.javaClass.getDeclaredMethod("loadNextPage").apply {
+            isAccessible = true
+        }
+        loadNextPageMethod.invoke(panel)
+
+        runInEdtAndWait {
+            PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        }
+
+        try {
+            verify { mockCfnClient.getStackResources(match { it.nextToken == "token1" }) }
+        } finally {
+            panel.dispose()
+        }
+    }
+}


### PR DESCRIPTION
Add the stack resources panel to the new cloudformation tool window.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
The stack resources panel includes a table that shows the resource's Logical ID, Physical ID, Resource Type, and Status. This change includes pagination, and auto refreshing when a stack is in a transient state. 

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
