### PR TITLE
ci: add per-product release-maturity radar for latest profile

### DIFF
--- a/.github/workflows/verify-upcoming.yml
+++ b/.github/workflows/verify-upcoming.yml
@@ -13,8 +13,8 @@ name: JetBrains release radar
 on:
   workflow_dispatch: {}
   schedule:
-    # Mondays 15:00 UTC
-    - cron: "0 15 * * 1"
+    # Fridays 12:00 UTC
+    - cron: "0 12 * * 5"
 
 permissions:
   contents: read

--- a/.github/workflows/verify-upcoming.yml
+++ b/.github/workflows/verify-upcoming.yml
@@ -1,10 +1,15 @@
-name: Verify against upcoming JetBrains release
+name: JetBrains release radar
 
-# Weekly awareness signal: detects when JetBrains has published an EAP/RC for the NEXT major that we don't
-# support yet, and posts to Slack so the team can plan the migration. Plugin Verifier runs against that
-# upcoming build too, but only to enrich the notification (compatible vs. API breaks) — it never gates the
-# alert. Non-gating, off the release path. No dedup: it re-notifies weekly until we ship support (the probe
-# stops matching once the profile is added), which is the intended persistent nag.
+# Weekly awareness signals about JetBrains releases, posted to Slack. Two independent jobs:
+#
+#   verify-upcoming    — the NEXT major we don't support yet (e.g. 263 while latest is 262): has an EAP/RC
+#                        appeared? If so, notify + run Plugin Verifier to enrich with compatible/API-break.
+#   latest-maturity    — the major we ALREADY support (e.g. 262): has our pinned build matured to GA? If we
+#                        pin an EAP/RC and JetBrains has since published a higher channel for that branch,
+#                        notify so we bump the pin (EAP -> RC -> GA). Silent once we're on stable.
+#
+# Both are non-gating, off the release path, and use "no dedup" — they re-notify weekly until the state
+# clears (profile added / pin bumped)
 on:
   workflow_dispatch: {}
   schedule:
@@ -101,10 +106,121 @@ jobs:
           else
             STATUS="Plugin Verifier reported problems (API break or verification error) — migration likely needed. See the run for the report."
           fi
-          echo "message=:jetbrains: Upcoming JetBrains release detected that AWS Toolkit does not support yet: ${RELEASES} (built against ${{ steps.profile.outputs.latest }}). ${STATUS} ${RUN_URL}" >> "$GITHUB_OUTPUT"
+          echo "message=[JetBrains] Upcoming JetBrains release detected that AWS Toolkit does not support yet: ${RELEASES} (built against ${{ steps.profile.outputs.latest }}). ${STATUS} ${RUN_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack
         if: steps.upcoming.outputs.found == 'true'
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "message": "${{ steps.compose.outputs.message }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ON_DUTY_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: WEBHOOK_TRIGGER
+
+  # Is the major we already support still pinned to a pre-GA build while JetBrains has moved on? Compares
+  # the channel of our pin (from IdeVersions) against the highest channel published for the same branch in
+  # the JetBrains releases feed. Notifies only when we're pre-GA AND something more mature is available.
+  latest-maturity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Print tasks only — no compile — so the bootstrap JDK is enough; no per-profile JDK needed here.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '21'
+
+      # Our side: the latest profile's branch, its overall (minimum) channel used as a cheap gate, and the
+      # per-product channels used to name exactly which products lag.
+      - name: Resolve our pin
+        id: pin
+        run: |
+          BRANCH=$(./gradlew -q printLatestBranch | grep -E '^[0-9]+$' | tail -1)
+          MIN_CHANNEL=$(./gradlew -q printLatestChannel | grep -E '^(EAP|BETA|RC|STABLE)$' | tail -1)
+          PRODUCTS=$(./gradlew -q printLatestChannelsByProduct | grep -E '^[a-z]+=(EAP|BETA|RC|STABLE)$')
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "min_channel=$MIN_CHANNEL" >> "$GITHUB_OUTPUT"
+          {
+            echo "products<<PRODUCTS_EOF"
+            echo "$PRODUCTS"
+            echo "PRODUCTS_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Branch $BRANCH — overall channel $MIN_CHANNEL; per-product:"
+          echo "$PRODUCTS"
+
+      # Compare EACH product against ITS OWN JetBrains product feed. IDEA Ultimate/Community (IIU/IIC),
+      # Rider (RD), and Gateway (GW) release on independent schedules for the same branch — IDEA reaching GA
+      # does NOT imply Rider's or Gateway's GA exists yet — so each product is measured against its own feed's
+      # highest channel for the branch. A product is "behind" only if our pin is below its own upstream max.
+      # One combined notification lists the laggards. All feeds fetched in a single multi-code request.
+      # The min_channel gate short-circuits when every product is already STABLE (nothing can be higher).
+      - name: Evaluate per-product maturity
+        id: compose
+        if: steps.pin.outputs.min_channel != 'STABLE'
+        run: |
+          BRANCH="${{ steps.pin.outputs.branch }}"
+          rank() { case "$1" in EAP|eap) echo 1;; BETA|beta) echo 2;; RC|rc) echo 3;; STABLE|release) echo 4;; *) echo 0;; esac; }
+          label() { case "$1" in release) echo "GA/stable";; rc) echo "an RC";; beta) echo "a Beta";; *) echo "an EAP";; esac; }
+          # Map our product name to its JetBrains releases-feed product code.
+          feed_code() {
+            case "$1" in
+              ultimate) echo "IIU";;
+              community) echo "IIC";;
+              rider) echo "RD";;
+              gateway) echo "GW";;
+              *) echo "";;
+            esac
+          }
+          # printf (not echo) to round-trip the JSON without mangling embedded control chars.
+          FEED=$(curl -fsSL --max-time 30 \
+            "https://data.services.jetbrains.com/products/releases?code=IIU,IIC,RD,GW&type=eap,beta,rc,release&latest=false")
+
+          BEHIND=""
+          UPTODATE=""
+          while IFS='=' read -r PROD CH; do
+            [ -z "$PROD" ] && continue
+            CODE=$(feed_code "$PROD")
+            if [ -z "$CODE" ]; then
+              # Unknown product -> no feed to compare against; surface it rather than silently dropping.
+              UPTODATE="${UPTODATE:+$UPTODATE, }$PROD ($CH; no feed mapping)"
+              continue
+            fi
+            BEST=$(printf '%s' "$FEED" | jq -r --arg code "$CODE" --arg br "$BRANCH" '
+              (.[$code] // [])
+              | map(select(.build | startswith($br + ".")))
+              | map(. + {rank: ({"eap":1,"beta":2,"rc":3,"release":4}[.type] // 0)})
+              | (max_by(.rank) // {})
+              | "\(.type // "none")\t\(.version // "")"')
+            UP_CH=$(printf '%s' "$BEST" | cut -f1)
+            UP_VER=$(printf '%s' "$BEST" | cut -f2)
+            if [ "$(rank "$CH")" -lt "$(rank "$UP_CH")" ]; then
+              BEHIND="${BEHIND:+$BEHIND; }$PROD (on $CH — $(label "$UP_CH") ${UP_VER} available)"
+            else
+              UPTODATE="${UPTODATE:+$UPTODATE, }$PROD ($CH)"
+            fi
+          done <<'PRODUCTS_EOF'
+          ${{ steps.pin.outputs.products }}
+          PRODUCTS_EOF
+
+          if [ -n "$BEHIND" ]; then
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            MSG="[JetBrains] AWS Toolkit ${BRANCH}: products behind their own JetBrains release channel — ${BEHIND}."
+            [ -n "$UPTODATE" ] && MSG="${MSG} Up to date: ${UPTODATE}."
+            MSG="${MSG} Consider bumping the lagging SDK pins. ${RUN_URL}"
+            echo "notify=true" >> "$GITHUB_OUTPUT"
+            echo "message=${MSG}" >> "$GITHUB_OUTPUT"
+            echo "Behind: $BEHIND | Up to date: ${UPTODATE:-none} — will notify."
+          else
+            echo "notify=false" >> "$GITHUB_OUTPUT"
+            echo "Every product is at or above its own upstream channel — nothing newer, no notification."
+          fi
+
+      - name: Notify Slack
+        if: steps.compose.outputs.notify == 'true'
         uses: slackapi/slack-github-action@v1.23.0
         with:
           payload: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,31 @@ tasks.register("printLatestProfile") {
     }
 }
 
+// Prints the branch number of the latest supported profile (e.g. "262")
+tasks.register("printLatestBranch") {
+    doLast {
+        println(IdeVersions.latestBranchNumber())
+    }
+}
+
+// Prints the release channel (EAP/BETA/RC/STABLE) we're pinned to for the latest supported profile.
+// This is the minimum across products
+tasks.register("printLatestChannel") {
+    doLast {
+        println(IdeVersions.latestProfileChannel().name)
+    }
+}
+
+// Prints one "product=CHANNEL" line per shipped IDE product (ultimate/rider/gateway) for the latest profile
+
+tasks.register("printLatestChannelsByProduct") {
+    doLast {
+        IdeVersions.latestProfileChannelsByProduct().forEach { (product, channel) ->
+            println("$product=${channel.name}")
+        }
+    }
+}
+
 if (idea.project != null) { // may be null during script compilation
     idea {
         project {

--- a/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
+++ b/buildSrc/src/main/kotlin/software/aws/toolkits/gradle/intellij/IdeVersions.kt
@@ -185,7 +185,53 @@ object IdeVersions {
     // Plugin Verifier / SDK build numbers use the branch form (e.g. "263"), not the marketing form ("2026.3").
     fun upcomingBranchNumber(): String = shortenedIdeProfileName(nextProfileName())
 
+    // Branch form of the latest supported profile (e.g. "2026.2" -> "262")
+    fun latestBranchNumber(): String = shortenedIdeProfileName(latestProfileName())
+
+    /**
+     * Per-product release channel for the latest profile's shipped IDE pins, inferred from each SDK
+     * coordinate.
+     */
+    fun latestProfileChannelsByProduct(): List<Pair<String, ReleaseChannel>> {
+        val profile = ideProfiles[latestProfileName()] ?: error("no latest profile defined")
+        // gateway is nullable on Profile (not every profile ships it), so drop it when absent.
+        return listOfNotNull(
+            "rider" to profile.rider,
+            "ultimate" to profile.ultimate,
+            profile.gateway?.let { "gateway" to it },
+        ).map { (product, p) -> product to classifyChannel(p.sdkVersion) }
+    }
+
+    /**
+     * The latest profile's overall maturity — the minimum across its per-product channels
+     */
+    fun latestProfileChannel(): ReleaseChannel =
+        latestProfileChannelsByProduct().minByOrNull { it.second.rank }?.second ?: ReleaseChannel.STABLE
+
     private fun resolveIdeProfileName(providers: ProviderFactory): Provider<String> = providers.gradleProperty("ideProfileName")
+}
+
+/**
+ * IDE release maturity, ordered by [rank]. Ranks are aligned with the `type` values in the JetBrains
+ * releases feed (eap=1, beta=2, rc=3, release=4)
+ */
+enum class ReleaseChannel(val rank: Int) {
+    EAP(1), BETA(2), RC(3), STABLE(4),
+}
+
+/**
+ * Classifies an SDK coordinate string into a [ReleaseChannel].
+ * e.g. "2026.2-SNAPSHOT" (EAP), "2026.2-RC1-SNAPSHOT" (RC), and clean "2026.2" (GA).
+ * RC is checked before EAP because RC snapshots also contain "SNAPSHOT".
+ */
+internal fun classifyChannel(sdkVersion: String): ReleaseChannel {
+    val v = sdkVersion.uppercase()
+    return when {
+        "RC" in v -> ReleaseChannel.RC
+        "BETA" in v -> ReleaseChannel.BETA
+        "EAP" in v || "SNAPSHOT" in v -> ReleaseChannel.EAP
+        else -> ReleaseChannel.STABLE
+    }
 }
 
 open class ProductProfile(

--- a/buildSrc/src/test/kotlin/software/aws/toolkits/gradle/intellij/ReleaseChannelTest.kt
+++ b/buildSrc/src/test/kotlin/software/aws/toolkits/gradle/intellij/ReleaseChannelTest.kt
@@ -1,0 +1,41 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.gradle.intellij
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class ReleaseChannelTest(private val sdkVersion: String, private val expected: ReleaseChannel) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0} -> {1}")
+        fun data(): Collection<Array<Any>> = listOf(
+            // GA / stable — clean marketing strings
+            arrayOf("2026.2", ReleaseChannel.STABLE),
+            arrayOf("2026.2.0.1", ReleaseChannel.STABLE),
+            arrayOf("262.8665.258", ReleaseChannel.STABLE),
+
+            // EAP — snapshot builds
+            arrayOf("2026.2-SNAPSHOT", ReleaseChannel.EAP),
+            arrayOf("2026.3-EAP-SNAPSHOT", ReleaseChannel.EAP),
+            arrayOf("263-EAP-SNAPSHOT", ReleaseChannel.EAP),
+
+            // RC — checked before EAP since RC snapshots also carry "SNAPSHOT"
+            arrayOf("2026.2-RC1-SNAPSHOT", ReleaseChannel.RC),
+            arrayOf("2026.2-RC2", ReleaseChannel.RC),
+
+            // Beta
+            arrayOf("2026.2-BETA", ReleaseChannel.BETA)
+        )
+    }
+
+    @Test
+    fun `classifies SDK coordinate channel`() {
+        assertThat(classifyChannel(sdkVersion)).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
<!--- If you are a new contributor, please take a look at the README and CONTRIBUTING documents --->
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Follow up improvement to https://github.com/aws/aws-toolkit-jetbrains/pull/6414, catching more relevant release cases.

Adds a second job to the scheduled `JetBrains release radar` workflow (`.github/workflows/verify-upcoming.yml`) that watches the major we **already** support and nudges us when our SDK pin lags what JetBrains has published.

The existing `verify-upcoming` job answers "should we start on the *next* major?". This new `latest-maturity` job answers the complementary question: "is our pin for the *current* profile still pre-GA while JetBrains has moved on?" — e.g. we're built against a 2026.2 EAP/RC and an RC or GA is now available for that branch. It's a weekly awareness signal only: non-gating, off the release path, and posts to the same Slack webhook. No dedup — it re-nags weekly until the pin is bumped, at which point it self-clears.

**How it decides (per product, against that product's own feed):**
- Each shipped IDE product for the latest profile (ultimate/rider/gateway) is classified into a channel (EAP < BETA < RC < STABLE) from its `sdkVersion` in `IdeVersions.kt`.
- Each product is compared against **its own** JetBrains releases feed — Ultimate→`IIU`, Rider→`RD`, Gateway→`GW`, Community→`IIC`. This matters because these products release on independent schedules: IDEA reaching GA does **not** mean Rider's/Gateway's GA exists yet, so each is measured against its own upstream max for the branch.
- Notifies (one combined message naming the laggards) iff at least one product is strictly below its own upstream channel. If every product is already STABLE, the job short-circuits before hitting the network.

**Example Slack message:**
> [JetBrains] AWS Toolkit 262: products behind their own JetBrains release channel — ultimate (on RC — GA/stable 2026.2 available). Up to date: rider (RC), gateway (RC). Consider bumping the lagging SDK pins. \<run-url\>

**Changes:**
- `IdeVersions.kt` — `latestProfileChannelsByProduct()` (per-product channel), `latestProfileChannel()` (min, used as the cheap skip-gate), `latestBranchNumber()`, plus the `ReleaseChannel` enum and `classifyChannel()`.
- `build.gradle.kts` — `printLatestBranch`, `printLatestChannel`, `printLatestChannelsByProduct` tasks so the workflow can read these without hardcoding.
- `.github/workflows/verify-upcoming.yml` — new `latest-maturity` job; workflow renamed to "JetBrains release radar" to cover both directions.
- `ReleaseChannelTest.kt` — parameterized unit test for `classifyChannel()` covering the real pin formats (`2026.2-SNAPSHOT`→EAP, `2026.2-RC1-SNAPSHOT`→RC, `2026.2`→STABLE).

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [ ] A short description of the change has been added to the **CHANGELOG** if the change is customer-facing in the IDE. <!-- N/A — CI-only, not customer-facing -->
- [ ] I have added metrics for my changes (if required) <!-- N/A -->
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
