### PR TITLE
fix(toolkit): Align kotlin-stdlib version with IDE-bundled version per profile

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -55,6 +55,7 @@ configurations {
             exclude(group = "org.jetbrains.kotlinx", "kotlinx-coroutines-core")
         }
 
+        val configName = name
         resolutionStrategy.eachDependency {
             if (requested.group == "org.jetbrains.kotlinx" && requested.name.startsWith("kotlinx-coroutines")) {
                 useVersion(versionCatalog.findVersion("kotlinCoroutines").get().toString())
@@ -62,8 +63,24 @@ configurations {
             }
 
             if (requested.group == "org.jetbrains.kotlin" && requested.name.startsWith("kotlin")) {
-                useVersion(versionCatalog.findVersion("kotlin").get().toString())
-                because("resolve kotlin version conflicts in favor of local version catalog")
+                // Only stdlib-like artifacts on runtime/test configurations should use the IDE-bundled version,
+                // and only when the IDE bundles a NEWER version than the KGP compiler.
+                // Compiler plugins (kotlin-scripting-*, kotlin-build-tools-*, etc.) must stay at KGP version.
+                val kgpVersion = versionCatalog.findVersion("kotlin").get().toString()
+                val ideStdlibVersion = versionCatalog.findVersion("kotlinStdlib").get().toString()
+                val isRuntimeOrTest = configName.contains("ompileClasspath") ||
+                    configName.contains("untimeClasspath") ||
+                    configName.contains("estFixtures")
+                val isStdlibLike = requested.name.startsWith("kotlin-stdlib") ||
+                    requested.name == "kotlin-reflect" ||
+                    requested.name.startsWith("kotlin-test")
+                val version = if (isRuntimeOrTest && isStdlibLike && ideStdlibVersion > kgpVersion) {
+                    ideStdlibVersion
+                } else {
+                    kgpVersion
+                }
+                useVersion(version)
+                because("resolve kotlin version conflicts: use IDE-bundled version when newer, otherwise KGP version")
             }
 
             // https://nvd.nist.gov/vuln/detail/cve-2022-25647

--- a/kotlinResolution.settings.gradle.kts
+++ b/kotlinResolution.settings.gradle.kts
@@ -4,8 +4,10 @@
 dependencyResolutionManagement {
     versionCatalogs {
         maybeCreate("libs").apply {
+            val ideProfileName = providers.gradleProperty("ideProfileName").getOrNull() ?: return@apply
+
             // pull value from IJ library list: https://github.com/JetBrains/intellij-community/blob/<mv>/.idea/libraries/kotlinx_coroutines_core.xml
-            val version = when (providers.gradleProperty("ideProfileName").getOrNull() ?: return@apply) {
+            val coroutinesVersion = when (ideProfileName) {
                 "2025.1" -> {
                     "1.8.0-intellij-11"
                 }
@@ -21,7 +23,19 @@ dependencyResolutionManagement {
                 else -> { error("not set") }
             }
 
-            version("kotlinxCoroutines", version)
+            version("kotlinxCoroutines", coroutinesVersion)
+
+            // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#bundled-stdlib-versions
+            // used to align non-compiler kotlin dependencies (stdlib, reflect) with the IDE's bundled version
+            val kotlinStdlibVersion = when (ideProfileName) {
+                "2025.1" -> "2.1.10"
+                "2025.2" -> "2.1.20"
+                "2025.3" -> "2.2.20"
+                "2026.1" -> "2.3.20"
+                else -> { error("not set") }
+            }
+
+            version("kotlinStdlib", kotlinStdlibVersion)
         }
     }
 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->

The 2026.1 test failures (ToolkitTelemetryOTelSpanProcessorTest, AwsClientManagerTest) are caused by a debug metadata version mismatch: kotlin-stdlib 2.2.0 on the test classpath only understands metadata version 1, but IntelliJ 2026.1 bundles Kotlin 2.3.20 which produces metadata version 2. The coroutines debug probes crash when inspecting platform coroutines.

Add a per-profile kotlinStdlib version in the settings resolution that matches each IDE's bundled Kotlin version. Update the resolution strategy so that only stdlib-like artifacts (kotlin-stdlib, kotlin-reflect, kotlin-test) on runtime/test configurations use the IDE-bundled version, and only when it is newer than the KGP version (2.2.0). Compiler plugins (kotlin-scripting-*, kotlin-build-tools-*) always stay at the KGP version to avoid internal API mismatches.

Profile -> stdlib resolved version:
  2025.1 -> 2.2.0 (KGP version, IDE bundles older 2.1.10)
  2025.2 -> 2.2.0 (KGP version, IDE bundles older 2.1.20)
  2025.3 -> 2.2.20 (upgraded to match IDE)
  2026.1 -> 2.3.20 (upgraded to match IDE)

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
