### PR TITLE
fix(gateway): Enable Gateway plugin build for 2026.1

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/ProductInfoPatcher.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/ProductInfoPatcher.kt
@@ -1,0 +1,54 @@
+// Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.gradle.intellij
+
+import java.io.File
+
+/**
+ * Gateway 2026.1 product-info.json has moduleV2/productModuleV2 layout entries without
+ * "classPath". intellij-plugin-structure declares ProductModuleV2.classPath as non-null
+ * Kotlin parameter, so Jackson throws NPE during deserialization.
+ *
+ * Bug exists on master: https://github.com/JetBrains/intellij-plugin-verifier
+ * (intellij-plugin-structure/structure-intellij/.../ProductInfo.kt)
+ *
+ * Patches cached product-info.json to add empty classPath arrays where missing.
+ */
+object ProductInfoPatcher {
+    private val MISSING_CLASSPATH = Regex(
+        """(?s)"kind"\s*:\s*"(moduleV2|productModuleV2)"\s*\}"""
+    )
+
+    fun patchGatewayProductInfo(gradleUserHome: File) {
+        val caches = gradleUserHome.resolve("caches")
+        if (!caches.isDirectory) return
+
+        caches.listFiles()
+            ?.filter { it.isDirectory && it.name.matches(Regex("\\d+\\.\\d+")) }
+            ?.forEach { versionDir ->
+                val transformsDir = versionDir.resolve("transforms")
+                if (!transformsDir.isDirectory) return@forEach
+                transformsDir.listFiles()?.forEach inner@{ transformDir ->
+                    val transformed = transformDir.resolve("transformed")
+                    if (!transformed.isDirectory) return@inner
+                    transformed.listFiles()
+                        ?.filter { it.name.startsWith("JetBrainsGateway") }
+                        ?.forEach { gatewayDir ->
+                            patchFile(gatewayDir.resolve("product-info.json"))
+                        }
+                }
+            }
+    }
+
+    private fun patchFile(productInfo: File) {
+        if (!productInfo.isFile) return
+        val content = productInfo.readText()
+        val patched = MISSING_CLASSPATH.replace(content) {
+            "\"kind\": \"${it.groupValues[1]}\",\n      \"classPath\": []\n    }"
+        }
+        if (patched != content) {
+            productInfo.writeText(patched)
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -110,6 +110,17 @@ dependencies {
             create(type, version, useInstaller = false)
         } else {
             create(IntelliJPlatformType.Gateway, version)
+
+            // Gateway 2026.1 product-info.json has layout entries without "classPath".
+            // intellij-plugin-structure crashes on these (ProductModuleV2.classPath is non-null).
+            // Bug exists on master: https://github.com/JetBrains/intellij-plugin-verifier
+            // Force-resolve IDE, patch product-info.json, then let bundledPlugins proceed.
+            afterEvaluate {
+                configurations.findByName("intellijPlatformDependency")?.resolve()
+                software.aws.toolkits.gradle.intellij.ProductInfoPatcher.patchGatewayProductInfo(
+                    gradle.gradleUserHomeDir
+                )
+            }
         }
 
         bundledPlugins(toolkitIntelliJ.productProfile().map { it.bundledPlugins })

--- a/plugins/toolkit/jetbrains-core/resources/META-INF/inactive/plugin-gateway.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/inactive/plugin-gateway.xml
@@ -14,7 +14,9 @@
     <incompatible-with>com.intellij.modules.python</incompatible-with>
     <incompatible-with>com.intellij.java</incompatible-with>
 
-    <xi:include href="/META-INF/module-core.xml" />
+    <xi:include href="/META-INF/module-core.xml">
+        <xi:fallback/>
+    </xi:include>
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceInterface="software.aws.toolkit.jetbrains.core.credentials.ToolkitConnectionManager"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -170,7 +170,7 @@ file("plugins").listFiles()?.forEach root@ {
             if (it.name == "jetbrains-gateway") {
                 when (providers.gradleProperty("ideProfileName").get()) {
                     // buildSrc is evaluated after settings so we can't key off of IdeVersions.kt
-                    "2025.1", "2025.2", "2026.1" -> {
+                    "2025.1", "2025.2" -> {
                         return@forEach
                     }
                 }


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

Gateway 2026.1's `product-info.json` contains `moduleV2`/`productModuleV2` layout entries
without a `classPath` field. The `intellij-plugin-structure` library declares
`ProductModuleV2.classPath` as a non-null Kotlin parameter, so Jackson throws a
`NullPointerException` during deserialization, failing the build with "IDE is invalid".

This bug exists on the upstream master branch of
[intellij-plugin-verifier](https://github.com/JetBrains/intellij-plugin-verifier)
(`ProductInfo.kt` — `ModuleV2` was fixed with a `@JsonCreator` factory, but
`ProductModuleV2` was not), so no version of the library can be upgraded to as a fix.

**Fix:**
- Added `ProductInfoPatcher` in buildSrc that patches cached `product-info.json` files,
  adding empty `classPath: []` to layout entries missing it.
- In `toolkit-intellij-subplugin.gradle.kts`, force-resolve the Gateway IDE dependency in
  `afterEvaluate` and run the patcher before `bundledPlugins` reads `product-info.json`.
  This makes the build work on first run with a clean Gradle cache.
- Added `xi:fallback` to the `module-core.xml` xi:include in `plugin-gateway.xml`.
- Removed `2026.1` from the Gateway skip list in `settings.gradle.kts`.

Tested this change and conformed that JetBrains Gateway 2026.1 is compatible for the CodeCatalyst provider.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)

## License

I confirm that my contribution is made under the terms of the Apache 2.0 license.
