### PR TITLE
ci(262): provision required JDK per profile and skip excluded Rider tasks for 2026.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@
 import org.jetbrains.gradle.ext.ProjectSettings
 import org.jetbrains.gradle.ext.TaskTriggersConfig
 import software.aws.toolkits.gradle.changelog.tasks.GenerateGithubChangeLog
+import software.aws.toolkits.gradle.jvmTarget
 
 plugins {
     id("base")
@@ -44,6 +45,15 @@ dependencies {
 tasks.register("runIde") {
     doFirst {
         throw GradleException("Use project specific runIde command, i.e. :plugin-toolkit:intellij-standalone:runIde")
+    }
+}
+
+// Prints the major JDK version required to build the currently-selected IDE profile (e.g. "21" or "25").
+// CI buildspecs use this to provision the right JDK without hardcoding per-profile version mappings.
+tasks.register("printJvmTarget") {
+    val target = project.jvmTarget()
+    doLast {
+        println(target.get().majorVersion)
     }
 }
 

--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -36,7 +36,13 @@ phases:
       - cat $AWS_CONFIG_FILE
       - chmod +x gradlew
       # --no-parallel: plugin 2.16 cached layout index is shared; parallel test tasks resolve bundled plugins against wrong IDE (fatal on Gradle 9)
-      - DISPLAY=:22 ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME integrationTest coverageReport -x :plugin-toolkit:jetbrains-rider:integrationTest --no-parallel --info --console plain
+      # jetbrains-rider is excluded from the 2026.2 build graph (settings.gradle.kts), so don't reference its tasks for that profile
+      - |
+        if [ "$ALTERNATIVE_IDE_PROFILE_NAME" = "2026.2" ]; then
+          DISPLAY=:22 ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME integrationTest coverageReport --no-parallel --info --console plain
+        else
+          DISPLAY=:22 ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME integrationTest coverageReport -x :plugin-toolkit:jetbrains-rider:integrationTest --no-parallel --info --console plain
+        fi
       - |
         if [ $(docker ps -q | wc -l) -gt 0 ]; then
             echo 'Docker containers were not completely cleaned up!';

--- a/buildspec/windowsTests.yml
+++ b/buildspec/windowsTests.yml
@@ -8,12 +8,6 @@ env:
 phases:
   install:
     commands:
-      # force install java21 while we work throuh path issues
-      - |
-        $javaName = "C:\Program Files\Amazon Corretto" | ForEach-Object {
-          ls $_ | Where-Object {$_ -Like "jdk*"} | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name
-        }
-        $JAVA_HOME = "C:\Program Files\Amazon Corretto\$javaName"
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
@@ -27,22 +21,47 @@ phases:
         # See https://github.com/NuGet/NuGet.Client/pull/4259
         $Env:NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY = "3,1000"
 
-        $Env:JAVA_HOME = $JAVA_HOME
-
         if ($Env:CODEARTIFACT_DOMAIN_NAME -and $Env:CODEARTIFACT_REPO_NAME) {
           $Env:CODEARTIFACT_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format maven --query repositoryEndpoint --output text
           # $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
           $Env:CODEARTIFACT_AUTH_TOKEN=aws codeartifact get-authorization-token --domain $Env:CODEARTIFACT_DOMAIN_NAME --query authorizationToken --output text --duration-seconds 3600
         }
 
+        # Select JDK by the version the build actually requires for this profile (jvmTarget() is the single source of truth),
+        # installing the latest Corretto of that major if the managed image doesn't already ship it.
+        # Run after CodeArtifact setup so the printJvmTarget resolution uses the same repos as the build.
+        $correttoRoot = "C:\Program Files\Amazon Corretto"
+        # Bootstrap gradle with the highest Corretto already on the image (>=17 is enough to run Gradle and print the target)
+        $Env:JAVA_HOME = (Get-ChildItem $correttoRoot -Directory | Where-Object {$_.Name -Like "jdk*"} | Sort-Object -Descending -Property Name | Select-Object -First 1).FullName
+        $required = (./gradlew -q printJvmTarget -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" 2>$null | Where-Object {$_ -match '^\d+$'} | Select-Object -Last 1)
+        if (-Not $required) { Write-Host "Could not determine required JDK version"; exit -1 }
+        $jdk = Get-ChildItem $correttoRoot -Directory -ErrorAction SilentlyContinue | Where-Object {$_.Name -Like "jdk$required*"} | Select-Object -First 1
+        if (-Not $jdk) {
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          $msi = Join-Path $Env:TEMP "corretto$required.msi"
+          Invoke-WebRequest -Uri "https://corretto.aws/downloads/latest/amazon-corretto-$required-x64-windows-jdk.msi" -OutFile $msi
+          Start-Process msiexec.exe -ArgumentList "/i","`"$msi`"","/quiet","/norestart" -Wait
+          $jdk = Get-ChildItem $correttoRoot -Directory | Where-Object {$_.Name -Like "jdk$required*"} | Select-Object -First 1
+        }
+        $Env:JAVA_HOME = $jdk.FullName
+
         # Rider is very expensive (spikes our CI jobs to 50% CPU, so let it do the prep work in parallel, but run tests later
         # --no-parallel: plugin 2.16 cached layout index is shared; parallel test tasks resolve bundled plugins against wrong IDE (fatal on Gradle 9)
-        ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" check :plugin-toolkit:jetbrains-rider:compileTestKotlin -x :plugin-toolkit:jetbrains-rider:check --no-parallel --info --console plain --continue --stacktrace
-        if ($LastExitCode -ne 0) {
-          Write-Host "Command failed with exit code $LastExitCode"
-          exit -1
+        # jetbrains-rider is excluded from the 2026.2 build graph (settings.gradle.kts), so don't reference its tasks for that profile
+        if ("$Env:ALTERNATIVE_IDE_PROFILE_NAME" -eq "2026.2") {
+          ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" check --no-parallel --info --console plain --continue --stacktrace
+          if ($LastExitCode -ne 0) {
+            Write-Host "Command failed with exit code $LastExitCode"
+            exit -1
+          }
+        } else {
+          ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" check :plugin-toolkit:jetbrains-rider:compileTestKotlin -x :plugin-toolkit:jetbrains-rider:check --no-parallel --info --console plain --continue --stacktrace
+          if ($LastExitCode -ne 0) {
+            Write-Host "Command failed with exit code $LastExitCode"
+            exit -1
+          }
+          ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" :plugin-toolkit:jetbrains-rider:check coverageReport --no-parallel --info --console plain
         }
-        ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" :plugin-toolkit:jetbrains-rider:check coverageReport --no-parallel --info --console plain
 
   post_build:
     commands:

--- a/buildspec/windowsTestsForToolkit.yml
+++ b/buildspec/windowsTestsForToolkit.yml
@@ -8,12 +8,6 @@ env:
 phases:
   install:
     commands:
-      # force install java21 while we work through path issues
-      - |
-        $javaName = "C:\Program Files\Amazon Corretto" | ForEach-Object {
-          ls $_ | Where-Object {$_ -Like "jdk*"} | Sort-Object -Descending -Property Name | Select-Object -first 1 -expandproperty Name
-        }
-        $JAVA_HOME = "C:\Program Files\Amazon Corretto\$javaName"
       - |
         if(-Not($Env:CODE_COV_TOKEN -eq $null)) {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
@@ -27,17 +21,38 @@ phases:
         # See https://github.com/NuGet/NuGet.Client/pull/4259
         $Env:NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY = "3,1000"
 
-        $Env:JAVA_HOME = $JAVA_HOME
-
         if ($Env:CODEARTIFACT_DOMAIN_NAME -and $Env:CODEARTIFACT_REPO_NAME) {
           $Env:CODEARTIFACT_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format maven --query repositoryEndpoint --output text
           # $Env:CODEARTIFACT_NUGET_URL=aws codeartifact get-repository-endpoint --domain $Env:CODEARTIFACT_DOMAIN_NAME --repository $Env:CODEARTIFACT_REPO_NAME --format nuget --query repositoryEndpoint --output text
           $Env:CODEARTIFACT_AUTH_TOKEN=aws codeartifact get-authorization-token --domain $Env:CODEARTIFACT_DOMAIN_NAME --query authorizationToken --output text --duration-seconds 3600
         }
 
+        # Select JDK by the version the build actually requires for this profile (jvmTarget() is the single source of truth),
+        # installing the latest Corretto of that major if the managed image doesn't already ship it.
+        # Run after CodeArtifact setup so the printJvmTarget resolution uses the same repos as the build.
+        $correttoRoot = "C:\Program Files\Amazon Corretto"
+        # Bootstrap gradle with the highest Corretto already on the image (>=17 is enough to run Gradle and print the target)
+        $Env:JAVA_HOME = (Get-ChildItem $correttoRoot -Directory | Where-Object {$_.Name -Like "jdk*"} | Sort-Object -Descending -Property Name | Select-Object -First 1).FullName
+        $required = (./gradlew -q printJvmTarget -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" 2>$null | Where-Object {$_ -match '^\d+$'} | Select-Object -Last 1)
+        if (-Not $required) { Write-Host "Could not determine required JDK version"; exit -1 }
+        $jdk = Get-ChildItem $correttoRoot -Directory -ErrorAction SilentlyContinue | Where-Object {$_.Name -Like "jdk$required*"} | Select-Object -First 1
+        if (-Not $jdk) {
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          $msi = Join-Path $Env:TEMP "corretto$required.msi"
+          Invoke-WebRequest -Uri "https://corretto.aws/downloads/latest/amazon-corretto-$required-x64-windows-jdk.msi" -OutFile $msi
+          Start-Process msiexec.exe -ArgumentList "/i","`"$msi`"","/quiet","/norestart" -Wait
+          $jdk = Get-ChildItem $correttoRoot -Directory | Where-Object {$_.Name -Like "jdk$required*"} | Select-Object -First 1
+        }
+        $Env:JAVA_HOME = $jdk.FullName
+
          # Rider is very expensive (spikes our CI jobs to 50% CPU, so let it do the prep work in parallel, but run tests later
          # --no-parallel: plugin 2.16 cached layout index is shared; parallel test tasks resolve bundled plugins against wrong IDE (fatal on Gradle 9)
-        ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" :plugin-toolkit:intellij-standalone:check :plugin-toolkit:jetbrains-rider:compileTestKotlin -x :plugin-toolkit:jetbrains-rider:check --no-parallel --info --console plain --continue
+         # jetbrains-rider is excluded from the 2026.2 build graph (settings.gradle.kts), so don't reference its tasks for that profile
+        if ("$Env:ALTERNATIVE_IDE_PROFILE_NAME" -eq "2026.2") {
+          ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" :plugin-toolkit:intellij-standalone:check --no-parallel --info --console plain --continue
+        } else {
+          ./gradlew -PideProfileName="$Env:ALTERNATIVE_IDE_PROFILE_NAME" :plugin-toolkit:intellij-standalone:check :plugin-toolkit:jetbrains-rider:compileTestKotlin -x :plugin-toolkit:jetbrains-rider:check --no-parallel --info --console plain --continue
+        }
         if ($LastExitCode -ne 0) {
           Write-Host "Command failed with exit code $LastExitCode"
           exit -1


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Fixes two CI failures on the 2026.2 (262) profile:

* **Rider task-selection error** — `jetbrains-rider` is excluded from the 2026.2 build graph, but some buildspecs still name its tasks, so Gradle fails at task selection (`project 'jetbrains-rider' not found`). Guarded the Rider references in `windowsTests.yml`, `windowsTestsForToolkit.yml`, and `linuxIntegrationTests.yml` so they're dropped for 2026.2 and unchanged for other profiles.
* **Missing JDK 25 on Windows** — 2026.2 requires a JDK 25 toolchain, but the Windows managed image (`aws/codebuild/windows-base:2019-3.0`) only ships up to Corretto 21 per [documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html#windows-runtimes). There is no newer image version which includes JDK 25. Windows buildspecs now install the required JDK if the image lacks it.

To avoid editing buildspecs every release:
* Added a `printJvmTarget` Gradle task that prints the JDK major required by the current profile (from `jvmTarget()`, the single source of truth).
* Buildspecs read that value and install the latest Corretto of that major from `corretto.aws` only if missing (the latest URL pins the major, floats only the patch).

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
