### PR TITLE
ci: notify on upcoming-version detection with verify result

### DIFF
--- a/.github/workflows/verify-upcoming.yml
+++ b/.github/workflows/verify-upcoming.yml
@@ -1,0 +1,116 @@
+name: Verify against upcoming JetBrains release
+
+# Weekly awareness signal: detects when JetBrains has published an EAP/RC for the NEXT major that we don't
+# support yet, and posts to Slack so the team can plan the migration. Plugin Verifier runs against that
+# upcoming build too, but only to enrich the notification (compatible vs. API breaks) — it never gates the
+# alert. Non-gating, off the release path. No dedup: it re-notifies weekly until we ship support (the probe
+# stops matching once the profile is added), which is the intended persistent nag.
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Mondays 15:00 UTC
+    - cron: "0 15 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-upcoming:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Maximize Build Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          large-packages: false
+
+      # Bootstrap JDK just to run the print tasks (they don't compile anything).
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '21'
+
+      # Derive the latest supported profile and the JDK it needs — no hardcoded version/JDK.
+      - name: Resolve latest profile and required JDK
+        id: profile
+        run: |
+          LATEST=$(./gradlew -q printLatestProfile | grep -E '^[0-9]{4}\.[0-9]+$' | tail -1)
+          REQUIRED_JDK=$(./gradlew -q printJvmTarget -PideProfileName=$LATEST | grep -Eo '^[0-9]+$' | tail -1)
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "jdk=$REQUIRED_JDK" >> "$GITHUB_OUTPUT"
+          echo "Latest profile: $LATEST (JDK $REQUIRED_JDK)"
+
+      # Re-provision the JDK the latest profile actually needs.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: ${{ steps.profile.outputs.jdk }}
+
+      # Has JetBrains published an EAP/RC for the next major yet? printProductsReleases uses the same upcoming
+      # criteria as the verifyPlugin select{} block (both under -PverifyUpcoming); empty output = none yet.
+      # Detection — not verification result — is what drives the notification.
+      - name: Detect upcoming EAP/RC releases
+        id: upcoming
+        run: |
+          RELEASES=$(./gradlew -q -PideProfileName=${{ steps.profile.outputs.latest }} -PverifyUpcoming \
+            :plugin-toolkit:intellij-standalone:printProductsReleases --console plain \
+            | grep -E '^IU-' || true)
+          if [ -z "$RELEASES" ]; then
+            echo "No upcoming EAP/RC published yet — nothing to notify. Neutral no-op."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Upcoming release(s) detected:"
+            echo "$RELEASES"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "releases=$(echo "$RELEASES" | paste -sd ', ' -)" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Verify against the upcoming build to learn whether it breaks APIs we call. continue-on-error so a
+      # break (or a verification error) does NOT fail the job — the notification must fire either way.
+      # -x buildSearchableOptions keeps it off the JBR/JCEF path (Verifier is static bytecode analysis).
+      - name: Verify plugin against upcoming EAP/RC
+        id: verify
+        if: steps.upcoming.outputs.found == 'true'
+        continue-on-error: true
+        run: |
+          ./gradlew -PideProfileName=${{ steps.profile.outputs.latest }} -PverifyUpcoming \
+            :plugin-toolkit:intellij-standalone:verifyPlugin \
+            -x buildSearchableOptions --console plain
+
+      - name: Upload verifier reports
+        if: steps.upcoming.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-verifier-report
+          path: plugins/toolkit/intellij-standalone/build/reports/pluginVerifier/**
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # Build the awareness message. Fires whenever an upcoming release is detected, regardless of the verify
+      # result; the verify outcome only changes the wording (compatible / problems-found).
+      - name: Compose Slack message
+        id: compose
+        if: steps.upcoming.outputs.found == 'true'
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          RELEASES="${{ steps.upcoming.outputs.releases }}"
+          if [ "${{ steps.verify.outcome }}" = "success" ]; then
+            STATUS="the current build is bytecode-compatible (likely a low-effort migration) — but we still need to add the profile and publish support."
+          else
+            STATUS="Plugin Verifier reported problems (API break or verification error) — migration likely needed. See the run for the report."
+          fi
+          echo "message=:jetbrains: Upcoming JetBrains release detected that AWS Toolkit does not support yet: ${RELEASES} (built against ${{ steps.profile.outputs.latest }}). ${STATUS} ${RUN_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack
+        if: steps.upcoming.outputs.found == 'true'
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "message": "${{ steps.compose.outputs.message }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ON_DUTY_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: WEBHOOK_TRIGGER

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@
 import org.jetbrains.gradle.ext.ProjectSettings
 import org.jetbrains.gradle.ext.TaskTriggersConfig
 import software.aws.toolkits.gradle.changelog.tasks.GenerateGithubChangeLog
+import software.aws.toolkits.gradle.intellij.IdeVersions
 import software.aws.toolkits.gradle.jvmTarget
 
 plugins {
@@ -54,6 +55,14 @@ tasks.register("printJvmTarget") {
     val target = project.jvmTarget()
     doLast {
         println(target.get().majorVersion)
+    }
+}
+
+// Prints the latest supported IDE profile (e.g. "2026.2") so CI can build/verify against it without
+// hardcoding a version.
+tasks.register("printLatestProfile") {
+    doLast {
+        println(IdeVersions.latestProfileName())
     }
 }
 

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -167,6 +167,24 @@ object IdeVersions {
         ideProfiles[it] ?: throw IllegalStateException("Can't find profile for $it")
     }
 
+    // The newest profile we support (by year.minor), i.e. our latest GA target
+    fun latestProfileName(): String = ideProfiles.keys.maxByOrNull { name ->
+        val (year, minor) = name.split(".").map { it.toInt() }
+        year * 10 + minor
+    } ?: error("no IDE profiles defined")
+
+    /**
+     * The next JetBrains marketing version after [latest], following the 3-releases-per-year cadence
+     * (YYYY.1 -> YYYY.2 -> YYYY.3 -> (YYYY+1).1). E.g. "2025.3" -> "2026.1", "2026.2" -> "2026.3".
+     */
+    fun nextProfileName(latest: String = latestProfileName()): String {
+        val (year, minor) = latest.split(".").map { it.toInt() }
+        return if (minor >= 3) "${year + 1}.1" else "$year.${minor + 1}"
+    }
+
+    // Plugin Verifier / SDK build numbers use the branch form (e.g. "263"), not the marketing form ("2026.3").
+    fun upcomingBranchNumber(): String = shortenedIdeProfileName(nextProfileName())
+
     private fun resolveIdeProfileName(providers: ProviderFactory): Provider<String> = providers.gradleProperty("ideProfileName")
 }
 

--- a/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/toolkit-publish-root-conventions.gradle.kts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.intellij.platform.gradle.tasks.PatchPluginXmlTask
 import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware
 import software.aws.toolkits.gradle.intellij.IdeFlavor
+import software.aws.toolkits.gradle.intellij.IdeVersions
 import software.aws.toolkits.gradle.intellij.toolkitIntelliJ
 
 // publish-root should imply publishing-conventions, but we keep separate so that gateway always has the GW flavor
@@ -26,7 +28,30 @@ intellijPlatform {
             // recommended() appears to resolve latest EAP for a product?
             val version = toolkitIntelliJ.version().get()
             create(IntelliJPlatformType.IntellijIdeaUltimate, version)
+
+            // Opt-in (only when -PverifyUpcoming is set, e.g. the scheduled verify-upcoming CI job) so normal
+            // PR/release builds are unaffected. Verifies the current build against the NEXT major's pre-release
+            // builds to catch platform API breaks during the EAP/RC window.
+            if (providers.gradleProperty("verifyUpcoming").isPresent) {
+                select {
+                    types = listOf(IntelliJPlatformType.IntellijIdeaUltimate)
+                    channels = listOf(ProductRelease.Channel.EAP, ProductRelease.Channel.RC)
+                    sinceBuild = IdeVersions.upcomingBranchNumber()
+                    untilBuild = "${IdeVersions.upcomingBranchNumber()}.*"
+                }
+            }
         }
+    }
+}
+
+if (providers.gradleProperty("verifyUpcoming").isPresent) {
+    tasks.named<org.jetbrains.intellij.platform.gradle.tasks.PrintProductsReleasesTask>(
+        org.jetbrains.intellij.platform.gradle.Constants.Tasks.PRINT_PRODUCTS_RELEASES
+    ).configure {
+        types.set(listOf(IntelliJPlatformType.IntellijIdeaUltimate))
+        channels.set(listOf(ProductRelease.Channel.EAP, ProductRelease.Channel.RC))
+        sinceBuild.set(IdeVersions.upcomingBranchNumber())
+        untilBuild.set("${IdeVersions.upcomingBranchNumber()}.*")
     }
 }
 


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Adds a weekly CI job that gives the team early awareness when JetBrains publishes an EAP/RC for the **next** major IDE version that the AWS Toolkit doesn't support yet

Non-gating and entirely off the release path — it never blocks PRs or merges.

### How it works
1. **Detect** — a scheduled job resolves the latest supported profile and asks JetBrains' product feed (via the IntelliJ plugin's `printProductsReleases`) whether an EAP/RC exists for the *next* major. No version is hardcoded: it derives from `IdeVersions` and self-advances as profiles are added.
2. **Verify (enrich, don't gate)** — if an upcoming build exists, Plugin Verifier runs the current plugin against it (`continue-on-error`, so a break never fails the job). The result only changes the notification wording (bytecode-compatible vs. API breaks found).
3. **Notify** — on **detection** (not on failure), it posts to a Slack channel so the team knows a new version is coming and what the compatibility status is.

### Verification
- buildSrc compiles; version math verified across all cadence boundaries (`UPCOMING_BRANCH=263` for latest `2026.2`).
- `-PverifyUpcoming` config resolves cleanly; normal (no-flag) builds unaffected.
- Live probe against the real JetBrains feed: upcoming (`263`) criteria returns empty (no 2026.3 EAP exists yet → neutral skip path), while the current profile returns a real `IU-262.*` — confirming the empty result is genuine filtering, not a broken query.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
