### PR TITLE
Updating SNAPSHOT version to 4.8-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Toolkit Version
-toolkitVersion=4.7-SNAPSHOT
+toolkitVersion=4.8-SNAPSHOT
 
 # Publish Settings
 publishToken=


### PR DESCRIPTION
Manually update the snapshot version since automation failed
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
