### PR TITLE
fix(cloudformation): Cap CloudFormation LSP server heap at 384MB

### DIFF
--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
@@ -93,6 +93,7 @@ class CfnLspServerDescriptor private constructor(project: Project) :
 
         return GeneralCommandLine(nodePath.toString(), serverPath.toString(), "--stdio")
             .withWorkDirectory(serverPath.parent.toString())
+            .withEnvironment("NODE_OPTIONS", "--max-old-space-size=384")
     }
 
     private fun resolveNodeRuntime(): Path {


### PR DESCRIPTION
Set `NODE_OPTIONS --max-old-space-size=384` when spawning the CloudFormation language server process. Without this, V8 uses its default ~4GB ceiling and the process grows unbounded

This is to partially address memory consumption issues of the language server: https://github.com/aws/aws-toolkit-jetbrains/issues/6380 

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
