### PR TITLE
build: Upgrade IntelliJ Platform Gradle Plugin 2.7.1 → 2.12.0

### DIFF
--- a/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
@@ -7,8 +7,6 @@ import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.project
 import org.gradle.kotlin.dsl.provideDelegate
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
-import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformExtension
-import org.jetbrains.intellij.platform.gradle.plugins.project.DownloadRobotServerPluginTask
 import org.jetbrains.intellij.platform.gradle.tasks.TestIdeUiTask
 import software.aws.toolkits.gradle.ciOnly
 import software.aws.toolkits.gradle.intellij.IdeFlavor

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -97,6 +97,29 @@ tasks.processResources {
     duplicatesStrategy = DuplicatesStrategy.WARN
 }
 
+// IntelliJ Platform Gradle Plugin 2.8+ strictly resolves bundled plugin artifacts.
+// The community profile (IC) declares bundled plugins like com.intellij.java, com.intellij.gradle, etc.
+// When a non-IC module (IU, RD, GW) depends transitively on an IC module, those bundled plugin
+// coordinates leak into the non-IC module's test classpath with IC-xxx coordinates that can't
+// resolve against the non-IC SDK. Exclude them for any module whose flavor differs from IC.
+afterEvaluate {
+    val flavor = toolkitIntelliJ.ideFlavor.get()
+    if (flavor != IdeFlavor.IC) {
+        val communityBundledPlugins = listOf(
+            "com.intellij.java",
+            "com.intellij.gradle",
+            "org.jetbrains.idea.maven",
+            "com.intellij.properties",
+            "org.jetbrains.idea.reposearch",
+        )
+        configurations.matching { it.name == "testCompileClasspath" || it.name == "testRuntimeClasspath" }.configureEach {
+            communityBundledPlugins.forEach { pluginId ->
+                exclude(group = "bundledPlugin", module = pluginId)
+            }
+        }
+    }
+}
+
 tasks.processTestResources {
     // TODO how can we remove this
     duplicatesStrategy = DuplicatesStrategy.WARN

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -130,6 +130,10 @@ intellijPlatform {
     // find the name of first subproject depth, or root if not applied to a subproject hierarchy
     projectName.convention(generateSequence(project) { it.parent }.first { it.depth <= 1 }.name)
     instrumentCode = true
+    // Keep per-project sandbox isolation. Plugin 2.12+ defaults to a shared
+    // .intellijPlatform/sandbox/ directory which causes Gradle 9 implicit dependency errors
+    // and sandbox contamination between modules. Per-project sandbox eliminates both issues.
+    sandboxContainer.set(layout.buildDirectory.dir("idea-sandbox"))
 }
 
 dependencies {
@@ -147,7 +151,7 @@ dependencies {
                 }
             }
 
-            create(type, version, useInstaller = false)
+            create(type, version) { useInstaller = false }
         } else {
             create(IntelliJPlatformType.Gateway, version)
 

--- a/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
@@ -27,10 +27,10 @@ intellijPlatform {
             // Starting with 2025.3, IntelliJ IDEA is unified (no separate Community edition)
             val version = toolkitIntelliJ.version().get()
             if (version.startsWith("2025.3")) {
-                ide(provider { IntelliJPlatformType.IntellijIdeaUltimate }, toolkitIntelliJ.version())
+                create(IntelliJPlatformType.IntellijIdeaUltimate, version)
             } else {
-                ide(provider { IntelliJPlatformType.IntellijIdeaCommunity }, toolkitIntelliJ.version())
-                ide(provider { IntelliJPlatformType.IntellijIdeaUltimate }, toolkitIntelliJ.version())
+                create(IntelliJPlatformType.IntellijIdeaCommunity, version)
+                create(IntelliJPlatformType.IntellijIdeaUltimate, version)
             }
         }
     }
@@ -76,7 +76,7 @@ dependencies {
                 defaultType to toolkitIntelliJ.version()
             }
 
-            create(type, version, useInstaller = false)
+            create(type, version) { useInstaller = false }
             jetbrainsRuntime()
         }
     }

--- a/buildSrc/src/main/kotlin/toolkit-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-publishing-conventions.gradle.kts
@@ -39,7 +39,7 @@ intellijPlatform {
         channels.set(publishChannel.split(",").map { it.trim() })
     }
 
-    verifyPlugin {
+    pluginVerification {
         subsystemsToCheck.set(VerifyPluginTask.Subsystems.WITHOUT_ANDROID)
         // need to tune this
         failureLevel.set(listOf(VerifyPluginTask.FailureLevel.INVALID_PLUGIN))
@@ -61,7 +61,7 @@ configurations {
 }
 
 // not run as part of check because of memory pressue issues
-tasks.verifyPlugin {
+tasks.named<VerifyPluginTask>("verifyPlugin") {
     isEnabled = true
     // give each instance its own home dir
     systemProperty("plugin.verifier.home.dir", temporaryDir)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ detekt = "1.23.8"
 diff-util = "4.12"
 intellijExt = "1.1.8"
 # match with <root>/settings.gradle.kts
-intellijGradle = "2.11.0"
+intellijGradle = "2.12.0"
 intellijRemoteRobot = "0.11.22"
 jackson = "2.17.2"
 jacoco = "0.8.12"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ detekt = "1.23.8"
 diff-util = "4.12"
 intellijExt = "1.1.8"
 # match with <root>/settings.gradle.kts
-intellijGradle = "2.7.1"
+intellijGradle = "2.11.0"
 intellijRemoteRobot = "0.11.22"
 jackson = "2.17.2"
 jacoco = "0.8.12"

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/caws/DevFileSchemaProviderFactoryTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/caws/DevFileSchemaProviderFactoryTest.kt
@@ -29,7 +29,7 @@ class DevFileSchemaProviderFactoryTest {
 
     @Test
     fun testSchemaIsApplied() {
-        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getSystemPath())
+        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getSystemPath(), PathManager.getPluginsPath())
         val yamlJsonSchemaHighlightingInspection = YamlJsonSchemaHighlightingInspection()
         val fixture = projectRule.fixture
 

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/ecs/TaskSchemaProviderFactoryTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/ecs/TaskSchemaProviderFactoryTest.kt
@@ -29,7 +29,7 @@ class TaskSchemaProviderFactoryTest {
 
     @Test
     fun testSchemaIsApplied() {
-        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getSystemPath())
+        VfsRootAccess.allowRootAccess(disposableRule.disposable, PathManager.getSystemPath(), PathManager.getPluginsPath())
 
         val fixture = projectRule.fixture
 

--- a/plugins/toolkit/jetbrains-gateway/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-gateway/build.gradle.kts
@@ -5,6 +5,7 @@
 import net.bytebuddy.utility.RandomString
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.jetbrains.kotlin.gradle.internal.ensureParentDirsCreated
 import software.aws.toolkits.gradle.intellij.IdeFlavor
 import kotlin.io.encoding.Base64
@@ -176,7 +177,7 @@ tasks.integrationTest {
     environment("CWM_HOST_STATUS_OVER_HTTP_TOKEN", testToken)
 }
 
-tasks.verifyPlugin {
+tasks.named<VerifyPluginTask>("verifyPlugin") {
     doFirst {
         ides.forEach { ide ->
             val productInfo = ide.resolve("product-info.json")

--- a/sandbox-all/build.gradle.kts
+++ b/sandbox-all/build.gradle.kts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import software.aws.toolkits.gradle.intellij.IdeFlavor
 import software.aws.toolkits.gradle.intellij.toolkitIntelliJ
 
@@ -16,7 +17,7 @@ toolkitIntelliJ.apply {
     ideFlavor.set(IdeFlavor.values().firstOrNull { it.name == runIdeVariant.orNull } ?: IdeFlavor.IC)
 }
 
-tasks.verifyPlugin {
+tasks.named<VerifyPluginTask>("verifyPlugin") {
     isEnabled = false
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ pluginManagement {
 plugins {
     id("com.github.burrunan.s3-build-cache") version "1.9.4"
     id("com.gradle.develocity") version "4.3.3"
-    id("org.jetbrains.intellij.platform.settings") version "2.7.1"
+    id("org.jetbrains.intellij.platform.settings") version "2.11.0"
 }
 
 dependencyResolutionManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ pluginManagement {
 plugins {
     id("com.github.burrunan.s3-build-cache") version "1.9.4"
     id("com.gradle.develocity") version "4.3.3"
-    id("org.jetbrains.intellij.platform.settings") version "2.11.0"
+    id("org.jetbrains.intellij.platform.settings") version "2.12.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary

Upgrade IntelliJ Platform Gradle Plugin from 2.7.1 → 2.12.0. This is the first step toward 2026.2 (262) support — 2.12.0 fixes the Ivy module recursive lookup bug (present in 2.8–2.11) and adds module-descriptor parser improvements required for 262 EAP.

Replaces PR #6388 (2.11.0 — hit Ivy parser bug on Linux 2026.1) and #6389 (2.12.0 shared sandbox — Gradle 9 errors + test contamination).

## Changes

### Cross-flavor bundled plugin fix (plugin 2.8+ strict resolver)

- IC community bundled plugins leak into non-IC modules' test classpaths via transitive dependencies from `:plugin-core:jetbrains-community`
- Fix centralized in `toolkit-intellij-subplugin.gradle.kts`: non-IC modules (IU, RD, GW) automatically exclude IC bundled plugins (`com.intellij.java`, `com.intellij.gradle`, `org.jetbrains.idea.maven`, `com.intellij.properties`, `org.jetbrains.idea.reposearch`) from `testCompileClasspath` and `testRuntimeClasspath`

### Per-project sandbox isolation (plugin 2.12 key fix)

- Plugin 2.12+ defaults to a shared `.intellijPlatform/sandbox/` directory — causes Gradle 9 implicit dependency errors and sandbox contamination between modules on unified IU (2025.3+)
- Fix: one-line `sandboxContainer.set(layout.buildDirectory.dir("idea-sandbox"))` override keeps per-project isolation
- Eliminates need for any `.run/` XML changes, CI buildspec changes, or CONTRIBUTING.md path updates

### API migrations (removed in 2.12.0)

- `create(type, version, useInstaller = false)` → lambda form (2 call sites)
- `verifyPlugin { }` → `pluginVerification { }` with property assignment
- `ide(provider{...}, version)` → `create(type, version)` in pluginVerification.ides
- `tasks.verifyPlugin` → `tasks.named<VerifyPluginTask>("verifyPlugin")` (3 call sites)
- Remove `DownloadRobotServerPluginTask` import (class deleted)
- Remove unused `IntelliJPlatformExtension` import

### VfsRootAccess fixes (v2 plugin model)

- Add `PathManager.getPluginsPath()` to `VfsRootAccess.allowRootAccess()` in 2 schema test files affected by JAR relocation to `lib/modules/`

## Testing

All existing profiles (2025.1–2026.1) build and test identically. No behavioral test changes — only build infrastructure.

## Next step

2.12.0 → 2.17.0 (picks up 262 Kotlin/Java version mappings, cached IDE layout index, and stability fixes needed for the 2026.2 build profile).
