### PR TITLE
fix(cloudformation): handle credentials with empty session token

### DIFF
--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnCredentialsService.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnCredentialsService.kt
@@ -3,6 +3,7 @@
 
 package software.aws.toolkits.jetbrains.services.cfnlsp
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -161,7 +162,7 @@ internal class CfnCredentialsService(private val project: Project) : Disposable 
     }
 
     private fun encrypt(credentials: IamCredentials): String {
-        val payload = """{"data":${jacksonObjectMapper().writeValueAsString(credentials)}}"""
+        val payload = """{"data":${MAPPER.writeValueAsString(credentials)}}"""
         val jwe = JWEObject(
             JWEHeader(JWEAlgorithm.DIR, EncryptionMethod.A256GCM),
             Payload(payload)
@@ -174,6 +175,10 @@ internal class CfnCredentialsService(private val project: Project) : Disposable 
 
     companion object {
         private val LOG = getLogger<CfnCredentialsService>()
+
+        private val MAPPER = jacksonObjectMapper().apply {
+            setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        }
 
         fun getInstance(project: Project): CfnCredentialsService = project.service()
 

--- a/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnCredentialsServiceTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnCredentialsServiceTest.kt
@@ -1,0 +1,139 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cfnlsp
+
+import com.intellij.testFramework.ProjectRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+import software.aws.toolkit.core.credentials.ToolkitCredentialsProvider
+import software.aws.toolkit.core.region.AwsRegion
+import software.aws.toolkit.jetbrains.core.credentials.AwsConnectionManager
+import software.aws.toolkits.jetbrains.services.cfnlsp.protocol.UpdateCredentialsParams
+import java.util.concurrent.CompletableFuture
+
+class CfnCredentialsServiceTest {
+
+    @get:Rule
+    val projectRule = ProjectRule()
+
+    private lateinit var mockConnectionManager: AwsConnectionManager
+    private lateinit var mockCredentialProvider: ToolkitCredentialsProvider
+    private lateinit var mockCfnClient: CfnClientService
+    private lateinit var credentialsService: CfnCredentialsService
+
+    @Before
+    fun setUp() {
+        mockConnectionManager = mockk()
+        mockCredentialProvider = mockk()
+        mockCfnClient = mockk()
+
+        mockkObject(AwsConnectionManager)
+        mockkObject(CfnClientService)
+
+        every { AwsConnectionManager.getInstance(projectRule.project) } returns mockConnectionManager
+        every { CfnClientService.getInstance(projectRule.project) } returns mockCfnClient
+        every { mockCfnClient.updateIamCredentials(any()) } returns CompletableFuture.completedFuture(mockk())
+
+        // Mock the selectedRegion call that happens in constructor
+        every { mockConnectionManager.selectedRegion } returns null
+
+        credentialsService = CfnCredentialsService(projectRule.project)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(AwsConnectionManager)
+        unmockkObject(CfnClientService)
+    }
+
+    @Test
+    fun `sendCredentials excludes null sessionToken from payload`() {
+        val testRegion = AwsRegion("us-east-1", "US East 1", "aws")
+        val basicCredentials = AwsBasicCredentials.create("testAccessKey", "testSecretKey")
+        var capturedParams: UpdateCredentialsParams? = null
+
+        every { mockConnectionManager.selectedRegion } returns testRegion
+        every { mockConnectionManager.activeCredentialProvider } returns mockCredentialProvider
+        every { mockCredentialProvider.shortName } returns "testProfile"
+        every { mockCredentialProvider.resolveCredentials() } returns basicCredentials
+        every { mockCfnClient.updateIamCredentials(capture(slot<UpdateCredentialsParams>())) } answers {
+            capturedParams = firstArg()
+            CompletableFuture.completedFuture(mockk())
+        }
+
+        credentialsService.sendCredentials()
+
+        verify { mockCfnClient.updateIamCredentials(any()) }
+
+        // Verify the encrypted payload is sent
+        assertThat(capturedParams).isNotNull()
+        assertThat(capturedParams!!.encrypted).isTrue()
+        assertThat(capturedParams!!.data).isNotEmpty()
+
+        // Use reflection to verify the mapper excludes null sessionToken
+        val mapperField = CfnCredentialsService::class.java.getDeclaredField("MAPPER")
+        mapperField.isAccessible = true
+        val mapper = mapperField.get(null) as com.fasterxml.jackson.databind.ObjectMapper
+
+        val testCredentials = IamCredentials("testProfile", "us-east-1", "testAccessKey", "testSecretKey", null)
+        val json = mapper.writeValueAsString(testCredentials)
+
+        assertThat(json).doesNotContain("sessionToken")
+    }
+
+    @Test
+    fun `sendCredentials includes sessionToken when present`() {
+        val testRegion = AwsRegion("us-east-1", "US East 1", "aws")
+        val sessionCredentials = AwsSessionCredentials.create("testAccessKey", "testSecretKey", "testSessionToken")
+        var capturedParams: UpdateCredentialsParams? = null
+
+        every { mockConnectionManager.selectedRegion } returns testRegion
+        every { mockConnectionManager.activeCredentialProvider } returns mockCredentialProvider
+        every { mockCredentialProvider.shortName } returns "testProfile"
+        every { mockCredentialProvider.resolveCredentials() } returns sessionCredentials
+        every { mockCfnClient.updateIamCredentials(capture(slot<UpdateCredentialsParams>())) } answers {
+            capturedParams = firstArg()
+            CompletableFuture.completedFuture(mockk())
+        }
+
+        credentialsService.sendCredentials()
+
+        verify { mockCfnClient.updateIamCredentials(any()) }
+
+        // Verify the encrypted payload is sent
+        assertThat(capturedParams).isNotNull()
+        assertThat(capturedParams!!.encrypted).isTrue()
+        assertThat(capturedParams!!.data).isNotEmpty()
+
+        // Use reflection to verify the mapper includes non-null sessionToken
+        val mapperField = CfnCredentialsService::class.java.getDeclaredField("MAPPER")
+        mapperField.isAccessible = true
+        val mapper = mapperField.get(null) as com.fasterxml.jackson.databind.ObjectMapper
+
+        val testCredentials = IamCredentials("testProfile", "us-east-1", "testAccessKey", "testSecretKey", "testSessionToken")
+        val json = mapper.writeValueAsString(testCredentials)
+
+        assertThat(json).contains("\"sessionToken\":\"testSessionToken\"")
+    }
+
+    @Test
+    fun `sendCredentials returns early when no region selected`() {
+        every { mockConnectionManager.selectedRegion } returns null
+
+        credentialsService.sendCredentials()
+
+        verify(exactly = 0) { mockCfnClient.updateIamCredentials(any()) }
+    }
+}

--- a/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnCredentialsServiceTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/services/cfnlsp/CfnCredentialsServiceTest.kt
@@ -79,8 +79,10 @@ class CfnCredentialsServiceTest {
 
         // Verify the encrypted payload is sent
         assertThat(capturedParams).isNotNull()
-        assertThat(capturedParams!!.encrypted).isTrue()
-        assertThat(capturedParams!!.data).isNotEmpty()
+        capturedParams?.let {
+            assertThat(it.encrypted).isTrue()
+            assertThat(it.data).isNotEmpty()
+        }
 
         // Use reflection to verify the mapper excludes null sessionToken
         val mapperField = CfnCredentialsService::class.java.getDeclaredField("MAPPER")
@@ -114,8 +116,10 @@ class CfnCredentialsServiceTest {
 
         // Verify the encrypted payload is sent
         assertThat(capturedParams).isNotNull()
-        assertThat(capturedParams!!.encrypted).isTrue()
-        assertThat(capturedParams!!.data).isNotEmpty()
+        capturedParams?.let {
+            assertThat(it.encrypted).isTrue()
+            assertThat(it.data).isNotEmpty()
+        }
 
         // Use reflection to verify the mapper includes non-null sessionToken
         val mapperField = CfnCredentialsService::class.java.getDeclaredField("MAPPER")


### PR DESCRIPTION
When credentials do not include session token, correctly parse and send to LSP Server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Previously, the CfnCredentialsService was not properly handling null values for the session token. This caused credentials that did not use session token to fail to send to the LSP Server.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
