### PR TITLE
fix(cloudformation): Start CloudFormation LSP upon toolkit activation

### DIFF
--- a/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
@@ -290,6 +290,7 @@
         <notificationGroup id="aws.cfn.telemetry" displayType="STICKY_BALLOON" key="cloudformation.telemetry.prompt.title"/>
 
         <postStartupActivity implementation="software.aws.toolkits.jetbrains.services.cfnlsp.CfnTelemetryPrompter"/>
+        <postStartupActivity implementation="software.aws.toolkits.jetbrains.services.cfnlsp.CfnLspStartupActivity"/>
 
         <!--Sticky notifications -->
         <notificationGroup id="aws.toolkit_sticky" displayType="STICKY_BALLOON" key="aws.settings.title"/>

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnLspStartupActivity.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnLspStartupActivity.kt
@@ -1,0 +1,19 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cfnlsp
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import com.intellij.platform.lsp.api.LspServerManager
+import software.aws.toolkits.jetbrains.services.cfnlsp.server.CfnLspServerDescriptor
+import software.aws.toolkits.jetbrains.services.cfnlsp.server.CfnLspServerSupportProvider
+
+internal class CfnLspStartupActivity : StartupActivity {
+    override fun runActivity(project: Project) {
+        LspServerManager.getInstance(project).ensureServerStarted(
+            CfnLspServerSupportProvider::class.java,
+            CfnLspServerDescriptor.getInstance(project)
+        )
+    }
+}

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/explorer/CloudFormationToolWindow.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/explorer/CloudFormationToolWindow.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.intellij.platform.lsp.api.LspServerManager
 import software.aws.toolkits.jetbrains.ToolkitPlaces
 import software.aws.toolkits.jetbrains.core.credentials.CredentialManager
 import software.aws.toolkits.jetbrains.core.credentials.ToolkitConnection
@@ -18,8 +17,6 @@ import software.aws.toolkits.jetbrains.core.explorer.AbstractExplorerTreeToolWin
 import software.aws.toolkits.jetbrains.core.gettingstarted.requestCredentialsForExplorer
 import software.aws.toolkits.jetbrains.services.cfnlsp.resources.ResourceLoader
 import software.aws.toolkits.jetbrains.services.cfnlsp.resources.ResourceTypesManager
-import software.aws.toolkits.jetbrains.services.cfnlsp.server.CfnLspServerDescriptor
-import software.aws.toolkits.jetbrains.services.cfnlsp.server.CfnLspServerSupportProvider
 import software.aws.toolkits.jetbrains.services.cfnlsp.stacks.ChangeSetsManager
 import software.aws.toolkits.jetbrains.services.cfnlsp.stacks.StacksManager
 import software.aws.toolkits.jetbrains.ui.CenteredInfoPanel
@@ -52,7 +49,6 @@ internal class CloudFormationToolWindow(private val project: Project) : Abstract
         }
         subscribeToConnectionChanges()
         updateContent()
-        ensureLspServerStarted()
     }
 
     private fun subscribeToConnectionChanges() {
@@ -79,13 +75,6 @@ internal class CloudFormationToolWindow(private val project: Project) : Abstract
         } else {
             setContent(this.tree)
         }
-    }
-
-    private fun ensureLspServerStarted() {
-        LspServerManager.getInstance(project).ensureServerStarted(
-            CfnLspServerSupportProvider::class.java,
-            CfnLspServerDescriptor.getInstance(project)
-        )
     }
 
     companion object {


### PR DESCRIPTION
Wait for the LSP Server to be initialized before creating the tool window.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
This change starts the LSP Server upon toolkit activation. Previously, the LSP Server would lazy load based on if the CloudFormation panel was selected or if a yaml or json file was opened

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
