### PR TITLE
fix(rider): Restore rd-gen model generation for both 2025.x and 2026.1

### DIFF
--- a/plugins/toolkit/jetbrains-rider/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-rider/build.gradle.kts
@@ -136,6 +136,42 @@ val rdModelJarFile: File by lazy {
 configure<RdGenExtension> {
     verbose = true
     packages = "model"
+
+    if (!ideProfile.name.startsWith("2026")) {
+        // rd-gen pre-2026 compiles sources internally and requires these extension properties
+        javaClass.getMethod("setHashFolder", String::class.java).invoke(this, rdgenDir.toString())
+        javaClass.getMethod("classpath", Array<Any>::class.java).invoke(this, arrayOf<Any>({ rdModelJarFile }))
+        javaClass.getMethod("sources", Array<Any>::class.java).invoke(this, arrayOf<Any>(projectDir.resolve("protocol/model")))
+    }
+}
+
+// Pre-compile model sources for rd-gen 2026.1+ which no longer has built-in Kotlin compilation
+val compiledModelsDir = File("$nonLazyBuildDir/rdgen/compiled-models")
+val compileModelSources = if (ideProfile.name.startsWith("2026")) {
+    val kotlinCompilerConfig = configurations.detachedConfiguration(
+        dependencies.create("org.jetbrains.kotlin:kotlin-compiler-embeddable:${libs.versions.kotlin.get()}")
+    )
+
+    tasks.register<JavaExec>("compileModelSources") {
+        group = protocolGroup
+        description = "Compiles RD model sources for rd-gen 2026.1+"
+
+        mainClass.set("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")
+        classpath(kotlinCompilerConfig)
+
+        val rdGenClasspath = project.buildscript.configurations.getByName("classpath")
+        args(
+            "-cp", (rdGenClasspath.files + rdModelJarFile).joinToString(File.pathSeparator),
+            "-d", compiledModelsDir.absolutePath,
+            "-jvm-target", "21",
+            modelDir.absolutePath
+        )
+
+        inputs.dir(modelDir)
+        outputs.dir(compiledModelsDir)
+    }
+} else {
+    null
 }
 
 // TODO: migrate to official rdgen gradle plugin https://www.jetbrains.com/help/resharper/sdk/Rider.html#plugin-project-jvm
@@ -143,9 +179,13 @@ val generateModels = tasks.named<JavaExec>("generateModels") {
     group = protocolGroup
     description = "Generates protocol models"
 
-    // rd-gen 2026.1+ only adds rd-* jars to classpath, missing kotlin-stdlib
-    classpath(project.buildscript.configurations.getByName("classpath"))
-    classpath(rdModelJarFile)
+    if (ideProfile.name.startsWith("2026")) {
+        // rd-gen 2026.1+ only adds rd-* jars to classpath, missing kotlin-stdlib
+        compileModelSources?.let { dependsOn(it) }
+        classpath(project.buildscript.configurations.getByName("classpath"))
+        classpath(rdModelJarFile)
+        classpath(File("$nonLazyBuildDir/rdgen/compiled-models"))
+    }
 
     inputs.dir(file("protocol/model"))
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Commit 292181d74 removed hashFolder, classpath, and sources from the RdGenExtension config to accommodate rd-gen 2026.1 API changes, but this broke the 2025.x build and left 2026.1 model generation non-functional.

All the automated unit tests on Linux and Windows were failing with the message below
```
Execution failed for task ':plugin-toolkit:jetbrains-rider:compileKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details
```

**Fix**
For pre-2026 profiles, restore the extension properties via reflection to avoid script compilation failures when the 2026.1 rd-gen jar is on the buildscript classpath.

For 2026.1+, add a compileModelSources task that pre-compiles model sources with an external Kotlin compiler, since rd-gen 2026.1 removed its built-in Kotlin compilation support.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
