### PR TITLE
build(262): enable jetbrains-rider for 2026.2 GA

### DIFF
--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -152,14 +152,11 @@ object IdeVersions {
                 )
             ),
             rider = RiderProfile(
-                // Rider 2026.2 is still pre-release (RC1) with a closed-source backend API that shifted; the
-                // jetbrains-rider module is excluded from the 2026.2 build in settings.gradle.kts, so this entry
-                // is currently unused. Re-enable the module and switch to "2026.2" / "2026.2.0" once Rider GAs.
-                sdkVersion = "2026.2-RC1-SNAPSHOT",
+                sdkVersion = "2026.2",
                 bundledPlugins = commonPlugins,
                 netFrameworkTarget = "net472",
-                rdGenVersion = "2026.2.4",
-                nugetVersion = "2026.2.0-eap06"
+                rdGenVersion = "2026.2.5",
+                nugetVersion = "2026.2.0"
             )
         )
     ).associateBy { it.name }

--- a/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-intellij-subplugin.gradle.kts
@@ -92,7 +92,23 @@ configurations {
                 exclude(group = "bundledPlugin", module = "org.jetbrains.idea.maven")
                 exclude(group = "bundledPlugin", module = "com.intellij.gradle")
                 exclude(group = "bundledPlugin", module = "com.intellij.properties")
-                exclude(group = "bundledModule")
+                // jcef became a bundled plugin the community/ultimate profiles depend on (2026.2); it leaks
+                // transitively via jetbrains-community testFixtures and can't resolve as IU against the RD/GW SDK
+                exclude(group = "bundledPlugin", module = "com.intellij.modules.jcef")
+                if (project.name.contains("jetbrains-rider")) {
+                    // Rider needs its own RD-flavored bundled modules (declared in its build.gradle.kts for 2026.2)
+                    // on the test classpath, so we can't blanket-exclude the group. Instead drop only the modules
+                    // that leak transitively from jetbrains-community/-core and resolve with IU coordinates.
+                    listOf(
+                        "intellij.platform.collaborationTools",
+                        "intellij.platform.collaborationTools.auth",
+                        "intellij.platform.collaborationTools.auth.base",
+                        "intellij.platform.vcs.dvcs.impl",
+                        "intellij.libraries.microba",
+                    ).forEach { exclude(group = "bundledModule", module = it) }
+                } else {
+                    exclude(group = "bundledModule")
+                }
             }
         }
     }

--- a/plugins/toolkit/jetbrains-rider/build.gradle.kts
+++ b/plugins/toolkit/jetbrains-rider/build.gradle.kts
@@ -78,6 +78,16 @@ dependencies {
             "2025.1, 2025.3" -> {
                 bundledModule("intellij.rider")
             }
+            // 2026.2 split the Rider backend/rd-client APIs (Solution/workspace model, LifetimedProjectComponent,
+            // RdDispatcher, CSharpLanguage, project-model extensions) into productModuleV2 modules that are no longer
+            // on the default compile classpath, so declare them explicitly. Symbols are unchanged from 2026.1.
+            "2026.2" -> {
+                bundledModule("intellij.rider")
+                bundledModule("intellij.rider.rdclient.dotnet")
+                bundledModule("intellij.rider.languages")
+                bundledModule("intellij.rd.client")
+                bundledModule("intellij.rd.client.base")
+            }
         }
     }
 

--- a/plugins/toolkit/jetbrains-rider/it-243-261/software/aws/toolkits/jetbrains/utils/GoldFile.kt
+++ b/plugins/toolkit/jetbrains-rider/it-243-261/software/aws/toolkits/jetbrains/utils/GoldFile.kt
@@ -1,0 +1,10 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.utils
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.rider.projectView.solutionDirectory
+
+// Pre-2026.2: debugProgramAfterAttach's gold-file parameter is a java.io.File.
+internal fun goldFile(project: Project, name: String) = project.solutionDirectory.resolve(name)

--- a/plugins/toolkit/jetbrains-rider/it-262+/software/aws/toolkits/jetbrains/utils/GoldFile.kt
+++ b/plugins/toolkit/jetbrains-rider/it-262+/software/aws/toolkits/jetbrains/utils/GoldFile.kt
@@ -1,0 +1,10 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.utils
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.rider.projectView.solutionDirectoryPath
+
+// 2026.2+: debugProgramAfterAttach's gold-file parameter is a java.nio.file.Path (was java.io.File before).
+internal fun goldFile(project: Project, name: String) = project.solutionDirectoryPath.resolve(name)

--- a/plugins/toolkit/jetbrains-rider/it/software/aws/toolkits/jetbrains/utils/RiderTestUtils.kt
+++ b/plugins/toolkit/jetbrains-rider/it/software/aws/toolkits/jetbrains/utils/RiderTestUtils.kt
@@ -18,7 +18,6 @@ import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.XDebuggerManager
 import com.intellij.xdebugger.XDebuggerManagerListener
 import com.jetbrains.rdclient.util.idea.waitAndPump
-import com.jetbrains.rider.projectView.solutionDirectory
 import com.jetbrains.rider.test.scriptingApi.DebugTestExecutionContext
 import com.jetbrains.rider.test.scriptingApi.debugProgramAfterAttach
 import com.jetbrains.rider.test.scriptingApi.dumpFullCurrentData
@@ -103,7 +102,8 @@ fun executeRunConfigurationAndWaitRider(runConfiguration: RunConfiguration, exec
         resumeSession()
     }
 
-    debugProgramAfterAttach(session.get(), runConfiguration.project.solutionDirectory.resolve("expected.gold"), waitAndTest, true)
+    // goldFile() is version-split: debugProgramAfterAttach's gold-file param is File pre-262, Path in 262+
+    debugProgramAfterAttach(session.get(), goldFile(runConfiguration.project, "expected.gold"), waitAndTest, true)
 
     return executionFuture.get()
 }

--- a/plugins/toolkit/jetbrains-rider/tst-243-261/base/SolutionFunctionFile.kt
+++ b/plugins/toolkit/jetbrains-rider/tst-243-261/base/SolutionFunctionFile.kt
@@ -1,0 +1,12 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package base
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.rider.projectView.solutionDirectory
+import com.jetbrains.rider.test.scriptingApi.getVirtualFileFromPath
+
+// Pre-2026.2: getVirtualFileFromPath's base-dir parameter is a java.io.File, which is what solutionDirectory returns.
+internal fun solutionFunctionFile(project: Project) =
+    getVirtualFileFromPath("src/HelloWorld/Function.cs", project.solutionDirectory)

--- a/plugins/toolkit/jetbrains-rider/tst-262+/base/SolutionFunctionFile.kt
+++ b/plugins/toolkit/jetbrains-rider/tst-262+/base/SolutionFunctionFile.kt
@@ -1,0 +1,12 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package base
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.rider.projectView.solutionDirectoryPath
+import com.jetbrains.rider.test.scriptingApi.getVirtualFileFromPath
+
+// 2026.2+: getVirtualFileFromPath's base-dir parameter is a java.nio.file.Path (was java.io.File before).
+internal fun solutionFunctionFile(project: Project) =
+    getVirtualFileFromPath("src/HelloWorld/Function.cs", project.solutionDirectoryPath)

--- a/plugins/toolkit/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
+++ b/plugins/toolkit/jetbrains-rider/tst/base/AwsReuseSolutionTestBase.kt
@@ -3,9 +3,7 @@
 
 package base
 
-import com.jetbrains.rider.projectView.solutionDirectory
 import com.jetbrains.rider.test.debugger.XDebuggerTestHelper
-import com.jetbrains.rider.test.scriptingApi.getVirtualFileFromPath
 /**
  * Base test class that uses the same solution per test class.
  * Solution re-open logic takes time. We can avoid this by using the same solution instance per every test in a class
@@ -20,8 +18,9 @@ abstract class AwsReuseSolutionTestBase : BaseTestWithSolution() {
     // https://github.com/JetBrains/fsharp-support/blob/93ab17493a34a0bc0fd4c70b11adde02f81455c4/rider-fsharp/src/test/kotlin/debugger/AsyncDebuggerTest.kt#L6
     // Unlike our other projects we do not have a document to work with, so there might not be a nice way to do it.
     fun setBreakpoint(line: Int = 15) {
-        // Same as com.jetbrains.rider.test.scriptingApi.toggleBreakpoint, but with the correct base directory
-        XDebuggerTestHelper.toggleBreakpoint(project, getVirtualFileFromPath("src/HelloWorld/Function.cs", project.solutionDirectory), line - 1)
+        // Same as com.jetbrains.rider.test.scriptingApi.toggleBreakpoint, but with the correct base directory.
+        // solutionFunctionFile() is version-split (getVirtualFileFromPath's base-dir param is File pre-262, Path in 262+).
+        XDebuggerTestHelper.toggleBreakpoint(project, solutionFunctionFile(project), line - 1)
     }
 
     override val backendLoadedTimeout = backendStartTimeout

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -176,18 +176,6 @@ file("plugins").listFiles()?.forEach root@ {
                 }
             }
 
-            if (it.name == "jetbrains-rider") {
-                when (providers.gradleProperty("ideProfileName").get()) {
-                    // Rider 2026.2 is still pre-release (RC1) with a closed-source backend API that shifted
-                    // significantly (solution/workspace model, language registration, RdDispatcher, etc.) -
-                    // deferred to a follow-up PR once the API stabilizes at GA. Other 2026.2 flavors (IU/IC)
-                    // already compile cleanly.
-                    "2026.2" -> {
-                        return@forEach
-                    }
-                }
-            }
-
             val projectName = path.joinToString(separator = ":", prefix = ":")
             include(projectName)
             project(projectName).projectDir = it


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Enables the `jetbrains-rider` module for Rider 2026.2, now that it has GA'd (build `262.8665.328`). Rider was excluded from the 2026.2 build when the profile was first added because it was still pre-release (RC1) with an unstable backend API; this re-enables it against the GA SDK. No production/runtime behavior changes — this is build tooling plus test-source compatibility.

**Profile → GA versions** (`IdeVersions.kt`), verified against the public registries:
- `sdkVersion`: `2026.2-RC1-SNAPSHOT` → `2026.2`
- `rdGenVersion`: `2026.2.4` → `2026.2.5` (Maven Central latest release)
- `nugetVersion`: `2026.2.0-eap06` → `2026.2.0` (`JetBrains.Rider.SDK` stable)

**Re-enable the module** (`settings.gradle.kts`): removed the `2026.2` guard that excluded `jetbrains-rider` from the build graph.

**Bundled-module classpath (the bulk of the work)** (`jetbrains-rider/build.gradle.kts`): compiling against 2026.2 initially produced ~55 "unresolved reference" errors (`solution`, `workspace`, `LifetimedProjectComponent`, `RdDispatcher`, `CSharpLanguage`, `IProtocolHost`, project-model extensions, etc.). These symbols are **unchanged** — they still exist at their original FQNs — but 2026.2 split them into `productModuleV2` modules that are no longer on the default compile classpath (same platform modular-split behavior as the existing `intellij.rider` `bundledModule` / `FIX_WHEN_MIN_IS_253` marker, [intellij-platform-gradle-plugin#1774](https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1774)). Declared the required modules explicitly for `2026.2`:
- `intellij.rider`, `intellij.rider.rdclient.dotnet`, `intellij.rider.languages`, `intellij.rd.client`, `intellij.rd.client.base`

**JCEF test-classpath leak** (`toolkit-intellij-subplugin.gradle.kts`): the `com.intellij.modules.jcef` bundled plugin (added to the community/ultimate profiles for 2026.2) leaks transitively into Rider's test classpath via `jetbrains-community` testFixtures and can't resolve as `IU` against the RD SDK. Excluded it for the non-IC modules, and narrowed the previously-blanket `exclude(group = "bundledModule")` so Rider's own RD-flavored modules survive on the test classpath while the genuinely-leaking IC/platform modules (collaborationTools, dvcs, microba) stay excluded.

**One genuine API change** — version-split source dirs: in 2026.2 the base-dir parameter of the Rider test helpers `getVirtualFileFromPath(...)` and `debugProgramAfterAttach(...)` changed from `java.io.File` to `java.nio.file.Path`. Following the repo's existing version-specific source-dir pattern, the two diverging call sites were extracted into small helpers with pre-262 and 262+ implementations:
- `tst-243-261/…/SolutionFunctionFile.kt` (uses `solutionDirectory` → `File`) and `tst-262+/…/SolutionFunctionFile.kt` (uses `solutionDirectoryPath` → `Path`)
- `it-243-261/…/GoldFile.kt` and `it-262+/…/GoldFile.kt` (same split)

The shared test logic stays in the common `tst/` and `it/` dirs.

### Verification
Successfully compiled `:plugin-toolkit:jetbrains-rider` main + test + integration-test source sets locally for 2026.2, 2026.1, and 2025.3:

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
