### PR TITLE
feat(cloudformation): Update how cloudformation lsp determines clientId

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@ codewhisperer/ @aws/codewhisperer-team
 mynah-ui/ @aws/flare
 mynah-ui/package.json @aws/flare @aws/elastic-gumby @aws/earlybird @aws/codewhisperer-team
 mynah-ui/package-lock.json @aws/flare @aws/elastic-gumby @aws/earlybird @aws/codewhisperer-team
+plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/ @aws-cloudformation/cfn-dev-productivity
 
 # nested within chat/, so needs to be after to take precedence
 amazonqFeatureDev/ @aws/earlybird

--- a/plugins/core/core/src/software/aws/toolkit/core/lambda/LambdaRuntime.kt
+++ b/plugins/core/core/src/software/aws/toolkit/core/lambda/LambdaRuntime.kt
@@ -21,7 +21,13 @@ enum class LambdaRuntime(
     NODEJS16_X(Runtime.NODEJS16_X, minSamDebugging = "1.49.0", minSamInit = "1.49.0", architectures = LambdaArchitecture.Companion.ARM_COMPATIBLE),
     NODEJS18_X(Runtime.NODEJS18_X, minSamDebugging = "1.65.0", minSamInit = "1.65.0", architectures = LambdaArchitecture.Companion.ARM_COMPATIBLE),
     NODEJS20_X(Runtime.NODEJS20_X, minSamDebugging = "1.102.0", minSamInit = "1.102.0", architectures = LambdaArchitecture.Companion.ARM_COMPATIBLE),
-    NODEJS22_X(null, minSamDebugging = "1.127.0", minSamInit = "1.127.0", architectures = LambdaArchitecture.Companion.ARM_COMPATIBLE, runtimeOverride = "nodejs22.x"),
+    NODEJS22_X(
+        null,
+        minSamDebugging = "1.127.0",
+        minSamInit = "1.127.0",
+        architectures = LambdaArchitecture.Companion.ARM_COMPATIBLE,
+        runtimeOverride = "nodejs22.x"
+    ),
     JAVA8_AL2(Runtime.JAVA8_AL2, minSamDebugging = "1.2.0", architectures = LambdaArchitecture.Companion.ARM_COMPATIBLE),
     JAVA11(Runtime.JAVA11, architectures = LambdaArchitecture.Companion.ARM_COMPATIBLE),
     JAVA17(Runtime.JAVA17, minSamDebugging = "1.81.0", minSamInit = "1.81.0", architectures = LambdaArchitecture.Companion.ARM_COMPATIBLE),

--- a/plugins/core/jetbrains-community/src/software/aws/toolkit/jetbrains/settings/AwsSettings.kt
+++ b/plugins/core/jetbrains-community/src/software/aws/toolkit/jetbrains/settings/AwsSettings.kt
@@ -117,8 +117,8 @@ class DefaultAwsSettings : PersistentStateComponent<AwsConfiguration>, AwsSettin
     override val clientId: UUID
         @Synchronized get() {
             val id = when {
-                ApplicationManager.getApplication().isUnitTestMode || System.getProperty("robot-server.port") != null -> "ffffffff-ffff-ffff-ffff-ffffffffffff"
-                isTelemetryEnabled == false -> "11111111-1111-1111-1111-111111111111"
+                ApplicationManager.getApplication().isUnitTestMode || System.getProperty("robot-server.port") != null -> TEST_CLIENT_ID
+                isTelemetryEnabled == false -> TELEMETRY_DISABLED_CLIENT_ID
                 else -> {
                     preferences.get(CLIENT_ID_KEY, UUID.randomUUID().toString()).also {
                         preferences.put(CLIENT_ID_KEY, it.toString())
@@ -133,6 +133,12 @@ class DefaultAwsSettings : PersistentStateComponent<AwsConfiguration>, AwsSettin
         const val CLIENT_ID_KEY = "CLIENT_ID"
         private const val ID_AUTO_UPDATE = "autoUpdate"
         private const val ID_AUTO_UPDATE_NOTIFY = "autoUpdateNotification"
+
+        const val TEST_CLIENT_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff" // unit-test/robot environments
+        const val TELEMETRY_DISABLED_CLIENT_ID = "11111111-1111-1111-1111-111111111111"
+        private val ANONYMOUS_IDS = listOf(TEST_CLIENT_ID, TELEMETRY_DISABLED_CLIENT_ID).map { UUID.fromString(it) }.toSet()
+
+        fun isAnonymousClientId(clientId: UUID): Boolean = clientId in ANONYMOUS_IDS
     }
 }
 

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/settings/AwsSettingsTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/settings/AwsSettingsTest.kt
@@ -21,6 +21,7 @@ import software.aws.toolkit.core.telemetry.TelemetryBatcher
 import software.aws.toolkit.core.telemetry.TelemetryPublisher
 import software.aws.toolkit.jetbrains.services.telemetry.NoOpPublisher
 import software.aws.toolkit.jetbrains.services.telemetry.TelemetryService
+import java.util.UUID
 
 @ExtendWith(ApplicationExtension::class)
 class AwsSettingsTest {
@@ -71,5 +72,20 @@ class AwsSettingsTest {
         assertThat(changeCaptor.firstValue).isEqualTo(value)
         inOrder.verify(batcher).onTelemetryEnabledChanged(value, onChangeEventCaptor.firstValue)
         inOrder.verify(awsConfiguration).isTelemetryEnabled = value
+    }
+
+    @Test
+    fun `isAnonymousClientId is true for the test sentinel`() {
+        assertThat(DefaultAwsSettings.isAnonymousClientId(UUID.fromString(DefaultAwsSettings.TEST_CLIENT_ID))).isTrue()
+    }
+
+    @Test
+    fun `isAnonymousClientId is true for the telemetry-disabled sentinel`() {
+        assertThat(DefaultAwsSettings.isAnonymousClientId(UUID.fromString(DefaultAwsSettings.TELEMETRY_DISABLED_CLIENT_ID))).isTrue()
+    }
+
+    @Test
+    fun `isAnonymousClientId is false for a real client id`() {
+        assertThat(DefaultAwsSettings.isAnonymousClientId(UUID.randomUUID())).isFalse()
     }
 }

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
@@ -25,6 +25,7 @@ import software.aws.toolkit.core.utils.getLogger
 import software.aws.toolkit.core.utils.info
 import software.aws.toolkit.core.utils.warn
 import software.aws.toolkit.jetbrains.settings.AwsSettings
+import software.aws.toolkit.jetbrains.settings.DefaultAwsSettings
 import software.aws.toolkit.jetbrains.utils.notifyError
 import software.aws.toolkits.jetbrains.core.lsp.NodeRuntimeResolver
 import software.aws.toolkits.jetbrains.services.cfnlsp.CfnCredentialsService
@@ -165,16 +166,23 @@ class CfnLspServerDescriptor private constructor(project: Project) :
         val settings = CfnLspSettings.getInstance()
         val credentialsService = CfnCredentialsService.getInstance(project)
 
+        val clientId = AwsSettings.getInstance().clientId
+        val clientInfo = mutableMapOf(
+            "extension" to mapOf(
+                "name" to "toolkit-jetbrains",
+                "version" to CfnLspExtensionConfig.EXTENSION_VERSION
+            )
+        )
+
+        // Only forward real clientIds, otherwise let server handle it
+        if (!DefaultAwsSettings.isAnonymousClientId(clientId)) {
+            clientInfo.put("clientId", clientId.toString())
+        }
+
         return mapOf(
             "handledSchemaProtocols" to listOf("file"),
             "aws" to mapOf(
-                "clientInfo" to mapOf(
-                    "extension" to mapOf(
-                        "name" to CfnLspExtensionConfig.EXTENSION_NAME,
-                        "version" to CfnLspExtensionConfig.EXTENSION_VERSION
-                    ),
-                    "clientId" to AwsSettings.getInstance().clientId.toString()
-                ),
+                "clientInfo" to clientInfo.toMap(),
                 "telemetryEnabled" to settings.isTelemetryEnabled,
                 "encryption" to mapOf(
                     "key" to credentialsService.encryptionKeyBase64,

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
@@ -167,7 +167,7 @@ class CfnLspServerDescriptor private constructor(project: Project) :
         val credentialsService = CfnCredentialsService.getInstance(project)
 
         val clientId = AwsSettings.getInstance().clientId
-        val clientInfo = mutableMapOf(
+        val clientInfo = mutableMapOf<String, Any>(
             "extension" to mapOf(
                 "name" to "toolkit-jetbrains",
                 "version" to CfnLspExtensionConfig.EXTENSION_VERSION
@@ -176,7 +176,7 @@ class CfnLspServerDescriptor private constructor(project: Project) :
 
         // Only forward real clientIds, otherwise let server handle it
         if (!DefaultAwsSettings.isAnonymousClientId(clientId)) {
-            clientInfo.put("clientId", clientId.toString())
+            clientInfo["clientId"] = clientId.toString()
         }
 
         return mapOf(


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)

## Description
* CloudFormation LSP telemetry enablement and ToolKit telemetry enablement settings are separate, so they cannot share clientId when ToolKit sets it to be anonymous
* Use ToolKit clientId when its a valid non anonymous id
* Fixing preexisting lint issue in Lambda

## Checklist
- [x ] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
