### PR TITLE
build(262): add IntelliJ Platform 2026.2 build target

### DIFF
--- a/.run/Run AWS Toolkit - Community [2026.2].run.xml
+++ b/.run/Run AWS Toolkit - Community [2026.2].run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run AWS Toolkit - Community [2026.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.2">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IU-2026.2/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PrunIdeVariant=IC -PideProfileName=2026.2" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":plugin-toolkit:intellij-standalone:runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run AWS Toolkit - Gateway [2026.2].run.xml
+++ b/.run/Run AWS Toolkit - Gateway [2026.2].run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run AWS Toolkit - Gateway [2026.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.2">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/jetbrains-gateway/build/idea-sandbox/jetbrains-gateway/GW-2026.2/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value=" -PideProfileName=2026.2" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":plugin-toolkit:jetbrains-gateway:runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run AWS Toolkit - Rider [2026.2].run.xml
+++ b/.run/Run AWS Toolkit - Rider [2026.2].run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run AWS Toolkit - Rider [2026.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.2">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/RD-2026.2/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PrunIdeVariant=RD -PideProfileName=2026.2" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":plugin-toolkit:intellij-standalone:runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run AWS Toolkit - Ultimate [2026.2].run.xml
+++ b/.run/Run AWS Toolkit - Ultimate [2026.2].run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run AWS Toolkit - Ultimate [2026.2]" type="GradleRunConfiguration" factoryName="Gradle" folderName="2026.2">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/plugins/toolkit/intellij-standalone/build/idea-sandbox/intellij-standalone/IU-2026.2/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PrunIdeVariant=IU -PideProfileName=2026.2" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":plugin-toolkit:intellij-standalone:runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/generateConfigs.py
+++ b/.run/generateConfigs.py
@@ -60,7 +60,7 @@ def write_config(mv: str, ide: IdeVariant, plugin: PluginVariant):
         f.write(TEMPLATE.format(plugin=plugin, variant=ide, major_version=mv, sandbox_type=sandbox_type))
 
 if __name__ == '__main__':
-    mvs = ["2025.1", "2025.2", "2025.3", "2026.1"]
+    mvs = ["2025.1", "2025.2", "2025.3", "2026.1", "2026.2"]
     ides = [
         IdeVariant("Community", "IC"),
         IdeVariant("Rider", "RD"),

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/BuildScriptUtils.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/BuildScriptUtils.kt
@@ -28,7 +28,7 @@ fun Project.jvmTarget(): Provider<JavaVersion> = withCurrentProfileName {
 // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#stdlib-miscellaneous
 fun Project.kotlinTarget(): Provider<String> = withCurrentProfileName {
     when (it) {
-        "2025.1", "2025.2", "2025.3", "2026.1" -> KotlinVersionEnum.KOTLIN_2_1
+        "2025.1", "2025.2", "2025.3", "2026.1", "2026.2" -> KotlinVersionEnum.KOTLIN_2_1
         else -> error("not set")
     }.version
 }

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -191,6 +191,49 @@ object IdeVersions {
                 rdGenVersion = "2026.1.3",
                 nugetVersion = "2026.1.0"
             )
+        ),
+        Profile(
+            name = "2026.2",
+            gateway = ProductProfile(
+                sdkVersion = "2026.2",
+                bundledPlugins = listOf("org.jetbrains.plugins.terminal")
+            ),
+            community = ProductProfile(
+                sdkVersion = "2026.2",
+                bundledPlugins = commonPlugins + listOf(
+                    "com.intellij.java",
+                    "com.intellij.gradle",
+                    "org.jetbrains.idea.maven",
+                    "com.intellij.properties"
+                ),
+                marketplacePlugins = listOf(
+                    "org.toml.lang:262.8665.176",
+                    "PythonCore:262.8665.258",
+                    "Docker:262.8665.185",
+                    "com.intellij.modules.json:262.8665.258"
+                )
+            ),
+            ultimate = ProductProfile(
+                sdkVersion = "2026.2",
+                bundledPlugins = commonPlugins + listOf(
+                    "JavaScript",
+                    "JavaScriptDebugger",
+                    "com.intellij.database"
+                ),
+                marketplacePlugins = listOf(
+                    "Pythonid:262.8665.258",
+                    "org.jetbrains.plugins.go:262.8665.258",
+                    "com.intellij.modules.json:262.8665.258"
+                )
+            ),
+            rider = RiderProfile(
+                // Rider 2026.2 still EAP — pin to EAP snapshot until GA, then switch to "2026.2" / "2026.2.0".
+                sdkVersion = "2026.2-SNAPSHOT",
+                bundledPlugins = commonPlugins,
+                netFrameworkTarget = "net472",
+                rdGenVersion = "2026.2.4",
+                nugetVersion = "2026.2.0-eap06"
+            )
         )
     ).associateBy { it.name }
 

--- a/kotlinResolution.settings.gradle.kts
+++ b/kotlinResolution.settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
                     "1.10.1-intellij-5"
                 }
 
-                "2026.1" -> {
+                "2026.1", "2026.2" -> {
                     "1.10.2-intellij-1"
                 }
 
@@ -32,6 +32,7 @@ dependencyResolutionManagement {
                 "2025.2" -> "2.1.20"
                 "2025.3" -> "2.2.20"
                 "2026.1" -> "2.3.20"
+                "2026.2" -> "2.4.0"
                 else -> { error("not set") }
             }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -170,7 +170,7 @@ file("plugins").listFiles()?.forEach root@ {
             if (it.name == "jetbrains-gateway") {
                 when (providers.gradleProperty("ideProfileName").get()) {
                     // buildSrc is evaluated after settings so we can't key off of IdeVersions.kt
-                    "2025.1", "2025.2", "2025.3", "2026.1" -> {
+                    "2025.1", "2025.2", "2025.3", "2026.1", "2026.2" -> {
                         return@forEach
                     }
                 }


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Adds the IntelliJ Platform **2026.2 (262)** build profile so the toolkit can be built and
tested against the 2026.2 IDE line. Mirrors the 261 build-target work (#6334).

**IntelliJ IDEA 2026.2 reached GA on 2026-07-16** (build `262.8665.*`), so the IDEA
gateway/community/ultimate profiles use the `2026.2` release marketing version — consistent
with every other profile in `IdeVersions.kt`. **Rider 2026.2 is still EAP** (latest `2026.2-EAP9`,
no stable SDK published yet), so its SDK is pinned to `2026.2-SNAPSHOT` / nuget `2026.2.0-eap06`
with an inline note to switch to the release version once Rider 2026.2 ships.

Changes:
- **`IdeVersions.kt`** — new `2026.2` profile. IDEA SDK `2026.2`; marketplace plugins pinned to
  their `262.8665.*` builds (TOML, Python, Docker, Go, JSON). Rider on EAP snapshot coordinates.
- **`BuildScriptUtils.kt`** — map `2026.2` to the `KOTLIN_2_1` language/API target (unchanged from 261).
- **`kotlinResolution.settings.gradle.kts`** — coroutines `1.10.2-intellij-1` and bundled kotlin-stdlib
  `2.4.0` for 2026.2, sourced from the JetBrains `262` branch.
- **`settings.gradle.kts`** — add `2026.2` to the Gateway module skip-list (Gateway enablement is
  tracked separately, same as 261).
- **`.run/generateConfigs.py`** + generated `.run/*.xml` — add 2026.2 run configurations for
  Community / Ultimate / Rider / Gateway.

Validation:
- `./gradlew help -PideProfileName=2026.2` configures successfully; existing profiles (incl. 2026.1)
  remain green.
- Verified the Rider `2026.2-SNAPSHOT` SDK and the `262.8665.*` marketplace plugin coordinates
  resolve/download.

> Note: this PR adds the build target only. Compilation against 262 (the LSP client API rename /
> source-set split) is handled in a follow-up `fix(262):` PR.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.