### PR TITLE
fix(cloudformation): Make CloudFormation LSP download strategy consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Build/
 venv/
 guitest.log
 stale_outputs_checked
+.classpath
 # sam build directory
 .aws-sam/
 
@@ -36,3 +37,6 @@ ui-tests/bin
 #CodeWhispererChat
 node_modules
 !mynah-ui/package-lock.json
+
+# Eclipse
+**/org.eclipse.buildship.core.prefs

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
@@ -67,9 +67,30 @@ class CfnLspServerDescriptor private constructor(project: Project) :
     override fun createLsp4jClient(handler: LspServerNotificationsHandler): Lsp4jClient =
         CfnLspClient(CfnLspNotificationsHandler(handler), project)
 
+    private val registeredMarkerDirs = java.util.concurrent.ConcurrentHashMap.newKeySet<Path>()
+    private val shutdownHookInstalled = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    private fun registerMarkerCleanup(versionDir: Path) {
+        registeredMarkerDirs.add(versionDir)
+        if (shutdownHookInstalled.compareAndSet(false, true)) {
+            Runtime.getRuntime().addShutdownHook(
+                Thread {
+                    registeredMarkerDirs.forEach { installer.inUseTracker.removeMarker(it) }
+                }
+            )
+        }
+    }
+
     override fun createCommandLine(): GeneralCommandLine {
         val serverPath = try {
-            installer.getServerPath()
+            installer.getServerPath().also {
+                val versionDir = installer.resolvedVersionDir
+                if (versionDir != null) {
+                    installer.inUseTracker.writeMarker(versionDir, "aws-toolkit-jetbrains")
+                    registerMarkerCleanup(versionDir)
+                }
+                installer.cleanupAfterResolve()
+            }
         } catch (e: CfnLspException) {
             LOG.warn(e) { "Failed to get CloudFormation LSP server" }
             notifyLspError(e)

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/CfnLspExtensionConfig.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/CfnLspExtensionConfig.kt
@@ -7,7 +7,7 @@ import software.aws.toolkit.jetbrains.AwsPlugin
 import software.aws.toolkit.jetbrains.AwsToolkit
 
 object CfnLspExtensionConfig {
-    const val EXTENSION_NAME: String = AwsToolkit.TOOLKIT_PLUGIN_ID
+    const val EXTENSION_NAME: String = "aws.toolkit.jetbrains"
     val EXTENSION_VERSION: String = AwsToolkit.PLUGINS_INFO[AwsPlugin.TOOLKIT]?.version ?: "unknown"
     const val ENCRYPTION_MODE = "JWT"
     const val TELEMETRY_NOTIFICATION_GROUP_ID = "aws.cfn.telemetry"

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspInstaller.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspInstaller.kt
@@ -3,12 +3,12 @@
 
 package software.aws.toolkits.jetbrains.services.cfnlsp.server
 
-import com.intellij.ide.util.PropertiesComponent
 import software.aws.toolkit.core.utils.debug
 import software.aws.toolkit.core.utils.error
 import software.aws.toolkit.core.utils.getLogger
 import software.aws.toolkit.core.utils.info
 import software.aws.toolkit.core.utils.warn
+import software.aws.toolkit.jetbrains.isDeveloperMode
 import software.aws.toolkits.jetbrains.core.lsp.getToolkitsCacheRoot
 import software.aws.toolkits.jetbrains.utils.ZipDecompressor
 import software.aws.toolkits.resources.AwsToolkitBundle.message
@@ -18,12 +18,12 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.file.Files
 import java.nio.file.Path
-import java.security.MessageDigest
+import java.nio.file.StandardCopyOption
 import kotlin.io.path.isDirectory
 
 internal class CfnLspInstaller(
     private val storageDir: Path = defaultStorageDir(),
-    private val manifestAdapter: GitHubManifestAdapter = GitHubManifestAdapter(CfnLspEnvironment.fromEnvironment()),
+    private val manifestAdapter: GitHubManifestAdapter = GitHubManifestAdapter(determineEnvironment()),
 ) {
     private val httpClient = HttpClient.newBuilder()
         .followRedirects(HttpClient.Redirect.NORMAL)
@@ -31,14 +31,24 @@ internal class CfnLspInstaller(
         .build()
 
     private val versionRange = SemVerRange.parse(CfnLspServerConfig.SUPPORTED_VERSION_RANGE)
+    val inUseTracker = InUseTracker()
+    var resolvedVersionDir: Path? = null
+        private set
 
     fun getServerPath(): Path {
+        val devPath = tryDevBundlePath()
+        if (devPath != null) {
+            LOG.info { "Using dev LSP bundle: $devPath" }
+            return devPath
+        }
+
         val release = try {
-            manifestAdapter.getLatestRelease().also { saveManifestCache() }
+            manifestAdapter.getLatestRelease()
         } catch (e: Exception) {
+            saveManifestCache()
             LOG.warn(e) { "Failed to fetch manifest, trying cached manifest" }
             tryFromCachedManifest() ?: run {
-                LOG.warn { "No cached manifest, trying cached server" }
+                LOG.warn { "No cached manifest, searching for installed LSP" }
                 return findCachedServer() ?: throw CfnLspException(
                     message("cloudformation.lsp.error.manifest_failed"),
                     CfnLspException.ErrorCode.MANIFEST_FETCH_FAILED,
@@ -46,18 +56,49 @@ internal class CfnLspInstaller(
                 )
             }
         }
+        saveManifestCache()
 
         val versionDir = storageDir.resolve(release.version)
-        val serverPath = versionDir.resolve(CfnLspServerConfig.SERVER_FILE)
+        resolvedVersionDir = versionDir
+        val serverPath = findServerFileInDir(versionDir)
 
-        cleanupLegacyStorageDir()
-
-        return if (Files.exists(serverPath)) {
+        return if (serverPath != null) {
             LOG.info { "Using cached CloudFormation LSP ${release.version}" }
             serverPath
         } else {
-            downloadAndInstall(release).also { cleanupOldVersions(release.version) }
+            downloadAndInstall(release)
         }
+    }
+
+    /** Run post-resolve cleanup. Call AFTER the in-use marker for the current version has been written. */
+    fun cleanupAfterResolve() {
+        val version = resolvedVersionDir?.fileName?.toString() ?: return
+        cleanupLegacyStorageDir()
+        cleanupOldVersions(version)
+    }
+
+    private fun tryDevBundlePath(): Path? {
+        if (!isDevelopmentEnvironment()) return null
+
+        val devBundle = System.getenv("CFN_LSP_DEV_BUNDLE") ?: System.getProperty("cfn.lsp.dev.bundle")
+        if (devBundle.isNullOrBlank()) return null
+
+        val path = Path.of(devBundle)
+        val serverFile = if (path.fileName?.toString() == CfnLspServerConfig.SERVER_FILE) {
+            path
+        } else {
+            path.resolve(CfnLspServerConfig.SERVER_FILE)
+        }
+
+        if (Files.exists(serverFile)) return serverFile
+        LOG.warn { "CFN_LSP_DEV_BUNDLE set but server file not found: $serverFile" }
+        return null
+    }
+
+    private fun isDevelopmentEnvironment(): Boolean = try {
+        isDeveloperMode()
+    } catch (_: Exception) {
+        false
     }
 
     private fun tryFromCachedManifest(): ServerRelease? {
@@ -71,23 +112,42 @@ internal class CfnLspInstaller(
         }
     }
 
-    /**
-     * Finds the highest compatible cached server version.
-     * Uses semver comparison to pick the best available fallback.
-     */
     private fun findCachedServer(): Path? {
         if (!Files.exists(storageDir)) return null
 
         return Files.list(storageDir).use { stream ->
             stream.toList()
-                .filter { it.isDirectory() }
-                .filter { Files.exists(it.resolve(CfnLspServerConfig.SERVER_FILE)) }
-                .mapNotNull { dir -> SemVer.parse(dir.fileName.toString())?.let { dir to it } }
-                .filter { (_, ver) -> versionRange.satisfiedBy(ver) }
-                .maxByOrNull { (_, ver) -> ver }
-                ?.first
-                ?.resolve(CfnLspServerConfig.SERVER_FILE)
-                ?.also { LOG.info { "Using fallback cached server: $it" } }
+                .filter { it.isDirectory() && !it.fileName.toString().contains(".tmp.") }
+                .mapNotNull { dir ->
+                    val serverFile = findServerFileInDir(dir)
+                    val ver = SemVer.parse(dir.fileName.toString())
+                    if (serverFile != null && ver != null) Triple(dir, serverFile, ver) else null
+                }
+                .filter { (_, _, ver) -> versionRange.satisfiedBy(ver) }
+                .maxByOrNull { (_, _, ver) -> ver }
+                ?.let { (dir, serverFile, _) ->
+                    resolvedVersionDir = dir
+                    LOG.info { "Using fallback cached server: $serverFile" }
+                    serverFile
+                }
+        }
+    }
+
+    /**
+     * Finds the server file in a version directory, checking both the root
+     * and subdirectories (zip extraction creates a subdirectory).
+     */
+    private fun findServerFileInDir(versionDir: Path): Path? {
+        val direct = versionDir.resolve(CfnLspServerConfig.SERVER_FILE)
+        if (Files.exists(direct)) return direct
+
+        if (!Files.exists(versionDir)) return null
+        return Files.list(versionDir).use { stream ->
+            stream.filter { Files.isDirectory(it) }
+                .map { it.resolve(CfnLspServerConfig.SERVER_FILE) }
+                .filter { Files.exists(it) }
+                .findFirst()
+                .orElse(null)
         }
     }
 
@@ -105,16 +165,42 @@ internal class CfnLspInstaller(
             )
         }
 
-        // Verify hash if available
         if (release.hashes.isNotEmpty()) {
             verifyHash(zipBytes, release.hashes)
         }
 
         val targetDir = storageDir.resolve(release.version)
+
+        // Another IDE instance may have already installed this version
+        val existingServer = findServerFileInDir(targetDir)
+        if (existingServer != null) {
+            LOG.info { "Server already exists at $existingServer, skipping extraction" }
+            return existingServer
+        }
+
+        // Atomic to prevent partial installs visible to concurrent IDE instances
+        val pid = ProcessHandle.current().pid()
+        val tmpDir = storageDir.resolve("${release.version}.tmp.$pid")
         try {
-            Files.createDirectories(targetDir)
-            ZipDecompressor(zipBytes).use { it.extract(targetDir.toFile()) }
+            Files.createDirectories(tmpDir)
+            ZipDecompressor(zipBytes).use { it.extract(tmpDir.toFile()) }
+
+            try {
+                Files.move(tmpDir, targetDir, StandardCopyOption.ATOMIC_MOVE)
+            } catch (e: Exception) {
+                LOG.debug { "Atomic move failed, checking if another process completed it: ${e.message}" }
+                tmpDir.toFile().deleteRecursively()
+                if (!Files.exists(targetDir)) {
+                    throw CfnLspException(
+                        message("cloudformation.lsp.error.extraction_failed"),
+                        CfnLspException.ErrorCode.EXTRACTION_FAILED
+                    )
+                }
+            }
+        } catch (e: CfnLspException) {
+            throw e
         } catch (e: Exception) {
+            tmpDir.toFile().deleteRecursively()
             LOG.error(e) { "Failed to extract CloudFormation LSP" }
             throw CfnLspException(
                 message("cloudformation.lsp.error.extraction_failed"),
@@ -123,15 +209,19 @@ internal class CfnLspInstaller(
             )
         }
 
-        val serverPath = targetDir.resolve(CfnLspServerConfig.SERVER_FILE)
+        val serverPath = findServerFileInDir(targetDir)
+            ?: throw CfnLspException(
+                "Server file not found after extraction in $targetDir",
+                CfnLspException.ErrorCode.EXTRACTION_FAILED
+            )
         LOG.info { "CloudFormation LSP installed to: $serverPath" }
         return serverPath
     }
 
     private fun verifyHash(data: ByteArray, expectedHashes: List<String>) {
         for (expected in expectedHashes) {
-            val (algorithm, hash) = parseHashString(expected) ?: continue
-            val computed = computeHash(data, algorithm)
+            val (algorithm, hash) = HashUtils.parseHashString(expected) ?: continue
+            val computed = HashUtils.computeHash(data, algorithm)
             if (computed.equals(hash, ignoreCase = true)) {
                 LOG.debug { "Hash verification passed ($algorithm)" }
                 return
@@ -153,22 +243,28 @@ internal class CfnLspInstaller(
             legacyDir.toFile().deleteRecursively()
             LOG.info { "Removed legacy LSP directory: $legacyDir" }
         } catch (e: Exception) {
-            LOG.warn(e) { "Failed to remove legacy LSP directory" }
+            LOG.warn(e) { "Failed to remove legacy LSP directory: $legacyDir" }
         }
     }
 
-    /**
-     * Removes old versions, keeping the current version and one compatible fallback.
-     */
     private fun cleanupOldVersions(currentVersion: String) {
         if (!Files.exists(storageDir)) return
 
         try {
-            val dirs = Files.list(storageDir).use { stream ->
-                stream.filter { it.isDirectory() }.toList()
-            }
+            val allDirs = Files.list(storageDir).use { it.toList() }.filter { Files.isDirectory(it) }
 
-            // Keep the highest compatible version other than current as fallback
+            // Sweep stale .tmp.<pid> dirs from crashed runs
+            allDirs.filter { it.fileName.toString().contains(".tmp.") }
+                .forEach { tmpDir ->
+                    val pid = tmpDir.fileName.toString().substringAfterLast(".tmp.").toLongOrNull()
+                    if (pid == null || !ProcessHandle.of(pid).isPresent) {
+                        LOG.debug { "Removing stale tmp dir: ${tmpDir.fileName}" }
+                        tmpDir.toFile().deleteRecursively()
+                    }
+                }
+
+            val dirs = allDirs.filter { !it.fileName.toString().contains(".tmp.") }
+
             val fallbackDir = dirs
                 .filter { it.fileName.toString() != currentVersion }
                 .mapNotNull { dir -> SemVer.parse(dir.fileName.toString())?.let { dir to it } }
@@ -180,6 +276,11 @@ internal class CfnLspInstaller(
 
             dirs.filter { it.fileName.toString() !in keep }
                 .forEach { oldDir ->
+                    inUseTracker.cleanStaleMarkers(oldDir)
+                    if (inUseTracker.isInUse(oldDir)) {
+                        LOG.debug { "Skipping in-use version: ${oldDir.fileName}" }
+                        return@forEach
+                    }
                     LOG.debug { "Removing old LSP version: ${oldDir.fileName}" }
                     oldDir.toFile().deleteRecursively()
                 }
@@ -207,14 +308,19 @@ internal class CfnLspInstaller(
     private fun saveManifestCache() {
         val json = manifestAdapter.getCachedManifest() ?: return
         try {
-            PropertiesComponent.getInstance().setValue(MANIFEST_CACHE_KEY, json)
+            Files.createDirectories(storageDir)
+            val cachePath = storageDir.resolve(MANIFEST_CACHE_FILE)
+            val tmpPath = storageDir.resolve("$MANIFEST_CACHE_FILE.tmp.${ProcessHandle.current().pid()}")
+            Files.writeString(tmpPath, json)
+            Files.move(tmpPath, cachePath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
         } catch (e: Exception) {
             LOG.debug { "Failed to save manifest cache: ${e.message}" }
         }
     }
 
     private fun loadManifestCache(): String? = try {
-        PropertiesComponent.getInstance().getValue(MANIFEST_CACHE_KEY)
+        val cachePath = storageDir.resolve(MANIFEST_CACHE_FILE)
+        if (Files.exists(cachePath)) Files.readString(cachePath) else null
     } catch (e: Exception) {
         LOG.debug { "Failed to load manifest cache: ${e.message}" }
         null
@@ -222,26 +328,26 @@ internal class CfnLspInstaller(
 
     companion object {
         private val LOG = getLogger<CfnLspInstaller>()
-        private const val MANIFEST_CACHE_KEY = "aws.cloudformation.lsp.manifest"
+        private const val MANIFEST_CACHE_FILE = "manifest.json"
 
-        fun defaultStorageDir(): Path = getToolkitsCacheRoot().resolve("language-servers").resolve("cloudformation-languageserver")
+        fun defaultStorageDir(): Path = cfnLspCacheRoot()
 
-        internal fun parseHashString(hashString: String): Pair<String, String>? {
-            // Format: "sha256:abc123..." or "sha384:abc123..."
-            val parts = hashString.split(":", limit = 2)
-            return if (parts.size == 2) parts[0] to parts[1] else null
-        }
+        private fun cfnLspCacheRoot(): Path = when {
+            com.intellij.openapi.util.SystemInfo.isWindows -> java.nio.file.Paths.get(System.getenv("LOCALAPPDATA"))
+            com.intellij.openapi.util.SystemInfo.isMac -> java.nio.file.Paths.get(System.getProperty("user.home"), "Library", "Caches")
+            else -> java.nio.file.Paths.get(System.getProperty("user.home"), ".cache")
+        }.resolve("aws").resolve("language-servers").resolve("cloudformation-languageserver")
 
-        internal fun computeHash(data: ByteArray, algorithm: String): String {
-            val digestAlgorithm = when (algorithm.lowercase()) {
-                "sha256" -> "SHA-256"
-                "sha384" -> "SHA-384"
-                "sha512" -> "SHA-512"
-                else -> algorithm.uppercase()
+        private fun determineEnvironment(): CfnLspEnvironment {
+            val envProp = System.getProperty("cfn.lsp.environment") ?: System.getenv("CFN_LSP_ENVIRONMENT")
+            if (envProp != null) {
+                try {
+                    return CfnLspEnvironment.valueOf(envProp.uppercase())
+                } catch (_: IllegalArgumentException) {
+                }
             }
-            return MessageDigest.getInstance(digestAlgorithm)
-                .digest(data)
-                .joinToString("") { "%02x".format(it) }
+
+            return CfnLspEnvironment.PROD
         }
     }
 }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/server/GitHubManifestAdapter.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/server/GitHubManifestAdapter.kt
@@ -67,7 +67,12 @@ internal class GitHubManifestAdapter(
     internal fun parseManifest(json: String): ServerRelease {
         val root = mapper.readTree(json)
         val envKey = environment.name.lowercase()
-        var versions: List<ManifestVersion> = mapper.readValue(root.get(envKey).toString())
+        val envNode = root.get(envKey)
+            ?: error("No versions in manifest for environment '$envKey'")
+        var versions: List<ManifestVersion> = mapper.readValue(envNode.toString())
+        if (versions.isEmpty()) {
+            error("Empty version list in manifest for environment '$envKey'")
+        }
 
         if (SystemInfo.isLinux && legacyLinuxDetector.useLegacyLinux()) {
             LOG.info { "Legacy Linux environment detected, using $LEGACY_LINUX_PLATFORM builds" }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/server/HashUtils.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/server/HashUtils.kt
@@ -1,0 +1,25 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cfnlsp.server
+
+import java.security.MessageDigest
+
+internal object HashUtils {
+    fun parseHashString(hashString: String): Pair<String, String>? {
+        val parts = hashString.split(":", limit = 2)
+        return if (parts.size == 2) parts[0] to parts[1] else null
+    }
+
+    fun computeHash(data: ByteArray, algorithm: String): String {
+        val digestAlgorithm = when (algorithm.lowercase()) {
+            "sha256" -> "SHA-256"
+            "sha384" -> "SHA-384"
+            "sha512" -> "SHA-512"
+            else -> algorithm.uppercase()
+        }
+        return MessageDigest.getInstance(digestAlgorithm)
+            .digest(data)
+            .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/server/InUseTracker.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/cfnlsp/server/InUseTracker.kt
@@ -1,0 +1,59 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cfnlsp.server
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+internal class InUseTracker {
+    fun writeMarker(versionDir: Path, app: String) {
+        try {
+            val pid = ProcessHandle.current().pid()
+            val marker = versionDir.resolve(".inuse.$pid")
+            val content = """{"pid":$pid,"app":"$app","timestamp":${System.currentTimeMillis()}}"""
+            val tmp = versionDir.resolve(".inuse.$pid.tmp")
+            Files.writeString(tmp, content)
+            Files.move(tmp, marker, StandardCopyOption.ATOMIC_MOVE)
+        } catch (_: Exception) {
+        }
+    }
+
+    fun removeMarker(versionDir: Path) {
+        try {
+            val pid = ProcessHandle.current().pid()
+            Files.deleteIfExists(versionDir.resolve(".inuse.$pid"))
+        } catch (_: Exception) {
+        }
+    }
+
+    fun isInUse(versionDir: Path): Boolean {
+        try {
+            return Files.list(versionDir).use { stream ->
+                stream.filter { it.fileName.toString().startsWith(".inuse.") }
+                    .anyMatch { marker ->
+                        val pid = marker.fileName.toString().substringAfter(".inuse.").toLongOrNull()
+                        pid != null && ProcessHandle.of(pid).isPresent
+                    }
+            }
+        } catch (_: Exception) {
+            return false
+        }
+    }
+
+    fun cleanStaleMarkers(versionDir: Path) {
+        try {
+            Files.list(versionDir).use { stream ->
+                stream.filter { it.fileName.toString().startsWith(".inuse.") }
+                    .forEach { marker ->
+                        val pid = marker.fileName.toString().substringAfter(".inuse.").toLongOrNull() ?: return@forEach
+                        if (!ProcessHandle.of(pid).isPresent) {
+                            try { Files.deleteIfExists(marker) } catch (_: Exception) {}
+                        }
+                    }
+            }
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspInstallerTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspInstallerTest.kt
@@ -162,28 +162,101 @@ class CfnLspInstallerTest {
 
     @Test
     fun `parseHashString extracts algorithm and hash`() {
-        assertThat(CfnLspInstaller.parseHashString("sha256:abc123def456"))
+        assertThat(HashUtils.parseHashString("sha256:abc123def456"))
             .isEqualTo("sha256" to "abc123def456")
     }
 
     @Test
     fun `parseHashString returns null for invalid format`() {
-        assertThat(CfnLspInstaller.parseHashString("invalidhash")).isNull()
+        assertThat(HashUtils.parseHashString("invalidhash")).isNull()
     }
 
     @Test
     fun `computeHash calculates sha256 correctly`() {
-        val hash = CfnLspInstaller.computeHash("test data".toByteArray(), "sha256")
+        val hash = HashUtils.computeHash("test data".toByteArray(), "sha256")
         assertThat(hash).isEqualTo("916f0027a575074ce72a331777c3478d6513f786a591bd892da1a577bf2335f9")
     }
 
     @Test
     fun `computeHash calculates sha384 correctly`() {
-        val hash = CfnLspInstaller.computeHash("test data".toByteArray(), "sha384")
+        val hash = HashUtils.computeHash("test data".toByteArray(), "sha384")
         assertThat(hash).hasSize(96) // SHA-384 produces 96 hex characters
     }
 
+    // --- new behavior: server file inside extraction subdir ---
+
+    @Test
+    fun `findCachedServer locates server file nested in extraction subdirectory`() {
+        val storageDir = tempFolder.newFolder("lsp-storage").toPath()
+        val versionDir = storageDir.resolve("1.4.0")
+        val extractedDir = versionDir.resolve("cloudformation-language-server")
+        Files.createDirectories(extractedDir)
+        Files.createFile(extractedDir.resolve(CfnLspServerConfig.SERVER_FILE))
+
+        val result = CfnLspInstaller(storageDir).findCachedServerForTest()
+
+        assertThat(result).isEqualTo(extractedDir.resolve(CfnLspServerConfig.SERVER_FILE))
+    }
+
+    @Test
+    fun `findCachedServer excludes partial tmp extraction directories`() {
+        val storageDir = tempFolder.newFolder("lsp-storage").toPath()
+        createServerVersion(storageDir, "1.4.0")
+        // Simulate a crashed concurrent extraction — must not be picked up as a version
+        val tmpDir = storageDir.resolve("1.5.0.tmp.99999")
+        Files.createDirectories(tmpDir)
+        Files.createFile(tmpDir.resolve(CfnLspServerConfig.SERVER_FILE))
+
+        val result = CfnLspInstaller(storageDir).findCachedServerForTest()
+
+        assertThat(result?.parent?.fileName.toString()).isEqualTo("1.4.0")
+    }
+
+    // --- new behavior: tmp sweeping and in-use protection during cleanup ---
+
+    @Test
+    fun `cleanupOldVersions removes stale tmp dirs from crashed processes`() {
+        val storageDir = tempFolder.newFolder("lsp-storage").toPath()
+        createServerVersion(storageDir, "1.4.0")
+        val staleTmp = storageDir.resolve("1.5.0.tmp.$deadPid")
+        Files.createDirectories(staleTmp)
+
+        CfnLspInstaller(storageDir).cleanupOldVersionsForTest("1.4.0")
+
+        assertThat(Files.exists(staleTmp)).isFalse()
+    }
+
+    @Test
+    fun `cleanupOldVersions preserves tmp dirs belonging to live processes`() {
+        val storageDir = tempFolder.newFolder("lsp-storage").toPath()
+        createServerVersion(storageDir, "1.4.0")
+        val livePid = ProcessHandle.current().pid()
+        val liveTmp = storageDir.resolve("1.5.0.tmp.$livePid")
+        Files.createDirectories(liveTmp)
+
+        CfnLspInstaller(storageDir).cleanupOldVersionsForTest("1.4.0")
+
+        assertThat(Files.exists(liveTmp)).isTrue()
+    }
+
+    @Test
+    fun `cleanupOldVersions skips deletion of versions marked in-use`() {
+        val storageDir = tempFolder.newFolder("lsp-storage").toPath()
+        createServerVersion(storageDir, "1.0.0") // would normally be deleted (not current, not fallback)
+        createServerVersion(storageDir, "1.3.0") // fallback
+        createServerVersion(storageDir, "1.4.0") // current
+        InUseTracker().writeMarker(storageDir.resolve("1.0.0"), "other-ide")
+
+        CfnLspInstaller(storageDir).cleanupOldVersionsForTest("1.4.0")
+
+        assertThat(Files.exists(storageDir.resolve("1.0.0"))).isTrue()
+        assertThat(Files.exists(storageDir.resolve("1.3.0"))).isTrue()
+        assertThat(Files.exists(storageDir.resolve("1.4.0"))).isTrue()
+    }
+
     // --- helpers ---
+
+    private val deadPid = 2_147_483_646L
 
     private fun createServerVersion(storageDir: Path, version: String) {
         val dir = storageDir.resolve(version)

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cfnlsp/server/GitHubManifestAdapterTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cfnlsp/server/GitHubManifestAdapterTest.kt
@@ -254,6 +254,33 @@ class GitHubManifestAdapterTest {
         assertThat(result.version).isEqualTo("10.0.0")
     }
 
+    @Test
+    fun `parseManifest errors when environment key is missing from manifest`() {
+        val adapter = GitHubManifestAdapter(
+            environment = CfnLspEnvironment.BETA,
+            versionRange = SemVerRange.parse("<2.0.0"),
+        )
+
+        // manifest only has "prod", adapter expects "beta"
+        val manifest = buildManifestJson("prod", listOf("1.4.0"))
+
+        assertThatThrownBy { adapter.parseManifest(manifest) }
+            .hasMessageContaining("beta")
+    }
+
+    @Test
+    fun `parseManifest errors when environment version list is empty`() {
+        val adapter = GitHubManifestAdapter(
+            environment = CfnLspEnvironment.PROD,
+            versionRange = SemVerRange.parse("<2.0.0"),
+        )
+
+        val manifest = jacksonObjectMapper().writeValueAsString(mapOf("prod" to emptyList<Any>()))
+
+        assertThatThrownBy { adapter.parseManifest(manifest) }
+            .hasMessageContaining("Empty version list")
+    }
+
     // --- helpers ---
 
     private fun buildManifestJson(env: String, versions: List<String>): String =

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cfnlsp/server/InUseTrackerTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cfnlsp/server/InUseTrackerTest.kt
@@ -1,0 +1,97 @@
+// Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cfnlsp.server
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Files
+
+class InUseTrackerTest {
+
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private val tracker = InUseTracker()
+
+    @Test
+    fun `writeMarker creates pid-scoped marker file in version dir`() {
+        val versionDir = tempFolder.newFolder("1.4.0").toPath()
+        val pid = ProcessHandle.current().pid()
+
+        tracker.writeMarker(versionDir, "aws-toolkit-jetbrains")
+
+        val marker = versionDir.resolve(".inuse.$pid")
+        assertThat(Files.exists(marker)).isTrue()
+        assertThat(Files.readString(marker)).contains("\"pid\":$pid", "\"app\":\"aws-toolkit-jetbrains\"")
+    }
+
+    @Test
+    fun `isInUse returns true when current process has written marker`() {
+        val versionDir = tempFolder.newFolder("1.4.0").toPath()
+        tracker.writeMarker(versionDir, "app")
+
+        assertThat(tracker.isInUse(versionDir)).isTrue()
+    }
+
+    @Test
+    fun `isInUse returns false when only stale pid markers present`() {
+        val versionDir = tempFolder.newFolder("1.4.0").toPath()
+        Files.writeString(versionDir.resolve(".inuse.$DEAD_PID"), "{}")
+
+        assertThat(tracker.isInUse(versionDir)).isFalse()
+    }
+
+    @Test
+    fun `isInUse returns false when no markers exist`() {
+        val versionDir = tempFolder.newFolder("1.4.0").toPath()
+        assertThat(tracker.isInUse(versionDir)).isFalse()
+    }
+
+    @Test
+    fun `removeMarker deletes only current process marker`() {
+        val versionDir = tempFolder.newFolder("1.4.0").toPath()
+        val otherMarker = versionDir.resolve(".inuse.$DEAD_PID")
+        Files.writeString(otherMarker, "{}")
+        tracker.writeMarker(versionDir, "app")
+
+        tracker.removeMarker(versionDir)
+
+        val ownMarker = versionDir.resolve(".inuse.${ProcessHandle.current().pid()}")
+        assertThat(Files.exists(ownMarker)).isFalse()
+        assertThat(Files.exists(otherMarker)).isTrue()
+    }
+
+    @Test
+    fun `cleanStaleMarkers removes markers for dead pids but keeps live ones`() {
+        val versionDir = tempFolder.newFolder("1.4.0").toPath()
+        val staleMarker = versionDir.resolve(".inuse.$DEAD_PID")
+        Files.writeString(staleMarker, "{}")
+        tracker.writeMarker(versionDir, "app")
+        val liveMarker = versionDir.resolve(".inuse.${ProcessHandle.current().pid()}")
+
+        tracker.cleanStaleMarkers(versionDir)
+
+        assertThat(Files.exists(staleMarker)).isFalse()
+        assertThat(Files.exists(liveMarker)).isTrue()
+    }
+
+    @Test
+    fun `cleanStaleMarkers ignores files without pid suffix`() {
+        val versionDir = tempFolder.newFolder("1.4.0").toPath()
+        val garbage = versionDir.resolve(".inuse.not-a-pid")
+        Files.writeString(garbage, "{}")
+
+        tracker.cleanStaleMarkers(versionDir)
+
+        assertThat(Files.exists(garbage)).isTrue()
+    }
+
+    companion object {
+        // Max pid on Linux is 2^22; on macOS 99999. This value is guaranteed unused.
+        private const val DEAD_PID = 2_147_483_646L
+    }
+}


### PR DESCRIPTION
## Summary

These changes make the CloudFormation LSP server download, installation, caching, and cleanup strategy consistent across all client plugins and safe for concurrent multi-IDE usage.

Previously each plugin had its own ad-hoc approach to downloading and managing the LSP binary. Now all clients share the same design:

- **Atomic installs** — download to a PID-stamped temp directory, then rename into place
- **PID-based in-use tracking** — marker files prevent one IDE from deleting a version another is actively using
- **File-based manifest caching** — a plain `manifest.json` on disk replaces IDE-specific storage
- **Unified cache directory** — all plugins write to the same OS-standard cache path
- **Stale temp cleanup** — sweeps orphaned `.tmp.<pid>` directories from crashed processes
- **Local fallback resolution** — when both network and cached manifest fail, scans installed versions for a usable binary

---

## Motivation

Users commonly have both the standalone CloudFormation extension AND the AWS Toolkit installed in VS Code, or use both VS Code and JetBrains. Without a shared cache directory and in-use tracking, these plugins fight over the same LSP binary — downloading redundant copies, deleting each other's active versions, and corrupting installations mid-session.

The LSP download happens over the network from GitHub. In corporate environments with proxies, air-gapped networks, or intermittent connectivity, the download can fail at any point. The previous code had minimal resilience: no atomic writes (corruption on crash), no offline fallback (complete failure), and IDE-specific caching (no cross-plugin benefit).


**`CfnLspInstaller.kt`** — Major rewrite. Atomic download via tmp directory + `Files.move()`. New `findServerFileInDir()` handles nested extraction subdirectories. `cleanupOldVersions()` sweeps stale tmp dirs and checks in-use markers before deleting. File-based manifest cache replaces `PropertiesComponent`. New `tryDevBundlePath()` reads `CFN_LSP_DEV_BUNDLE` env var for dev mode. `cfnLspCacheRoot()` computes OS-standard cache paths. `determineEnvironment()` supports env var/system property override. `cleanupAfterResolve()` separates cleanup from resolution so the caller can write a marker first.

**`CfnLspServerSupportProvider.kt`** — Writes in-use marker after `getServerPath()`. Registers a JVM shutdown hook (`Runtime.getRuntime().addShutdownHook`) to remove markers on exit. Uses `ConcurrentHashMap` + `AtomicBoolean` for thread-safe hook registration. Calls `cleanupAfterResolve()` after the marker is written.

**`CfnLspExtensionConfig.kt`** — `EXTENSION_NAME` hardcoded to `"aws.toolkit.jetbrains"` instead of deriving from `AwsToolkit.TOOLKIT_PLUGIN_ID`.

**`GitHubManifestAdapter.kt`** — Adds null check for environment key in manifest JSON and validates the version list is non-empty.

**`HashUtils.kt`** *(new)* — Extracted `parseHashString()` and `computeHash()` from `CfnLspInstaller` into a standalone utility object.

**`InUseTracker.kt`** *(new)* — Kotlin implementation of PID-based marker tracking using `ProcessHandle`. Same API surface as the TypeScript versions: `writeMarker()`, `removeMarker()`, `isInUse()`, `cleanStaleMarkers()`.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License

I confirm that my contribution is made under the terms of the Apache 2.0 license.
