### PR TITLE
build: Upgrade IntelliJ Platform Gradle Plugin 2.7.1 → 2.12.0

### DIFF
--- a/.run/Run AWS Toolkit - Community [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IC-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2025.2].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.2/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IC-2025.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IC-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Community [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IC-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Gateway [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Gateway [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Gateway [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/GW-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/jetbrains-gateway/GW-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Gateway [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Gateway [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Gateway [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/GW-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/jetbrains-gateway/GW-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/RD-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.2].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.2/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/RD-2025.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/RD-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/RD-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IU-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.2].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.2/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IU-2025.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IU-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IU-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/generateConfigs.py
+++ b/.run/generateConfigs.py
@@ -8,6 +8,7 @@ class PluginVariant:
     name: str
     path: str
     gradle_project: str
+    sandbox_name: str  # Gradle project name used in .intellijPlatform/sandbox/{sandbox_name}/
 
 @dataclass
 class IdeVariant:
@@ -23,7 +24,7 @@ class IdeVariant:
 
 TEMPLATE = '''<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run {plugin.name} - {variant.pretty} [{major_version}]" type="GradleRunConfiguration" factoryName="Gradle" folderName="{major_version}">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/{plugin.path}/build/idea-sandbox/{variant.short}-{major_version}/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/{plugin.sandbox_name}/{variant.short}-{major_version}/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -59,7 +60,7 @@ if __name__ == '__main__':
         IdeVariant("Ultimate", "IU"),
     ]
     plugins = [
-        PluginVariant("AWS Toolkit", "toolkit/intellij-standalone", ":plugin-toolkit:intellij-standalone"),
+        PluginVariant("AWS Toolkit", "toolkit/intellij-standalone", ":plugin-toolkit:intellij-standalone", "intellij-standalone"),
     ]
 
 
@@ -71,4 +72,4 @@ if __name__ == '__main__':
 
     # gateway only supported from last 'stable' version onwards
     for mv in mvs[2:]:
-        write_config(mv, IdeVariant("Gateway", "GW"), PluginVariant("AWS Toolkit", "toolkit/jetbrains-gateway", ":plugin-toolkit:jetbrains-gateway"))
+        write_config(mv, IdeVariant("Gateway", "GW"), PluginVariant("AWS Toolkit", "toolkit/jetbrains-gateway", ":plugin-toolkit:jetbrains-gateway", "jetbrains-gateway"))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,10 +158,10 @@ If the tests run too quickly, you can tell the UI tests to wait for the debugger
 
 - Log messages (`LOG.info`, `LOG.error()`, …) by default are written to:
   ```
-  plugins/toolkit/intellij/build/idea-sandbox/system/log/idea.log
-  plugins/toolkit/intellij/build/idea-sandbox/system-test/logs/idea.log  # Tests
+  .intellijPlatform/sandbox/intellij-standalone/IC-{version}/log/idea.log
+  .intellijPlatform/sandbox/intellij-standalone/IC-{version}-test/logs/idea.log  # Tests
 
-  plugins/toolkit/jetbrains-gateway/build/idea-sandbox/system/logs/idea.log  # Gateway
+  .intellijPlatform/sandbox/jetbrains-gateway/GW-{version}/logs/idea.log  # Gateway
   ```
 - DEBUG-level log messages are skipped by default. To enable them, add the
   following line to the _Help_ \> _Debug Log Settings_ dialog in the IDE

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,13 @@ tasks.coverageReport {
     mustRunAfter(rootProject.subprojects.map { it.tasks.withType<AbstractTestTask>() })
 }
 
+// With IntelliJ Platform Gradle Plugin 2.12+, the IDE sandbox moved from build/idea-sandbox
+// to .intellijPlatform/sandbox/ which is outside the build/ directory. Hook into `clean` so
+// that `./gradlew clean` restores the previous behavior of removing all generated artifacts.
+tasks.named<Delete>("clean") {
+    delete(rootProject.file(".intellijPlatform/sandbox"))
+}
+
 allprojects {
     tasks.configureEach {
         if (this is JavaForkOptions) {

--- a/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
@@ -7,8 +7,6 @@ import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.project
 import org.gradle.kotlin.dsl.provideDelegate
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
-import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformExtension
-import org.jetbrains.intellij.platform.gradle.plugins.project.DownloadRobotServerPluginTask
 import org.jetbrains.intellij.platform.gradle.tasks.TestIdeUiTask
 import software.aws.toolkits.gradle.ciOnly
 import software.aws.toolkits.gradle.intellij.IdeFlavor
@@ -72,13 +70,12 @@ dependencies {
 //        val type = toolkitIntelliJ.ideFlavor.map { IntelliJPlatformType.fromCode(it.toString()) }
 //        val version = toolkitIntelliJ.version()
 //
-//        create(type, version, useInstaller = false)
+//        create(type, version) { useInstaller = false }
 //    }
 
     implementation(project(":plugin-toolkit:jetbrains-core"))
     implementation(project(":plugin-toolkit:jetbrains-ultimate"))
     project.findProject(":plugin-toolkit:jetbrains-gateway")?.let {
-        // does this need to be the instrumented variant?
         implementation(it)
         gatewayResources(project(":plugin-toolkit:jetbrains-gateway", configuration = "gatewayResources"))
     }

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -97,6 +97,29 @@ tasks.processResources {
     duplicatesStrategy = DuplicatesStrategy.WARN
 }
 
+// IntelliJ Platform Gradle Plugin 2.8+ strictly resolves bundled plugin artifacts.
+// The community profile (IC) declares bundled plugins like com.intellij.java, com.intellij.gradle, etc.
+// When a non-IC module (IU, RD, GW) depends transitively on an IC module, those bundled plugin
+// coordinates leak into the non-IC module's test classpath with IC-xxx coordinates that can't
+// resolve against the non-IC SDK. Exclude them for any module whose flavor differs from IC.
+afterEvaluate {
+    val flavor = toolkitIntelliJ.ideFlavor.get()
+    if (flavor != IdeFlavor.IC) {
+        val communityBundledPlugins = listOf(
+            "com.intellij.java",
+            "com.intellij.gradle",
+            "org.jetbrains.idea.maven",
+            "com.intellij.properties",
+            "org.jetbrains.idea.reposearch",
+        )
+        configurations.matching { it.name == "testCompileClasspath" || it.name == "testRuntimeClasspath" }.configureEach {
+            communityBundledPlugins.forEach { pluginId ->
+                exclude(group = "bundledPlugin", module = pluginId)
+            }
+        }
+    }
+}
+
 tasks.processTestResources {
     // TODO how can we remove this
     duplicatesStrategy = DuplicatesStrategy.WARN

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -147,7 +147,7 @@ dependencies {
                 }
             }
 
-            create(type, version, useInstaller = false)
+            create(type, version) { useInstaller = false }
         } else {
             create(IntelliJPlatformType.Gateway, version)
 
@@ -203,6 +203,31 @@ tasks.withType<Test>().configureEach {
     val jetbrainsCoreTestResources = project(":plugin-toolkit:jetbrains-core").projectDir.resolve("tst-resources")
     systemProperty("idea.log.config.properties.file", jetbrainsCoreTestResources.resolve("toolkit-test-log.properties"))
     systemProperty("org.gradle.project.ideProfileName", ideProfile.name)
+
+    // Multiple projects write into the shared sandbox directory (.intellijPlatform/sandbox/{TYPE-VER}/plugins-test/).
+    // Gradle 9 promotes implicit task dependency detection from warning to error — if a Test task reads
+    // from an output directory that another project's prepareTestSandbox wrote to without a declared
+    // dependency, the build fails.
+    //
+    // We use mustRunAfter (NOT dependsOn) because:
+    // - dependsOn forces ALL producers to execute, contaminating the shared sandbox with every module's
+    //   plugins — this causes test failures when unrelated plugins load into the test classpath
+    // - mustRunAfter only declares ordering: "if both tasks are already in the graph, run the producer
+    //   first" — it satisfies Gradle 9 validation without pulling in unrelated modules
+    val sharedSandboxProducers = listOf(
+        ":plugin-toolkit:intellij-standalone",
+        ":plugin-toolkit:jetbrains-core",
+        ":plugin-toolkit:jetbrains-ultimate",
+        ":plugin-core:jetbrains-community",
+        ":plugin-core:jetbrains-ultimate",
+        ":sandbox-all",
+    )
+    sharedSandboxProducers.forEach { projectPath ->
+        val resolved = project.rootProject.findProject(projectPath)
+        if (resolved != null && resolved != project) {
+            mustRunAfter("$projectPath:prepareTestSandbox")
+        }
+    }
 }
 
 tasks.withType<JavaExec>().configureEach {

--- a/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
@@ -27,10 +27,10 @@ intellijPlatform {
             // Starting with 2025.3, IntelliJ IDEA is unified (no separate Community edition)
             val version = toolkitIntelliJ.version().get()
             if (version.startsWith("2025.3")) {
-                ide(provider { IntelliJPlatformType.IntellijIdeaUltimate }, toolkitIntelliJ.version())
+                create(IntelliJPlatformType.IntellijIdeaUltimate, version)
             } else {
-                ide(provider { IntelliJPlatformType.IntellijIdeaCommunity }, toolkitIntelliJ.version())
-                ide(provider { IntelliJPlatformType.IntellijIdeaUltimate }, toolkitIntelliJ.version())
+                create(IntelliJPlatformType.IntellijIdeaCommunity, version)
+                create(IntelliJPlatformType.IntellijIdeaUltimate, version)
             }
         }
     }
@@ -76,7 +76,7 @@ dependencies {
                 defaultType to toolkitIntelliJ.version()
             }
 
-            create(type, version, useInstaller = false)
+            create(type, version) { useInstaller = false }
             jetbrainsRuntime()
         }
     }

--- a/buildSrc/src/main/kotlin/toolkit-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-publishing-conventions.gradle.kts
@@ -39,7 +39,7 @@ intellijPlatform {
         channels.set(publishChannel.split(",").map { it.trim() })
     }
 
-    verifyPlugin {
+    pluginVerification {
         subsystemsToCheck.set(VerifyPluginTask.Subsystems.WITHOUT_ANDROID)
         // need to tune this
         failureLevel.set(listOf(VerifyPluginTask.FailureLevel.INVALID_PLUGIN))
@@ -61,7 +61,7 @@ configurations {
 }
 
 // not run as part of check because of memory pressue issues
-tasks.verifyPlugin {
+tasks.named<VerifyPluginTask>("verifyPlugin") {
     isEnabled = true
     // give each instance its own home dir
     systemProperty("plugin.verifier.home.dir", temporaryDir)

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -57,7 +57,7 @@ phases:
     commands:
       - TEST_ARTIFACTS="/tmp/testArtifacts"
       - mkdir -p $TEST_ARTIFACTS/test-reports
-      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/system*/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmq --include='*/' --include '**/.intellijPlatform/sandbox/**/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
 

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -55,7 +55,7 @@ phases:
       - TEST_ARTIFACTS="/tmp/testArtifacts"
       - mkdir -p $TEST_ARTIFACTS/test-reports
       - mkdir -p $BUILD_ARTIFACTS
-      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmq --include='*/' --include '**/.intellijPlatform/sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
       - find plugins -path '*/build/distributions/*.zip' -exec cp {} $BUILD_ARTIFACTS/ \; || touch $BUILD_ARTIFACTS/build_failed

--- a/buildspec/linuxTestsForToolkit.yml
+++ b/buildspec/linuxTestsForToolkit.yml
@@ -47,7 +47,7 @@ phases:
       - TEST_ARTIFACTS="/tmp/testArtifacts"
       - mkdir -p $TEST_ARTIFACTS/test-reports
       - mkdir -p $BUILD_ARTIFACTS
-      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmq --include='*/' --include '**/.intellijPlatform/sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
       - cp -r ./plugins/toolkit/intellij-standalone/build/distributions/*.zip $BUILD_ARTIFACTS/ || touch $BUILD_ARTIFACTS/build_failed

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -50,7 +50,7 @@ phases:
 
       - pkill -SIGINT ffmpeg && sleep 5
 
-      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmq --include='*/' --include '**/.intellijPlatform/sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
 

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -55,7 +55,7 @@ phases:
           }
         }
 
-        copyArtifacts "*\build\idea-sandbox\*\log*" $script:TEST_ARTIFACTS
+        copyArtifacts "*\.intellijPlatform\sandbox\*\log*" $script:TEST_ARTIFACTS
         copyArtifacts "*\build\reports" $script:TEST_ARTIFACTS
 
         copyArtifacts "*\test-results" $script:TEST_REPORTS

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -59,7 +59,7 @@ phases:
 
         function copyArtifacts($root) {
             copyFolder $root "build/reports/" $script:TEST_ARTIFACTS
-            copyFolder $root "build/idea-sandbox/system-test/log/" $script:TEST_ARTIFACTS
+            copyFolder $root ".intellijPlatform/sandbox/" $script:TEST_ARTIFACTS
             copyFolder $root "build/test-results/test/" $script:TEST_REPORTS
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ detekt = "1.23.8"
 diff-util = "4.12"
 intellijExt = "1.1.8"
 # match with <root>/settings.gradle.kts
-intellijGradle = "2.11.0"
+intellijGradle = "2.12.0"
 intellijRemoteRobot = "0.11.22"
 jackson = "2.17.2"
 jacoco = "0.8.12"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ detekt = "1.23.8"
 diff-util = "4.12"
 intellijExt = "1.1.8"
 # match with <root>/settings.gradle.kts
-intellijGradle = "2.7.1"
+intellijGradle = "2.11.0"
 intellijRemoteRobot = "0.11.22"
 jackson = "2.17.2"
 jacoco = "0.8.12"

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/caws/DevFileSchemaProviderFactoryTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/caws/DevFileSchemaProviderFactoryTest.kt
@@ -29,7 +29,7 @@ class DevFileSchemaProviderFactoryTest {
 
     @Test
     fun testSchemaIsApplied() {
-        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getSystemPath())
+        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getSystemPath(), PathManager.getPluginsPath())
         val yamlJsonSchemaHighlightingInspection = YamlJsonSchemaHighlightingInspection()
         val fixture = projectRule.fixture
 

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/CreateResourceFileStatusHandlerTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/CreateResourceFileStatusHandlerTest.kt
@@ -3,7 +3,10 @@
 
 package software.aws.toolkits.jetbrains.services.dynamic.explorer
 
+import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.ProjectRule
 import com.intellij.testFramework.runInEdtAndWait
 import org.assertj.core.api.Assertions.assertThat
@@ -41,6 +44,10 @@ class CreateResourceFileStatusHandlerTest {
     @Rule
     val mockClientManager = MockClientManagerRule()
 
+    @JvmField
+    @Rule
+    val disposableRule = DisposableRule()
+
     private lateinit var cloudControlClient: CloudControlClient
     private lateinit var createResourceHandler: CreateResourceFileStatusHandler
     private lateinit var connectionSettings: ConnectionSettings
@@ -49,6 +56,7 @@ class CreateResourceFileStatusHandlerTest {
 
     @Before
     fun setup() {
+        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getPluginsPath())
         fileEditorManager = FileEditorManager.getInstance(projectRule.project)
         connectionSettings = ConnectionSettings(aToolkitCredentialsProvider(), anAwsRegion())
         cloudControlClient = mockClientManager.create(connectionSettings.region, connectionSettings.credentials)

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/ResourceSchemaProviderFactoryTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/dynamic/explorer/ResourceSchemaProviderFactoryTest.kt
@@ -3,6 +3,9 @@
 
 package software.aws.toolkits.jetbrains.services.dynamic.explorer
 
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.testFramework.DisposableRule
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.testFramework.RuleChain
 import com.intellij.testFramework.runInEdtAndWait
@@ -34,6 +37,10 @@ class ResourceSchemaProviderFactoryTest {
 
     @Rule
     @JvmField
+    val disposableRule = DisposableRule()
+
+    @Rule
+    @JvmField
     val ruleChain = RuleChain(
         projectRule,
         resourceCache
@@ -41,6 +48,7 @@ class ResourceSchemaProviderFactoryTest {
 
     @Before
     fun setup() {
+        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getPluginsPath())
         val schema = "{\n" +
             "  \"properties\": {\n" +
             "    \"RetentionInDays\": {\n" +

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/ecs/TaskSchemaProviderFactoryTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/ecs/TaskSchemaProviderFactoryTest.kt
@@ -29,7 +29,7 @@ class TaskSchemaProviderFactoryTest {
 
     @Test
     fun testSchemaIsApplied() {
-        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getSystemPath())
+        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getSystemPath(), PathManager.getPluginsPath())
 
         val fixture = projectRule.fixture
 

--- a/plugins/toolkit/jetbrains-gateway/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-gateway/build.gradle.kts
@@ -5,6 +5,7 @@
 import net.bytebuddy.utility.RandomString
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.jetbrains.kotlin.gradle.internal.ensureParentDirsCreated
 import software.aws.toolkits.gradle.intellij.IdeFlavor
 import kotlin.io.encoding.Base64
@@ -176,7 +177,7 @@ tasks.integrationTest {
     environment("CWM_HOST_STATUS_OVER_HTTP_TOKEN", testToken)
 }
 
-tasks.verifyPlugin {
+tasks.named<VerifyPluginTask>("verifyPlugin") {
     doFirst {
         ides.forEach { ide ->
             val productInfo = ide.resolve("product-info.json")

--- a/sandbox-all/build.gradle.kts
+++ b/sandbox-all/build.gradle.kts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import software.aws.toolkits.gradle.intellij.IdeFlavor
 import software.aws.toolkits.gradle.intellij.toolkitIntelliJ
 
@@ -16,7 +17,7 @@ toolkitIntelliJ.apply {
     ideFlavor.set(IdeFlavor.values().firstOrNull { it.name == runIdeVariant.orNull } ?: IdeFlavor.IC)
 }
 
-tasks.verifyPlugin {
+tasks.named<VerifyPluginTask>("verifyPlugin") {
     isEnabled = false
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ pluginManagement {
 plugins {
     id("com.github.burrunan.s3-build-cache") version "1.9.4"
     id("com.gradle.develocity") version "4.3.3"
-    id("org.jetbrains.intellij.platform.settings") version "2.7.1"
+    id("org.jetbrains.intellij.platform.settings") version "2.11.0"
 }
 
 dependencyResolutionManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ pluginManagement {
 plugins {
     id("com.github.burrunan.s3-build-cache") version "1.9.4"
     id("com.gradle.develocity") version "4.3.3"
-    id("org.jetbrains.intellij.platform.settings") version "2.11.0"
+    id("org.jetbrains.intellij.platform.settings") version "2.12.0"
 }
 
 dependencyResolutionManagement {

--- a/tmp-all/build.gradle.kts
+++ b/tmp-all/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
         val type = toolkitIntelliJ.ideFlavor.map { IntelliJPlatformType.fromCode(it.toString()) }
         val version = toolkitIntelliJ.version()
 
-        create(type, version, useInstaller = false)
+        create(type, version) { useInstaller = false }
         jetbrainsRuntime()
 
         localPlugin(project(":plugin-amazonq"))


### PR DESCRIPTION
## Summary

Upgrade IntelliJ Platform Gradle Plugin from 2.7.1 → 2.12.0. This is the first step toward 2026.2 (262) support — 2.12.0 fixes the Ivy module recursive lookup bug (present in 2.8–2.11) and adds module-descriptor parser improvements required for 262 EAP.

Replaces PR #6387 (single-shot 2.7.1 → 2.17.0 which had CI test timing issues) and #6388 (2.11.0 which hit the Ivy parser bug on Linux 2026.1).

## Changes

### Cross-flavor bundled plugin fix (centralized)

- Plugin 2.8+ strict resolver exposed a latent project architecture bug: IC community bundled plugins leak into non-IC modules' test classpaths via transitive dependencies
- Fix centralized in `toolkit-intellij-subplugin.gradle.kts`: non-IC modules (IU, RD, GW) automatically exclude IC bundled plugins (`com.intellij.java`, `com.intellij.gradle`, `org.jetbrains.idea.maven`, `com.intellij.properties`, `org.jetbrains.idea.reposearch`) from `testCompileClasspath` and `testRuntimeClasspath`

### Shared sandbox implicit dependency fix (Gradle 9)

- Plugin 2.12.0 moves sandbox from per-project `build/idea-sandbox` to shared `.intellijPlatform/sandbox/{TYPE-VER}/` — multiple projects now write into the same directory tree
- Gradle 9 promotes implicit task dependency detection from warning to error, so the shared sandbox triggers a hard failure
- Fix: declare `mustRunAfter` (not `dependsOn`) from all subplugin `Test` tasks to all sibling `prepareTestSandbox` tasks that may share the sandbox
- `mustRunAfter` satisfies Gradle 9 validation (ordering declaration) without forcing execution — `dependsOn` would contaminate the shared sandbox by pulling in every module's plugins into the test classpath

### Version bump

- `gradle/libs.versions.toml`: `intellijGradle = "2.12.0"`
- `settings.gradle.kts`: `org.jetbrains.intellij.platform.settings` version `"2.12.0"`

### API migrations (removed in 2.12.0)

- `create(type, version, useInstaller = false)` → lambda form (4 call sites)
- `verifyPlugin { }` → `pluginVerification { }` with property assignment
- `ide(provider{...}, version)` → `create(type, version)` in pluginVerification.ides
- `tasks.verifyPlugin` → `tasks.named<VerifyPluginTask>("verifyPlugin")` (3 call sites)
- Remove `DownloadRobotServerPluginTask` import (class deleted)
- Remove unused `IntelliJPlatformExtension` import

### Sandbox path change (2.12.0)

- `build/idea-sandbox` → `.intellijPlatform/sandbox/{project}/{TYPE-VER}`
- Update `generateConfigs.py` template + regenerate 14 `.run/` XMLs
- Update 6 CI buildspec rsync/copy patterns
- Update `CONTRIBUTING.md` log path docs
- Hook root `clean` task to delete `.intellijPlatform/sandbox/`

### VfsRootAccess fixes (v2 plugin model)

- Add `PathManager.getPluginsPath()` to `VfsRootAccess.allowRootAccess()` in 4 schema test files affected by JAR relocation to `lib/modules/`
