### PR TITLE
test: fix integrations tests, DiskCache permission issues

### DIFF
--- a/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/sso/DiskCacheTest.kt
+++ b/plugins/core/jetbrains-community/tst/software/aws/toolkit/jetbrains/core/credentials/sso/DiskCacheTest.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.util.io.NioFiles
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.extension.ExtendWith
@@ -544,6 +545,9 @@ class DiskCacheTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
+    // root bypasses POSIX permission checks, so the file op never throws AccessDeniedException and the
+    // self-healing perm-fix path under test is never exercised (the CI integration job runs as root)
+    @DisabledIfSystemProperty(named = "user.name", matches = "root")
     fun `handles error saving client registration when user home is not writable`() {
         Files.newDirectoryStream(cacheRoot).forEach { NioFiles.deleteRecursively(it) }
         cacheRoot.resolve("fakehome").apply {
@@ -577,6 +581,8 @@ class DiskCacheTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
+    // root can write to a 0-permission file, so the AccessDeniedException that drives the perm-fix never fires
+    @DisabledIfSystemProperty(named = "user.name", matches = "root")
     fun `handles error saving client registration when client registration is not writable`() {
         val key = DeviceAuthorizationClientRegistrationCacheKey(
             startUrl = ssoUrl,
@@ -610,6 +616,8 @@ class DiskCacheTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
+    // root can read a 0-permission file, so the AccessDeniedException that drives the perm-fix never fires
+    @DisabledIfSystemProperty(named = "user.name", matches = "root")
     fun `handles reading client registration when file is owned but not readable`() {
         val key = DeviceAuthorizationClientRegistrationCacheKey(
             startUrl = ssoUrl,

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/UpdaterTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/cloudformation/stack/UpdaterTest.kt
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.aws.toolkits.jetbrains.services.cloudformation.stack
 
+import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.ProjectRule
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -29,6 +31,7 @@ import software.aws.toolkit.core.utils.delegateMock
 import software.aws.toolkit.jetbrains.core.MockClientManagerRule
 import software.aws.toolkit.jetbrains.utils.satisfiesKt
 import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import javax.swing.JLabel
@@ -56,9 +59,19 @@ class UpdaterTest {
     private val updateListener = mock<UpdateListener>()
     private val resourceListener = mock<ResourceListener>()
 
+    // Updater holds a self-rescheduling Alarm; dispose it so no leaked callback fires against the
+    // mock client after the test ends (which pollutes a later, unrelated test with a logged error).
+    // CopyOnWriteArrayList because the first test creates its Updater on the EDT
+    private val updaters = CopyOnWriteArrayList<Updater>()
+
     @Before
     fun setUp() {
         arrayOf(treeView, eventsTable).forEach { whenever(it.component).thenReturn(JLabel()) }
+    }
+
+    @After
+    fun tearDown() {
+        updaters.forEach { Disposer.dispose(it) }
     }
 
     @Test
@@ -109,7 +122,7 @@ class UpdaterTest {
                 client = client,
                 setPagesAvailable = { p -> availablePages = p },
                 stackId = "1234"
-            ).start()
+            ).also { updaters.add(it) }.start()
         }
 
         arrayOf(setStackStatus, fillResources, insertEvents).forEach { it.waitFor() }
@@ -161,7 +174,7 @@ class UpdaterTest {
             client = client,
             setPagesAvailable = { },
             stackId = "1234"
-        ).applyFilter { it.logicalResourceId() == "L1" }
+        ).also { updaters.add(it) }.applyFilter { it.logicalResourceId() == "L1" }
 
         fillResources.waitFor()
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Fixes CI test failures that surface in the Linux integration-test report (Ex: https://github.com/aws/aws-toolkit-jetbrains/pull/6408). Both are test-only fixes; no production behavior changes.

**1. `DiskCacheTest` POSIX-permission failures (3 tests)**

The integration job runs Gradle as **root**, whereas the unit job runs as a non-root `codebuild-user`. These three tests validate the self-healing permission logic in `PathUtils` (`tryFileOp`/`tryDirOp` → `tryFixPerms`), which only runs when a file/dir operation throws `AccessDeniedException`. Root bypasses POSIX permission bits, so:
- Reading/writing a `0`-permission file and traversing a `r-xr-xr-x` dir succeed → no `AccessDeniedException` → the perm-fix path under test never fires → permissions stay as-set (`---------` / `r-xr-xr-x` instead of the expected healed `rw-------` / `rwxr-xr-x`).
- Even if an ADE were thrown, `tryFixPerms` deliberately refuses to `chmod` root-owned files.

These are inherently non-root tests. Added `@DisabledIfSystemProperty(named = "user.name", matches = "root")` alongside the existing `@DisabledOnOs(OS.WINDOWS)` guard, mirroring the `ownership.name != "root"` invariant the production code itself relies on. They continue to run (and pass) in the non-root unit job, so coverage is preserved.

**2. `ToolkitTelemetryOTelSpanProcessorTest` "UncaughtExceptionsBeforeTest"**

A misattributed, pre-existing flake. The real cause is in the suppressed exception: `UpdaterTest` constructs `Updater` instances (each holds a 10 ms self-rescheduling `Alarm`) and never disposes them. After the test ends, a leaked alarm callback fires `describeStackResources` against the now-cleared Mockito inline mock (`Mock accessed after inline mocks were cleared`), which is logged as an error and attributed to whichever test JUnit starts next. Fixed by tracking the created `Updater`s and disposing them in `@After` — the `Alarm` is a child disposable, so disposal cancels its pending requests.

### Verification
- Both affected test source sets compile for 2025.3.
- `DiskCacheTest` runs (not skipped) and passes as a non-root user locally, confirming the root guard only disables under root.

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
