### PR TITLE
build: Upgrade Gradle 8.13 → 9.6.1

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@
 
 buildscript {
     // This has to be here otherwise properties are not loaded and nothing works
-    val props = `java.util`.Properties()
+    val props = java.util.Properties()
     file("${project.projectDir.parent}/gradle.properties").inputStream().use { props.load(it) }
     props.entries.forEach { project.extensions.add(it.key.toString(), it.value) }
 }

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/tasks/CreateRelease.kt
@@ -27,7 +27,7 @@ open class CreateRelease @Inject constructor(projectLayout: ProjectLayout) : Cha
 
     @Input
     @Optional
-    val issuesUrl: Provider<String?> = project.objects.property(String::class.java).convention("https://github.com/aws/aws-toolkit-jetbrains/issues")
+    val issuesUrl: Property<String> = project.objects.property(String::class.java).convention("https://github.com/aws/aws-toolkit-jetbrains/issues")
 
     @OutputFile
     val releaseFile: RegularFileProperty = project.objects.fileProperty().convention(changesDirectory.file(releaseVersion.map { "$it.json" }))

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/tasks/GenerateChangeLog.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/tasks/GenerateChangeLog.kt
@@ -18,7 +18,7 @@ import software.aws.toolkits.gradle.changelog.JetBrainsWriter
 abstract class GenerateChangeLog(private val shouldStage: Boolean) : ChangeLogTask() {
     @Input
     @Optional
-    val repoUrl: Provider<String?> = project.objects.property(String::class.java).convention("https://github.com/aws/aws-toolkit-jetbrains")
+    val repoUrl: Property<String> = project.objects.property(String::class.java).convention("https://github.com/aws/aws-toolkit-jetbrains")
 
     @Input
     val includeUnreleased: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/tasks/NewChange.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/changelog/tasks/NewChange.kt
@@ -19,7 +19,7 @@ open class NewChange : ChangeLogTask() {
     @TaskAction
     fun create() {
         val changeType = if (project.hasProperty("changeType")) {
-            (project.property("changeType") as? String?)?.toUpperCase()?.let { ChangeType.valueOf(it) }
+            (project.property("changeType") as? String?)?.uppercase()?.let { ChangeType.valueOf(it) }
         } else defaultChangeType
         val description = if (project.hasProperty("description")) {
             project.property("description") as? String?

--- a/buildSrc/src/main/kotlin/toolkit-git-secrets.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-git-secrets.gradle.kts
@@ -10,37 +10,34 @@ plugins {
 
 val downloadGitSecrets = tasks.register<Download>("downloadGitSecrets") {
     src("https://raw.githubusercontent.com/awslabs/git-secrets/master/git-secrets")
-    dest("$buildDir/git-secrets")
+    dest(layout.buildDirectory.file("git-secrets"))
     onlyIfModified(true)
     useETag(true)
+}
+
+val gitSecretsRegister = tasks.register<Exec>("gitSecretsRegister") {
+    dependsOn(downloadGitSecrets)
+    workingDir(rootDir)
+    val path = "${layout.buildDirectory.get().asFile}${File.pathSeparator}"
+    environment = environment.apply { replace("PATH", path + getOrDefault("PATH", "")) }
+    commandLine("/bin/sh", "${layout.buildDirectory.get().asFile}/git-secrets", "--register-aws")
+}
+
+val gitSecretsAllowDummy = tasks.register<Exec>("gitSecretsAllowDummy") {
+    dependsOn(gitSecretsRegister)
+    workingDir(rootDir)
+    commandLine("git", "config", "--add", "secrets.allowed", "123456789012")
 }
 
 val gitSecrets = tasks.register<Exec>("gitSecrets") {
     onlyIf {
         !DefaultNativePlatform.getCurrentOperatingSystem().isWindows
     }
-
-    dependsOn(downloadGitSecrets)
-    workingDir(project.rootDir)
-    val path = "$buildDir${File.pathSeparator}"
-    val patchendEnv = environment.apply { replace("PATH", path + getOrDefault("PATH", "")) }
-    environment = patchendEnv
-
-    commandLine("/bin/sh", "$buildDir/git-secrets", "--register-aws")
-
-    // cleaner than having multiple separate exec tasks
-    doLast {
-        exec {
-            workingDir(project.rootDir)
-            commandLine("git", "config", "--add", "secrets.allowed", "123456789012")
-        }
-
-        exec {
-            workingDir(project.rootDir)
-            environment = patchendEnv
-            commandLine("/bin/sh", "$buildDir/git-secrets", "--scan")
-        }
-    }
+    dependsOn(gitSecretsAllowDummy)
+    workingDir(rootDir)
+    val path = "${layout.buildDirectory.get().asFile}${File.pathSeparator}"
+    environment = environment.apply { replace("PATH", path + getOrDefault("PATH", "")) }
+    commandLine("/bin/sh", "${layout.buildDirectory.get().asFile}/git-secrets", "--scan")
 }
 
 tasks.findByName("check")?.let {

--- a/buildSrc/src/main/kotlin/toolkit-integration-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-integration-testing.gradle.kts
@@ -55,8 +55,8 @@ val testJar = tasks.named<Jar>("testJar").configure {
 
 idea {
     module {
-        testSourceDirs = testSourceDirs + integrationTests.java.srcDirs
-        testResourceDirs = testResourceDirs + integrationTests.resources.srcDirs
+        testSources.from(integrationTests.java.srcDirs)
+        testResources.from(integrationTests.resources.srcDirs)
     }
 }
 val integrationTestConfiguration: Test.() -> Unit = {

--- a/buildSrc/src/main/kotlin/toolkit-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-testing.gradle.kts
@@ -114,7 +114,5 @@ configurations.register("coverageDataElements") {
         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
         attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("jacoco-coverage-data"))
     }
-    tasks.withType<Test>().configureEach {
-        outgoing.artifact(extensions.getByType<JacocoTaskExtension>().destinationFile!!)
-    }
+    outgoing.artifact(tasks.test.map { it.extensions.getByType<JacocoTaskExtension>().destinationFile!! })
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugins/toolkit/jetbrains-core/tst-242-252/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
+++ b/plugins/toolkit/jetbrains-core/tst-242-252/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
@@ -79,10 +79,19 @@ fun HeavyJavaCodeInsightTestFixtureRule.setUpGradleProject(compatibility: String
                 id 'java'
             }
 
-            sourceCompatibility = '$compatibility'
-            targetCompatibility = '$compatibility'
+            java {
+                sourceCompatibility = JavaVersion.toVersion('$compatibility')
+                targetCompatibility = JavaVersion.toVersion('$compatibility')
+            }
         """.trimIndent()
     ).virtualFile
+
+    // Gradle 9+ requires a settings file (and removed the -b flag for specifying build files directly)
+    fixture.addFileToModule(
+        this.module,
+        "settings.gradle",
+        ""
+    )
 
     // Use our project's own Gradle version
     this.copyGradleFiles()
@@ -115,7 +124,7 @@ fun HeavyJavaCodeInsightTestFixtureRule.setUpGradleProject(compatibility: String
 
     val gradleProjectSettings = GradleProjectSettings().apply {
         withQualifiedModuleNames()
-        externalProjectPath = buildFile.path
+        externalProjectPath = buildFile.parent.path
     }
 
     val externalSystemSettings = ExternalSystemApiUtil.getSettings(project, GradleConstants.SYSTEM_ID)

--- a/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
+++ b/plugins/toolkit/jetbrains-core/tst-253+/software/aws/toolkits/jetbrains/utils/JavaTestUtils.kt
@@ -79,10 +79,19 @@ fun HeavyJavaCodeInsightTestFixtureRule.setUpGradleProject(compatibility: String
                 id 'java'
             }
 
-            sourceCompatibility = '$compatibility'
-            targetCompatibility = '$compatibility'
+            java {
+                sourceCompatibility = JavaVersion.toVersion('$compatibility')
+                targetCompatibility = JavaVersion.toVersion('$compatibility')
+            }
         """.trimIndent()
     ).virtualFile
+
+    // Gradle 9+ requires a settings file (and removed the -b flag for specifying build files directly)
+    fixture.addFileToModule(
+        this.module,
+        "settings.gradle",
+        ""
+    )
 
     // Use our project's own Gradle version
     this.copyGradleFiles()
@@ -115,7 +124,7 @@ fun HeavyJavaCodeInsightTestFixtureRule.setUpGradleProject(compatibility: String
 
     val gradleProjectSettings = GradleProjectSettings().apply {
         withQualifiedModuleNames()
-        externalProjectPath = buildFile.path
+        externalProjectPath = buildFile.parent.path
     }
 
     val externalSystemSettings = ExternalSystemApiUtil.getSettings(project, GradleConstants.SYSTEM_ID)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,8 +40,8 @@ pluginManagement {
 }
 
 plugins {
-    id("com.github.burrunan.s3-build-cache") version "1.5"
-    id("com.gradle.develocity") version "3.17.6"
+    id("com.github.burrunan.s3-build-cache") version "1.9.4"
+    id("com.gradle.develocity") version "4.3.3"
     id("org.jetbrains.intellij.platform.settings") version "2.7.1"
 }
 


### PR DESCRIPTION
build: Upgrade Gradle 8.13 → 9.6.1

Prerequisite for IntelliJ Platform Plugin 2.17.0 (which requires Gradle 9.0+, needed for 262 EAP support).

Version bumps:
- Gradle wrapper: 8.13 → 9.6.1
- com.gradle.develocity: 3.17.6 → 4.3.3 (Gradle 9 compat)
- com.github.burrunan.s3-build-cache: 1.5 → 1.9.4 (Gradle 9 compat)

Gradle 9 build script fixes (removed APIs):
- `java.util`.Properties() backtick syntax → java.util.Properties()
- Provider<String?> → Property<String> (stricter task inputs)
- .toUpperCase() → .uppercase() (Kotlin deprecation)
- doLast { exec {} } → separate Exec tasks (toolkit-git-secrets)
- testSourceDirs mutable setter → testSources.from()
- withType<Test>().configureEach in outgoing → lazy provider
- $buildDir → layout.buildDirectory

Test fixes (Gradle 9 removed -b flag and top-level sourceCompatibility):
- JavaTestUtils: externalProjectPath set to directory, not build file
- JavaTestUtils: add empty settings.gradle (required by Gradle 9)
- JavaTestUtils: move sourceCompatibility into java {} block

Testing: buildPlugin + JavaLambdaBuilderTest pass for 2025.3. Plugin loads and works in runIde.
