### PR TITLE
fix(lambda): lambda local invoke UI not opening

### DIFF
--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/RawSettings.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/RawSettings.kt
@@ -44,7 +44,7 @@ class RawSettings(private val project: Project) {
 
     private fun createUIComponents() {
         runtimeModel = SortedComboBoxModel(compareBy(Comparator.naturalOrder()) { it.toString() })
-        architectureModel = CollectionComboBoxModel(LambdaArchitecture.values().toList())
+        architectureModel = CollectionComboBoxModel(LambdaArchitecture.values().toMutableList())
         runtime = ComboBox(runtimeModel)
         architecture = ComboBox(architectureModel)
         handlerPanel = HandlerPanel(project)

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/RawSettingsArchitectureModelTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/RawSettingsArchitectureModelTest.kt
@@ -1,0 +1,48 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
+
+import com.intellij.ui.CollectionComboBoxModel
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.Test
+import software.aws.toolkit.core.lambda.LambdaArchitecture
+
+/**
+ * Regression test for https://github.com/aws/aws-toolkit-jetbrains/issues/6363
+ *
+ * On IntelliJ Platform 2026.x, [CollectionComboBoxModel.replaceAll] internally calls
+ * [java.util.AbstractList.clear] on the backing list. If the model was constructed
+ * with an immutable list (e.g. the result of `Array.toList()`), this throws
+ * [UnsupportedOperationException] and the entire local Lambda run configuration
+ * editor fails to open.
+ *
+ * The fix is to construct [CollectionComboBoxModel] with a mutable list.
+ */
+class RawSettingsArchitectureModelTest {
+
+    @Test
+    fun architectureModelSupportsReplaceAllWithoutThrowing() {
+        // Mirrors the construction in RawSettings.createUIComponents()
+        val architectureModel = CollectionComboBoxModel(LambdaArchitecture.values().toMutableList())
+
+        assertThatCode {
+            architectureModel.replaceAll(mutableListOf(LambdaArchitecture.X86_64, LambdaArchitecture.ARM64))
+        }.doesNotThrowAnyException()
+
+        assertThat(architectureModel.items)
+            .containsExactly(LambdaArchitecture.X86_64, LambdaArchitecture.ARM64)
+    }
+
+    @Test
+    fun architectureModelSupportsReplaceAllWithSingleArchitecture() {
+        val architectureModel = CollectionComboBoxModel(LambdaArchitecture.values().toMutableList())
+
+        assertThatCode {
+            architectureModel.replaceAll(mutableListOf(LambdaArchitecture.DEFAULT))
+        }.doesNotThrowAnyException()
+
+        assertThat(architectureModel.items).containsExactly(LambdaArchitecture.DEFAULT)
+    }
+}

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/RawSettingsArchitectureModelTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/RawSettingsArchitectureModelTest.kt
@@ -10,15 +10,11 @@ import org.junit.Test
 import software.aws.toolkit.core.lambda.LambdaArchitecture
 
 /**
- * Regression test for https://github.com/aws/aws-toolkit-jetbrains/issues/6363
- *
  * On IntelliJ Platform 2026.x, [CollectionComboBoxModel.replaceAll] internally calls
  * [java.util.AbstractList.clear] on the backing list. If the model was constructed
  * with an immutable list (e.g. the result of `Array.toList()`), this throws
  * [UnsupportedOperationException] and the entire local Lambda run configuration
  * editor fails to open.
- *
- * The fix is to construct [CollectionComboBoxModel] with a mutable list.
  */
 class RawSettingsArchitectureModelTest {
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -170,7 +170,7 @@ file("plugins").listFiles()?.forEach root@ {
             if (it.name == "jetbrains-gateway") {
                 when (providers.gradleProperty("ideProfileName").get()) {
                     // buildSrc is evaluated after settings so we can't key off of IdeVersions.kt
-                    "2025.1", "2025.2" -> {
+                    "2025.1", "2025.2", "2025.3", "2026.1" -> {
                         return@forEach
                     }
                 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
https://github.com/aws/aws-toolkit-jetbrains/issues/6363

On IntelliJ 2026.x the platform's CollectionListModel.replaceAll() calls clear() on the backing list. RawSettings constructed CollectionComboBoxModel with the immutable result of LambdaArchitecture.values().toList(), causing UnsupportedOperationException and silent failure of the run config editor. This blocked all local Lambda run configurations regardless of runtime.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
