### PR TITLE
fix(ci): Pin Qodana linter image to 2025.1 to fix JDK 25 incompatibility

### DIFF
--- a/qodana-configs/duplicated-code/qodana.yaml
+++ b/qodana-configs/duplicated-code/qodana.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-linter: jetbrains/qodana-jvm-community:latest
+linter: jetbrains/qodana-jvm-community:2025.1
 projectJDK: "21"
 bootstrap: ./gradlew :plugin-core:sdk-codegen:generateSdks :plugin-core:jetbrains-community:generateTelemetry :plugin-toolkit:jetbrains-rider:generateModels
 exclude:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-linter: jetbrains/qodana-jvm-community:latest
+linter: jetbrains/qodana-jvm-community:2025.3
 projectJDK: "21"
 bootstrap: ./gradlew :plugin-core:sdk-codegen:generateSdks :plugin-core:jetbrains-community:generateTelemetry :plugin-toolkit:jetbrains-rider:generateModels
 profile:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-linter: jetbrains/qodana-jvm-community:2025.3
+linter: jetbrains/qodana-jvm-community:2025.1
 projectJDK: "21"
 bootstrap: ./gradlew :plugin-core:sdk-codegen:generateSdks :plugin-core:jetbrains-community:generateTelemetry :plugin-toolkit:jetbrains-rider:generateModels
 profile:


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

### Problem

The `jetbrains/qodana-jvm-community:latest` Docker tag was updated ~April 20 to Qodana 2026.1, which bundles JBR SDK 25 (JDK 25.0.2). Gradle 8.13 only supports up to Java 23-24, causing the build to fail with a cryptic version-parsing error:

```
FAILURE: Build failed with an exception.
    What went wrong: 25.0.2
```

### Fix

Pin the linter image in `qodana.yaml` to `2025.1` instead of `:latest`, preventing silent breakage when JetBrains publishes new container images.

**Note:** Pinned version `2025.1` instead of `2025.3`, because it matches the CLI version bundled in `JetBrains/qodana-action@v2025.1.1`.

### Testing

- Verified Qodana scan completes successfully with the pinned image

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
