### PR TITLE
build: Upgrade IntelliJ Platform Gradle Plugin 2.12.0 → 2.13.0

### DIFF
--- a/.run/Run AWS Toolkit - Community [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IC-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2025.2].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.2/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IC-2025.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IC-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Community [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IC-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Gateway [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Gateway [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Gateway [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/GW-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/jetbrains-gateway/GW-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Gateway [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Gateway [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Gateway [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/GW-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/jetbrains-gateway/GW-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/RD-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.2].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.2/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/RD-2025.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/RD-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/RD-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IU-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.2].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.2/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IU-2025.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IU-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IU-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/generateConfigs.py
+++ b/.run/generateConfigs.py
@@ -8,6 +8,7 @@ class PluginVariant:
     name: str
     path: str
     gradle_project: str
+    project_name: str
 
 @dataclass
 class IdeVariant:
@@ -23,7 +24,7 @@ class IdeVariant:
 
 TEMPLATE = '''<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run {plugin.name} - {variant.pretty} [{major_version}]" type="GradleRunConfiguration" factoryName="Gradle" folderName="{major_version}">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/{plugin.path}/build/idea-sandbox/{variant.short}-{major_version}/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/{plugin.path}/build/idea-sandbox/{plugin.project_name}/{variant.short}-{major_version}/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -59,7 +60,7 @@ if __name__ == '__main__':
         IdeVariant("Ultimate", "IU"),
     ]
     plugins = [
-        PluginVariant("AWS Toolkit", "toolkit/intellij-standalone", ":plugin-toolkit:intellij-standalone"),
+        PluginVariant("AWS Toolkit", "toolkit/intellij-standalone", ":plugin-toolkit:intellij-standalone", "intellij-standalone"),
     ]
 
 
@@ -71,4 +72,4 @@ if __name__ == '__main__':
 
     # gateway only supported from last 'stable' version onwards
     for mv in mvs[2:]:
-        write_config(mv, IdeVariant("Gateway", "GW"), PluginVariant("AWS Toolkit", "toolkit/jetbrains-gateway", ":plugin-toolkit:jetbrains-gateway"))
+        write_config(mv, IdeVariant("Gateway", "GW"), PluginVariant("AWS Toolkit", "toolkit/jetbrains-gateway", ":plugin-toolkit:jetbrains-gateway", "jetbrains-gateway"))

--- a/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
@@ -46,6 +46,9 @@ val gatewayResources = configurations.register("gatewayResources") {
 intellijPlatform {
     projectName = "aws-toolkit-jetbrains"
     instrumentCode = false
+    // Override sandbox into build/ so runIde uses build/idea-sandbox/{projectName}/{TYPE-VER}/
+    // instead of the 2.12+ default .intellijPlatform/sandbox/ at repo root.
+    sandboxContainer.set(layout.buildDirectory.dir("idea-sandbox"))
 }
 
 tasks.prepareSandbox {

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -130,9 +130,10 @@ intellijPlatform {
     // find the name of first subproject depth, or root if not applied to a subproject hierarchy
     projectName.convention(generateSequence(project) { it.parent }.first { it.depth <= 1 }.name)
     instrumentCode = true
-    // Keep per-project sandbox isolation. Plugin 2.12+ defaults to a shared
-    // .intellijPlatform/sandbox/ directory which causes Gradle 9 implicit dependency errors
-    // and sandbox contamination between modules. Per-project sandbox eliminates both issues.
+    // Keep per-project sandbox isolation. This project builds multiple IDE flavors (IC, IU, RD, GW)
+    // in one Gradle invocation. The shared sandbox (plugin 2.13+ default) resolves bundled plugins
+    // against a single IDE, breaking non-IC modules (e.g. com.intellij.database not found when
+    // root is IC). Per-project sandbox gives each module its own resolution context.
     sandboxContainer.set(layout.buildDirectory.dir("idea-sandbox"))
 }
 

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -57,7 +57,7 @@ phases:
     commands:
       - TEST_ARTIFACTS="/tmp/testArtifacts"
       - mkdir -p $TEST_ARTIFACTS/test-reports
-      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/system*/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/**/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
 

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -55,7 +55,7 @@ phases:
           }
         }
 
-        copyArtifacts "*\build\idea-sandbox\*\log*" $script:TEST_ARTIFACTS
+        copyArtifacts "*\build\idea-sandbox\*\*\log*" $script:TEST_ARTIFACTS
         copyArtifacts "*\build\reports" $script:TEST_ARTIFACTS
 
         copyArtifacts "*\test-results" $script:TEST_REPORTS

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -49,22 +49,16 @@ phases:
         $script:TEST_ARTIFACTS=Join-Path $env:TEMP testArtifacts
         $script:TEST_REPORTS=Join-Path $script:TEST_ARTIFACTS test-reports
 
-        function copyFolder($basedir, $subdir, $destdir) {
-          $src = Join-Path "." -ChildPath $basedir | Join-Path -ChildPath $subdir
-          $dest = Join-Path $destdir -ChildPath $basedir | Join-Path -ChildPath $subDir
-          if( (Get-ChildItem $src -ErrorAction SilentlyContinue | Measure-Object).Count -ne 0) {
-            Copy-Item $src $dest -Recurse -Force -ErrorAction SilentlyContinue
+        function copyArtifacts($filter, $destdir) {
+          Get-ChildItem -Recurse -Directory -ErrorAction SilentlyContinue | Where-Object { $_.FullName -Like "$filter" } | ForEach-Object {
+              Copy-Item -Path $_.FullName -Destination "$destdir/$(Resolve-Path -Relative $_.FullName)" -Recurse -Container
           }
         }
 
-        function copyArtifacts($root) {
-            copyFolder $root "build/reports/" $script:TEST_ARTIFACTS
-            copyFolder $root "build/idea-sandbox/system-test/log/" $script:TEST_ARTIFACTS
-            copyFolder $root "build/test-results/test/" $script:TEST_REPORTS
-        }
+        copyArtifacts "*\build\idea-sandbox\*\*\log*" $script:TEST_ARTIFACTS
+        copyArtifacts "*\build\reports" $script:TEST_ARTIFACTS
 
-        copyArtifacts "."
-        Get-ChildItem -Directory | ForEach-Object { copyArtifacts $_.Name }
+        copyArtifacts "*\test-results" $script:TEST_REPORTS
 
         if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
           $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ detekt = "1.23.8"
 diff-util = "4.12"
 intellijExt = "1.1.8"
 # match with <root>/settings.gradle.kts
-intellijGradle = "2.12.0"
+intellijGradle = "2.13.0"
 intellijRemoteRobot = "0.11.22"
 jackson = "2.17.2"
 jacoco = "0.8.12"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ pluginManagement {
 plugins {
     id("com.github.burrunan.s3-build-cache") version "1.9.4"
     id("com.gradle.develocity") version "4.3.3"
-    id("org.jetbrains.intellij.platform.settings") version "2.12.0"
+    id("org.jetbrains.intellij.platform.settings") version "2.13.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Incremental step toward 2026.2 support — plugin 2.17+ is required for 262 Kotlin/Java version mappings and module-descriptors.jar parsing.


## Summary

Upgrade IntelliJ Platform Gradle Plugin 2.12.0 → 2.13.0. Override `sandboxContainer` on the aggregate root so `runIde` sandbox lives in `build/` instead of repo-root `.intellijPlatform/sandbox/`. Update run configs and CI buildspecs for the new `{projectName}` path segment.

## Why

Plugin 2.13 fixes sandbox isolation for multi-module projects (each module gets its own sandbox subdirectory, eliminating the `prepareSandbox` cross-contamination bug from 2.12). The sandbox path changes from `build/idea-sandbox/{TYPE-VER}/` to `build/idea-sandbox/{projectName}/{TYPE-VER}/`.

Without the `sandboxContainer` override on the aggregate root, `runIde` writes to `.intellijPlatform/sandbox/` at repo root — outside `build/`, not cleaned by `./gradlew clean`, and not matching the `.run/` config log paths.

## Testing

- `runIde` IC-2025.1 — plugin loads, idea.log tab works ✓
- `runIde` IC-2026.1 — plugin loads ✓
- CI: all Linux (4 profiles) + Windows (4 profiles) pass ✓

## Changes (22 files)

- `gradle/libs.versions.toml` + `settings.gradle.kts`: version bump 2.12.0 → 2.13.0
- `buildSrc/.../toolkit-intellij-subplugin.gradle.kts`: updated `sandboxContainer` comment (multi-flavor isolation rationale)
- `buildSrc/.../temp-toolkit-intellij-root-conventions.gradle.kts`: add `sandboxContainer.set(layout.buildDirectory.dir("idea-sandbox"))`
- 14 `.run/` XMLs + `generateConfigs.py`: add `{projectName}` segment to log path
- 3 CI buildspec YMLs (`linuxIntegrationTests`, `windowsTests`, `windowsTestsForToolkit`): update artifact collection globs for extra directory level
