### PR TITLE
fix(262): verify against IntelliJ IDEA Ultimate for 2026.x

### DIFF
--- a/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
@@ -26,7 +26,7 @@ intellijPlatform {
             // recommended() appears to resolve latest EAP for a product?
             // Starting with 2025.3, IntelliJ IDEA is unified (no separate Community edition)
             val version = toolkitIntelliJ.version().get()
-            if (version.startsWith("2025.3")) {
+            if (version.startsWith("2025.3") || version.startsWith("2026.")) {
                 create(IntelliJPlatformType.IntellijIdeaUltimate, version)
             } else {
                 create(IntelliJPlatformType.IntellijIdeaCommunity, version)


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Fix plugin verification for 2026.x builds. Per comment, `Starting with 2025.3, IntelliJ IDEA is unified (no separate Community edition)` so we should only test against Ultimate and not Community

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [x] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
