### PR TITLE
build(ci): windows unit test failure File accessed outside allowed roots

### DIFF
--- a/plugins/amazonq/codewhisperer/jetbrains-community/tst-253+/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtilTest.kt
+++ b/plugins/amazonq/codewhisperer/jetbrains-community/tst-253+/software/aws/toolkits/jetbrains/services/codewhisperer/util/CodeWhispererUtilTest.kt
@@ -4,7 +4,6 @@
 package software.aws.toolkits.jetbrains.services.codewhisperer.util
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.HeavyPlatformTestCase
 import com.intellij.testFramework.replaceService
 import io.mockk.every
@@ -24,7 +23,6 @@ class CodeWhispererUtilTest : HeavyPlatformTestCase() {
 
     override fun setUp() {
         super.setUp()
-        VfsRootAccess.allowRootAccess(testRootDisposable, "C:/Program Files/pypy3.11-v7.3.20-win64")
         mockRegionProviderExtension.apply(
             object : org.junit.runners.model.Statement() {
                 override fun evaluate() {}


### PR DESCRIPTION
…

<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)






```
Task :plugin-amazonq:codewhisperer:jetbrains-community:test
    ERROR: File accessed outside allowed roots: file://C:/Program Files/pypy3.11-v7.3.20-win64/pypy.exe;
    Allowed roots: [/usr/local/bin, C:/codebuild/tmp/output/src2965710481/src/plugins/amazonq/codewhisperer/jetbrains-community/build/idea-sandbox/IC-2025.3/config-test, C:/Users/ContainerAdministrator/AppData/Local/Temp, C:/Users/ContainerAdministrator, C:/Users/ContainerAdministrator/AppData/Local/Temp/, /usr/bin, C:/codebuild/tmp/output/src2965710481/src/plugins/amazonq/codewhisperer/jetbrains-community/build, C:/Users/ContainerAdministrator/AppData/Local/Temp/codeWhispererWhatIsAction update should be disabled and invisible when terms of service have not been accepted_3AGlPOqKtzKCXRz4XrXISXhbTYA, C:/Program Files/pypy3.10-v7.3.17-win64, C:/Users/ContainerAdministrator/.gradle/caches/8.13/transforms/b02afabe9e7f044d2e6f6620b057e754/transformed/ideaIC-2025.3, C:/Users/ContainerAdministrator/.gradle/caches/8.13/transforms/af4bbf0094cc75544d928a2d54867f33/transformed/jbr-jbr_jcef-21.0.8-windows-x64-b1163.69/jbr_jcef-21.0.8-windows-x64-b1163.69, C:/Users/ContainerAdministrator/.gradle] [Plugin: PythonCore]
```



## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
