### PR TITLE
fix(262): 2026.2 test compilation and Linux test JVM for IntelliJ 2026.2

### DIFF
--- a/buildspec/linuxIntegrationTests.yml
+++ b/buildspec/linuxIntegrationTests.yml
@@ -35,9 +35,15 @@ phases:
       - ls -alh $AWS_CONFIG_FILE
       - cat $AWS_CONFIG_FILE
       - chmod +x gradlew
+      # Select the JDK this profile requires (jvmTarget() is the single source of truth). Forked tasks
+      # (test, instrumentCode) run on the launcher JVM, so JAVA_HOME must match the compiled bytecode version 
+      # or they fail to load classes
       # --no-parallel: plugin 2.16 cached layout index is shared; parallel test tasks resolve bundled plugins against wrong IDE (fatal on Gradle 9)
       # jetbrains-rider is excluded from the 2026.2 build graph (settings.gradle.kts), so don't reference its tasks for that profile
       - |
+        REQUIRED_JDK=$(./gradlew -q printJvmTarget -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME | grep -Eo '^[0-9]+$' | tail -1)
+        export JAVA_HOME=/usr/lib/jvm/java-${REQUIRED_JDK}-amazon-corretto.x86_64
+        echo "Using JAVA_HOME=$JAVA_HOME for profile $ALTERNATIVE_IDE_PROFILE_NAME"
         if [ "$ALTERNATIVE_IDE_PROFILE_NAME" = "2026.2" ]; then
           DISPLAY=:22 ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME integrationTest coverageReport --no-parallel --info --console plain
         else

--- a/buildspec/linuxTests.yml
+++ b/buildspec/linuxTests.yml
@@ -40,9 +40,16 @@ phases:
         fi
 
       - chmod +x gradlew
+      # Select the JDK this profile requires (jvmTarget() is the single source of truth). Forked tasks
+      # (test, instrumentCode) run on the launcher JVM, so JAVA_HOME must match the compiled bytecode version 
+      # or they fail to load classes
+      - |
+        REQUIRED_JDK=$(su codebuild-user -c "./gradlew -q printJvmTarget -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME" | grep -Eo '^[0-9]+$' | tail -1)
+        export JAVA_HOME=/usr/lib/jvm/java-${REQUIRED_JDK}-amazon-corretto.x86_64
+        echo "Using JAVA_HOME=$JAVA_HOME for profile $ALTERNATIVE_IDE_PROFILE_NAME"
       # --no-parallel: plugin 2.16 cached layout index is shared; parallel test tasks resolve bundled plugins against wrong IDE (fatal on Gradle 9)
-      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME check coverageReport --no-parallel --info --stacktrace --console plain --continue"
-      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME buildPlugin --no-parallel"
+      - su codebuild-user -c "JAVA_HOME=$JAVA_HOME ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME check coverageReport --no-parallel --info --stacktrace --console plain --continue"
+      - su codebuild-user -c "JAVA_HOME=$JAVA_HOME ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME buildPlugin --no-parallel"
       - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
       - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
       - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"

--- a/buildspec/linuxTestsForToolkit.yml
+++ b/buildspec/linuxTestsForToolkit.yml
@@ -32,9 +32,16 @@ phases:
         fi
 
       - chmod +x gradlew
+      # Select the JDK this profile requires (jvmTarget() is the single source of truth). Forked tasks
+      # (test, instrumentCode) run on the launcher JVM, so JAVA_HOME must match the compiled bytecode version 
+      # or they fail to load classes
+      - |
+        REQUIRED_JDK=$(su codebuild-user -c "./gradlew -q printJvmTarget -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME" | grep -Eo '^[0-9]+$' | tail -1)
+        export JAVA_HOME=/usr/lib/jvm/java-${REQUIRED_JDK}-amazon-corretto.x86_64
+        echo "Using JAVA_HOME=$JAVA_HOME for profile $ALTERNATIVE_IDE_PROFILE_NAME"
       # --no-parallel: plugin 2.16 cached layout index is shared; parallel test tasks resolve bundled plugins against wrong IDE (fatal on Gradle 9)
-      - su codebuild-user -c "./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME :plugin-toolkit:intellij-standalone:check coverageReport --no-parallel --info --console plain --continue"
-      - ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME :plugin-toolkit:intellij-standalone:buildPlugin --no-parallel
+      - su codebuild-user -c "JAVA_HOME=$JAVA_HOME ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME :plugin-toolkit:intellij-standalone:check coverageReport --no-parallel --info --console plain --continue"
+      - JAVA_HOME=$JAVA_HOME ./gradlew -PideProfileName=$ALTERNATIVE_IDE_PROFILE_NAME :plugin-toolkit:intellij-standalone:buildPlugin --no-parallel
       - VCS_COMMIT_ID="${CODEBUILD_RESOLVED_SOURCE_VERSION}"
       - CI_BUILD_URL=$(echo $CODEBUILD_BUILD_URL | sed 's/#/%23/g') # Encode `#` in the URL because otherwise the url is clipped in the Codecov.io site
       - CI_BUILD_ID="${CODEBUILD_BUILD_ID}"

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/profiles/ProfileCredentialsIdentifierSsoTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/profiles/ProfileCredentialsIdentifierSsoTest.kt
@@ -5,13 +5,14 @@ package software.aws.toolkit.jetbrains.core.credentials.profiles
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.TestDisposable
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import com.intellij.testFramework.replaceService
 import migration.software.aws.toolkit.core.ToolkitClientManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
 import software.amazon.awssdk.services.ssooidc.SsoOidcClient
 import software.amazon.awssdk.services.ssooidc.model.SsoOidcException
@@ -20,7 +21,7 @@ import software.aws.toolkit.jetbrains.core.credentials.sso.DiskCache
 import software.aws.toolkit.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider
 import software.aws.toolkit.jetbrains.core.credentials.sso.bearer.NoTokenInitializedException
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class ProfileCredentialsIdentifierSsoTest {
     private val sut = ProfileCredentialsIdentifierSso("", "", "", null)
 

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/profiles/ProfileCredentialsIdentifierSsoTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/profiles/ProfileCredentialsIdentifierSsoTest.kt
@@ -5,14 +5,13 @@ package software.aws.toolkit.jetbrains.core.credentials.profiles
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.TestDisposable
 import com.intellij.testFramework.replaceService
 import migration.software.aws.toolkit.core.ToolkitClientManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
 import software.amazon.awssdk.services.ssooidc.SsoOidcClient
 import software.amazon.awssdk.services.ssooidc.model.SsoOidcException
@@ -21,7 +20,7 @@ import software.aws.toolkit.jetbrains.core.credentials.sso.DiskCache
 import software.aws.toolkit.jetbrains.core.credentials.sso.bearer.InteractiveBearerTokenProvider
 import software.aws.toolkit.jetbrains.core.credentials.sso.bearer.NoTokenInitializedException
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class ProfileCredentialsIdentifierSsoTest {
     private val sut = ProfileCredentialsIdentifierSso("", "", "", null)
 

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/sso/DiskCacheTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/sso/DiskCacheTest.kt
@@ -5,12 +5,13 @@ package software.aws.toolkit.jetbrains.core.credentials.sso
 
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.NioFiles
-import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import software.aws.toolkit.core.utils.readText
 import software.aws.toolkit.core.utils.test.assertPosixPermissions
@@ -27,7 +28,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import kotlin.io.path.setPosixFilePermissions
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class DiskCacheTest {
     private val now = Instant.now()
     private val clock = Clock.fixed(now, ZoneOffset.UTC)

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/sso/DiskCacheTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/sso/DiskCacheTest.kt
@@ -5,13 +5,12 @@ package software.aws.toolkit.jetbrains.core.credentials.sso
 
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.NioFiles
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import software.aws.toolkit.core.utils.readText
 import software.aws.toolkit.core.utils.test.assertPosixPermissions
@@ -28,8 +27,8 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import kotlin.io.path.setPosixFilePermissions
 
+@TestApplication
 class DiskCacheTest {
-    @ExtendWith(ApplicationExtension::class)
     private val now = Instant.now()
     private val clock = Clock.fixed(now, ZoneOffset.UTC)
 

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationFormatUtilsTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationFormatUtilsTest.kt
@@ -6,7 +6,7 @@ package software.aws.toolkit.jetbrains.core.notifications
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.ProjectRule
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -29,7 +28,7 @@ import java.io.InputStream
 import java.nio.file.Paths
 import java.util.stream.Stream
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class NotificationFormatUtilsTest {
     @Rule
     @JvmField

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationFormatUtilsTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationFormatUtilsTest.kt
@@ -6,8 +6,8 @@ package software.aws.toolkit.jetbrains.core.notifications
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -28,7 +29,7 @@ import java.io.InputStream
 import java.nio.file.Paths
 import java.util.stream.Stream
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class NotificationFormatUtilsTest {
     @Rule
     @JvmField

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationManagerTest.kt
@@ -3,14 +3,15 @@
 
 package software.aws.toolkit.jetbrains.core.notifications
 
-import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.ProjectRule
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extension
 import org.junit.jupiter.api.extension.RegisterExtension
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class NotificationManagerTest {
 
     val projectRule = ProjectRule()

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationManagerTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationManagerTest.kt
@@ -3,15 +3,14 @@
 
 package software.aws.toolkit.jetbrains.core.notifications
 
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extension
 import org.junit.jupiter.api.extension.RegisterExtension
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class NotificationManagerTest {
 
     val projectRule = ProjectRule()

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationPollingServiceTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationPollingServiceTest.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkit.jetbrains.core.notifications
 
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -12,14 +12,13 @@ import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import software.aws.toolkit.core.utils.RemoteResourceResolver
 import software.aws.toolkit.core.utils.UpdateCheckResult
 import software.aws.toolkit.jetbrains.core.RemoteResourceResolverProvider
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class NotificationPollingServiceTest {
     private lateinit var sut: NotificationPollingService
     private lateinit var mockResolver: RemoteResourceResolver

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationPollingServiceTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationPollingServiceTest.kt
@@ -3,7 +3,7 @@
 
 package software.aws.toolkit.jetbrains.core.notifications
 
-import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -12,13 +12,14 @@ import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import software.aws.toolkit.core.utils.RemoteResourceResolver
 import software.aws.toolkit.core.utils.UpdateCheckResult
 import software.aws.toolkit.jetbrains.core.RemoteResourceResolverProvider
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class NotificationPollingServiceTest {
     private lateinit var sut: NotificationPollingService
     private lateinit var mockResolver: RemoteResourceResolver

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationResourceResolverTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationResourceResolverTest.kt
@@ -3,12 +3,13 @@
 
 package software.aws.toolkit.jetbrains.core.notifications
 
-import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import software.aws.toolkit.core.utils.DefaultRemoteResourceResolver
 import software.aws.toolkit.core.utils.UpdateCheckResult
@@ -17,7 +18,7 @@ import java.nio.file.Path
 import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class NotificationResourceResolverTest {
     private lateinit var urlFetcher: UrlFetcher
     private lateinit var sut: DefaultRemoteResourceResolver

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationResourceResolverTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/NotificationResourceResolverTest.kt
@@ -3,13 +3,12 @@
 
 package software.aws.toolkit.jetbrains.core.notifications
 
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import software.aws.toolkit.core.utils.DefaultRemoteResourceResolver
 import software.aws.toolkit.core.utils.UpdateCheckResult
@@ -18,7 +17,7 @@ import java.nio.file.Path
 import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class NotificationResourceResolverTest {
     private lateinit var urlFetcher: UrlFetcher
     private lateinit var sut: DefaultRemoteResourceResolver

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/ProcessNotificationsBaseTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/ProcessNotificationsBaseTest.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkit.jetbrains.core.notifications
 
 import com.intellij.openapi.project.Project
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -14,10 +14,9 @@ import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import java.util.concurrent.atomic.AtomicBoolean
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class ProcessNotificationsBaseTest {
     private lateinit var sut: ProcessNotificationsBase
     private lateinit var project: Project

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/ProcessNotificationsBaseTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/notifications/ProcessNotificationsBaseTest.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkit.jetbrains.core.notifications
 
 import com.intellij.openapi.project.Project
-import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -14,9 +14,10 @@ import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import java.util.concurrent.atomic.AtomicBoolean
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class ProcessNotificationsBaseTest {
     private lateinit var sut: ProcessNotificationsBase
     private lateinit var project: Project

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/services/telemetry/otel/OtelBaseTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/services/telemetry/otel/OtelBaseTest.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkit.jetbrains.services.telemetry.otel
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.TraceId
 import io.opentelemetry.context.Context
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.AfterEachCallback
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.params.ParameterizedTest
@@ -42,7 +41,7 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class OtelBaseTest {
     private companion object {
         @RegisterExtension

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/services/telemetry/otel/OtelBaseTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/services/telemetry/otel/OtelBaseTest.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkit.jetbrains.services.telemetry.otel
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.TraceId
 import io.opentelemetry.context.Context
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.params.ParameterizedTest
@@ -41,7 +42,7 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class OtelBaseTest {
     private companion object {
         @RegisterExtension

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/services/telemetry/otel/ToolkitTelemetryOTelSpanProcessorTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/services/telemetry/otel/ToolkitTelemetryOTelSpanProcessorTest.kt
@@ -3,8 +3,8 @@
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.TestDisposable
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import com.intellij.testFramework.replaceService
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanId
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
@@ -36,7 +37,7 @@ import software.aws.toolkits.telemetry.Telemetry
 import java.time.Instant
 // import software.aws.toolkits.jetbrains.core.CoreTestHelper
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class ToolkitTelemetryOTelSpanProcessorTest {
     private class TestTelemetryService(
         publisher: TelemetryPublisher = NoOpPublisher(),

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/services/telemetry/otel/ToolkitTelemetryOTelSpanProcessorTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/services/telemetry/otel/ToolkitTelemetryOTelSpanProcessorTest.kt
@@ -3,7 +3,7 @@
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.TestDisposable
 import com.intellij.testFramework.replaceService
 import io.opentelemetry.api.trace.Span
@@ -13,7 +13,6 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
@@ -37,7 +36,7 @@ import software.aws.toolkits.telemetry.Telemetry
 import java.time.Instant
 // import software.aws.toolkits.jetbrains.core.CoreTestHelper
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class ToolkitTelemetryOTelSpanProcessorTest {
     private class TestTelemetryService(
         publisher: TelemetryPublisher = NoOpPublisher(),

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/settings/AwsSettingsTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/settings/AwsSettingsTest.kt
@@ -5,13 +5,14 @@ package software.aws.toolkit.jetbrains.settings
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.TestDisposable
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import com.intellij.testFramework.replaceService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -22,7 +23,7 @@ import software.aws.toolkit.jetbrains.services.telemetry.NoOpPublisher
 import software.aws.toolkit.jetbrains.services.telemetry.TelemetryService
 import java.util.UUID
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class AwsSettingsTest {
     private class TestTelemetryService(
         publisher: TelemetryPublisher = NoOpPublisher(),

--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/settings/AwsSettingsTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/settings/AwsSettingsTest.kt
@@ -5,14 +5,13 @@ package software.aws.toolkit.jetbrains.settings
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.TestDisposable
 import com.intellij.testFramework.replaceService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -23,7 +22,7 @@ import software.aws.toolkit.jetbrains.services.telemetry.NoOpPublisher
 import software.aws.toolkit.jetbrains.services.telemetry.TelemetryService
 import java.util.UUID
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class AwsSettingsTest {
     private class TestTelemetryService(
         publisher: TelemetryPublisher = NoOpPublisher(),

--- a/plugins/toolkit/jetbrains-core/it/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderIntegrationTest.kt
+++ b/plugins/toolkit/jetbrains-core/it/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderIntegrationTest.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkits.jetbrains.core.credentials.sso.bearer
 
 import com.intellij.openapi.util.Disposer
-import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assumptions.assumeThat
 import org.junit.jupiter.api.MethodOrderer
@@ -27,8 +27,7 @@ import java.nio.file.Path
 import java.time.Instant
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-@TestApplication
-@ExtendWith(SsoLoginExtension::class)
+@ExtendWith(TestApplicationExtension::class, SsoLoginExtension::class)
 @SsoLogin("codecatalyst-test-account")
 @DisabledIfEnvironmentVariable(named = "IS_PROD", matches = "false")
 class InteractiveBearerTokenProviderIntegrationTest {

--- a/plugins/toolkit/jetbrains-core/it/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderIntegrationTest.kt
+++ b/plugins/toolkit/jetbrains-core/it/software/aws/toolkits/jetbrains/core/credentials/sso/bearer/InteractiveBearerTokenProviderIntegrationTest.kt
@@ -4,7 +4,7 @@
 package software.aws.toolkits.jetbrains.core.credentials.sso.bearer
 
 import com.intellij.openapi.util.Disposer
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assumptions.assumeThat
 import org.junit.jupiter.api.MethodOrderer
@@ -27,7 +27,8 @@ import java.nio.file.Path
 import java.time.Instant
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-@ExtendWith(ApplicationExtension::class, SsoLoginExtension::class)
+@TestApplication
+@ExtendWith(SsoLoginExtension::class)
 @SsoLogin("codecatalyst-test-account")
 @DisabledIfEnvironmentVariable(named = "IS_PROD", matches = "false")
 class InteractiveBearerTokenProviderIntegrationTest {

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/feedback/SendFeedbackWithExperimentsMetadataTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/feedback/SendFeedbackWithExperimentsMetadataTest.kt
@@ -6,13 +6,12 @@ package software.aws.toolkits.jetbrains.feedback
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Disposer
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.ExtensionTestUtil
 import com.intellij.testFramework.junit5.TestDisposable
 import com.intellij.testFramework.replaceService
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import software.amazon.awssdk.services.toolkittelemetry.model.Sentiment
@@ -26,7 +25,7 @@ import software.aws.toolkits.jetbrains.core.experiments.DummyExperiment
 import software.aws.toolkits.jetbrains.core.experiments.ToolkitExperimentManager
 import software.aws.toolkits.jetbrains.core.experiments.setState
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class SendFeedbackWithExperimentsMetadataTest {
     private class TestTelemetryService(publisher: TelemetryPublisher = NoOpPublisher(), batcher: TelemetryBatcher) : TelemetryService(publisher, batcher)
 

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/feedback/SendFeedbackWithExperimentsMetadataTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/feedback/SendFeedbackWithExperimentsMetadataTest.kt
@@ -6,12 +6,13 @@ package software.aws.toolkits.jetbrains.feedback
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Disposer
-import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.ExtensionTestUtil
 import com.intellij.testFramework.junit5.TestDisposable
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import com.intellij.testFramework.replaceService
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import software.amazon.awssdk.services.toolkittelemetry.model.Sentiment
@@ -25,7 +26,7 @@ import software.aws.toolkits.jetbrains.core.experiments.DummyExperiment
 import software.aws.toolkits.jetbrains.core.experiments.ToolkitExperimentManager
 import software.aws.toolkits.jetbrains.core.experiments.setState
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class SendFeedbackWithExperimentsMetadataTest {
     private class TestTelemetryService(publisher: TelemetryPublisher = NoOpPublisher(), batcher: TelemetryBatcher) : TelemetryService(publisher, batcher)
 

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/caws/CawsClientCustomizerTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/caws/CawsClientCustomizerTest.kt
@@ -3,9 +3,8 @@
 
 package software.aws.toolkits.jetbrains.services.caws
 
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -15,7 +14,7 @@ import software.amazon.awssdk.services.codecatalyst.CodeCatalystClientBuilder
 import software.aws.toolkits.jetbrains.utils.rules.RegistryExtension
 import java.net.URI
 
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 class CawsClientCustomizerTest {
     @JvmField
     @RegisterExtension

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/caws/CawsClientCustomizerTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/caws/CawsClientCustomizerTest.kt
@@ -3,8 +3,9 @@
 
 package software.aws.toolkits.jetbrains.services.caws
 
-import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -14,7 +15,7 @@ import software.amazon.awssdk.services.codecatalyst.CodeCatalystClientBuilder
 import software.aws.toolkits.jetbrains.utils.rules.RegistryExtension
 import java.net.URI
 
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 class CawsClientCustomizerTest {
     @JvmField
     @RegisterExtension

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectActionTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectActionTest.kt
@@ -274,11 +274,6 @@ class UploadObjectActionTest : ObjectActionTestBase() {
 
     private fun createFileChooserMock(files: List<File>) {
         val dialog = object : FileChooserDialog {
-            @Deprecated("needs to be implemented, but interface doesn't provide default impl")
-            override fun choose(toSelect: VirtualFile?, project: Project?): Array<VirtualFile> = toSelect?.let {
-                choose(project, it)
-            } ?: choose(project)
-
             override fun choose(project: Project?, vararg toSelect: VirtualFile): Array<VirtualFile> {
                 val lfs = LocalFileSystem.getInstance()
                 return files.mapNotNull {

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectActionTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/s3/objectActions/UploadObjectActionTest.kt
@@ -273,6 +273,7 @@ class UploadObjectActionTest : ObjectActionTestBase() {
     }
 
     private fun createFileChooserMock(files: List<File>) {
+        @Suppress("ObjectLiteralToLambda")
         val dialog = object : FileChooserDialog {
             override fun choose(project: Project?, vararg toSelect: VirtualFile): Array<VirtualFile> {
                 val lfs = LocalFileSystem.getInstance()

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/MockFileChooser.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/MockFileChooser.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.mock
 import java.nio.file.Path
 
 fun createMockFileChooser(disposable: Disposable, vararg files: Path) {
+    @Suppress("ObjectLiteralToLambda")
     val dialog = object : FileChooserDialog {
         override fun choose(project: Project?, vararg toSelect: VirtualFile): Array<VirtualFile> {
             val lfs = LocalFileSystem.getInstance()

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/MockFileChooser.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/utils/MockFileChooser.kt
@@ -18,11 +18,6 @@ import java.nio.file.Path
 
 fun createMockFileChooser(disposable: Disposable, vararg files: Path) {
     val dialog = object : FileChooserDialog {
-        @Deprecated("needs to be implemented, but interface doesn't provide default impl")
-        override fun choose(toSelect: VirtualFile?, project: Project?): Array<VirtualFile> = toSelect?.let {
-            choose(project, it)
-        } ?: choose(project)
-
         override fun choose(project: Project?, vararg toSelect: VirtualFile): Array<VirtualFile> {
             val lfs = LocalFileSystem.getInstance()
             return files.mapNotNull {

--- a/plugins/toolkit/jetbrains-gateway/it/software/aws/toolkits/jetbrains/gateway/DevEnvConnectTest.kt
+++ b/plugins/toolkit/jetbrains-gateway/it/software/aws/toolkits/jetbrains/gateway/DevEnvConnectTest.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.remoteDev.downloader.JetBrainsClientDownloaderConfigurationProvider
 import com.intellij.remoteDev.downloader.TestJetBrainsClientDownloaderConfigurationProvider
 import com.intellij.remoteDev.hostStatus.UnattendedHostStatus
-import com.intellij.testFramework.ApplicationExtension
+import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.registerOrReplaceServiceInstance
 import com.intellij.util.io.HttpRequests
 import com.intellij.util.net.NetUtils
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 import org.junit.jupiter.api.extension.AfterAllCallback
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -66,7 +65,7 @@ import kotlin.reflect.KFunction
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
-@ExtendWith(ApplicationExtension::class)
+@TestApplication
 @SsoLogin("codecatalyst-test-account")
 @DisabledIfEnvironmentVariable(named = "IS_PROD", matches = "false")
 @DisabledIfSystemProperty(named = "org.gradle.project.ideProfileName", matches = "202*.*", disabledReason = "Flakes on 233+")

--- a/plugins/toolkit/jetbrains-gateway/it/software/aws/toolkits/jetbrains/gateway/DevEnvConnectTest.kt
+++ b/plugins/toolkit/jetbrains-gateway/it/software/aws/toolkits/jetbrains/gateway/DevEnvConnectTest.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.remoteDev.downloader.JetBrainsClientDownloaderConfigurationProvider
 import com.intellij.remoteDev.downloader.TestJetBrainsClientDownloaderConfigurationProvider
 import com.intellij.remoteDev.hostStatus.UnattendedHostStatus
-import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
 import com.intellij.testFramework.registerOrReplaceServiceInstance
 import com.intellij.util.io.HttpRequests
 import com.intellij.util.net.NetUtils
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -65,7 +66,7 @@ import kotlin.reflect.KFunction
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
-@TestApplication
+@ExtendWith(TestApplicationExtension::class)
 @SsoLogin("codecatalyst-test-account")
 @DisabledIfEnvironmentVariable(named = "IS_PROD", matches = "false")
 @DisabledIfSystemProperty(named = "org.gradle.project.ideProfileName", matches = "202*.*", disabledReason = "Flakes on 233+")


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Fixes the 2026.2 (`262`) CI failures on Linux and Windows. Two parts: 262 test-source compatibility (which also affects all profiles once it compiles), and the Linux test JVM.

### 1. Test sources against the 262 SDK

- **`com.intellij.testFramework.ApplicationExtension` was removed in 262.** Replaced its 14 usages with `@ExtendWith(com.intellij.testFramework.junit5.impl.TestApplicationExtension::class)` — the direct, behavior-preserving successor (sets up the test Application, same as before).
  - Note: the higher-level `@TestApplication` annotation also exists, but it additionally enables leak-tracking (`TestApplicationLeakTrackerExtension`) that the current tests don't satisfy, so `TestApplicationExtension` is the correct 1:1 replacement.
  - `DiskCacheTest` had `@ExtendWith(ApplicationExtension::class)` incorrectly on a field; moved it to the class.
  - `InteractiveBearerTokenProviderIntegrationTest` combines it with `SsoLoginExtension`: `@ExtendWith(TestApplicationExtension::class, SsoLoginExtension::class)`.
- **`FileChooserDialog.choose(VirtualFile?, Project?)` was removed** (only `choose(Project, vararg VirtualFile)` remains). Dropped the deprecated override in `MockFileChooser.kt` and `UploadObjectActionTest.kt`. Since that leaves a single-method anonymous object, added `@Suppress("ObjectLiteralToLambda")` (matching existing usage in `TestUtils.kt`).

### 2. Linux forks test/instrument JVMs on the wrong JDK

The 2026.2 profile compiles to Java 25 bytecode, but the Linux buildspecs launched Gradle on the image's default JDK (21), so `test`/`instrumentCode` (which fork on the launcher JVM) couldn't load the 25 classes (`class file version 69.0`). The buildspecs now select the JDK the profile requires via a `printJvmTarget` Gradle task driven by `jvmTarget()`. Other profiles are unaffected (they resolve JDK 21).

> A Gradle `java { toolchain {} }` block was tried but doesn't fix this — `instrumentCode` ignores the toolchain and uses the launcher JVM.

The Windows buildspecs already select the required JDK (https://github.com/aws/aws-toolkit-jetbrains/pull/6402), so they only needed the
test-source fix in (1).

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
