### PR TITLE
feat(jetbrains): add CDK Language Server (cdk lsp) integration

### DIFF
--- a/.changes/next-release/Feature-cdkLanguageServer.json
+++ b/.changes/next-release/Feature-cdkLanguageServer.json
@@ -1,0 +1,4 @@
+{
+    "type": "feature",
+    "description": "CDK: Language server support for CDK apps in paid JetBrains IDEs (2025.3+) - diagnostics, hover, template-to-source navigation, and construct/synth CodeLens, backed by the `cdk lsp` CLI."
+}

--- a/plugins/toolkit/jetbrains-core/resources-253+/META-INF/aws.toolkit.cdk.lsp.xml
+++ b/plugins/toolkit/jetbrains-core/resources-253+/META-INF/aws.toolkit.cdk.lsp.xml
@@ -1,0 +1,27 @@
+<!-- Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<!--
+  Loaded only when com.intellij.modules.lsp is present (paid JetBrains IDEs,
+  2025.3+). In Community editions the plugin still loads; CDK language features
+  are simply absent. Mirrors aws.toolkit.cloudformation.lsp.xml.
+-->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceImplementation="software.aws.toolkits.jetbrains.settings.CdkLspSettings"/>
+
+        <postStartupActivity implementation="software.aws.toolkits.jetbrains.services.cdklsp.CdkLspStartupActivity"/>
+
+        <platform.lsp.serverSupportProvider
+            implementation="software.aws.toolkits.jetbrains.services.cdklsp.server.CdkLspServerSupportProvider"/>
+
+        <!-- CodeLens bridge: the platform LSP API does not surface codeLens. A
+             frontend codeVisionProvider (not daemon-bound) lets us recompute the
+             lenses on demand via CodeVisionHost.invalidateProvider after the
+             auto-synth toggle, without requiring an editor edit. -->
+        <codeInsight.codeVisionProvider
+            implementation="software.aws.toolkits.jetbrains.services.cdklsp.CdkCodeLensProvider"/>
+
+        <notificationGroup id="aws.cdk.lsp" displayType="STICKY_BALLOON"/>
+    </extensions>
+</idea-plugin>

--- a/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
+++ b/plugins/toolkit/jetbrains-core/resources/META-INF/plugin.xml
@@ -110,6 +110,7 @@
     <depends optional="true" config-file="ext-python.xml">com.intellij.modules.python</depends>
     <depends optional="true" config-file="ext-gateway.xml">com.jetbrains.gateway</depends>
     <depends optional="true" config-file="aws.toolkit.cloudformation.lsp.xml">com.intellij.modules.lsp</depends>
+    <depends optional="true" config-file="aws.toolkit.cdk.lsp.xml">com.intellij.modules.lsp</depends>
 
     <xi:include href="services/caws.xml" xpointer="xpointer(/idea-plugin/*)">
         <xi:fallback/>

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/CdkCliResolver.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/CdkCliResolver.kt
@@ -1,0 +1,97 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cdklsp
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.PathEnvironmentVariableUtil
+import com.intellij.execution.util.ExecUtil
+import com.intellij.openapi.util.SystemInfo
+import software.aws.toolkit.core.utils.debug
+import software.aws.toolkit.core.utils.getLogger
+import software.aws.toolkit.core.utils.warn
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** First aws-cdk release that ships `cdk lsp` (aws/aws-cdk-cli#1681, tag aws-cdk@v2.1132.0). */
+internal val MINIMUM_CDK_LSP_VERSION = intArrayOf(2, 1132, 0)
+
+/** The floor rendered for user-facing messages, derived from the single source of truth above. */
+internal val MINIMUM_CDK_LSP_VERSION_STRING = MINIMUM_CDK_LSP_VERSION.joinToString(".")
+
+/** Where the CDK CLI was found (mirrors the VS Code discovery ladder). */
+internal enum class CdkCliSource { SETTING, NODE_MODULES, PATH }
+
+internal data class ResolvedCdkCli(val path: Path, val source: CdkCliSource, val version: String)
+
+/**
+ * Resolves the user's `cdk` CLI for a given CDK app directory, in order:
+ *   1. an explicit configured path (aws.cdk.cliPath),
+ *   2. the app's local node_modules/.bin/cdk (walking up),
+ *   3. `cdk` on PATH.
+ * Only returns a CLI whose version is >= [MINIMUM_CDK_LSP_VERSION]; older or
+ * missing CLIs return null so the caller can prompt to upgrade rather than
+ * spawn a `cdk` that has no `lsp` command. Preferring the project-local CLI
+ * keeps the language server aligned with the version the project synths with.
+ */
+internal object CdkCliResolver {
+    private val LOG = getLogger<CdkCliResolver>()
+    private val binName = if (SystemInfo.isWindows) "cdk.cmd" else "cdk"
+
+    fun resolve(appDir: Path, configuredPath: String?): ResolvedCdkCli? {
+        // 1. Setting override.
+        configuredPath?.takeIf { it.isNotBlank() }?.let {
+            val p = Path.of(it)
+            versionOf(p)?.let { v -> return ResolvedCdkCli(p, CdkCliSource.SETTING, v) }
+            LOG.warn { "aws.cdk.cliPath is set but unusable: $it" }
+        }
+
+        // 2. Workspace-local node_modules/.bin/cdk, walking up from the app dir.
+        findInNodeModules(appDir)?.let { p ->
+            versionOf(p)?.let { v -> return ResolvedCdkCli(p, CdkCliSource.NODE_MODULES, v) }
+        }
+
+        // 3. PATH (IDE resolves the login-shell PATH natively via this API).
+        PathEnvironmentVariableUtil.findAllExeFilesInPath("cdk")
+            .asSequence()
+            .map { it.toPath() }
+            .firstNotNullOfOrNull { p -> versionOf(p)?.let { v -> ResolvedCdkCli(p, CdkCliSource.PATH, v) } }
+            ?.let { return it }
+
+        return null
+    }
+
+    private fun findInNodeModules(appDir: Path): Path? {
+        var dir: Path? = appDir
+        while (dir != null) {
+            val candidate = dir.resolve("node_modules").resolve(".bin").resolve(binName)
+            if (Files.isRegularFile(candidate) && Files.isExecutable(candidate)) return candidate
+            dir = dir.parent
+        }
+        return null
+    }
+
+    /** Returns the parsed version string if `<cdk> --version` reports >= the floor, else null. */
+    private fun versionOf(cdk: Path): String? {
+        if (!Files.isRegularFile(cdk) || !Files.isExecutable(cdk)) return null
+        return try {
+            val out = ExecUtil.execAndGetOutput(GeneralCommandLine(cdk.toString(), "--version"), 5000)
+            if (out.exitCode != 0) return null
+            val version = Regex("""(\d+)\.(\d+)\.(\d+)""").find(out.stdout)?.value ?: return null
+            if (meetsMinimum(version)) version else null
+        } catch (e: Exception) {
+            LOG.debug(e) { "Failed to probe cdk version at $cdk" }
+            null
+        }
+    }
+
+    private fun meetsMinimum(version: String): Boolean {
+        val parts = version.split(".").map { it.toIntOrNull() ?: 0 }
+        for (i in 0..2) {
+            val a = parts.getOrElse(i) { 0 }
+            val b = MINIMUM_CDK_LSP_VERSION[i]
+            if (a != b) return a > b
+        }
+        return true
+    }
+}

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/CdkCodeLensProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/CdkCodeLensProvider.kt
@@ -1,0 +1,211 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cdklsp
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.intellij.codeInsight.codeVision.CodeVisionAnchorKind
+import com.intellij.codeInsight.codeVision.CodeVisionHost
+import com.intellij.codeInsight.codeVision.CodeVisionProvider
+import com.intellij.codeInsight.codeVision.CodeVisionRelativeOrdering
+import com.intellij.codeInsight.codeVision.CodeVisionState
+import com.intellij.codeInsight.codeVision.ui.model.ClickableTextCodeVisionEntry
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.platform.lsp.api.LspServerManager
+import com.intellij.platform.lsp.api.LspServerState
+import org.eclipse.lsp4j.CodeLensParams
+import org.eclipse.lsp4j.Command
+import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import software.aws.toolkit.core.utils.getLogger
+import software.aws.toolkit.core.utils.info
+import software.aws.toolkit.core.utils.warn
+import software.aws.toolkits.jetbrains.services.cdklsp.server.CdkLspServerSupportProvider
+import java.util.concurrent.TimeUnit
+
+/**
+ * Bridges the CDK language server's `textDocument/codeLens` into IntelliJ
+ * CodeVision, because the platform LSP API does not surface codeLens.
+ *
+ * Implemented as a frontend [CodeVisionProvider] (not DaemonBound) so its lenses
+ * can be recomputed on demand via `CodeVisionHost.invalidateProvider` after a
+ * server-state change (the auto-synth toggle) without requiring an editor edit.
+ * A DaemonBound provider caches against the PSI modification stamp, which a
+ * server-side toggle doesn't change, so its label would stay stale until an edit.
+ *
+ * Flow: fetch the server's codeLenses for the file (off the EDT) and render each
+ * as a clickable CodeVision entry. The `cdkExplorer.openResource` lens is handled
+ * client-side (navigate to the synthesized-template location); the auto-synth
+ * lenses round-trip to the server via workspace/executeCommand.
+ */
+internal class CdkCodeLensProvider : CodeVisionProvider<VirtualFile?> {
+    override val name: String get() = "AWS CDK resources"
+    override val id: String get() = "aws.cdk.codeLens"
+    override val groupId: String get() = id
+    override val relativeOrderings: List<CodeVisionRelativeOrdering> get() = emptyList()
+    override val defaultAnchor: CodeVisionAnchorKind get() = CodeVisionAnchorKind.Top
+
+    // Runs on the UI thread: cheaply capture the file for the background compute.
+    override fun precomputeOnUiThread(editor: Editor): VirtualFile? =
+        FileDocumentManager.getInstance().getFile(editor.document)
+
+    override fun computeCodeVision(editor: Editor, uiData: VirtualFile?): CodeVisionState {
+        val project = editor.project ?: return CodeVisionState.READY_EMPTY
+        val vFile = uiData ?: return CodeVisionState.READY_EMPTY
+
+        val server = LspServerManager.getInstance(project)
+            .getServersForProvider(CdkLspServerSupportProvider::class.java)
+            .firstOrNull() ?: return CodeVisionState.READY_EMPTY
+
+        // The server object exists before its lsp4j connection is initialized.
+        // Issuing a request too early throws UninitializedPropertyAccessException
+        // (lsp4jServerConnector). Only ask once it's fully connected.
+        if (server.state != LspServerState.Running) return CodeVisionState.READY_EMPTY
+
+        val uri = server.descriptor.getFileUri(vFile)
+        val lenses = try {
+            // Round-trip a standard lsp4j request through the running server.
+            val future = java.util.concurrent.CompletableFuture<List<org.eclipse.lsp4j.CodeLens>?>()
+            server.sendNotification { lsp ->
+                lsp.textDocumentService.codeLens(CodeLensParams(TextDocumentIdentifier(uri)))
+                    .whenComplete { result, error ->
+                        if (error != null) future.completeExceptionally(error) else future.complete(result)
+                    }
+            }
+            future.get(2, TimeUnit.SECONDS).orEmpty()
+        } catch (e: Exception) {
+            LOG.warn(e) { "Failed to fetch CDK codeLenses for $uri" }
+            return CodeVisionState.READY_EMPTY
+        }
+
+        val doc = editor.document
+        val entries = lenses.mapNotNull { lens ->
+            val command = lens.command ?: return@mapNotNull null
+            // LSP ranges can be stale relative to the (possibly edited) document.
+            // Skip anything out of bounds rather than throwing out of the whole pass.
+            val startLine = lens.range.start.line
+            val endLine = lens.range.end.line
+            if (startLine !in 0 until doc.lineCount || endLine !in 0 until doc.lineCount) {
+                return@mapNotNull null
+            }
+            val start = (doc.getLineStartOffset(startLine) + lens.range.start.character).coerceIn(0, doc.textLength)
+            val end = (doc.getLineStartOffset(endLine) + lens.range.end.character).coerceIn(start, doc.textLength)
+            val entry = ClickableTextCodeVisionEntry(
+                text = command.title,
+                providerId = id,
+                onClick = { _, clickEditor -> onLensClick(project, command, clickEditor) }
+            )
+            TextRange(start, end) to entry
+        }
+        return CodeVisionState.Ready(entries)
+    }
+
+    /** Route a lens click: openResource navigates client-side; other commands are server executeCommands. */
+    private fun onLensClick(project: Project, command: Command, editor: Editor) {
+        LOG.info { "CDK CodeLens clicked: ${command.command}" }
+        if (command.command == OPEN_RESOURCE_COMMAND) {
+            onOpenResource(project, command.arguments)
+        } else {
+            executeServerCommand(project, command, editor)
+        }
+    }
+
+    /** Forward a server command (synthNow / enable/disableAutoSynth) via workspace/executeCommand. */
+    private fun executeServerCommand(project: Project, command: Command, editor: Editor) {
+        val server = LspServerManager.getInstance(project)
+            .getServersForProvider(CdkLspServerSupportProvider::class.java)
+            .firstOrNull() ?: return
+        if (server.state != LspServerState.Running) {
+            LOG.info { "CDK LSP not running; skipping command ${command.command}" }
+            return
+        }
+        LOG.info { "Forwarding CDK LSP executeCommand: ${command.command}" }
+        server.sendNotification { lsp ->
+            lsp.workspaceService.executeCommand(ExecuteCommandParams(command.command, command.arguments.orEmpty()))
+                .whenComplete { _, _ ->
+                    // The command toggled server-side state (e.g. auto-synth on/off).
+                    // Recompute this provider's lenses so the enable<->disable label
+                    // updates without an edit. A daemon restart won't do it: CodeVision
+                    // caches entries against the (unchanged) PSI modification stamp, so
+                    // invalidateProvider is the API that forces the re-query.
+                    ApplicationManager.getApplication().invokeLater {
+                        project.service<CodeVisionHost>()
+                            .invalidateProvider(CodeVisionHost.LensInvalidateSignal(editor, listOf(id)))
+                    }
+                }
+        }
+    }
+
+    /** Client-side handler for `cdkExplorer.openResource`: navigate to the chosen target. */
+    private fun onOpenResource(project: Project, arguments: List<Any?>?) {
+        val choices = parseChoices(arguments)
+        when {
+            choices.isEmpty() -> return
+            choices.size == 1 -> navigate(project, choices.first())
+            else -> JBPopupFactory.getInstance()
+                .createPopupChooserBuilder(choices)
+                .setTitle("Open resource in synthesized template")
+                .setItemChosenCallback { navigate(project, it) }
+                .createPopup()
+                .showInFocusCenter()
+        }
+    }
+
+    private fun navigate(project: Project, choice: ResourceChoice) {
+        val vFile = VirtualFileManager.getInstance().findFileByUrl(choice.uri) ?: return
+        OpenFileDescriptor(project, vFile, choice.line, choice.character).navigate(true)
+    }
+
+    private data class ResourceChoice(val label: String, val description: String, val uri: String, val line: Int, val character: Int) {
+        // Rendered in the chooser popup.
+        override fun toString(): String = if (description.isBlank()) label else "$label  \u2014  $description"
+    }
+
+    /**
+     * The server sends `arguments: [ [ { label, description, target: { uri, range:{start:{line,character}} } } ] ]`.
+     * lsp4j hands these back as gson JsonElements.
+     */
+    private fun parseChoices(arguments: List<Any?>?): List<ResourceChoice> {
+        val first = arguments?.firstOrNull() as? JsonElement ?: return emptyList()
+        val array = when {
+            first.isJsonArray -> first.asJsonArray
+            else -> return emptyList()
+        }
+        return array.mapNotNull { el ->
+            val obj = el as? JsonObject ?: return@mapNotNull null
+            val target = obj.getAsJsonObject("target") ?: return@mapNotNull null
+            val start = target.getAsJsonObject("range")?.getAsJsonObject("start") ?: return@mapNotNull null
+            ResourceChoice(
+                label = obj.primitiveString("label").orEmpty(),
+                description = obj.primitiveString("description").orEmpty(),
+                uri = target.primitiveString("uri") ?: return@mapNotNull null,
+                line = start.primitiveInt("line") ?: 0,
+                character = start.primitiveInt("character") ?: 0
+            )
+        }
+    }
+
+    // gson `.asString`/`.asInt` throw on JsonNull or non-primitives; guard first.
+    private fun JsonObject.primitiveString(name: String): String? =
+        get(name)?.takeIf { it.isJsonPrimitive }?.asString
+
+    private fun JsonObject.primitiveInt(name: String): Int? =
+        get(name)?.takeIf { it.isJsonPrimitive }?.asInt
+
+    companion object {
+        private val LOG = getLogger<CdkCodeLensProvider>()
+
+        // The one lens command handled client-side; everything else round-trips to the server.
+        private const val OPEN_RESOURCE_COMMAND = "cdkExplorer.openResource"
+    }
+}

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/CdkLspStartupActivity.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/CdkLspStartupActivity.kt
@@ -1,0 +1,29 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cdklsp
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.platform.lsp.api.LspServerManager
+import software.aws.toolkits.jetbrains.services.cdklsp.server.CdkLspServerSupportProvider
+import software.aws.toolkits.jetbrains.settings.CdkLspSettingsChangeListener
+
+/**
+ * Restarts the CDK language server when aws.cdk.cliPath / aws.cdk.appDir change,
+ * so a new CLI or app dir takes effect without an IDE restart.
+ */
+internal class CdkLspStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        ApplicationManager.getApplication().messageBus
+            .connect(project)
+            .subscribe(
+                CdkLspSettingsChangeListener.TOPIC,
+                CdkLspSettingsChangeListener {
+                    LspServerManager.getInstance(project)
+                        .stopAndRestartIfNeeded(CdkLspServerSupportProvider::class.java)
+                }
+            )
+    }
+}

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/server/CdkLspClient.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/server/CdkLspClient.kt
@@ -1,0 +1,18 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cdklsp.server
+
+import com.intellij.platform.lsp.api.Lsp4jClient
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
+
+/**
+ * Minimal LSP client. The `cdk lsp` server advertises hover, definition, and
+ * diagnostics (auto-wired by the platform LSP API) plus codeLens. The platform
+ * API does not surface codeLens, so the open-resource lens is handled by
+ * CdkCodeLensProvider (fetches lenses from this server, navigates on click). No
+ * custom server->client notifications are needed today.
+ */
+internal class CdkLspClient(
+    handler: LspServerNotificationsHandler,
+) : Lsp4jClient(handler)

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/server/CdkLspServerSupportProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cdklsp/server/CdkLspServerSupportProvider.kt
@@ -1,0 +1,117 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.cdklsp.server
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.lsp.api.Lsp4jClient
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
+import com.intellij.platform.lsp.api.LspServerSupportProvider
+import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import org.eclipse.lsp4j.services.LanguageServer
+import software.aws.toolkit.core.utils.getLogger
+import software.aws.toolkit.core.utils.info
+import software.aws.toolkits.jetbrains.services.cdklsp.CdkCliResolver
+import software.aws.toolkits.jetbrains.services.cdklsp.MINIMUM_CDK_LSP_VERSION_STRING
+import software.aws.toolkits.jetbrains.settings.CdkLspSettings
+import java.nio.file.Path
+
+// Source files the server links (ts/py/java) plus synthesized templates for
+// template -> construct go-to-definition. Matches the VS Code documentSelector.
+private val CDK_SOURCE_EXTENSIONS = setOf("ts", "py", "java")
+
+private fun VirtualFile.isCdkRelevant(): Boolean =
+    extension?.lowercase() in CDK_SOURCE_EXTENSIONS || name.endsWith(".template.json")
+
+// CdkLspServerSupportProvider must not be moved/renamed if referenced by class name.
+internal class CdkLspServerSupportProvider : LspServerSupportProvider {
+    override fun fileOpened(
+        project: Project,
+        file: VirtualFile,
+        serverStarter: LspServerSupportProvider.LspServerStarter,
+    ) {
+        if (ApplicationManager.getApplication().isUnitTestMode) return
+        // Gate: only start where there's a CDK app and the file is source/template.
+        if (file.isCdkRelevant() && findCdkAppDir(project) != null) {
+            serverStarter.ensureServerStarted(CdkLspServerDescriptor.getInstance(project))
+        }
+    }
+}
+
+class CdkLspServerDescriptor private constructor(project: Project) :
+    ProjectWideLspServerDescriptor(project, "AWS CDK") {
+
+    // Resolved once per (re)start in createCommandLine and reused by
+    // createInitializationOptions, so both agree and a settings-change restart
+    // re-resolves. createCommandLine always runs before the init options.
+    private var currentAppDir: Path? = null
+
+    override val lsp4jServerClass: Class<out LanguageServer> = LanguageServer::class.java
+
+    override fun isSupportedFile(file: VirtualFile) = file.isCdkRelevant()
+
+    override fun createLsp4jClient(handler: LspServerNotificationsHandler): Lsp4jClient = CdkLspClient(handler)
+
+    override fun createCommandLine(): GeneralCommandLine {
+        val appDir = findCdkAppDir(project) ?: error("No CDK app (cdk.json) found in project")
+        currentAppDir = appDir
+
+        // Settings changes (cliPath/appDir) restart the server via CdkLspStartupActivity.
+        val resolved = CdkCliResolver.resolve(appDir, configuredPath = CdkLspSettings.getInstance().cliPath)
+        if (resolved == null) {
+            notifyUpgrade(project)
+            error("No AWS CDK CLI >= $MINIMUM_CDK_LSP_VERSION_STRING found for CDK language features")
+        }
+
+        LOG.info { "Starting `cdk lsp` for $appDir (cdk ${resolved.version} via ${resolved.source})" }
+        // `cdk lsp` speaks LSP over stdio and logs to stderr; no transport flag needed.
+        return GeneralCommandLine(resolved.path.toString(), "lsp").withWorkDirectory(appDir.toString())
+    }
+
+    // The server reads its app dir from this option (parity with the VS Code client).
+    override fun createInitializationOptions(): Any = mapOf("applicationDir" to currentAppDir?.toString())
+
+    private fun notifyUpgrade(project: Project) {
+        com.intellij.notification.Notification(
+            "aws.cdk.lsp",
+            "AWS CDK",
+            "CDK language features need the AWS CDK CLI >= $MINIMUM_CDK_LSP_VERSION_STRING. Upgrade the CLI or set aws.cdk.cliPath.",
+            NotificationType.WARNING
+        ).notify(project)
+    }
+
+    companion object {
+        private val LOG = getLogger<CdkLspServerDescriptor>()
+        private val instances = mutableMapOf<Project, CdkLspServerDescriptor>()
+
+        fun getInstance(project: Project): CdkLspServerDescriptor =
+            instances.getOrPut(project) { CdkLspServerDescriptor(project) }
+    }
+}
+
+/**
+ * Locate the CDK app directory (the folder containing cdk.json). The
+ * aws.cdk.appDir setting takes precedence; otherwise the lowest-path cdk.json
+ * wins so the pick is deterministic when a workspace has several apps.
+ */
+private fun findCdkAppDir(project: Project): Path? {
+    // Explicit override wins.
+    CdkLspSettings.getInstance().appDir.takeIf { it.isNotBlank() }?.let { return Path.of(it) }
+
+    // FilenameIndex requires a read action and ready indexes. createCommandLine
+    // runs on a pooled thread during startup (possibly dumb mode), so query in
+    // smart mode under a read lock. Deterministic pick (lowest path); node_modules ignored.
+    val cdkJson = DumbService.getInstance(project).runReadActionInSmartMode<VirtualFile?> {
+        FilenameIndex.getVirtualFilesByName("cdk.json", GlobalSearchScope.projectScope(project))
+            .filter { !it.path.contains("/node_modules/") }
+            .minByOrNull { it.path }
+    } ?: return null
+    return cdkJson.parent?.toNioPath()
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/CdkLspSettings.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/settings/CdkLspSettings.kt
@@ -1,0 +1,55 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.RoamingType
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+import com.intellij.util.messages.Topic
+
+fun interface CdkLspSettingsChangeListener {
+    fun settingsChanged()
+
+    companion object {
+        val TOPIC = Topic.create("CDK LSP Settings Changed", CdkLspSettingsChangeListener::class.java)
+    }
+}
+
+@Service
+@State(name = "cdkLspSettings", storages = [Storage("awsToolkit.xml", roamingType = RoamingType.DISABLED)])
+internal class CdkLspSettings : PersistentStateComponent<CdkLspSettings.State> {
+    private var state = State()
+
+    override fun getState(): State = state
+    override fun loadState(state: State) { this.state = state }
+
+    fun notifySettingsChanged() {
+        ApplicationManager.getApplication().messageBus
+            .syncPublisher(CdkLspSettingsChangeListener.TOPIC)
+            .settingsChanged()
+    }
+
+    /** Absolute path to the `cdk` CLI. Empty = auto-discover (node_modules, then PATH). */
+    var cliPath: String
+        get() = state.cliPath
+        set(value) { state.cliPath = value }
+
+    /** Directory of the CDK app (folder with cdk.json). Empty = auto-detect. */
+    var appDir: String
+        get() = state.appDir
+        set(value) { state.appDir = value }
+
+    data class State(
+        var cliPath: String = "",
+        var appDir: String = "",
+    )
+
+    companion object {
+        fun getInstance(): CdkLspSettings = service()
+    }
+}


### PR DESCRIPTION
Adds the AWS CDK Language Server (cdk lsp, GA in aws-cdk 2.1132.0) to the JetBrains toolkit, following the CloudFormation LSP integration. Paid IDEs, 2025.3+ (gated on com.intellij.modules.lsp).

**Features**

- Discovers the user's cdk CLI via a ladder: aws.cdk.cliPath setting → the app's node_modules/.bin/cdk → cdk on PATH. Version-probes and only starts for >= 2.1132.0, otherwise prompts to upgrade.
- Runs cdk lsp over stdio through the platform LSP API, gated on finding a cdk.json.
- Diagnostics (policy-validation squiggles), hover (resolved CFN properties), and go-to-definition from a synthesized *.template.json back to construct source.
- CodeLenses on constructs: open-resource navigation into the template, plus an auto-synth toggle.

**Design decisions**

- CodeLens is a frontend CodeVisionProvider, not DaemonBound. The platform LSP API does not surface codeLens, so a CodeVision bridge fetches the server's lenses. A DaemonBound provider caches against the PSI modification stamp, which a server-state change (the auto-synth toggle) does not bump, so the label would stay stale until an edit. A frontend provider is recomputed on demand with CodeVisionHost.invalidateProvider, which is how the toggle refreshes.
- Single server per project, discovered not bundled, so the language server matches the version the project synths with.
- Startup stays off the UI thread; the CLI resolution that touches indexes runs under a read action in smart mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
