### PR TITLE
fix(ci): Improve Mac CI reliability and fix flaky tests

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -16,11 +16,13 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 21
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 21
+        distribution: 'corretto'
+        java-version: '21'
+        cache: 'gradle'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/plugins/core/jetbrains-community/tst-253+/software/aws/toolkit/jetbrains/core/gettingstarted/SetupAuthenticationDialogTest.kt
+++ b/plugins/core/jetbrains-community/tst-253+/software/aws/toolkit/jetbrains/core/gettingstarted/SetupAuthenticationDialogTest.kt
@@ -4,6 +4,7 @@
 package software.aws.toolkit.jetbrains.core.gettingstarted
 
 import com.intellij.openapi.components.service
+import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.TestDialog
 import com.intellij.openapi.ui.TestDialogManager
 import com.intellij.testFramework.HeavyPlatformTestCase
@@ -13,7 +14,6 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.whenever
@@ -264,7 +264,6 @@ class SetupAuthenticationDialogTest : HeavyPlatformTestCase() {
         }
     }
 
-    // TODO: Fix StsClient mock exception throwing in 2025.3 migration - this test expects an exception but mock doesn't throw
     fun `test validate IAM tab fails if credentials are invalid`() {
         val state = SetupAuthenticationDialogState().apply {
             selectedTab.set(SetupAuthenticationTabs.IAM_LONG_LIVED)
@@ -282,6 +281,12 @@ class SetupAuthenticationDialogTest : HeavyPlatformTestCase() {
             whenever(it.getCallerIdentity(any<GetCallerIdentityRequest>())).thenThrow(StsException.builder().message("Some service exception message").build())
         }
 
+        var errorDialogMessage: String? = null
+        TestDialogManager.setTestDialog { message ->
+            errorDialogMessage = message
+            Messages.OK
+        }
+
         runInEdtAndWait {
             val sut = SetupAuthenticationDialog(
                 project,
@@ -289,9 +294,10 @@ class SetupAuthenticationDialogTest : HeavyPlatformTestCase() {
                 sourceOfEntry = SourceOfEntry.UNKNOWN,
                 featureId = FeatureId.Unknown
             )
-            val exception = assertThrows<Exception> { sut.doOKAction() }
-            assertThat(exception.message).isEqualTo(AwsCoreBundle.message("gettingstarted.setup.iam.profile.invalid_credentials"))
+            sut.doOKAction()
         }
+
+        assertThat(errorDialogMessage).isEqualTo(AwsCoreBundle.message("gettingstarted.setup.iam.profile.invalid_credentials"))
     }
 
     fun `test validate IAM tab succeeds if credentials are invalid`() {

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnLspStartupActivity.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnLspStartupActivity.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.cfnlsp
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.platform.lsp.api.LspServerManager
@@ -11,6 +12,8 @@ import software.aws.toolkits.jetbrains.services.cfnlsp.server.CfnLspServerSuppor
 
 internal class CfnLspStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
+        if (ApplicationManager.getApplication().isUnitTestMode) return
+
         CfnCredentialsService.getInstance(project) // eagerly initialize to register settings change listener
         LspServerManager.getInstance(project).ensureServerStarted(
             CfnLspServerSupportProvider::class.java,

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
@@ -8,6 +8,7 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -47,6 +48,7 @@ internal class CfnLspServerSupportProvider : LspServerSupportProvider {
         file: VirtualFile,
         serverStarter: LspServerSupportProvider.LspServerStarter,
     ) {
+        if (ApplicationManager.getApplication().isUnitTestMode) return
         if (file.isCfnTemplate()) {
             serverStarter.ensureServerStarted(CfnLspServerDescriptor.getInstance(project))
         }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3ViewerPanelTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/editor/S3ViewerPanelTest.kt
@@ -16,7 +16,9 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
 import software.aws.toolkit.core.utils.test.aString
+import software.aws.toolkit.jetbrains.utils.spinUntil
 import software.aws.toolkits.jetbrains.utils.rules.EdtDisposableRule
+import java.time.Duration
 
 class S3ViewerPanelTest {
     @Rule
@@ -50,6 +52,10 @@ class S3ViewerPanelTest {
 
     @Test
     fun `data provider selected nodes key returns table selected values`() {
+        spinUntil(Duration.ofSeconds(5)) {
+            sut.treeTable.table.rowCount > 0
+        }
+
         runInEdtAndWait {
             sut.treeTable.table.clearSelection()
             assertThat(DataManager.getInstance().getDataContext(sut.component).getData(S3EditorDataKeys.SELECTED_NODES)).isEmpty()


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
- Update `mac.yml` to use `actions/checkout@v4` and `actions/setup-java@v4`
  with Corretto distribution and Gradle caching (v1/v2 deprecated June 2026)
- Skip CFN LSP server startup in unit test mode (`CfnLspStartupActivity`,
  `CfnLspServerSupportProvider`) — the server was interfering with test
  sandboxes, causing flaky failures in ProfileWatcherTest, LoginBrowserTest,
  and JavaLambdaLineMarkerTest
- Fix `SetupAuthenticationDialogTest` to verify error dialog instead of
  `assertThrows` (broken since 2025.3 migration, had existing TODO)
- Fix `S3ViewerPanelTest` to wait for table data before asserting on selection

## Checklist
- [X] My code follows the code style of this project
- [X] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
