### PR TITLE
deps: deprecate IDE 2025.1 and 2025.2 (min version 2025.3)

### DIFF
--- a/.changes/next-release/deprecation-2025-1-2025-2.json
+++ b/.changes/next-release/deprecation-2025-1-2025-2.json
@@ -1,0 +1,4 @@
+{
+    "type": "deprecation",
+    "description": "Support for IDEs based on the 2025.1 and 2025.2 platforms is being deprecated and will be removed in an upcoming release. The minimum supported version will be 2025.3."
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/MinimumVersionChange.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/notification/MinimumVersionChange.kt
@@ -55,8 +55,8 @@ class MinimumVersionChange @JvmOverloads constructor(isUnderTest: Boolean = fals
     }
 
     companion object {
-        const val MIN_VERSION = 251
-        const val MIN_VERSION_HUMAN = "2025.1"
+        const val MIN_VERSION = 253
+        const val MIN_VERSION_HUMAN = "2025.3"
 
         // Used by tests to make sure the prompt never shows up
         const val SKIP_PROMPT = "aws.suppress_deprecation_prompt"


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
<!--- If appropriate, providing screenshots will help us review your contribution -->
<!--- If there is a related issue, please provide a link here -->
Mark IDE versions 2025.1 and 2025.2 as deprecated in upcoming release

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
