### PR TITLE
fix(cfn): Launch LSP with compatible glibc

### DIFF
--- a/.changes/next-release/bugfix-7c1e9a24-3b8d-4f52-9a6c-1e0d5b7f83a2.json
+++ b/.changes/next-release/bugfix-7c1e9a24-3b8d-4f52-9a6c-1e0d5b7f83a2.json
@@ -1,0 +1,4 @@
+{
+  "type" : "bugfix",
+  "description" : "Fixed the CloudFormation Language Server failing to start on Linux hosts whose system glibc is older than 2.28. Node.js is now launched against a compatible glibc runtime when one is available, and a clear compatibility error is shown otherwise instead of repeatedly retrying."
+}

--- a/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
+++ b/plugins/core/resources/resources/software/aws/toolkits/resources/MessagesBundle.properties
@@ -603,6 +603,7 @@ cloudformation.lsp.action.download_node=Download Node.js
 cloudformation.lsp.error.download_failed=Failed to download CloudFormation LSP. Check your network connection.
 cloudformation.lsp.error.extraction_failed=Failed to extract CloudFormation LSP.
 cloudformation.lsp.error.hash_mismatch=Downloaded file integrity check failed. The file may be corrupted.
+cloudformation.lsp.error.incompatible_glibc=The CloudFormation Language Server requires glibc 2.28 or newer, and no compatible runtime was found. Install a compatible glibc runtime or set AWS_TOOLKIT_LSP_GLIBC_DIR to its installation directory.
 cloudformation.lsp.error.manifest_failed=Failed to fetch CloudFormation LSP manifest. Check your network connection.
 cloudformation.lsp.error.no_compatible_version=No compatible CloudFormation LSP version found for your platform.
 cloudformation.lsp.error.node_not_found=Node.js not found. Install or configure Node.js for CloudFormation Language Server.

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
@@ -29,6 +29,7 @@ import software.aws.toolkit.jetbrains.AwsToolkit
 import software.aws.toolkit.jetbrains.settings.AwsSettings
 import software.aws.toolkit.jetbrains.settings.DefaultAwsSettings
 import software.aws.toolkit.jetbrains.utils.notifyError
+import software.aws.toolkits.jetbrains.core.lsp.LinuxGlibcNodeLauncher
 import software.aws.toolkits.jetbrains.core.lsp.LspInstallException
 import software.aws.toolkits.jetbrains.core.lsp.LspProcessLauncher
 import software.aws.toolkits.jetbrains.core.lsp.NodeRuntimeResolver
@@ -41,8 +42,7 @@ import java.nio.file.Path
 
 internal val CFN_SUPPORTED_EXTENSIONS = setOf("yaml", "yml", "json", "template", "cfn", "txt")
 
-private fun VirtualFile.isCfnTemplate(): Boolean =
-    extension?.lowercase() in CFN_SUPPORTED_EXTENSIONS
+private fun VirtualFile.isCfnTemplate(): Boolean = extension?.lowercase() in CFN_SUPPORTED_EXTENSIONS
 
 // CfnLspServerSupportProvider must not be moved/renamed since we are hard-coding its class name
 internal class CfnLspServerSupportProvider : LspServerSupportProvider {
@@ -61,6 +61,7 @@ internal class CfnLspServerSupportProvider : LspServerSupportProvider {
 class CfnLspServerDescriptor private constructor(
     project: Project,
     private val installer: CfnLspInstaller = CfnLspInstaller(),
+    private val glibcLauncher: LinuxGlibcNodeLauncher = LinuxGlibcNodeLauncher(),
 ) : LspProcessLauncher(
     project,
     "AWS CloudFormation",
@@ -103,17 +104,25 @@ class CfnLspServerDescriptor private constructor(
             throw e
         }
 
-        LOG.info { "Starting CloudFormation LSP: node=$nodePath, server=$serverPath" }
+        val launch = try {
+            glibcLauncher.resolveLaunchCommand(nodePath, message("cloudformation.lsp.error.incompatible_glibc"))
+        } catch (e: LspInstallException) {
+            LOG.warn(e) { "No compatible glibc runtime for CloudFormation LSP" }
+            notifyLspError(e)
+            throw e
+        }
 
-        return GeneralCommandLine(nodePath.toString(), serverPath.toString(), "--stdio")
+        LOG.info { "Starting CloudFormation LSP: executable=${launch.command.first()}, server=$serverPath" }
+
+        return GeneralCommandLine(launch.command)
+            .withParameters(serverPath.toString(), "--stdio")
             .withWorkDirectory(serverPath.parent.toString())
     }
 
-    private fun resolveNodeRuntime(): Path =
-        NodeRuntimeResolver.resolve(
-            configuredPath = CfnLspSettings.getInstance().nodeRuntimePath,
-            nodeNotFoundMessage = message("cloudformation.lsp.error.node_not_found"),
-        )
+    private fun resolveNodeRuntime(): Path = NodeRuntimeResolver.resolve(
+        configuredPath = CfnLspSettings.getInstance().nodeRuntimePath,
+        nodeNotFoundMessage = message("cloudformation.lsp.error.node_not_found"),
+    )
 
     private fun notifyLspError(e: LspInstallException) {
         val content = when (e.errorCode) {
@@ -123,6 +132,7 @@ class CfnLspServerDescriptor private constructor(
             LspInstallException.ErrorCode.EXTRACTION_FAILED -> message("cloudformation.lsp.error.extraction_failed")
             LspInstallException.ErrorCode.NODE_NOT_FOUND -> message("cloudformation.lsp.error.node_not_found")
             LspInstallException.ErrorCode.HASH_VERIFICATION_FAILED -> message("cloudformation.lsp.error.hash_mismatch")
+            LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC -> message("cloudformation.lsp.error.incompatible_glibc")
         }
 
         notifyError(

--- a/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
+++ b/plugins/toolkit/jetbrains-core/src-253+/software/aws/toolkits/jetbrains/services/cfnlsp/server/CfnLspServerSupportProvider.kt
@@ -29,7 +29,6 @@ import software.aws.toolkit.jetbrains.AwsToolkit
 import software.aws.toolkit.jetbrains.settings.AwsSettings
 import software.aws.toolkit.jetbrains.settings.DefaultAwsSettings
 import software.aws.toolkit.jetbrains.utils.notifyError
-import software.aws.toolkits.jetbrains.core.lsp.LinuxGlibcNodeLauncher
 import software.aws.toolkits.jetbrains.core.lsp.LspInstallException
 import software.aws.toolkits.jetbrains.core.lsp.LspProcessLauncher
 import software.aws.toolkits.jetbrains.core.lsp.NodeRuntimeResolver
@@ -38,7 +37,6 @@ import software.aws.toolkits.jetbrains.services.cfnlsp.CfnLspServerProtocol
 import software.aws.toolkits.jetbrains.services.cfnlsp.CfnNodePromptState
 import software.aws.toolkits.jetbrains.settings.CfnLspSettings
 import software.aws.toolkits.resources.AwsToolkitBundle.message
-import java.nio.file.Path
 
 internal val CFN_SUPPORTED_EXTENSIONS = setOf("yaml", "yml", "json", "template", "cfn", "txt")
 
@@ -61,7 +59,6 @@ internal class CfnLspServerSupportProvider : LspServerSupportProvider {
 class CfnLspServerDescriptor private constructor(
     project: Project,
     private val installer: CfnLspInstaller = CfnLspInstaller(),
-    private val glibcLauncher: LinuxGlibcNodeLauncher = LinuxGlibcNodeLauncher(),
 ) : LspProcessLauncher(
     project,
     "AWS CloudFormation",
@@ -96,19 +93,16 @@ class CfnLspServerDescriptor private constructor(
             throw e
         }
 
-        val nodePath = try {
-            resolveNodeRuntime()
-        } catch (e: Exception) {
-            LOG.warn(e) { "Failed to resolve Node.js runtime" }
-            notifyNodeError()
-            throw e
-        }
-
         val launch = try {
-            glibcLauncher.resolveLaunchCommand(nodePath, message("cloudformation.lsp.error.incompatible_glibc"))
+            resolveNodeRuntime()
         } catch (e: LspInstallException) {
-            LOG.warn(e) { "No compatible glibc runtime for CloudFormation LSP" }
-            notifyLspError(e)
+            if (e.errorCode == LspInstallException.ErrorCode.NODE_NOT_FOUND) {
+                LOG.warn(e) { "Failed to resolve Node.js runtime" }
+                notifyNodeError()
+            } else {
+                LOG.warn(e) { "No compatible glibc runtime for CloudFormation LSP" }
+                notifyLspError(e)
+            }
             throw e
         }
 
@@ -119,9 +113,10 @@ class CfnLspServerDescriptor private constructor(
             .withWorkDirectory(serverPath.parent.toString())
     }
 
-    private fun resolveNodeRuntime(): Path = NodeRuntimeResolver.resolve(
+    private fun resolveNodeRuntime() = NodeRuntimeResolver.resolveLaunchCommand(
         configuredPath = CfnLspSettings.getInstance().nodeRuntimePath,
         nodeNotFoundMessage = message("cloudformation.lsp.error.node_not_found"),
+        incompatibleGlibcMessage = message("cloudformation.lsp.error.incompatible_glibc"),
     )
 
     private fun notifyLspError(e: LspInstallException) {

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/BoundedCommandRunner.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/BoundedCommandRunner.kt
@@ -52,7 +52,7 @@ internal class DefaultBoundedCommandRunner(
                 CommandOutput(exitCode = process.exitValue(), stdout = readBounded(outputFile), timedOut = false)
             } else {
                 process.destroyForcibly()
-                process.waitFor(terminationGraceSeconds, TimeUnit.SECONDS)
+                process.waitFor(TERMINATION_GRACE_SECONDS, TimeUnit.SECONDS)
                 CommandOutput(exitCode = -1, stdout = readBounded(outputFile), timedOut = true)
             }
         } catch (e: Exception) {
@@ -65,10 +65,10 @@ internal class DefaultBoundedCommandRunner(
 
     private fun readBounded(file: Path): String = try {
         file.toFile().inputStream().use { stream ->
-            val buffer = ByteArray(maxOutputBytes)
+            val buffer = ByteArray(MAX_OUTPUT_BYTES)
             var total = 0
-            while (total < maxOutputBytes) {
-                val read = stream.read(buffer, total, maxOutputBytes - total)
+            while (total < MAX_OUTPUT_BYTES) {
+                val read = stream.read(buffer, total, MAX_OUTPUT_BYTES - total)
                 if (read < 0) break
                 total += read
             }
@@ -80,7 +80,7 @@ internal class DefaultBoundedCommandRunner(
     }
 
     private companion object {
-        const val maxOutputBytes = 64 * 1024
-        const val terminationGraceSeconds = 1L
+        const val MAX_OUTPUT_BYTES = 64 * 1024
+        const val TERMINATION_GRACE_SECONDS = 1L
     }
 }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/BoundedCommandRunner.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/BoundedCommandRunner.kt
@@ -1,0 +1,86 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.lsp
+
+import software.aws.toolkit.core.utils.debug
+import software.aws.toolkit.core.utils.getLogger
+import software.aws.toolkit.core.utils.warn
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+/**
+ * Result of a bounded command execution. [stdout] is capped in size, and process failures are reported
+ * here rather than thrown.
+ */
+internal data class CommandOutput(val exitCode: Int, val stdout: String, val timedOut: Boolean) {
+    val succeeded: Boolean get() = !timedOut && exitCode == 0
+}
+
+/**
+ * Runs a command as an explicit argument vector (never through a shell), captures a bounded amount of
+ * merged stdout/stderr, and forcibly destroys the process if it does not finish within the timeout.
+ * Implementations must not throw for ordinary process failures.
+ */
+internal fun interface BoundedCommandRunner {
+    fun run(command: List<String>, timeout: Duration): CommandOutput
+}
+
+internal class DefaultBoundedCommandRunner(
+    private val createOutputFile: () -> Path = { Files.createTempFile("aws-toolkit-lsp-probe-", ".out") },
+) : BoundedCommandRunner {
+    private val log = getLogger<DefaultBoundedCommandRunner>()
+
+    override fun run(command: List<String>, timeout: Duration): CommandOutput {
+        val outputFile = try {
+            createOutputFile()
+        } catch (e: Exception) {
+            log.warn(e) { "Could not create a temp file to capture command output" }
+            return CommandOutput(exitCode = -1, stdout = "", timedOut = false)
+        }
+
+        return try {
+            val process = ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .redirectOutput(outputFile.toFile())
+                .start()
+            process.outputStream.close()
+
+            if (process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                CommandOutput(exitCode = process.exitValue(), stdout = readBounded(outputFile), timedOut = false)
+            } else {
+                process.destroyForcibly()
+                process.waitFor(terminationGraceSeconds, TimeUnit.SECONDS)
+                CommandOutput(exitCode = -1, stdout = readBounded(outputFile), timedOut = true)
+            }
+        } catch (e: Exception) {
+            log.debug(e) { "Command could not be executed: ${command.firstOrNull()}" }
+            CommandOutput(exitCode = -1, stdout = "", timedOut = false)
+        } finally {
+            runCatching { Files.deleteIfExists(outputFile) }
+        }
+    }
+
+    private fun readBounded(file: Path): String = try {
+        file.toFile().inputStream().use { stream ->
+            val buffer = ByteArray(maxOutputBytes)
+            var total = 0
+            while (total < maxOutputBytes) {
+                val read = stream.read(buffer, total, maxOutputBytes - total)
+                if (read < 0) break
+                total += read
+            }
+            String(buffer, 0, total, Charsets.UTF_8)
+        }
+    } catch (e: Exception) {
+        log.debug(e) { "Could not read captured command output" }
+        ""
+    }
+
+    private companion object {
+        const val maxOutputBytes = 64 * 1024
+        const val terminationGraceSeconds = 1L
+    }
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/GlibcVersion.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/GlibcVersion.kt
@@ -1,0 +1,37 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.lsp
+
+/**
+ * A glibc runtime version expressed as its `major.minor` components.
+ *
+ * This model is used to compare the configured Node.js runtime with the minimum version required
+ * by native language-server dependencies.
+ */
+internal data class GlibcVersion(val major: Int, val minor: Int) : Comparable<GlibcVersion> {
+    override fun compareTo(other: GlibcVersion): Int =
+        compareValuesBy(this, other, GlibcVersion::major, GlibcVersion::minor)
+
+    override fun toString(): String = "$major.$minor"
+
+    companion object {
+        /** Minimum glibc required by the CloudFormation language server's native dependencies (for example LMDB). */
+        val REQUIRED: GlibcVersion = GlibcVersion(2, 28)
+
+        private val MAJOR_MINOR = Regex("""(\d+)\.(\d+)""")
+
+        /**
+         * Extracts the first `major.minor` version from strings such as `"2.28"`, `"glibc 2.26"`, or
+         * `"ldd (GNU libc) 2.31"`. Returns `null` for blank input or text that carries no version (for
+         * example a musl banner), so callers can treat an unknown libc safely.
+         */
+        fun parse(raw: String?): GlibcVersion? {
+            if (raw.isNullOrBlank()) return null
+            val match = MAJOR_MINOR.find(raw) ?: return null
+            val major = match.groupValues[1].toIntOrNull() ?: return null
+            val minor = match.groupValues[2].toIntOrNull() ?: return null
+            return GlibcVersion(major, minor)
+        }
+    }
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/LinuxGlibcNodeLauncher.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/LinuxGlibcNodeLauncher.kt
@@ -1,0 +1,213 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.lsp
+
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.util.system.CpuArch
+import software.aws.toolkit.core.utils.debug
+import software.aws.toolkit.core.utils.getLogger
+import software.aws.toolkit.core.utils.info
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+
+/**
+ * A fixed Node.js expression that prints the running interpreter's real ELF path (using
+ * `/proc/self/exe` when available so shell wrappers and overridden `argv[0]` are handled), its current
+ * `LD_LIBRARY_PATH`, and its runtime glibc version. Each value is emitted on its own prefixed line so it
+ * can be parsed even when merged with unrelated diagnostics. `glibcVersionRuntime` is absent on
+ * musl/non-glibc runtimes, which safely yields an empty value.
+ */
+internal const val NODE_RUNTIME_PROBE_EXPR: String =
+    "const fs=require('fs');const h=(process.report&&process.report.getReport().header)||{};" +
+        "let e=process.execPath;try{e=fs.realpathSync('/proc/self/exe')}catch{};" +
+        "process.stdout.write(" +
+        "'NODE_EXEC_PATH='+e+'\\n'+" +
+        "'NODE_LIBRARY_PATH='+(process.env.LD_LIBRARY_PATH||'')+'\\n'+" +
+        "'NODE_GLIBC_RUNTIME='+(h.glibcVersionRuntime||'')+'\\n')"
+
+/** Dynamic-loader file name for a supported CPU architecture. */
+internal enum class LinuxArch(val loaderName: String) {
+    X64("ld-linux-x86-64.so.2"),
+    ARM64("ld-linux-aarch64.so.1"),
+}
+
+/** Structured launch command: [command] holds the Node.js invocation tokens, executable first. */
+internal data class NodeLaunchCommand(val command: List<String>)
+
+/** Minimal filesystem surface the launcher needs, extracted so candidate resolution can be tested off-host. */
+internal interface RuntimeFileSystem {
+    fun realPathOrNull(path: Path): Path?
+
+    fun isRegularFile(path: Path): Boolean
+
+    fun isExecutable(path: Path): Boolean
+}
+
+internal object DefaultRuntimeFileSystem : RuntimeFileSystem {
+    override fun realPathOrNull(path: Path): Path? = try {
+        path.toRealPath()
+    } catch (_: Exception) {
+        null
+    }
+
+    override fun isRegularFile(path: Path): Boolean = Files.isRegularFile(path)
+
+    override fun isExecutable(path: Path): Boolean = Files.isExecutable(path)
+}
+
+/**
+ * Decides how to launch the CloudFormation language server's Node.js process on Linux so that native
+ * modules requiring a newer glibc can load.
+ *
+ * The launcher first asks the configured Node.js wrapper for its real executable path, current
+ * `LD_LIBRARY_PATH`, and runtime glibc version. When that version already meets [required], the
+ * wrapper is launched directly, so Windows, macOS, and healthy Linux hosts keep their existing
+ * behaviour. If the runtime cannot be identified safely, startup fails with an actionable compatibility
+ * error rather than risking a native-module crash.
+ *
+ * When the runtime glibc is too old, the launcher looks for an alternate glibc runtime explicitly
+ * configured by the user or installed by Homebrew/Linuxbrew. It validates each candidate by running
+ * the real Node.js ELF through the candidate loader, and returns
+ * `<loader> --library-path <paths> <real-node>` for the first candidate that raises the runtime glibc
+ * to [required]. If none qualifies it throws a typed [LspInstallException] so startup fails with a
+ * clear message instead of crash-looping.
+ *
+ * Nothing global is mutated: no `LD_LIBRARY_PATH`, `ldconfig`, system files, or downloaded runtime files.
+ */
+internal class LinuxGlibcNodeLauncher(
+    private val isLinux: Boolean = SystemInfo.isLinux,
+    private val arch: LinuxArch = currentArch(),
+    private val required: GlibcVersion = GlibcVersion.REQUIRED,
+    private val env: (String) -> String? = { System.getenv(it) },
+    private val runner: BoundedCommandRunner = DefaultBoundedCommandRunner(),
+    private val fs: RuntimeFileSystem = DefaultRuntimeFileSystem,
+) {
+    private data class NodeProbe(val execPath: String, val libraryPath: String, val glibcRuntime: String)
+
+    private data class GlibcCandidate(val loader: Path, val libcDir: Path)
+
+    fun resolveLaunchCommand(nodeWrapper: Path, incompatibleGlibcMessage: String): NodeLaunchCommand {
+        val direct = NodeLaunchCommand(listOf(nodeWrapper.toString()))
+        if (!isLinux) return direct
+
+        val probe = probeNode(listOf(nodeWrapper.toString(), "-e", NODE_RUNTIME_PROBE_EXPR))
+            ?: throw incompatibleGlibc(incompatibleGlibcMessage)
+
+        val runtimeGlibc = GlibcVersion.parse(probe.glibcRuntime)
+            ?: throw incompatibleGlibc(incompatibleGlibcMessage)
+        if (runtimeGlibc >= required) {
+            LOG.debug { "Node.js runtime glibc $runtimeGlibc satisfies the $required floor; launching it directly" }
+            return direct
+        }
+
+        LOG.info {
+            "Node.js runtime glibc $runtimeGlibc is below the $required floor; searching for a compatible glibc runtime"
+        }
+        val realNode = pathOrNull(probe.execPath) ?: throw incompatibleGlibc(incompatibleGlibcMessage)
+        val candidate = discoverLibraryDirectories()
+            .firstNotNullOfOrNull { libDir -> validateCandidate(libDir, realNode, probe.libraryPath) }
+            ?: throw incompatibleGlibc(incompatibleGlibcMessage)
+
+        val libraryPath = buildLibraryPath(probe.libraryPath, candidate.libcDir)
+        LOG.info { "Launching CloudFormation language server through alternate glibc loader ${candidate.loader}" }
+        return NodeLaunchCommand(listOf(candidate.loader.toString(), "--library-path", libraryPath, realNode.toString()))
+    }
+
+    private fun probeNode(command: List<String>): NodeProbe? {
+        val output = runNode(command) ?: return null
+        val execPath = output.lineValue("NODE_EXEC_PATH=").orEmpty()
+        if (execPath.isBlank()) return null
+        return NodeProbe(
+            execPath = execPath,
+            libraryPath = output.lineValue("NODE_LIBRARY_PATH=").orEmpty(),
+            glibcRuntime = output.lineValue("NODE_GLIBC_RUNTIME=").orEmpty(),
+        )
+    }
+
+    private fun runNode(command: List<String>): String? {
+        val output = runner.run(command, PROCESS_TIMEOUT)
+        if (!output.succeeded) {
+            LOG.debug { "Node.js invocation did not succeed (exit=${output.exitCode}, timedOut=${output.timedOut})" }
+            return null
+        }
+        return output.stdout
+    }
+
+    private fun discoverLibraryDirectories(): Sequence<Path> = sequence {
+        explicitOptInRoot()?.let { yieldAll(libraryDirectoriesUnder(it)) }
+        homebrewGlibcPrefix()?.let { yieldAll(libraryDirectoriesUnder(it)) }
+    }.distinct()
+
+    private fun explicitOptInRoot(): Path? = env(ENV_GLIBC_DIR)?.trim()?.takeIf { it.isNotEmpty() }?.let(::pathOrNull)
+
+    private fun homebrewGlibcPrefix(): Path? {
+        val output = runner.run(listOf("brew", "--prefix", "glibc"), PROCESS_TIMEOUT)
+        if (!output.succeeded) return null
+        return output.stdout.lineSequence()
+            .map(String::trim)
+            .mapNotNull(::pathOrNull)
+            .lastOrNull(Path::isAbsolute)
+    }
+
+    private fun libraryDirectoriesUnder(root: Path): List<Path> =
+        listOf(root, root.resolve("lib"), root.resolve("lib64"))
+
+    private fun validateCandidate(libDir: Path, realNode: Path, nodeLibraryPath: String): GlibcCandidate? {
+        val candidate = toCandidate(libDir) ?: return null
+        val libraryPath = buildLibraryPath(nodeLibraryPath, candidate.libcDir)
+        val command = listOf(candidate.loader.toString(), "--library-path", libraryPath, realNode.toString(), "-e", NODE_RUNTIME_PROBE_EXPR)
+        val output = runNode(command) ?: return null
+        val glibc = GlibcVersion.parse(output.lineValue("NODE_GLIBC_RUNTIME=")) ?: return null
+        return if (glibc >= required) candidate else null
+    }
+
+    private fun toCandidate(libDir: Path): GlibcCandidate? {
+        val loader = libDir.resolve(arch.loaderName)
+        val libc = libDir.resolve(LIBC_FILENAME)
+        if (!fs.isRegularFile(loader) || !fs.isExecutable(loader) || !fs.isRegularFile(libc)) return null
+
+        val realLoader = fs.realPathOrNull(loader) ?: return null
+        val realLibc = fs.realPathOrNull(libc) ?: return null
+        val loaderDir = realLoader.parent ?: return null
+        // Loader and libc must resolve into the same real directory; reject symlink escapes / mismatched pairs.
+        if (loaderDir != realLibc.parent) return null
+        if (!fs.isRegularFile(realLoader) || !fs.isExecutable(realLoader) || !fs.isRegularFile(realLibc)) return null
+
+        return GlibcCandidate(loader = realLoader, libcDir = loaderDir)
+    }
+
+    private fun buildLibraryPath(nodeLibraryPath: String, libcDir: Path): String {
+        val existing = nodeLibraryPath.split(File.pathSeparatorChar).map { it.trim() }.filter { it.isNotEmpty() }
+        return (existing + libcDir.toString()).joinToString(File.pathSeparator)
+    }
+
+    private fun incompatibleGlibc(message: String): LspInstallException =
+        LspInstallException(message, LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC)
+
+    private fun pathOrNull(raw: String): Path? = try {
+        Path.of(raw)
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun String.lineValue(prefix: String): String? =
+        lineSequence().firstOrNull { it.startsWith(prefix) }?.substring(prefix.length)?.trim()
+
+    companion object {
+        private val LOG = getLogger<LinuxGlibcNodeLauncher>()
+
+        /**
+         * Public opt-in: point this at a glibc install root (or a lib directory) to supply an alternate
+         * runtime on hosts whose system glibc is too old for the CloudFormation language server.
+         */
+        const val ENV_GLIBC_DIR = "AWS_TOOLKIT_LSP_GLIBC_DIR"
+
+        private const val LIBC_FILENAME = "libc.so.6"
+        private val PROCESS_TIMEOUT: Duration = Duration.ofSeconds(10)
+
+        private fun currentArch(): LinuxArch = if (CpuArch.CURRENT == CpuArch.ARM64) LinuxArch.ARM64 else LinuxArch.X64
+    }
+}

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/LinuxGlibcNodeLauncher.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/LinuxGlibcNodeLauncher.kt
@@ -34,9 +34,6 @@ internal enum class LinuxArch(val loaderName: String) {
     ARM64("ld-linux-aarch64.so.1"),
 }
 
-/** Structured launch command: [command] holds the Node.js invocation tokens, executable first. */
-internal data class NodeLaunchCommand(val command: List<String>)
-
 /** Minimal filesystem surface the launcher needs, extracted so candidate resolution can be tested off-host. */
 internal interface RuntimeFileSystem {
     fun realPathOrNull(path: Path): Path?

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/LspInstallException.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/LspInstallException.kt
@@ -13,5 +13,6 @@ class LspInstallException(message: String, val errorCode: ErrorCode, cause: Thro
         EXTRACTION_FAILED,
         NODE_NOT_FOUND,
         HASH_VERIFICATION_FAILED,
+        INCOMPATIBLE_GLIBC,
     }
 }

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/NodeRuntimeResolver.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/NodeRuntimeResolver.kt
@@ -43,6 +43,10 @@ internal fun buildWellKnownPaths(platform: Platform, home: Path): List<Path> {
             add(Path.of("C:/Program Files/nodejs/$exeName"))
             add(Path.of("C:/ProgramData/chocolatey/bin/$exeName"))
             add(home.resolve("scoop/apps/nodejs/current/$exeName"))
+        } else {
+            // Mise shims support processes that do not inherit shell activation, such as GUI-launched IDEs.
+            add(home.resolve(".local/share/mise/shims/$exeName"))
+            add(home.resolve(".local/share/rtx/shims/$exeName"))
         }
     }
 }
@@ -56,6 +60,17 @@ internal fun buildGlobPatterns(platform: Platform, home: Path, env: (String) -> 
         if (platform == Platform.MAC) {
             add("/opt/homebrew/Cellar/node*/*/bin/$exeName")
             add("/usr/local/Cellar/node*/*/bin/$exeName")
+        }
+
+        if (platform != Platform.WINDOWS) {
+            val dataHome = env("XDG_DATA_HOME")?.let { Path.of(it) } ?: home.resolve(".local/share")
+            val miseDataDirs = listOfNotNull(
+                env("MISE_DATA_DIR")?.let { Path.of(it) },
+                env("RTX_DATA_DIR")?.let { Path.of(it) },
+                dataHome.resolve("mise"),
+                dataHome.resolve("rtx"),
+            ).distinct()
+            miseDataDirs.forEach { add("$it/installs/node/*/bin/$exeName") }
         }
 
         // nvm
@@ -88,7 +103,7 @@ internal fun buildGlobPatterns(platform: Platform, home: Path, env: (String) -> 
 
 /**
  * Resolves a Node.js executable across system PATH, well-known install locations,
- * and version managers (nvm, fnm, volta). GUI-launched IDEs don't inherit shell
+ * and version managers (Mise/rtx, nvm, fnm, volta). GUI-launched IDEs don't inherit shell
  * PATH modifications, so we search common locations directly.
  */
 internal object NodeRuntimeResolver {
@@ -137,24 +152,24 @@ internal object NodeRuntimeResolver {
         autoDetect: (Int) -> Path? = ::detectAutomatically,
         isExecutable: (Path) -> Boolean = { Files.isExecutable(it) },
     ): Path = try {
-            resolveConfigured(configuredPath, isExecutable)
-                ?: autoDetect(minVersion)
-                ?: throw nodeNotFound(nodeNotFoundMessage)
-        } catch (e: LspInstallException) {
-            throw e
-        } catch (e: Exception) {
-            LOG.warn(e) { "Failed to resolve Node.js runtime; treating it as not found" }
-            throw nodeNotFound(nodeNotFoundMessage, e)
-        }
+        resolveConfigured(configuredPath, isExecutable)
+            ?: autoDetect(minVersion)
+            ?: throw nodeNotFound(nodeNotFoundMessage)
+    } catch (e: LspInstallException) {
+        throw e
+    } catch (e: Exception) {
+        LOG.warn(e) { "Failed to resolve Node.js runtime; treating it as not found" }
+        throw nodeNotFound(nodeNotFoundMessage, e)
+    }
 
     private fun detectAutomatically(minVersion: Int): Path? =
         resolveFromPath(minVersion) ?: resolveFromWellKnownLocations(minVersion)
 
     private fun resolveFromPath(minVersion: Int): Path? = PathEnvironmentVariableUtil.findAllExeFilesInPath(exeName)
-            .asSequence()
-            .map { it.toPath() }
-            .filter { Files.isRegularFile(it) && Files.isExecutable(it) }
-            .firstNotNullOfOrNull { it.takeIfVersionAtLeast(minVersion) }
+        .asSequence()
+        .map { it.toPath() }
+        .filter { Files.isRegularFile(it) && Files.isExecutable(it) }
+        .firstNotNullOfOrNull { it.takeIfVersionAtLeast(minVersion) }
 
     private fun resolveFromWellKnownLocations(minVersion: Int): Path? {
         val fromFixed = wellKnownPaths.asSequence()

--- a/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/NodeRuntimeResolver.kt
+++ b/plugins/toolkit/jetbrains-core/src/software/aws/toolkits/jetbrains/core/lsp/NodeRuntimeResolver.kt
@@ -17,6 +17,9 @@ import java.nio.file.Path
 
 internal enum class Platform { MAC, LINUX, WINDOWS }
 
+/** A fully resolved Node.js invocation, including any platform compatibility launcher. */
+internal data class NodeLaunchCommand(val command: List<String>)
+
 private val BIN_DIR = mapOf(Platform.MAC to "bin/", Platform.LINUX to "bin/", Platform.WINDOWS to "")
 private val EXE_NAME = mapOf(Platform.MAC to "node", Platform.LINUX to "node", Platform.WINDOWS to "node.exe")
 
@@ -103,13 +106,29 @@ internal object NodeRuntimeResolver {
     private val globPatterns: List<String> by lazy { buildGlobPatterns(platform, home) { System.getenv(it) } }
 
     /**
+     * Resolves Node.js and returns its complete launch command. On Linux, the command is adapted to
+     * use a compatible glibc loader when the resolved runtime does not meet the required glibc floor.
+     */
+    fun resolveLaunchCommand(
+        configuredPath: String?,
+        nodeNotFoundMessage: String,
+        incompatibleGlibcMessage: String,
+        minVersion: Int = 18,
+        autoDetect: (Int) -> Path? = ::detectAutomatically,
+        isExecutable: (Path) -> Boolean = { Files.isExecutable(it) },
+        adaptLaunchCommand: (Path, String) -> NodeLaunchCommand =
+            LinuxGlibcNodeLauncher()::resolveLaunchCommand,
+    ): NodeLaunchCommand {
+        val nodePath = resolve(configuredPath, nodeNotFoundMessage, minVersion, autoDetect, isExecutable)
+        return adaptLaunchCommand(nodePath, incompatibleGlibcMessage)
+    }
+
+    /**
      * Resolves the Node.js runtime from an explicit [configuredPath] when one is set, otherwise from
      * [autoDetect], using [minVersion] (18 by default). Every configuration or resolution failure —
      * a syntactically malformed explicit path, an exception thrown by auto-detection, or no runtime
      * found — is normalized to an [LspInstallException] with
-     * [LspInstallException.ErrorCode.NODE_NOT_FOUND] and the original cause preserved. A missing
-     * runtime is thus reported as a typed install failure rather than being papered over, letting a
-     * launcher distinguish it from failures that reinstalling a server would fix.
+     * [LspInstallException.ErrorCode.NODE_NOT_FOUND] and the original cause preserved.
      */
     fun resolve(
         configuredPath: String?,
@@ -117,8 +136,7 @@ internal object NodeRuntimeResolver {
         minVersion: Int = 18,
         autoDetect: (Int) -> Path? = ::detectAutomatically,
         isExecutable: (Path) -> Boolean = { Files.isExecutable(it) },
-    ): Path =
-        try {
+    ): Path = try {
             resolveConfigured(configuredPath, isExecutable)
                 ?: autoDetect(minVersion)
                 ?: throw nodeNotFound(nodeNotFoundMessage)
@@ -132,8 +150,7 @@ internal object NodeRuntimeResolver {
     private fun detectAutomatically(minVersion: Int): Path? =
         resolveFromPath(minVersion) ?: resolveFromWellKnownLocations(minVersion)
 
-    private fun resolveFromPath(minVersion: Int): Path? =
-        PathEnvironmentVariableUtil.findAllExeFilesInPath(exeName)
+    private fun resolveFromPath(minVersion: Int): Path? = PathEnvironmentVariableUtil.findAllExeFilesInPath(exeName)
             .asSequence()
             .map { it.toPath() }
             .filter { Files.isRegularFile(it) && Files.isExecutable(it) }

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/BoundedCommandRunnerTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/BoundedCommandRunnerTest.kt
@@ -1,0 +1,74 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.lsp
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import kotlin.io.path.absolutePathString
+
+class BoundedCommandRunnerTest {
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun `successful process returns its output and removes the capture file`() {
+        lateinit var captureFile: Path
+        val runner = DefaultBoundedCommandRunner {
+            Files.createTempFile(tempFolder.root.toPath(), "probe-", ".out").also { captureFile = it }
+        }
+
+        val output = runner.run(javaCommand("success"), Duration.ofSeconds(10))
+
+        assertThat(output.succeeded).isTrue()
+        assertThat(output.stdout).contains("PROCESS_OK")
+        assertThat(Files.exists(captureFile)).isFalse()
+    }
+
+    @Test
+    fun `timed out process is forcibly terminated`() {
+        val runner = DefaultBoundedCommandRunner()
+
+        val output = runner.run(javaCommand("sleep"), Duration.ofMillis(200))
+
+        assertThat(output.succeeded).isFalse()
+        assertThat(output.timedOut).isTrue()
+        assertThat(output.exitCode).isEqualTo(-1)
+    }
+
+    @Test
+    fun `returned output is capped at 64 KiB`() {
+        val runner = DefaultBoundedCommandRunner()
+
+        val output = runner.run(javaCommand("large-output"), Duration.ofSeconds(10))
+
+        assertThat(output.succeeded).isTrue()
+        assertThat(output.stdout.toByteArray()).hasSize(64 * 1024)
+        assertThat(output.stdout).containsOnlyOnce("OUTPUT_START")
+        assertThat(output.stdout).doesNotContain("OUTPUT_END")
+    }
+
+    private fun javaCommand(mode: String): List<String> {
+        val executable = Path.of(
+            System.getProperty("java.home"),
+            "bin",
+            if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) "java.exe" else "java",
+        )
+        val classpath = Path.of(System.getProperty("user.dir"), "build", "classes", "java", "test")
+            .absolutePathString()
+
+        return listOf(
+            executable.absolutePathString(),
+            "-cp",
+            classpath,
+            BoundedCommandRunnerTestProcess::class.java.name,
+            mode,
+        )
+    }
+}

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/BoundedCommandRunnerTestProcess.java
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/BoundedCommandRunnerTestProcess.java
@@ -1,0 +1,23 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.lsp;
+
+final class BoundedCommandRunnerTestProcess {
+    private BoundedCommandRunnerTestProcess() {}
+
+    public static void main(String[] args) throws Exception {
+        switch (args[0]) {
+            case "success" -> System.out.println("PROCESS_OK");
+            case "sleep" -> Thread.sleep(30_000L);
+            case "large-output" -> {
+                System.out.print("OUTPUT_START");
+                for (int i = 0; i < 128 * 1024; i++) {
+                    System.out.print('x');
+                }
+                System.out.print("OUTPUT_END");
+            }
+            default -> throw new IllegalArgumentException("Unknown test mode");
+        }
+    }
+}

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/GlibcVersionTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/GlibcVersionTest.kt
@@ -1,0 +1,61 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.lsp
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class GlibcVersionTest {
+    @Test
+    fun `parse reads a bare major minor string`() {
+        assertThat(GlibcVersion.parse("2.28")).isEqualTo(GlibcVersion(2, 28))
+    }
+
+    @Test
+    fun `parse reads getconf style output`() {
+        assertThat(GlibcVersion.parse("glibc 2.26")).isEqualTo(GlibcVersion(2, 26))
+    }
+
+    @Test
+    fun `parse reads ldd style output with trailing text`() {
+        val ldd = """
+            ldd (GNU libc) 2.31
+            Copyright (C) 2020 Free Software Foundation, Inc.
+        """.trimIndent()
+
+        assertThat(GlibcVersion.parse(ldd)).isEqualTo(GlibcVersion(2, 31))
+    }
+
+    @Test
+    fun `parse returns null for null blank and non-version input`() {
+        assertThat(GlibcVersion.parse(null)).isNull()
+        assertThat(GlibcVersion.parse("")).isNull()
+        assertThat(GlibcVersion.parse("   ")).isNull()
+        assertThat(GlibcVersion.parse("musl libc")).isNull()
+    }
+
+    @Test
+    fun `compareTo orders by major then minor numerically`() {
+        assertThat(GlibcVersion(2, 26)).isLessThan(GlibcVersion(2, 28))
+        assertThat(GlibcVersion(2, 31)).isGreaterThan(GlibcVersion(2, 28))
+        assertThat(GlibcVersion(3, 0)).isGreaterThan(GlibcVersion(2, 99))
+        assertThat(GlibcVersion(2, 28)).isEqualByComparingTo(GlibcVersion(2, 28))
+    }
+
+    @Test
+    fun `compareTo is numeric not lexicographic`() {
+        // A string compare would rank "2.9" above "2.10"; the numeric compare must not.
+        assertThat(GlibcVersion(2, 9)).isLessThan(GlibcVersion(2, 10))
+    }
+
+    @Test
+    fun `required floor is glibc 2 28`() {
+        assertThat(GlibcVersion.REQUIRED).isEqualTo(GlibcVersion(2, 28))
+    }
+
+    @Test
+    fun `toString renders major minor`() {
+        assertThat(GlibcVersion(2, 28).toString()).isEqualTo("2.28")
+    }
+}

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/LinuxGlibcNodeLauncherTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/LinuxGlibcNodeLauncherTest.kt
@@ -1,0 +1,357 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.core.lsp
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import java.nio.file.Path
+
+class LinuxGlibcNodeLauncherTest {
+    private val wrapper = Path.of("/usr/bin/node")
+    private val realNode = "/opt/node/bin/node"
+    private val nodeLib = "/opt/node/lib"
+    private val message = "CloudFormation Language Server needs a newer glibc"
+
+    private fun ok(stdout: String) = CommandOutput(exitCode = 0, stdout = stdout, timedOut = false)
+
+    private fun failure() = CommandOutput(exitCode = 127, stdout = "", timedOut = false)
+
+    private fun report(execPath: String = realNode, libraryPath: String = nodeLib, glibc: String): String =
+        "NODE_EXEC_PATH=$execPath\nNODE_LIBRARY_PATH=$libraryPath\nNODE_GLIBC_RUNTIME=$glibc\n"
+
+    /**
+     * Answers the node probe, an optional `brew --prefix glibc`, and every loader validation. A command
+     * containing `--library-path` is a validation run; a command whose second token is `-e` is the wrapper probe.
+     */
+    private fun scenarioRunner(
+        probe: CommandOutput,
+        brewPrefix: String? = null,
+        validationGlibc: String = "2.28",
+    ): BoundedCommandRunner = BoundedCommandRunner { command, _ ->
+        when {
+            command.firstOrNull() == "brew" -> if (brewPrefix != null) ok(brewPrefix) else failure()
+            command.contains("--library-path") -> ok(report(glibc = validationGlibc))
+            command.getOrNull(1) == "-e" -> probe
+            else -> failure()
+        }
+    }
+
+    private class FakeFs(
+        private val regularFiles: Set<String> = emptySet(),
+        private val executables: Set<String> = emptySet(),
+        private val realPaths: Map<String, String> = emptyMap(),
+    ) : RuntimeFileSystem {
+        override fun realPathOrNull(path: Path): Path? = Path.of(realPaths[path.toString()] ?: path.toString())
+
+        override fun isRegularFile(path: Path): Boolean = path.toString() in regularFiles
+
+        override fun isExecutable(path: Path): Boolean = path.toString() in executables
+    }
+
+    private fun fsWithCandidate(libDir: String, loaderName: String): FakeFs {
+        val loader = "$libDir/$loaderName"
+        val libc = "$libDir/libc.so.6"
+        return FakeFs(
+            regularFiles = setOf(loader, libc),
+            executables = setOf(loader),
+        )
+    }
+
+    @Test
+    fun `non-linux never probes and launches the wrapper directly`() {
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = false,
+            arch = LinuxArch.X64,
+            env = { error("environment must not be read on non-linux") },
+            runner = BoundedCommandRunner { _, _ -> error("no process may be launched on non-linux") },
+            fs = FakeFs(),
+        )
+
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command).containsExactly(wrapper.toString())
+    }
+
+    @Test
+    fun `runtime glibc at or above the floor launches the wrapper directly`() {
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { null },
+            runner = scenarioRunner(probe = ok(report(glibc = "2.31"))),
+            fs = FakeFs(),
+        )
+
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command).containsExactly(wrapper.toString())
+    }
+
+    @Test
+    fun `probes the wrapper with a fixed expression passed as an argument vector`() {
+        var probeCommand: List<String>? = null
+        val runner = BoundedCommandRunner { command, _ ->
+            if (command.getOrNull(1) == "-e") probeCommand = command
+            ok(report(glibc = "2.31"))
+        }
+        val launcher = LinuxGlibcNodeLauncher(isLinux = true, arch = LinuxArch.X64, env = {
+            null
+        }, runner = runner, fs = FakeFs())
+
+        launcher.resolveLaunchCommand(wrapper, message)
+
+        assertThat(probeCommand).containsExactly(wrapper.toString(), "-e", NODE_RUNTIME_PROBE_EXPR)
+        assertThat(NODE_RUNTIME_PROBE_EXPR).contains("/proc/self/exe")
+    }
+
+    @Test
+    fun `musl or unknown libc fails with a typed compatibility error`() {
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { null },
+            runner = scenarioRunner(probe = ok(report(glibc = ""))),
+            fs = FakeFs(),
+        )
+
+        assertThatThrownBy { launcher.resolveLaunchCommand(wrapper, message) }
+            .isInstanceOfSatisfying(LspInstallException::class.java) {
+                assertThat(it.errorCode).isEqualTo(LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC)
+            }
+    }
+
+    @Test
+    fun `malformed probe output fails with a typed compatibility error`() {
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { null },
+            runner = scenarioRunner(probe = ok("this is not the output we expect")),
+            fs = FakeFs(),
+        )
+
+        assertThatThrownBy { launcher.resolveLaunchCommand(wrapper, message) }
+            .isInstanceOfSatisfying(LspInstallException::class.java) {
+                assertThat(it.errorCode).isEqualTo(LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC)
+            }
+    }
+
+    @Test
+    fun `timed out probe fails with a typed compatibility error`() {
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { null },
+            runner = BoundedCommandRunner { _, _ ->
+                CommandOutput(exitCode = -1, stdout = report(glibc = "2.26"), timedOut = true)
+            },
+            fs = FakeFs(),
+        )
+
+        assertThatThrownBy { launcher.resolveLaunchCommand(wrapper, message) }
+            .isInstanceOfSatisfying(LspInstallException::class.java) {
+                assertThat(it.errorCode).isEqualTo(LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC)
+            }
+    }
+
+    @Test
+    fun `old glibc with a valid explicit candidate launches through the loader against the real node`() {
+        val root = "/custom/glibc228"
+        val libDir = "$root/lib"
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            runner = scenarioRunner(probe = ok(report(glibc = "2.26"))),
+            fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),
+        )
+
+        val command = launcher.resolveLaunchCommand(wrapper, message).command
+
+        assertThat(command).containsExactly("$libDir/ld-linux-x86-64.so.2", "--library-path", "$nodeLib:$libDir", realNode)
+    }
+
+    @Test
+    fun `library path lists the node paths before the candidate libc directory`() {
+        val root = "/custom/glibc228"
+        val libDir = "$root/lib"
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            runner = scenarioRunner(probe = ok(report(libraryPath = "/node/a:/node/b", glibc = "2.26"))),
+            fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),
+        )
+
+        val command = launcher.resolveLaunchCommand(wrapper, message).command
+
+        val libraryPath = command[command.indexOf("--library-path") + 1]
+        assertThat(libraryPath).isEqualTo("/node/a:/node/b:$libDir")
+    }
+
+    @Test
+    fun `arm64 loader name is used on arm64`() {
+        val root = "/custom/glibc228"
+        val libDir = "$root/lib"
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.ARM64,
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            runner = scenarioRunner(probe = ok(report(glibc = "2.26"))),
+            fs = fsWithCandidate(libDir, "ld-linux-aarch64.so.1"),
+        )
+
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo("$libDir/ld-linux-aarch64.so.1")
+    }
+
+    @Test
+    fun `explicit opt-in environment variable is used before Homebrew discovery`() {
+        val root = "/custom/glibc"
+        val libDir = "$root/lib"
+        var brewCalls = 0
+        val runner = BoundedCommandRunner { command, _ ->
+            when {
+                command.firstOrNull() == "brew" -> {
+                    brewCalls++
+                    failure()
+                }
+
+                command.contains("--library-path") -> ok(report(glibc = "2.28"))
+
+                else -> ok(report(glibc = "2.26"))
+            }
+        }
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            runner = runner,
+            fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),
+        )
+
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo("$libDir/ld-linux-x86-64.so.2")
+        assertThat(brewCalls).isZero()
+    }
+
+    @Test
+    fun `homebrew glibc prefix is used to discover a candidate`() {
+        val prefix = "/home/linuxbrew/.linuxbrew/opt/glibc"
+        val libDir = "$prefix/lib"
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { null },
+            runner = scenarioRunner(
+                probe = ok(report(glibc = "2.26")),
+                brewPrefix = "Warning: using a custom installation\n$prefix\n",
+            ),
+            fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),
+        )
+
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo("$libDir/ld-linux-x86-64.so.2")
+    }
+
+    @Test
+    fun `a symlink escape candidate is rejected and a later valid candidate is used`() {
+        val badRoot = "/custom/bad"
+        val badLibDir = "$badRoot/lib"
+        val goodRoot = "/home/linuxbrew/.linuxbrew/opt/glibc"
+        val goodLibDir = "$goodRoot/lib"
+        val fs = FakeFs(
+            regularFiles = setOf(
+                "$badLibDir/ld-linux-x86-64.so.2",
+                "$badLibDir/libc.so.6",
+                "$goodLibDir/ld-linux-x86-64.so.2",
+                "$goodLibDir/libc.so.6",
+            ),
+            executables = setOf("$badLibDir/ld-linux-x86-64.so.2", "$goodLibDir/ld-linux-x86-64.so.2"),
+            // The bad loader resolves outside its lib directory, so its real parent no longer matches libc's.
+            realPaths = mapOf("$badLibDir/ld-linux-x86-64.so.2" to "/somewhere/else/ld-linux-x86-64.so.2"),
+        )
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) badRoot else null },
+            runner = scenarioRunner(probe = ok(report(glibc = "2.26")), brewPrefix = goodRoot),
+            fs = fs,
+        )
+
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo("$goodLibDir/ld-linux-x86-64.so.2")
+    }
+
+    @Test
+    fun `a candidate missing its libc is rejected`() {
+        val root = "/custom/glibc228"
+        val libDir = "$root/lib"
+        val fs = FakeFs(
+            regularFiles = setOf("$libDir/ld-linux-x86-64.so.2"),
+            executables = setOf("$libDir/ld-linux-x86-64.so.2"),
+        )
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            runner = scenarioRunner(probe = ok(report(glibc = "2.26"))),
+            fs = fs,
+        )
+
+        assertThatThrownBy { launcher.resolveLaunchCommand(wrapper, message) }
+            .isInstanceOfSatisfying(LspInstallException::class.java) {
+                assertThat(it.errorCode).isEqualTo(LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC)
+            }
+    }
+
+    @Test
+    fun `a candidate with a non-executable loader is rejected`() {
+        val root = "/custom/glibc228"
+        val libDir = "$root/lib"
+        val fs = FakeFs(
+            regularFiles = setOf("$libDir/ld-linux-x86-64.so.2", "$libDir/libc.so.6"),
+            executables = emptySet(),
+        )
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            runner = scenarioRunner(probe = ok(report(glibc = "2.26"))),
+            fs = fs,
+        )
+
+        assertThatThrownBy { launcher.resolveLaunchCommand(wrapper, message) }
+            .isInstanceOf(LspInstallException::class.java)
+    }
+
+    @Test
+    fun `a candidate whose loader does not raise glibc to the floor is rejected`() {
+        val root = "/custom/glibc228"
+        val libDir = "$root/lib"
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            // Structurally valid, but running node through it still reports an old glibc.
+            runner = scenarioRunner(probe = ok(report(glibc = "2.26")), validationGlibc = "2.26"),
+            fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),
+        )
+
+        assertThatThrownBy { launcher.resolveLaunchCommand(wrapper, message) }
+            .isInstanceOfSatisfying(LspInstallException::class.java) {
+                assertThat(it.errorCode).isEqualTo(LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC)
+            }
+    }
+
+    @Test
+    fun `old glibc with no discoverable candidate fails with a typed incompatible glibc exception`() {
+        val launcher = LinuxGlibcNodeLauncher(
+            isLinux = true,
+            arch = LinuxArch.X64,
+            env = { null },
+            runner = scenarioRunner(probe = ok(report(glibc = "2.26"))),
+            fs = FakeFs(),
+        )
+
+        assertThatThrownBy { launcher.resolveLaunchCommand(wrapper, message) }
+            .isInstanceOfSatisfying(LspInstallException::class.java) {
+                assertThat(it.errorCode).isEqualTo(LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC)
+                assertThat(it.message).isEqualTo(message)
+            }
+    }
+}

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/LinuxGlibcNodeLauncherTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/LinuxGlibcNodeLauncherTest.kt
@@ -6,20 +6,31 @@ package software.aws.toolkits.jetbrains.core.lsp
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import java.io.File
 import java.nio.file.Path
 
 class LinuxGlibcNodeLauncherTest {
-    private val wrapper = Path.of("/usr/bin/node")
-    private val realNode = "/opt/node/bin/node"
-    private val nodeLib = "/opt/node/lib"
+    private val testRoot = Path.of(System.getProperty("java.io.tmpdir"))
+        .toAbsolutePath()
+        .resolve("linux-glibc-node-launcher-test")
+    private val wrapper = testPath("usr", "bin", "node")
+    private val realNode = testPath("opt", "node", "bin", "node")
+    private val nodeLib = testPath("opt", "node", "lib")
     private val message = "CloudFormation Language Server needs a newer glibc"
+
+    private fun testPath(vararg segments: String): Path = segments.fold(testRoot) { path, segment ->
+        path.resolve(segment)
+    }
 
     private fun ok(stdout: String) = CommandOutput(exitCode = 0, stdout = stdout, timedOut = false)
 
     private fun failure() = CommandOutput(exitCode = 127, stdout = "", timedOut = false)
 
-    private fun report(execPath: String = realNode, libraryPath: String = nodeLib, glibc: String): String =
-        "NODE_EXEC_PATH=$execPath\nNODE_LIBRARY_PATH=$libraryPath\nNODE_GLIBC_RUNTIME=$glibc\n"
+    private fun report(
+        execPath: String = realNode.toString(),
+        libraryPath: String = nodeLib.toString(),
+        glibc: String,
+    ): String = "NODE_EXEC_PATH=$execPath\nNODE_LIBRARY_PATH=$libraryPath\nNODE_GLIBC_RUNTIME=$glibc\n"
 
     /**
      * Answers the node probe, an optional `brew --prefix glibc`, and every loader validation. A command
@@ -39,20 +50,20 @@ class LinuxGlibcNodeLauncherTest {
     }
 
     private class FakeFs(
-        private val regularFiles: Set<String> = emptySet(),
-        private val executables: Set<String> = emptySet(),
-        private val realPaths: Map<String, String> = emptyMap(),
+        private val regularFiles: Set<Path> = emptySet(),
+        private val executables: Set<Path> = emptySet(),
+        private val realPaths: Map<Path, Path> = emptyMap(),
     ) : RuntimeFileSystem {
-        override fun realPathOrNull(path: Path): Path? = Path.of(realPaths[path.toString()] ?: path.toString())
+        override fun realPathOrNull(path: Path): Path? = realPaths[path] ?: path
 
-        override fun isRegularFile(path: Path): Boolean = path.toString() in regularFiles
+        override fun isRegularFile(path: Path): Boolean = path in regularFiles
 
-        override fun isExecutable(path: Path): Boolean = path.toString() in executables
+        override fun isExecutable(path: Path): Boolean = path in executables
     }
 
-    private fun fsWithCandidate(libDir: String, loaderName: String): FakeFs {
-        val loader = "$libDir/$loaderName"
-        val libc = "$libDir/libc.so.6"
+    private fun fsWithCandidate(libDir: Path, loaderName: String): FakeFs {
+        val loader = libDir.resolve(loaderName)
+        val libc = libDir.resolve("libc.so.6")
         return FakeFs(
             regularFiles = setOf(loader, libc),
             executables = setOf(loader),
@@ -154,58 +165,73 @@ class LinuxGlibcNodeLauncherTest {
 
     @Test
     fun `old glibc with a valid explicit candidate launches through the loader against the real node`() {
-        val root = "/custom/glibc228"
-        val libDir = "$root/lib"
+        val root = testPath("custom", "glibc228")
+        val libDir = root.resolve("lib")
         val launcher = LinuxGlibcNodeLauncher(
             isLinux = true,
             arch = LinuxArch.X64,
-            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root.toString() else null },
             runner = scenarioRunner(probe = ok(report(glibc = "2.26"))),
             fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),
         )
 
         val command = launcher.resolveLaunchCommand(wrapper, message).command
 
-        assertThat(command).containsExactly("$libDir/ld-linux-x86-64.so.2", "--library-path", "$nodeLib:$libDir", realNode)
+        assertThat(command).containsExactly(
+            libDir.resolve("ld-linux-x86-64.so.2").toString(),
+            "--library-path",
+            "$nodeLib${File.pathSeparator}$libDir",
+            realNode.toString(),
+        )
     }
 
     @Test
     fun `library path lists the node paths before the candidate libc directory`() {
-        val root = "/custom/glibc228"
-        val libDir = "$root/lib"
+        val root = testPath("custom", "glibc228")
+        val libDir = root.resolve("lib")
         val launcher = LinuxGlibcNodeLauncher(
             isLinux = true,
             arch = LinuxArch.X64,
-            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
-            runner = scenarioRunner(probe = ok(report(libraryPath = "/node/a:/node/b", glibc = "2.26"))),
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root.toString() else null },
+            runner = scenarioRunner(
+                probe = ok(
+                    report(
+                        libraryPath = listOf(testPath("node", "a"), testPath("node", "b"))
+                            .joinToString(File.pathSeparator),
+                        glibc = "2.26",
+                    )
+                )
+            ),
             fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),
         )
 
         val command = launcher.resolveLaunchCommand(wrapper, message).command
 
         val libraryPath = command[command.indexOf("--library-path") + 1]
-        assertThat(libraryPath).isEqualTo("/node/a:/node/b:$libDir")
+        assertThat(libraryPath).isEqualTo(
+            listOf(testPath("node", "a"), testPath("node", "b"), libDir).joinToString(File.pathSeparator)
+        )
     }
 
     @Test
     fun `arm64 loader name is used on arm64`() {
-        val root = "/custom/glibc228"
-        val libDir = "$root/lib"
+        val root = testPath("custom", "glibc228")
+        val libDir = root.resolve("lib")
         val launcher = LinuxGlibcNodeLauncher(
             isLinux = true,
             arch = LinuxArch.ARM64,
-            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root.toString() else null },
             runner = scenarioRunner(probe = ok(report(glibc = "2.26"))),
             fs = fsWithCandidate(libDir, "ld-linux-aarch64.so.1"),
         )
 
-        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo("$libDir/ld-linux-aarch64.so.1")
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo(libDir.resolve("ld-linux-aarch64.so.1").toString())
     }
 
     @Test
     fun `explicit opt-in environment variable is used before Homebrew discovery`() {
-        val root = "/custom/glibc"
-        val libDir = "$root/lib"
+        val root = testPath("custom", "glibc")
+        val libDir = root.resolve("lib")
         var brewCalls = 0
         val runner = BoundedCommandRunner { command, _ ->
             when {
@@ -222,19 +248,19 @@ class LinuxGlibcNodeLauncherTest {
         val launcher = LinuxGlibcNodeLauncher(
             isLinux = true,
             arch = LinuxArch.X64,
-            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root.toString() else null },
             runner = runner,
             fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),
         )
 
-        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo("$libDir/ld-linux-x86-64.so.2")
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo(libDir.resolve("ld-linux-x86-64.so.2").toString())
         assertThat(brewCalls).isZero()
     }
 
     @Test
     fun `homebrew glibc prefix is used to discover a candidate`() {
-        val prefix = "/home/linuxbrew/.linuxbrew/opt/glibc"
-        val libDir = "$prefix/lib"
+        val prefix = testPath("home", "linuxbrew", ".linuxbrew", "opt", "glibc")
+        val libDir = prefix.resolve("lib")
         val launcher = LinuxGlibcNodeLauncher(
             isLinux = true,
             arch = LinuxArch.X64,
@@ -246,49 +272,54 @@ class LinuxGlibcNodeLauncherTest {
             fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),
         )
 
-        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo("$libDir/ld-linux-x86-64.so.2")
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo(libDir.resolve("ld-linux-x86-64.so.2").toString())
     }
 
     @Test
     fun `a symlink escape candidate is rejected and a later valid candidate is used`() {
-        val badRoot = "/custom/bad"
-        val badLibDir = "$badRoot/lib"
-        val goodRoot = "/home/linuxbrew/.linuxbrew/opt/glibc"
-        val goodLibDir = "$goodRoot/lib"
+        val badRoot = testPath("custom", "bad")
+        val badLibDir = badRoot.resolve("lib")
+        val goodRoot = testPath("home", "linuxbrew", ".linuxbrew", "opt", "glibc")
+        val goodLibDir = goodRoot.resolve("lib")
         val fs = FakeFs(
             regularFiles = setOf(
-                "$badLibDir/ld-linux-x86-64.so.2",
-                "$badLibDir/libc.so.6",
-                "$goodLibDir/ld-linux-x86-64.so.2",
-                "$goodLibDir/libc.so.6",
+                badLibDir.resolve("ld-linux-x86-64.so.2"),
+                badLibDir.resolve("libc.so.6"),
+                goodLibDir.resolve("ld-linux-x86-64.so.2"),
+                goodLibDir.resolve("libc.so.6"),
             ),
-            executables = setOf("$badLibDir/ld-linux-x86-64.so.2", "$goodLibDir/ld-linux-x86-64.so.2"),
+            executables = setOf(
+                badLibDir.resolve("ld-linux-x86-64.so.2"),
+                goodLibDir.resolve("ld-linux-x86-64.so.2"),
+            ),
             // The bad loader resolves outside its lib directory, so its real parent no longer matches libc's.
-            realPaths = mapOf("$badLibDir/ld-linux-x86-64.so.2" to "/somewhere/else/ld-linux-x86-64.so.2"),
+            realPaths = mapOf(
+                badLibDir.resolve("ld-linux-x86-64.so.2") to testPath("somewhere", "else", "ld-linux-x86-64.so.2")
+            ),
         )
         val launcher = LinuxGlibcNodeLauncher(
             isLinux = true,
             arch = LinuxArch.X64,
-            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) badRoot else null },
-            runner = scenarioRunner(probe = ok(report(glibc = "2.26")), brewPrefix = goodRoot),
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) badRoot.toString() else null },
+            runner = scenarioRunner(probe = ok(report(glibc = "2.26")), brewPrefix = goodRoot.toString()),
             fs = fs,
         )
 
-        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo("$goodLibDir/ld-linux-x86-64.so.2")
+        assertThat(launcher.resolveLaunchCommand(wrapper, message).command.first()).isEqualTo(goodLibDir.resolve("ld-linux-x86-64.so.2").toString())
     }
 
     @Test
     fun `a candidate missing its libc is rejected`() {
-        val root = "/custom/glibc228"
-        val libDir = "$root/lib"
+        val root = testPath("custom", "glibc228")
+        val libDir = root.resolve("lib")
         val fs = FakeFs(
-            regularFiles = setOf("$libDir/ld-linux-x86-64.so.2"),
-            executables = setOf("$libDir/ld-linux-x86-64.so.2"),
+            regularFiles = setOf(libDir.resolve("ld-linux-x86-64.so.2")),
+            executables = setOf(libDir.resolve("ld-linux-x86-64.so.2")),
         )
         val launcher = LinuxGlibcNodeLauncher(
             isLinux = true,
             arch = LinuxArch.X64,
-            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root.toString() else null },
             runner = scenarioRunner(probe = ok(report(glibc = "2.26"))),
             fs = fs,
         )
@@ -301,16 +332,16 @@ class LinuxGlibcNodeLauncherTest {
 
     @Test
     fun `a candidate with a non-executable loader is rejected`() {
-        val root = "/custom/glibc228"
-        val libDir = "$root/lib"
+        val root = testPath("custom", "glibc228")
+        val libDir = root.resolve("lib")
         val fs = FakeFs(
-            regularFiles = setOf("$libDir/ld-linux-x86-64.so.2", "$libDir/libc.so.6"),
+            regularFiles = setOf(libDir.resolve("ld-linux-x86-64.so.2"), libDir.resolve("libc.so.6")),
             executables = emptySet(),
         )
         val launcher = LinuxGlibcNodeLauncher(
             isLinux = true,
             arch = LinuxArch.X64,
-            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root.toString() else null },
             runner = scenarioRunner(probe = ok(report(glibc = "2.26"))),
             fs = fs,
         )
@@ -321,12 +352,12 @@ class LinuxGlibcNodeLauncherTest {
 
     @Test
     fun `a candidate whose loader does not raise glibc to the floor is rejected`() {
-        val root = "/custom/glibc228"
-        val libDir = "$root/lib"
+        val root = testPath("custom", "glibc228")
+        val libDir = root.resolve("lib")
         val launcher = LinuxGlibcNodeLauncher(
             isLinux = true,
             arch = LinuxArch.X64,
-            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root else null },
+            env = { if (it == LinuxGlibcNodeLauncher.ENV_GLIBC_DIR) root.toString() else null },
             // Structurally valid, but running node through it still reports an old glibc.
             runner = scenarioRunner(probe = ok(report(glibc = "2.26")), validationGlibc = "2.26"),
             fs = fsWithCandidate(libDir, "ld-linux-x86-64.so.2"),

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/LspInstallExceptionTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/LspInstallExceptionTest.kt
@@ -35,7 +35,7 @@ class LspInstallExceptionTest {
     }
 
     @Test
-    fun `error codes cover all failure scenarios including NODE_NOT_FOUND`() {
+    fun `error codes cover all installation and runtime failure scenarios`() {
         val errorCodes = LspInstallException.ErrorCode.entries.toTypedArray()
 
         assertThat(errorCodes).containsExactlyInAnyOrder(
@@ -45,6 +45,7 @@ class LspInstallExceptionTest {
             LspInstallException.ErrorCode.EXTRACTION_FAILED,
             LspInstallException.ErrorCode.HASH_VERIFICATION_FAILED,
             LspInstallException.ErrorCode.NODE_NOT_FOUND,
+            LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC,
         )
     }
 

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/NodeRuntimeResolverTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/NodeRuntimeResolverTest.kt
@@ -39,6 +39,16 @@ class NodeRuntimeResolverTest {
     }
 
     @Test
+    fun `linux well-known paths include mise and legacy rtx shims`() {
+        val paths = buildWellKnownPaths(Platform.LINUX, home)
+
+        assertThat(paths).contains(
+            home.resolve(".local/share/mise/shims/node"),
+            home.resolve(".local/share/rtx/shims/node"),
+        )
+    }
+
+    @Test
     fun `windows well-known paths are valid`() {
         val paths = buildWellKnownPaths(Platform.WINDOWS, home)
         assertThat(paths).isNotEmpty
@@ -75,6 +85,39 @@ class NodeRuntimeResolverTest {
             fs.getPathMatcher("glob:$glob")
             Path.of(glob.substringBefore("*"))
         }
+    }
+
+    @Test
+    fun `mise and legacy rtx globs respect data directory environment variables`() {
+        val miseDataDir = Path.of("/custom/mise")
+        val rtxDataDir = Path.of("/custom/rtx")
+        val env: (String) -> String? = {
+            when (it) {
+                "MISE_DATA_DIR" -> miseDataDir.toString()
+                "RTX_DATA_DIR" -> rtxDataDir.toString()
+                else -> null
+            }
+        }
+
+        val patterns = buildGlobPatterns(Platform.LINUX, home, env)
+
+        assertThat(patterns).contains(
+            "$miseDataDir/installs/node/*/bin/node",
+            "$rtxDataDir/installs/node/*/bin/node",
+        )
+    }
+
+    @Test
+    fun `mise and legacy rtx globs use XDG data home`() {
+        val dataHome = Path.of("/custom/data")
+        val env: (String) -> String? = { if (it == "XDG_DATA_HOME") dataHome.toString() else null }
+
+        val patterns = buildGlobPatterns(Platform.LINUX, home, env)
+
+        assertThat(patterns).contains(
+            "${dataHome.resolve("mise")}/installs/node/*/bin/node",
+            "${dataHome.resolve("rtx")}/installs/node/*/bin/node",
+        )
     }
 
     @Test

--- a/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/NodeRuntimeResolverTest.kt
+++ b/plugins/toolkit/jetbrains-core/tst/software/aws/toolkits/jetbrains/core/lsp/NodeRuntimeResolverTest.kt
@@ -204,6 +204,44 @@ class NodeRuntimeResolverTest {
         }
     }
 
+    @Test
+    fun `launch command adapts the resolved runtime`() {
+        val incompatibleGlibcMessage = "incompatible glibc"
+        var adaptedPath: Path? = null
+        var adaptedMessage: String? = null
+
+        val launch = NodeRuntimeResolver.resolveLaunchCommand(
+            configuredPath = "",
+            nodeNotFoundMessage = nodeNotFoundMessage,
+            incompatibleGlibcMessage = incompatibleGlibcMessage,
+            autoDetect = { autoDetected },
+            adaptLaunchCommand = { path, message ->
+                adaptedPath = path
+                adaptedMessage = message
+                NodeLaunchCommand(listOf("loader", path.toString()))
+            },
+        )
+
+        assertThat(launch.command).containsExactly("loader", autoDetected.toString())
+        assertThat(adaptedPath).isEqualTo(autoDetected)
+        assertThat(adaptedMessage).isEqualTo(incompatibleGlibcMessage)
+    }
+
+    @Test
+    fun `incompatible glibc error from launch adaptation is preserved`() {
+        val expected = LspInstallException("incompatible glibc", LspInstallException.ErrorCode.INCOMPATIBLE_GLIBC)
+
+        assertThatThrownBy {
+            NodeRuntimeResolver.resolveLaunchCommand(
+                configuredPath = "",
+                nodeNotFoundMessage = nodeNotFoundMessage,
+                incompatibleGlibcMessage = expected.message.orEmpty(),
+                autoDetect = { autoDetected },
+                adaptLaunchCommand = { _, _ -> throw expected },
+            )
+        }.isSameAs(expected)
+    }
+
     private fun assertValidGlobs(patterns: List<String>) {
         assertThat(patterns).isNotEmpty
         patterns.forEach { glob ->


### PR DESCRIPTION
Probe the configured Node runtime before starting the CloudFormation language server. When its glibc is too old, validate and use an explicitly configured or Homebrew-provided runtime through its matching dynamic loader.

Fail with an actionable compatibility message when no safe runtime is available, and cover direct, alternate-loader, timeout, architecture, and malformed-runtime paths.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description
Fix CloudFormation language server failing to launch in AL2 (legacy linux) due to glibc 2.28 dependency of LMDB.

Tested on AL2 which crashed before this fix with `org.eclipse.lsp4j.jsonrpc.ResponseErrorException: Request initialize failed with message: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /local/home/zeemed/.cache/aws/language-servers/cloudformation-languageserver/1.10.0/node_modules/lmdb/build/Release/lmdb.node)`

Results:
```
Evidence from the current IntelliJ session:

  - Plugin version: 4.9-SNAPSHOT.262+592a212
  - Detected Node runtime glibc: 2.26
  - Selected alternate runtime: Homebrew glibc 2.39_1
  - Started through the matching ld-linux-x86-64.so.2
  - LMDB initialized successfully:

    Initialized LMDB v6 with stores: ['public_schemas', 'sam_schemas']

  - LSP reached running state:

    LSP server initialized in 1.960s
    name = AWS CloudFormation
    version = 1.10.0
    AWS CloudFormation initialized

  - Public and SAM schemas downloaded successfully.
  - Process is still alive and sleeping normally.
```

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [] A short description of the change has been added to the **[CHANGELOG](https://github.com/aws/aws-toolkit-jetbrains/blob/master/CONTRIBUTING.md#contributing-via-pull-requests)** if the change is customer-facing in the IDE.
- [ ] I have added metrics for my changes (if required)
 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
