### PR TITLE
fix(toolkit): restore RDS + IAM DB features in DataGrip

### DIFF
--- a/.changes/next-release/bugfix-rds-datagrip-packaging.json
+++ b/.changes/next-release/bugfix-rds-datagrip-packaging.json
@@ -1,0 +1,4 @@
+{
+  "type": "bugfix",
+  "description": "Restore RDS/Redshift explorer nodes and IAM/Secrets Manager database authentication in DataGrip and IntelliJ Ultimate ([#6395](https://github.com/aws/aws-toolkit-jetbrains/issues/6395))"
+}

--- a/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/temp-toolkit-intellij-root-conventions.gradle.kts
@@ -78,8 +78,11 @@ dependencies {
 
     // Plugin 2.15+ auto-packages .module dependencies into lib/modules/ where IntelliJ can't find
     // plugin.xml. jetbrains-core contains META-INF/plugin.xml — must be composed into the root JAR.
+    // jetbrains-ultimate contributes META-INF/IU.xml (RDS/Redshift explorer nodes + database
+    // connection interceptors) via xi:include, which only resolves from the main classpath.
     intellijPlatform {
         pluginComposedModule(project(":plugin-toolkit:jetbrains-core"))
+        pluginComposedModule(project(":plugin-toolkit:jetbrains-ultimate"))
     }
 
     implementation(project(":plugin-toolkit:jetbrains-core"))


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #6395

## Description

RDS/Redshift and IAM database auth disappeared from DataGrip and IntelliJ Ultimate since 4.3.

Cause: the build now packages `jetbrains-ultimate` (which holds `IU.xml` and the RDS code) into `lib/modules/`, where the `xi:include` in the main `plugin.xml` can't find it. `jetbrains-core` was already fixed this way; `jetbrains-ultimate` was missed.

Fix: compose it into the root jar too.

```kotlin
pluginComposedModule(project(":plugin-toolkit:jetbrains-ultimate"))
```

Verified by building from source: the produced zip has no `lib/modules/`, and the root jar now carries `IU.xml`, `ext-datagrip.xml`, and the RDS classes.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes (packaging-layout change; no test hook for artifact layout)
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] I have added metrics for my changes (not applicable)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
