### PR TITLE
build: Upgrade IntelliJ Platform Gradle Plugin 2.7.1 → 2.11.0

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -97,6 +97,29 @@ tasks.processResources {
     duplicatesStrategy = DuplicatesStrategy.WARN
 }
 
+// IntelliJ Platform Gradle Plugin 2.8+ strictly resolves bundled plugin artifacts.
+// The community profile (IC) declares bundled plugins like com.intellij.java, com.intellij.gradle, etc.
+// When a non-IC module (IU, RD, GW) depends transitively on an IC module, those bundled plugin
+// coordinates leak into the non-IC module's test classpath with IC-xxx coordinates that can't
+// resolve against the non-IC SDK. Exclude them for any module whose flavor differs from IC.
+afterEvaluate {
+    val flavor = toolkitIntelliJ.ideFlavor.get()
+    if (flavor != IdeFlavor.IC) {
+        val communityBundledPlugins = listOf(
+            "com.intellij.java",
+            "com.intellij.gradle",
+            "org.jetbrains.idea.maven",
+            "com.intellij.properties",
+            "org.jetbrains.idea.reposearch",
+        )
+        configurations.matching { it.name == "testCompileClasspath" || it.name == "testRuntimeClasspath" }.configureEach {
+            communityBundledPlugins.forEach { pluginId ->
+                exclude(group = "bundledPlugin", module = pluginId)
+            }
+        }
+    }
+}
+
 tasks.processTestResources {
     // TODO how can we remove this
     duplicatesStrategy = DuplicatesStrategy.WARN

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ detekt = "1.23.8"
 diff-util = "4.12"
 intellijExt = "1.1.8"
 # match with <root>/settings.gradle.kts
-intellijGradle = "2.7.1"
+intellijGradle = "2.11.0"
 intellijRemoteRobot = "0.11.22"
 jackson = "2.17.2"
 jacoco = "0.8.12"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ pluginManagement {
 plugins {
     id("com.github.burrunan.s3-build-cache") version "1.9.4"
     id("com.gradle.develocity") version "4.3.3"
-    id("org.jetbrains.intellij.platform.settings") version "2.7.1"
+    id("org.jetbrains.intellij.platform.settings") version "2.11.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary

Incremental step 1/N toward IntelliJ Platform Gradle Plugin 2.18.0 (required for 2026.2 support).

This is a **compatibility-only version bump** with zero API changes — 2.11.0 remains API-compatible with 2.7.1. It validates that the plugin works with Gradle 9.6.1 before crossing the breaking 2.12 boundary.

Includes a fix for a latent cross-flavor bundled plugin resolution bug unmasked by the stricter resolver in plugin 2.8+.

## Incremental Strategy

Replacing single-shot PR #6387 with smaller PRs:
1. **This PR:** 2.7.1 → 2.11.0 (version bump + bundled plugin fix)
2. **Next:** 2.11.0 → 2.12.0 (API migrations + sandbox path move + VfsRootAccess fixes)
3. **Final:** 2.12.0 → 2.18.0 (262 Kotlin/Java mappings + stability fixes)

## Changes

- `gradle/libs.versions.toml`: `intellijGradle = "2.11.0"`
- `settings.gradle.kts`: `org.jetbrains.intellij.platform.settings` version `"2.11.0"`
- `buildSrc/.../toolkit-intellij-subplugin.gradle.kts`: Centralized fix — non-IC modules automatically exclude IC community bundled plugins from test configurations

## Bundled Plugin Fix

IntelliJ Platform Gradle Plugin 2.8+ strictly resolves bundled plugin artifacts. Community (IC) bundled plugins (`com.intellij.java`, `com.intellij.gradle`, `org.jetbrains.idea.maven`, `com.intellij.properties`, `org.jetbrains.idea.reposearch`) leak into non-IC modules' test classpaths transitively from `:plugin-core:jetbrains-community`. Non-IC SDKs (IU on ≤2025.2, RD) can't resolve IC-coordinated artifacts.

Plugin 2.7.1's lenient resolver silently ignored this mismatch. The fix is centralized in `toolkit-intellij-subplugin`: after evaluation, any module whose flavor differs from IC automatically excludes these from `testCompileClasspath` and `testRuntimeClasspath`.

## Testing

Verified locally on Mac:
- `:plugin-toolkit:jetbrains-rider:compileTestKotlin` (2025.3) — passes
- `:plugin-toolkit:jetbrains-ultimate:compileTestKotlin` (2025.1, 2025.2) — passes
- `:plugin-toolkit:jetbrains-core:compileTestKotlin` (2025.3) — passes
