### PR TITLE
build: Upgrade IntelliJ Platform Gradle Plugin 2.12.0 → 2.13.0

### DIFF
--- a/.run/Run AWS Toolkit - Community [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IC-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2025.2].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.2/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IC-2025.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Community [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IC-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Community [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Community [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Community [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IC-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IC-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Gateway [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Gateway [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Gateway [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/GW-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/jetbrains-gateway/GW-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Gateway [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Gateway [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Gateway [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/GW-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/jetbrains-gateway/GW-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/RD-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.2].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.2/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/RD-2025.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/RD-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Rider [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Rider [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/RD-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/RD-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.1].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IU-2025.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.2].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.2].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.2">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.2/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IU-2025.2/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2025.3].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2025.3].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2025.3]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2025.3">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2025.3/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IU-2025.3/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run AWS Toolkit - Ultimate [2026.1].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2026.1].run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run AWS Toolkit - Ultimate [2026.1]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.1">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/IU-2026.1/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/intellij-standalone/IU-2026.1/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/generateConfigs.py
+++ b/.run/generateConfigs.py
@@ -8,6 +8,7 @@ class PluginVariant:
     name: str
     path: str
     gradle_project: str
+    project_name: str
 
 @dataclass
 class IdeVariant:
@@ -23,7 +24,7 @@ class IdeVariant:
 
 TEMPLATE = '''<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run {plugin.name} - {variant.pretty} [{major_version}]" type="GradleRunConfiguration" factoryName="Gradle" folderName="{major_version}">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/{plugin.path}/build/idea-sandbox/{variant.short}-{major_version}/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/.intellijPlatform/sandbox/{plugin.project_name}/{variant.short}-{major_version}/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -59,7 +60,7 @@ if __name__ == '__main__':
         IdeVariant("Ultimate", "IU"),
     ]
     plugins = [
-        PluginVariant("AWS Toolkit", "toolkit/intellij-standalone", ":plugin-toolkit:intellij-standalone"),
+        PluginVariant("AWS Toolkit", "toolkit/intellij-standalone", ":plugin-toolkit:intellij-standalone", "intellij-standalone"),
     ]
 
 
@@ -71,4 +72,4 @@ if __name__ == '__main__':
 
     # gateway only supported from last 'stable' version onwards
     for mv in mvs[2:]:
-        write_config(mv, IdeVariant("Gateway", "GW"), PluginVariant("AWS Toolkit", "toolkit/jetbrains-gateway", ":plugin-toolkit:jetbrains-gateway"))
+        write_config(mv, IdeVariant("Gateway", "GW"), PluginVariant("AWS Toolkit", "toolkit/jetbrains-gateway", ":plugin-toolkit:jetbrains-gateway", "jetbrains-gateway"))

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -130,10 +130,6 @@ intellijPlatform {
     // find the name of first subproject depth, or root if not applied to a subproject hierarchy
     projectName.convention(generateSequence(project) { it.parent }.first { it.depth <= 1 }.name)
     instrumentCode = true
-    // Keep per-project sandbox isolation. Plugin 2.12+ defaults to a shared
-    // .intellijPlatform/sandbox/ directory which causes Gradle 9 implicit dependency errors
-    // and sandbox contamination between modules. Per-project sandbox eliminates both issues.
-    sandboxContainer.set(layout.buildDirectory.dir("idea-sandbox"))
 }
 
 dependencies {

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -57,7 +57,7 @@ phases:
     commands:
       - TEST_ARTIFACTS="/tmp/testArtifacts"
       - mkdir -p $TEST_ARTIFACTS/test-reports
-      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/system*/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmq --include='*/' --include '**/.intellijPlatform/sandbox/**/log/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
 

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -55,7 +55,7 @@ phases:
       - TEST_ARTIFACTS="/tmp/testArtifacts"
       - mkdir -p $TEST_ARTIFACTS/test-reports
       - mkdir -p $BUILD_ARTIFACTS
-      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmq --include='*/' --include '**/.intellijPlatform/sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
       - find plugins -path '*/build/distributions/*.zip' -exec cp {} $BUILD_ARTIFACTS/ \; || touch $BUILD_ARTIFACTS/build_failed

--- a/buildspec/linuxTestsForToolkit.yml
+++ b/buildspec/linuxTestsForToolkit.yml
@@ -47,7 +47,7 @@ phases:
       - TEST_ARTIFACTS="/tmp/testArtifacts"
       - mkdir -p $TEST_ARTIFACTS/test-reports
       - mkdir -p $BUILD_ARTIFACTS
-      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmq --include='*/' --include '**/.intellijPlatform/sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
       - cp -r ./plugins/toolkit/intellij-standalone/build/distributions/*.zip $BUILD_ARTIFACTS/ || touch $BUILD_ARTIFACTS/build_failed

--- a/buildspec/linuxUiTests.yml
+++ b/buildspec/linuxUiTests.yml
@@ -50,7 +50,7 @@ phases:
 
       - pkill -SIGINT ffmpeg && sleep 5
 
-      - rsync -rmq --include='*/' --include '**/build/idea-sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
+      - rsync -rmq --include='*/' --include '**/.intellijPlatform/sandbox/**/log*/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/build/reports/**' --exclude='*' . $TEST_ARTIFACTS/ || true
       - rsync -rmq --include='*/' --include '**/test-results/**/*.xml' --exclude='*' . $TEST_ARTIFACTS/test-reports || true
 

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -55,7 +55,7 @@ phases:
           }
         }
 
-        copyArtifacts "*\build\idea-sandbox\*\log*" $script:TEST_ARTIFACTS
+        copyArtifacts ".intellijPlatform\sandbox\*\*\log*" $script:TEST_ARTIFACTS
         copyArtifacts "*\build\reports" $script:TEST_ARTIFACTS
 
         copyArtifacts "*\test-results" $script:TEST_REPORTS

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -49,22 +49,16 @@ phases:
         $script:TEST_ARTIFACTS=Join-Path $env:TEMP testArtifacts
         $script:TEST_REPORTS=Join-Path $script:TEST_ARTIFACTS test-reports
 
-        function copyFolder($basedir, $subdir, $destdir) {
-          $src = Join-Path "." -ChildPath $basedir | Join-Path -ChildPath $subdir
-          $dest = Join-Path $destdir -ChildPath $basedir | Join-Path -ChildPath $subDir
-          if( (Get-ChildItem $src -ErrorAction SilentlyContinue | Measure-Object).Count -ne 0) {
-            Copy-Item $src $dest -Recurse -Force -ErrorAction SilentlyContinue
+        function copyArtifacts($filter, $destdir) {
+          Get-ChildItem -Recurse -Directory -ErrorAction SilentlyContinue | Where-Object { $_.FullName -Like "$filter" } | ForEach-Object {
+              Copy-Item -Path $_.FullName -Destination "$destdir/$(Resolve-Path -Relative $_.FullName)" -Recurse -Container
           }
         }
 
-        function copyArtifacts($root) {
-            copyFolder $root "build/reports/" $script:TEST_ARTIFACTS
-            copyFolder $root "build/idea-sandbox/system-test/log/" $script:TEST_ARTIFACTS
-            copyFolder $root "build/test-results/test/" $script:TEST_REPORTS
-        }
+        copyArtifacts ".intellijPlatform\sandbox\*\*\log*" $script:TEST_ARTIFACTS
+        copyArtifacts "*\build\reports" $script:TEST_ARTIFACTS
 
-        copyArtifacts "."
-        Get-ChildItem -Directory | ForEach-Object { copyArtifacts $_.Name }
+        copyArtifacts "*\test-results" $script:TEST_REPORTS
 
         if(-Not($Env:CODEBUILD_BUILD_SUCCEEDING -eq "0" -Or $Env:CODE_COV_TOKEN -eq $null)) {
           $env:VCS_COMMIT_ID=$Env:CODEBUILD_RESOLVED_SOURCE_VERSION;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ detekt = "1.23.8"
 diff-util = "4.12"
 intellijExt = "1.1.8"
 # match with <root>/settings.gradle.kts
-intellijGradle = "2.12.0"
+intellijGradle = "2.13.0"
 intellijRemoteRobot = "0.11.22"
 jackson = "2.17.2"
 jacoco = "0.8.12"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ pluginManagement {
 plugins {
     id("com.github.burrunan.s3-build-cache") version "1.9.4"
     id("com.gradle.develocity") version "4.3.3"
-    id("org.jetbrains.intellij.platform.settings") version "2.12.0"
+    id("org.jetbrains.intellij.platform.settings") version "2.13.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary

Remove per-project `sandboxContainer` override — use the plugin 2.13 default `.intellijPlatform/sandbox/{projectName}/{TYPE-VER}`. Plugin 2.13 natively isolates per project name, so the manual override is no longer needed.

## Why

In 2.12, we overrode `sandboxContainer` to keep per-project isolation because the shared sandbox caused cross-module contamination. Plugin 2.13 fixes this by adding a `{projectName}` subdirectory, giving each module its own sandbox space natively.

Using the default location:
- Sandboxes survive `./gradlew clean` (no accidental loss of IDE config/licenses)
- Aligns with upstream JetBrains conventions
- Simpler build config (removes one override per module)

## Testing

- `runIde` IC-2025.1 — AWS Toolkit loads, idea.log tab works ✓
- `runIde` IC-2026.1 — AWS Toolkit loads ✓
- CI will verify all profiles

## Changes (24 files)

- `gradle/libs.versions.toml` + `settings.gradle.kts`: version bump 2.12.0 → 2.13.0
- `buildSrc/.../toolkit-intellij-subplugin.gradle.kts`: remove `sandboxContainer` override + old comment
- 14 `.run/` XMLs + `generateConfigs.py`: point to `.intellijPlatform/sandbox/{projectName}/{TYPE-VER}/`
- 6 CI buildspec YMLs: collect logs from `.intellijPlatform/sandbox/`
