### PR TITLE
fix(261): skip toolkit test failures 'Must be called inside a command'

### DIFF
--- a/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
+++ b/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
@@ -227,6 +227,7 @@ private fun findGradlew(): Path {
     throw IllegalStateException("Failed to locate gradlew")
 }
 
+@Suppress("RedundantSuspendModifier") // suspend kept for backward compatibility with callers using runBlocking
 internal suspend fun HeavyJavaCodeInsightTestFixtureRule.setUpMavenProject(): PsiClass {
     val fixture = this.fixture
     val pomFile = fixture.addFileToModule(

--- a/plugins/toolkit/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/NodeJsCodeInsightTestFixtureRule.kt
+++ b/plugins/toolkit/jetbrains-ultimate/tst/software/aws/toolkits/jetbrains/utils/rules/NodeJsCodeInsightTestFixtureRule.kt
@@ -36,13 +36,18 @@ import software.aws.toolkit.jetbrains.utils.rules.CodeInsightTestFixtureRule
  * If you wish to have just a [Project], you may use Intellij's [com.intellij.testFramework.ProjectRule]
  */
 class NodeJsCodeInsightTestFixtureRule : CodeInsightTestFixtureRule(NodeJsLightProjectDescriptor()) {
-    override fun createTestFixture(): CodeInsightTestFixture {
-        val codeInsightFixture = super.createTestFixture()
+    override fun before(description: org.junit.runner.Description) {
+        super.before(description)
         // JavaScript plugin services may not be available in newer IDE test environments (2026.1+)
+        // Check before fixture creation to avoid teardown issues with orphaned projects
         Assume.assumeTrue(
             "NodeJs plugin services not available in test environment",
             ApplicationManager.getApplication().getServiceIfCreated(NodeJsLocalInterpreterManager::class.java) != null
         )
+    }
+
+    override fun createTestFixture(): CodeInsightTestFixture {
+        val codeInsightFixture = super.createTestFixture()
         PsiTestUtil.addContentRoot(codeInsightFixture.module, codeInsightFixture.tempDirFixture.getFile(".")!!)
         codeInsightFixture.project.setNodeJsInterpreterVersion(SemVer("v8.10.10", 8, 10, 10))
         // JSRootConfiguration may not be available in newer IDE test environments (2026.1+)
@@ -99,6 +104,14 @@ class MockNodeJsInterpreter(private var version: SemVer) : NodeJsLocalInterprete
 }
 
 class HeavyNodeJsCodeInsightTestFixtureRule : CodeInsightTestFixtureRule() {
+    override fun before(description: org.junit.runner.Description) {
+        super.before(description)
+        Assume.assumeTrue(
+            "NodeJs plugin services not available in test environment",
+            ApplicationManager.getApplication().getServiceIfCreated(NodeJsLocalInterpreterManager::class.java) != null
+        )
+    }
+
     override fun createTestFixture(): CodeInsightTestFixture {
         val fixtureFactory = IdeaTestFixtureFactory.getFixtureFactory()
         val projectFixture = fixtureFactory.createFixtureBuilder(testName)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Fixing two test issues related to 2026.1
1. `:plugin-toolkit:jetbrains-ultimate:test` failures
    - Test failures in `RedshiftExplorerNodeTest` and others with error message `com.intellij.openapi.command.impl.UndoIllegalStateException: Must be called inside a command, finishEvent: com.intellij.openapi.command.impl.cmd.CmdEventImpl@7f842836`
    - In commit 355e14f878f20b916055220d1bd7ed0f31ae9607, the `Assume` check was inside `createTestFixture()`, which ran after the fixture/project was already created. When the test was skipped, the orphaned project's teardown triggered a 2026.1 `UndoManagerImpl` error that poisoned subsequent tests. Moved the `Assume` check to `before()` in both `NodeJsCodeInsightTestFixtureRule` and `HeavyNodeJsCodeInsightTestFixtureRule` so the fixture is never created when JS plugin services are unavailable.
2. `:plugin-toolkit:jetbrains-core:detektTest` RedundantSuspendModifier
    - Earlier Maven fix removed the only suspension point from `setUpMavenProject()`, making the suspend modifier redundant. Added `@Suppress("RedundantSuspendModifier")`

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
